### PR TITLE
Make sodiff create cache one repo at a time. Add logging, comments.

### DIFF
--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -67,7 +67,7 @@ $(SODIFF_REPO_FILE):
 sodiff-check: $(BUILT_PACKAGES_FILE) | $(SODIFF_REPO_FILE)
 	<$(BUILT_PACKAGES_FILE) $(SODIFF_SCRIPT) $(RPMS_DIR)/ $(SODIFF_REPO_FILE) $(RELEASE_MAJOR_ID) $(SODIFF_OUTPUT_FOLDER)
 	[ ! -f "$(SODIFF_SUMMARY_FILE)" ] \
-	|| [ `$(wc -w $(SODIFF_SUMMARY_FILE) | cut -f1 -d' ')`  -eq 0 ] \
+	|| [ "`$(wc -w $(SODIFF_SUMMARY_FILE) | cut -f1 -d' ')`"  -eq 0 ] \
 	|| ( echo "SRPM files that need to be updated due to sodiff:"; cat $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt ; $(call print_error,$@ failed - see $(SODIFF_SUMMARY_FILE) for a list of failed files.) )
 	echo "SODIFF finished - no changes detected."
 

--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -16,14 +16,7 @@ BUILD_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/build-summary.csv
 # A list of packages built during the current run
 BUILT_PACKAGES_FILE=$(SODIFF_OUTPUT_FOLDER)/built-packages.txt
 # Repositories that SODIFF runs the checks against
-ifneq ($(build_arch),x86_64)
-# Microsoft repository only exists for x86_64 - skip that .repo file;
-# otherwise package manager will signal an error due to being unable to make contact
-SODIFF_REPO_SOURCES="mariner-official-base.repo mariner-official-update.repo"
-else
 SODIFF_REPO_SOURCES="mariner-official-base.repo mariner-official-update.repo mariner-microsoft.repo"
-endif
-
 SODIFF_REPO_FILE=$(SCRIPTS_DIR)/sodiff/sodiff.repo
 # An artifact containing a list of packages that need to be dash-rolled due to their dependency having a new .so version
 SODIFF_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt
@@ -74,7 +67,7 @@ $(SODIFF_REPO_FILE):
 sodiff-check: $(BUILT_PACKAGES_FILE) | $(SODIFF_REPO_FILE)
 	<$(BUILT_PACKAGES_FILE) $(SODIFF_SCRIPT) $(RPMS_DIR)/ $(SODIFF_REPO_FILE) $(RELEASE_MAJOR_ID) $(SODIFF_OUTPUT_FOLDER)
 	[ ! -f "$(SODIFF_SUMMARY_FILE)" ] \
-	|| [ "`$(wc -w $(SODIFF_SUMMARY_FILE) | cut -f1 -d' ')`"  -eq 0 ] \
+	|| [ `$(wc -w $(SODIFF_SUMMARY_FILE) | cut -f1 -d' ')`  -eq 0 ] \
 	|| ( echo "SRPM files that need to be updated due to sodiff:"; cat $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt ; $(call print_error,$@ failed - see $(SODIFF_SUMMARY_FILE) for a list of failed files.) )
 	echo "SODIFF finished - no changes detected."
 

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -36,7 +36,7 @@ function log_to_file {
     >>$sodiff_log_file echo -- $@
 }
 
