### PR TITLE
Move TargetDisk config field to a dedicated type

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -7,7 +7,7 @@ Image configuration consists of two sections - Disks and SystemConfigs - that de
 Disks entry specifies the disk configuration like its size (for virtual disks), partitions and partition table.
 
 ## TargetDisk
-Required when building unattended ISO installer (`sudo make iso UNATTENDED_INSTALLER=y ...`). This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path. Each `Disk` requires its own `TargetDisk`.
+Required when building unattended ISO installers (`sudo make iso UNATTENDED_INSTALLER=y ...`). This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path. Each `Disk` requires its own `TargetDisk`.
 
 An example can be seen in [core-legacy-unattended-hyperv.json](/toolkit/imageconfigs/core-legacy-unattended-hyperv.json)
 
@@ -17,6 +17,8 @@ An example can be seen in [core-legacy-unattended-hyperv.json](/toolkit/imagecon
     "Value": "/dev/sda"
 }
 ```
+
+For more complex targeting of disks, see [IsKickStartBoot](#iskickstartboot) for using kickstart files and scripts to manually configure the install partitions.
 
 ### Artifacts
 Artifact (non-ISO image building only) defines the name, type and optional compression of the output CBL-Mariner image.

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -7,7 +7,16 @@ Image configuration consists of two sections - Disks and SystemConfigs - that de
 Disks entry specifies the disk configuration like its size (for virtual disks), partitions and partition table.
 
 ## TargetDisk
-Required when building unattended ISO installer. This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path.
+Required when building unattended ISO installer (`sudo make iso UNATTENDED_INSTALLER=y ...`). This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path. Each `Disk` requires its own `TargetDisk`.
+
+An example can be seen in [core-legacy-unattended-hyperv.json](/toolkit/imageconfigs/core-legacy-unattended-hyperv.json)
+
+``` json
+"TargetDisk": {
+    "Type": "path",
+    "Value": "/dev/sda"
+}
+```
 
 ### Artifacts
 Artifact (non-ISO image building only) defines the name, type and optional compression of the output CBL-Mariner image.

--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
@@ -130,7 +130,7 @@ func (ap *AutoPartitionWidget) SelectedSystemDevice() int {
 
 func (ap *AutoPartitionWidget) mustUpdateConfiguration(sysConfig *configuration.SystemConfig, cfg *configuration.Config) {
 	const (
-		targetDiskType     = "path"
+		targetDiskType     = configuration.TargetDiskTypePath
 		partitionTableType = "gpt"
 
 		bootPartitionName     = "esp"

--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
@@ -520,7 +520,7 @@ func (mp *ManualPartitionWidget) mustRemovePartition() {
 
 func (mp *ManualPartitionWidget) unmarshalPartitionTable() (err error) {
 	const (
-		targetDiskType     = "path"
+		targetDiskType     = configuration.TargetDiskTypePath
 		partitionTableType = "gpt"
 
 		rootMountPoint     = "/"

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -33,13 +33,6 @@ type RawBinary struct {
 	Seek      uint64 `json:"Seek"`
 }
 
-// TargetDisk [kickstart-only] defines the physical disk, to which
-// Mariner should be installed.
-type TargetDisk struct {
-	Type  string `json:"Type"`
-	Value string `json:"Value"`
-}
-
 // InstallScript defines a script to be run before or after other installation
 // steps and provides a way to pass parameters to it.
 type InstallScript struct {

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -95,9 +95,6 @@ func (d *Disk) IsValid() (err error) {
 		return fmt.Errorf("invalid [Disk]: %w", err)
 	}
 
-	// if err = disk.PartitionTableType.IsValid(); err != nil {
-	// 	return
-	// }
 	// for _, artifact := range disk.Artifacts {
 	// 	if err = artifact.IsValid(); err != nil {
 	// 		return
@@ -113,6 +110,11 @@ func (d *Disk) IsValid() (err error) {
 	// 		return
 	// 	}
 	// }
+
+	if err = d.TargetDisk.IsValid(); err != nil {
+		return
+	}
+
 	return
 }
 

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -49,11 +49,8 @@ func checkOverlappingePartitions(disk *Disk) (err error) {
 // also confirms that the MaxSize defined is large enough to accomodate all partitions. No partition should have an
 // end position that exceeds the MaxSize
 func checkMaxSizeCorrectness(disk *Disk) (err error) {
-	const (
-		realDiskType = "path"
-	)
 	//MaxSize is not relevant if target disk is specified.
-	if disk.TargetDisk.Type != realDiskType {
+	if disk.TargetDisk.Type != TargetDiskTypePath {
 		//Complain about 0 maxSize only when partitions are defined.
 		if disk.MaxSize <= 0 && len(disk.Partitions) != 0 {
 			return fmt.Errorf("a configuration without a defined target disk must have a non-zero MaxSize")

--- a/toolkit/tools/imagegen/configuration/disk_test.go
+++ b/toolkit/tools/imagegen/configuration/disk_test.go
@@ -164,6 +164,23 @@ func TestShouldFailMaxSizeInsufficient_Disk(t *testing.T) {
 	assert.Equal(t, "failed to parse [Disk]: invalid [Disk]: the MaxSize of 512 is not large enough to accomodate defined partitions ending at 1024.", err.Error())
 }
 
+func TestShouldFailNoSizeSet_Disk(t *testing.T) {
+	var checkedDisk Disk
+	invalidDisk := validDisk
+
+	invalidDisk.MaxSize = 0
+	invalidDisk.TargetDisk.Type = ""
+	invalidDisk.TargetDisk.Value = ""
+	err := invalidDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [Disk]: a configuration without a defined target disk must have a non-zero MaxSize", err.Error())
+
+	// remarshal runs IsValid() on [SystemConfig] prior to running it on [Config], so we get a different error message here.
+	err = remarshalJSON(invalidDisk, &checkedDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Disk]: invalid [Disk]: a configuration without a defined target disk must have a non-zero MaxSize", err.Error())
+}
+
 func TestShouldFailInvalidTargetDisk_Disk(t *testing.T) {
 	var checkedDisk Disk
 	invalidDisk := validDisk

--- a/toolkit/tools/imagegen/configuration/parse_partition.go
+++ b/toolkit/tools/imagegen/configuration/parse_partition.go
@@ -170,7 +170,7 @@ func processDisk(inputDiskValue string) (err error) {
 		disks[latestDiskIndex].PartitionTableType = partitionTableType
 
 		// Set TargetDisk and TargetDiskType for unattended installation
-		disks[latestDiskIndex].TargetDisk.Type = "path"
+		disks[latestDiskIndex].TargetDisk.Type = TargetDiskTypePath
 		disks[latestDiskIndex].TargetDisk.Value = diskValue
 
 		diskInfo[diskValue] = latestDiskIndex

--- a/toolkit/tools/imagegen/configuration/targetdisk.go
+++ b/toolkit/tools/imagegen/configuration/targetdisk.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TargetDisk [kickstart-only] defines the physical disk, to which
+// Mariner should be installed.
+type TargetDisk struct {
+	Type  TargetDiskType `json:"Type"`
+	Value string         `json:"Value"`
+}
+
+// IsValid returns an error if the RaidConfig is not valid
+func (t *TargetDisk) IsValid() (err error) {
+
+	// Validate TargetDiskType
+	if err = t.Type.IsValid(); err != nil {
+		return fmt.Errorf("invalid [TargetDisk]: %w", err)
+	}
+
+	// Path must include a path to a disk
+	if t.Type == TargetDiskTypePath {
+		if t.Value == "" {
+			return fmt.Errorf("invalid [TargetDisk]: Value must be specified for TargetDiskType of '%s'", TargetDiskTypePath)
+		}
+	}
+
+	// Only allow empty struct if target type is empty
+	if t.Type == TargetDiskTypeNone {
+		if t.Value != "" {
+			return fmt.Errorf("invalid [TargetDisk]: Value must be empty for TargetDiskType of '%s'", TargetDiskTypeNone)
+		}
+	}
+
+	return nil
+}
+
+// UnmarshalJSON Unmarshals a RaidConfig entry
+func (t *TargetDisk) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypeTargetDisk TargetDisk
+	err = json.Unmarshal(b, (*IntermediateTypeTargetDisk)(t))
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDisk]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = t.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDisk]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/targetdisk_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisk_test.go
@@ -1,0 +1,93 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//TestMain found in configuration_test.go.
+
+var (
+	validTargetDisk       TargetDisk = TargetDisk{}
+	invalidTargetDiskJSON            = `{"End": "abc"}`
+)
+
+func TestShouldSuccessParsingDefaultTargetDisk_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	err := marshalJSONString("{}", &checkedTargetDisk)
+	assert.NoError(t, err)
+	assert.Equal(t, TargetDisk{}, checkedTargetDisk)
+}
+
+func TestShouldSuccessParsingValidTargetDisk_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	err := remarshalJSON(validTargetDisk, &checkedTargetDisk)
+	assert.NoError(t, err)
+	assert.Equal(t, validTargetDisk, checkedTargetDisk)
+}
+
+func TestShouldPassTypePath_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	pathTargetDisk := validTargetDisk
+
+	pathTargetDisk.Type = "path"
+	pathTargetDisk.Value = "/dev/sda"
+
+	err := pathTargetDisk.IsValid()
+	assert.NoError(t, err)
+
+	err = remarshalJSON(pathTargetDisk, &checkedTargetDisk)
+	assert.NoError(t, err)
+	assert.Equal(t, pathTargetDisk, checkedTargetDisk)
+}
+
+func TestShouldFailTypePathNoValue_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	PathTargetDisk := validTargetDisk
+
+	PathTargetDisk.Type = "path"
+	PathTargetDisk.Value = ""
+
+	err := PathTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: Value must be specified for TargetDiskType of 'path'", err.Error())
+
+	err = remarshalJSON(PathTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: invalid [TargetDisk]: Value must be specified for TargetDiskType of 'path'", err.Error())
+}
+
+func TestShouldFailInvalidType_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	invalidTargetDisk := validTargetDisk
+
+	invalidTargetDisk.Type = "invalid"
+
+	err := invalidTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: invalid value for TargetDiskType (invalid)", err.Error())
+
+	err = remarshalJSON(invalidTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: failed to parse [TargetDiskType]: invalid value for TargetDiskType (invalid)", err.Error())
+}
+
+func TestShouldFailNonEmptyStructWithNoneType_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	invalidTargetDisk := validTargetDisk
+
+	invalidTargetDisk.Type = ""
+	invalidTargetDisk.Value = "/dev/sda"
+
+	err := invalidTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: Value must be empty for TargetDiskType of ''", err.Error())
+
+	err = remarshalJSON(invalidTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: invalid [TargetDisk]: Value must be empty for TargetDiskType of ''", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/targetdisk_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisk_test.go
@@ -34,7 +34,7 @@ func TestShouldPassTypePath_TargetDisk(t *testing.T) {
 	var checkedTargetDisk TargetDisk
 	pathTargetDisk := validTargetDisk
 
-	pathTargetDisk.Type = "path"
+	pathTargetDisk.Type = TargetDiskTypePath
 	pathTargetDisk.Value = "/dev/sda"
 
 	err := pathTargetDisk.IsValid()
@@ -49,7 +49,7 @@ func TestShouldFailTypePathNoValue_TargetDisk(t *testing.T) {
 	var checkedTargetDisk TargetDisk
 	PathTargetDisk := validTargetDisk
 
-	PathTargetDisk.Type = "path"
+	PathTargetDisk.Type = TargetDiskTypePath
 	PathTargetDisk.Value = ""
 
 	err := PathTargetDisk.IsValid()

--- a/toolkit/tools/imagegen/configuration/targetdisktype.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype.go
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TargetDiskType sets the backing disk type for the disk
+type TargetDiskType string
+
+const (
+	// TargetDiskTypePath means this is a /dev/sda or similar disk that already exists
+	TargetDiskTypePath TargetDiskType = "path"
+	// TargetDiskTypeNone means there is no target disk
+	TargetDiskTypeNone TargetDiskType = ""
+)
+
+func (t TargetDiskType) String() string {
+	return fmt.Sprint(string(t))
+}
+
+// GetValidTargetDiskTypes returns a list of all the supported
+// disk types
+func (t *TargetDiskType) GetValidTargetDiskTypes() (types []TargetDiskType) {
+	return []TargetDiskType{
+		TargetDiskTypePath,
+		TargetDiskTypeNone,
+	}
+}
+
+// IsValid returns an error if the TargetDiskType is not valid
+func (t *TargetDiskType) IsValid() (err error) {
+	for _, valid := range t.GetValidTargetDiskTypes() {
+		if *t == valid {
+			return
+		}
+	}
+	return fmt.Errorf("invalid value for TargetDiskType (%s)", t)
+}
+
+// UnmarshalJSON Unmarshals an TargetDiskType entry
+func (t *TargetDiskType) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypeTargetDiskType TargetDiskType
+	err = json.Unmarshal(b, (*IntermediateTypeTargetDiskType)(t))
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDiskType]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = t.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDiskType]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -1,0 +1,76 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMain found in configuration_test.go.
+
+var (
+	validTargetDiskTypes = []TargetDiskType{
+		TargetDiskType("path"),
+		TargetDiskType(""),
+	}
+	invalidTargetDiskType     = TargetDiskType("not_a_disk_type")
+	validTargetDiskTypeJSON   = `"path"`
+	invalidTargetDiskTypeJSON = `1234`
+)
+
+func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
+	var vdt TargetDiskType
+	assert.Equal(t, len(validTargetDiskTypes), len(vdt.GetValidTargetDiskTypes()))
+
+	for _, TargetDiskType := range validTargetDiskTypes {
+		found := false
+		for _, validTargetDiskType := range vdt.GetValidTargetDiskTypes() {
+			if TargetDiskType == validTargetDiskType {
+				found = true
+			}
+		}
+		assert.True(t, found)
+	}
+}
+
+func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
+	for _, validPolicy := range validTargetDiskTypes {
+		var checkedPolicy TargetDiskType
+
+		assert.NoError(t, validPolicy.IsValid())
+		err := remarshalJSON(validPolicy, &checkedPolicy)
+		assert.NoError(t, err)
+		assert.Equal(t, validPolicy, checkedPolicy)
+	}
+}
+
+func TestShouldFailParsingInvalidPolicy_TargetDiskType(t *testing.T) {
+	var checkedPolicy TargetDiskType
+
+	err := invalidTargetDiskType.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid value for TargetDiskType (not_a_disk_type)", err.Error())
+
+	err = remarshalJSON(invalidTargetDiskType, &checkedPolicy)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDiskType]: invalid value for TargetDiskType (not_a_disk_type)", err.Error())
+}
+
+func TestShouldSucceedParsingValidJSON_TargetDiskType(t *testing.T) {
+	var checkedPolicy TargetDiskType
+
+	err := marshalJSONString(validTargetDiskTypeJSON, &checkedPolicy)
+	assert.NoError(t, err)
+	assert.Equal(t, validTargetDiskTypes[0], checkedPolicy)
+}
+
+func TestShouldFailParsingInvalidJSON_TargetDiskType(t *testing.T) {
+	var checkedPolicy TargetDiskType
+
+	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedPolicy)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDiskType]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypeTargetDiskType", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -37,17 +37,17 @@ func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
 }
 
 func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
-	for _, validPolicy := range validTargetDiskTypes {
+	for _, validTargetDiskType := range validTargetDiskTypes {
 		var checkedTargetDiskTyp TargetDiskType
 
-		assert.NoError(t, validPolicy.IsValid())
-		err := remarshalJSON(validPolicy, &checkedTargetDiskTyp)
+		assert.NoError(t, validTargetDiskType.IsValid())
+		err := remarshalJSON(validTargetDiskType, &checkedTargetDiskTyp)
 		assert.NoError(t, err)
-		assert.Equal(t, validPolicy, checkedTargetDiskTyp)
+		assert.Equal(t, validTargetDiskType, checkedTargetDiskTyp)
 	}
 }
 
-func TestShouldFailParsingInvalidPolicy_TargetDiskType(t *testing.T) {
+func TestShouldFailParsingInvalidTargetDiskType_TargetDiskType(t *testing.T) {
 	var checkedTargetDiskTyp TargetDiskType
 
 	err := invalidTargetDiskType.IsValid()

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -38,39 +38,39 @@ func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
 
 func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
 	for _, validPolicy := range validTargetDiskTypes {
-		var checkedPolicy TargetDiskType
+		var checkedTargetDiskTyp TargetDiskType
 
 		assert.NoError(t, validPolicy.IsValid())
-		err := remarshalJSON(validPolicy, &checkedPolicy)
+		err := remarshalJSON(validPolicy, &checkedTargetDiskTyp)
 		assert.NoError(t, err)
-		assert.Equal(t, validPolicy, checkedPolicy)
+		assert.Equal(t, validPolicy, checkedTargetDiskTyp)
 	}
 }
 
 func TestShouldFailParsingInvalidPolicy_TargetDiskType(t *testing.T) {
-	var checkedPolicy TargetDiskType
+	var checkedTargetDiskTyp TargetDiskType
 
 	err := invalidTargetDiskType.IsValid()
 	assert.Error(t, err)
 	assert.Equal(t, "invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 
-	err = remarshalJSON(invalidTargetDiskType, &checkedPolicy)
+	err = remarshalJSON(invalidTargetDiskType, &checkedTargetDiskTyp)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 }
 
 func TestShouldSucceedParsingValidJSON_TargetDiskType(t *testing.T) {
-	var checkedPolicy TargetDiskType
+	var checkedTargetDiskTyp TargetDiskType
 
-	err := marshalJSONString(validTargetDiskTypeJSON, &checkedPolicy)
+	err := marshalJSONString(validTargetDiskTypeJSON, &checkedTargetDiskTyp)
 	assert.NoError(t, err)
-	assert.Equal(t, validTargetDiskTypes[0], checkedPolicy)
+	assert.Equal(t, validTargetDiskTypes[0], checkedTargetDiskTyp)
 }
 
 func TestShouldFailParsingInvalidJSON_TargetDiskType(t *testing.T) {
-	var checkedPolicy TargetDiskType
+	var checkedTargetDiskTyp TargetDiskType
 
-	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedPolicy)
+	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedTargetDiskTyp)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypeTargetDiskType", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -38,39 +38,39 @@ func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
 
 func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
 	for _, validTargetDiskType := range validTargetDiskTypes {
-		var checkedTargetDiskTyp TargetDiskType
+		var checkedTargetDiskType TargetDiskType
 
 		assert.NoError(t, validTargetDiskType.IsValid())
-		err := remarshalJSON(validTargetDiskType, &checkedTargetDiskTyp)
+		err := remarshalJSON(validTargetDiskType, &checkedTargetDiskType)
 		assert.NoError(t, err)
-		assert.Equal(t, validTargetDiskType, checkedTargetDiskTyp)
+		assert.Equal(t, validTargetDiskType, checkedTargetDiskType)
 	}
 }
 
 func TestShouldFailParsingInvalidTargetDiskType_TargetDiskType(t *testing.T) {
-	var checkedTargetDiskTyp TargetDiskType
+	var checkedTargetDiskType TargetDiskType
 
 	err := invalidTargetDiskType.IsValid()
 	assert.Error(t, err)
 	assert.Equal(t, "invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 
-	err = remarshalJSON(invalidTargetDiskType, &checkedTargetDiskTyp)
+	err = remarshalJSON(invalidTargetDiskType, &checkedTargetDiskType)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 }
 
 func TestShouldSucceedParsingValidJSON_TargetDiskType(t *testing.T) {
-	var checkedTargetDiskTyp TargetDiskType
+	var checkedTargetDiskType TargetDiskType
 
-	err := marshalJSONString(validTargetDiskTypeJSON, &checkedTargetDiskTyp)
+	err := marshalJSONString(validTargetDiskTypeJSON, &checkedTargetDiskType)
 	assert.NoError(t, err)
-	assert.Equal(t, validTargetDiskTypes[0], checkedTargetDiskTyp)
+	assert.Equal(t, validTargetDiskTypes[0], checkedTargetDiskType)
 }
 
 func TestShouldFailParsingInvalidJSON_TargetDiskType(t *testing.T) {
-	var checkedTargetDiskTyp TargetDiskType
+	var checkedTargetDiskType TargetDiskType
 
-	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedTargetDiskTyp)
+	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedTargetDiskType)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypeTargetDiskType", err.Error())
 }

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -333,10 +333,7 @@ func setupRootFS(outputDir, installRoot string) (extraMountPoints []*safechroot.
 }
 
 func setupDisk(outputDir, diskName string, liveInstallFlag bool, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption, readOnlyRootConfig configuration.ReadOnlyVerityRoot) (diskDevPath string, partIDToDevPathMap, partIDToFsTypeMap map[string]string, isLoopDevice bool, encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice, err error) {
-	const (
-		realDiskType = "path"
-	)
-	if diskConfig.TargetDisk.Type == realDiskType {
+	if diskConfig.TargetDisk.Type == configuration.TargetDiskTypePath {
 		if liveInstallFlag {
 			diskDevPath = diskConfig.TargetDisk.Value
 			partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, readOnlyRoot, err = setupRealDisk(diskDevPath, diskConfig, rootEncryption, readOnlyRootConfig)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Setting the groundwork for future work to add RAID drives. By moving the TargetDisk field to its own type we can support different configurations of `TargetDiskType` (`path`, `raid`, etc...). 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move `TargetDisk` and `TargetDiskType` to their own classes.
- Add unit tests and error checking to the above types

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build and test of images, ISOs, unattended ISOs