### PR TITLE
Add SODIFF_OPTIONAL_SOURCES to allow optional repo files to be added

### DIFF
--- a/toolkit/docs/how_it_works/6_analysis.md
+++ b/toolkit/docs/how_it_works/6_analysis.md
@@ -19,6 +19,8 @@ sodiff is a process which looks for new versions of `.so` files and provides a l
 To provide a list of packages that need to be rebuilt, simply run `sodiff-check` target. The target will fail if no packages has been built. In that case, one can run `fake-built-packages-list` target before making a sodiff check. This will allow to analyze all RPMs except just the locally built ones.
 
 ### Implementation
+ - sodiff uses RPM repositories to obtain package information. The RPM repositories included by default come from the base Mariner .repo files. They are concatenated and packaged during toolkit generation.
+ - Optional .repo files can be passed added by specifying them with `SODIFF_OPTIONAL_SOURCES` variable. The location of .repo files is relative to the `$(SPECS_DIR)/mariner-repos/` directory.
 
 ### Artifacts
 The artifacts are available in the `$(SODIFF_OUTPUT_FOLDER)`, which is `build/sodiff` by default.

--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -16,6 +16,7 @@ BUILD_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/build-summary.csv
 # A list of packages built during the current run
 BUILT_PACKAGES_FILE=$(SODIFF_OUTPUT_FOLDER)/built-packages.txt
 # Repositories that SODIFF runs the checks against
+
 ifneq ($(build_arch),x86_64)
 # Microsoft repository only exists for x86_64 - skip that .repo file;
 # otherwise package manager will signal an error due to being unable to make contact
@@ -23,6 +24,8 @@ SODIFF_REPO_SOURCES="mariner-official-base.repo mariner-official-update.repo"
 else
 SODIFF_REPO_SOURCES="mariner-official-base.repo mariner-official-update.repo mariner-microsoft.repo"
 endif
+
+SODIFF_OPTIONAL_SOURCES ?=
 
 SODIFF_REPO_FILE=$(SCRIPTS_DIR)/sodiff/sodiff.repo
 # An artifact containing a list of packages that need to be dash-rolled due to their dependency having a new .so version
@@ -66,7 +69,7 @@ fake-built-packages-list: | $(SODIFF_OUTPUT_FOLDER)
 	find $(RPMS_DIR) -type f -name '*.rpm' -exec basename {} \; > $(BUILT_PACKAGES_FILE)
 
 $(SODIFF_REPO_FILE):
-	echo $(SODIFF_REPO_SOURCES) | sed -E 's:([^ ]+[.]repo):$(SPECS_DIR)/mariner-repos/\1:g' | xargs cat > $(SODIFF_REPO_FILE)
+	echo $(SODIFF_REPO_SOURCES) $(SODIFF_OPTIONAL_SOURCES) | sed -E 's:([^ ]+[.]repo):$(SPECS_DIR)/mariner-repos/\1:g' | xargs cat > $(SODIFF_REPO_FILE)
 
 # sodiff-check: runs check in a mariner container. Each failed package will be listed in $(SODIFF_OUTPUT_FOLDER).
 .SILENT .PHONY: sodiff-check


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Previously, sodiff would use a fixed list of .repo files to query the package metadata. This PR adds `SODIFF_OPTIONAL_SOURCES` variable that allows user to specify additional .repo files.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `SODIFF_OPTIONAL_SOURCES` variable.
- Add documentation for the new variable.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