-# Split the abrdiged repo file and process each repo separately
+# Split the abridged repo file and process each repo separately
 # because if any of the repos is not accessible,
 # creating cache for the whole .repo file fails.
 # However, created caches accumulate, so creating multiple caches

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -39,8 +39,8 @@ function log_to_file {
 # Split the abrdiged repo file and process each repo separately
 # because if any of the repos is not accessible,
 # creating cache for the whole .repo file fails.
-# However, created cache combines , so creating multiple caches
-# Will not overwrite each other and any failures can be safely ignored
+# However, created caches accumulate, so creating multiple caches
+# will not overwrite each other and any failures can be safely ignored
 
 # Flag to track running cache creation for the first match of repo header - skip since repo file not created yet
 firstmatch=1

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -60,6 +60,8 @@ csplit -z -f 'repo' -b '_%d.repo' "$repo_file_path" '/^\[/' '{*}'
 for singe_repo_file in repo*.repo
 do
     makecache_with_common "$current_os" "$mariner_version" "$single_repo_file"
+    # Clean up as we go
+    rm -f "$single_repo_file"
 done
 
 # Cache created - now we can point to the abridged file.

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Required binaries:
 # rpm and dnf on Mariner

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -17,29 +17,30 @@ mkdir -p "$sodiff_out_dir"
 echo > "$sodiff_log_file"
 
 function makecache_with_common {
-    if [[ "$current_os" == mariner ]]; then
-        # Mariner uses DNF repoquery command
-        DNF_COMMAND=dnf
+    cur_os="$1"
+    release_version="$2"
+    if [[ "$cur_os" == mariner ]]; then
         # Cache RPM metadata
-        >/dev/null dnf -c "$1" --releasever $mariner_version -y makecache
+        >/dev/null dnf -c "$3" --releasever $release_version -y makecache
     else
-        # Ubuntu uses repoquery command from yum-utils
-        DNF_COMMAND=
         # Cache RPM metadata
         # Ubuntu does not come with gpgcheck plugin for yum
-        >/dev/null yum -c "$1" --releasever $mariner_version -y --nogpgcheck makecache
+        >/dev/null yum -c "$3" --releasever $release_version -y --nogpgcheck makecache
     fi
 }
 
 function set_common_options {
-    if [[ "$current_os" == mariner ]]; then
+    cur_os="$1"
+    release_version="$2"
+    file_path="$3"
+    if [[ "$cur_os" == mariner ]]; then
         # Mariner uses DNF repoquery command
         DNF_COMMAND=dnf
     else
         # Ubuntu uses repoquery command from yum-utils
         DNF_COMMAND=
     fi
-    common_options="-c $repo_file_path --releasever $mariner_version"
+    common_options="-c $file_path --releasever $release_version"
 }
 
 function log_to_file {
@@ -58,11 +59,11 @@ csplit -z -f 'repo' -b '_%d.repo' "$repo_file_path" '/^\[/' '{*}'
 # Updating cache with each repo info separately.
 for singe_repo_file in repo*.repo
 do
-    makecache_with_common "$single_repo_file"
+    makecache_with_common "$current_os" "$mariner_version" "$single_repo_file"
 done
 
 # Cache created - now we can point to the abridged file.
-set_common_options
+set_common_options "$current_os" "$mariner_version" "$repo_file_path"
 
 log_to_file "Cache created."
 

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Required binaries:
 # rpm and dnf on Mariner
@@ -9,41 +9,93 @@ repo_file_path="$2"
 mariner_version="$3"
 sodiff_out_dir="$4"
 sodiff_log_file="${sodiff_out_dir}/sodiff.log"
+current_os=$(cat /etc/os-release | grep ^ID | cut -d'=' -f2)
+temporary_repo_file="file.repo"
 
 # Setup output dir
 mkdir -p "$sodiff_out_dir"
-
-# Prepare mariner/ubuntu compatibility calls
-
-common_options="-c $repo_file_path --releasever $mariner_version"
-current_os=$(cat /etc/os-release | grep ^ID | cut -d'=' -f2)
-if [[ $current_os == mariner ]]; then
-    # Mariner uses DNF repoquery command
-    DNF_COMMAND=dnf
-    # Cache RPM metadata
-    >/dev/null dnf $common_options -y makecache
-else
-    # Ubuntu uses repoquery command from yum-utils
-    DNF_COMMAND=
-    # Cache RPM metadata
-    # Ubuntu does not come with gpgcheck plugin for yum
-    >/dev/null yum $common_options -y --nogpgcheck makecache
-fi
-
 # Empty the log file
 echo > "$sodiff_log_file"
+
+function makecache_with_common {
+    if [[ "$current_os" == mariner ]]; then
+        # Mariner uses DNF repoquery command
+        DNF_COMMAND=dnf
+        # Cache RPM metadata
+        >/dev/null dnf $common_options -y makecache
+    else
+        # Ubuntu uses repoquery command from yum-utils
+        DNF_COMMAND=
+        # Cache RPM metadata
+        # Ubuntu does not come with gpgcheck plugin for yum
+        >/dev/null yum $common_options -y --nogpgcheck makecache
+    fi
+}
+
+function log_to_file {
+    >>$sodiff_log_file echo -- $@
+}
+
+# Split the abrdiged repo file and process each repo separately
+# because if any of the repos is not accessible,
+# creating cache for the whole .repo file fails.
+# However, created cache combines , so creating multiple caches
+# Will not overwrite each other and any failures can be safely ignored
+
+# Flag to track running cache creation for the first match of repo header - skip since repo file not created yet
+firstmatch=1
+# Make common options point to the temporary repo file for now
+common_options="-c $temporary_repo_file --releasever $mariner_version"
+# IFS= prevents read from omitting leading/trailing whitespace
+# -r prevents read from interpreting backslash escapes
+while IFS= read -r line
+do
+    # If this is a start of a new repo definition
+    if grep -Eq "^\[[^]]+\]$" <<<"$line" ; then
+        # Do not run the operation on first match - repo file not filled yet
+        if [[ "$firstmatch" -eq 1 ]]; then
+            firstmatch=0
+        else
+            # Execute operation on the previous .repo file before proceeding with new one
+            makecache_with_common
+            echo ""
+        fi
+        log_to_file "Preparing cache for repo $line"
+        # Overwrite line to a repo file
+        printf '%s\n' "$line" > $temporary_repo_file
+    else
+        # Append line to a repo file
+        printf '%s\n' "$line" >> $temporary_repo_file
+    fi
+done < "$repo_file_path"
+# Run operation again for the final repo
+# In case repo file has only one repo definition, the command will
+# run twice on the same repo, but this is fine.
+makecache_with_common
+
+# Cache created - now we can point to the abridged file.
+common_options="-c $repo_file_path --releasever $mariner_version"
+
+log_to_file "Cache created."
 
 # Get packages from stdin
 pkgs=`cat`
 
+# Get a list of files requires_SOFILE where SOFILE is a name of a .so file that did not have a remote equivalent (SO that have been updated during this build but not released yet)
+# And its contents are the names of packages that depend upon that SOFILE (candidates for a rebuild)
+
 for rpmpackage in $pkgs; do
     package_path=$(find "$rpms_folder" -name "$rpmpackage" -type f)
     package_provides=`2>/dev/null rpm -qP "$package_path" | grep -E '[.]so[(.]' `
-    echo "Processing ${rpmpackage}..." >> "$sodiff_log_file"
+    log_to_file ""
+    log_to_file "Processing ${rpmpackage}..."
+    # Check every sofile provided by the rpm.
     for sofile in $package_provides; do
-        # Query local metadata for provides
+        # See if any package in the remote repositories provides this sofile yet.
         sos_found=$( $DNF_COMMAND repoquery $common_options --whatprovides $sofile | wc -l )
         if [ "$sos_found" -eq 0 ] ; then
+
+            log_to_file "Sofile $sofile not found remotely. It is either new so or a new version of preexisting sofile. "
             # SO file not found, meaning this might be a new .SO
             # or a new version of a preexisting .SO.
             # Check if the previous version exists in the database.
@@ -55,6 +107,7 @@ for rpmpackage in $pkgs; do
             sos_found=$( $DNF_COMMAND repoquery $common_options --whatprovides "${sofile_no_ver}*" | wc -l )
 
             if ! [ "$sos_found" -eq 0 ] ; then
+                log_to_file "Generic version of $sofile - $sofile_no_ver provided remotely, but $sofile_no_ver is not. This might be a new version of a so file."
                 # Generic version of SO was found.
                 # This means it's a new version of a preexisting SO.
                 # Log which packages depend on this functionality
@@ -66,20 +119,20 @@ done
 
 # Obtain a list of unique packages to be updated
 2>/dev/null cat "$sodiff_out_dir"/require* | sort -u > "$sodiff_out_dir"/sodiff-intermediate-summary.txt
-
 rm -f "$sodiff_out_dir"/sodiff-summary.txt
-
-# Remove packages that have been dash-rolled already.
 echo "$pkgs" > "$sodiff_out_dir/sodiff-built-packages.txt"
+
+# Remove packages that have been updated already.
 for package in $( cat "$sodiff_out_dir"/sodiff-intermediate-summary.txt ); do
     # Remove version and release
     package_stem=$(echo "$package" | rev | cut -f1,2 -d'-' --complement | rev)
+    log_to_file "Processing a potential candidate for update - $package_stem (${package})"
     # Find a highest version of package built during this run and remove .$ARCH.rpm ending
     highest_build_ver_pkg=$(grep -E "$package_stem-[0-9]" "$sodiff_out_dir"/sodiff-built-packages.txt | sort -Vr | head -n 1 | rev | cut -f1,2,3 -d'.' --complement | rev)
-
     # Check if versions differ
     if [[ "$package" == "$highest_build_ver_pkg" ]]; then
         # They do not: the version is not dash-rolled - report.
+        log_to_file "Potential candidate $package is the same as the remote one. Update needed."
         echo "$highest_build_ver_pkg" >> "$sodiff_out_dir"/sodiff-summary.txt
     fi
     # else:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In case any of the repositories in the .repo file argument to the sodiff shell script were not reachable, the whole cache creation would stop with no partial cache created. This makes queries to the .repo file later fail due to no cache being present.

By creating cache one-by-one, unreachable repositories are not problematic and the process works as expected.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Split .repo file argument for sodiff shell script and create cache for one repo at a time.
- Add more detailed logging
- Add comments

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local sodiff run
