### PR TITLE
Reduce systemd `%check` failures from 23 -> 6

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -31,6 +31,7 @@ Patch8:         serve-stale-0002-resolved-Initialize-until_valid-while-storing-n
 Patch9:         mariner-2-do-not-default-zstd-journal-files-for-backwards-compatibility.patch
 BuildRequires:  audit-devel
 BuildRequires:  cryptsetup-devel
+BuildRequires:  dbus
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
 BuildRequires:  gettext
@@ -44,11 +45,14 @@ BuildRequires:  libgcrypt-devel
 BuildRequires:  libselinux-devel
 BuildRequires:  libxslt
 BuildRequires:  lz4-devel
+BuildRequires:  mariner-release
 BuildRequires:  meson
 BuildRequires:  pam-devel
 BuildRequires:  perl-XML-Parser
 BuildRequires:  python3-jinja2
+BuildRequires:  sudo
 BuildRequires:  tpm2-tss-devel
+BuildRequires:  tzdata
 BuildRequires:  util-linux-devel
 BuildRequires:  xz-devel
 BuildRequires:  zstd-devel
@@ -182,6 +186,12 @@ install -D -m 0644 %{SOURCE4} %{buildroot}%{_libdir}/systemd/system-preset/99-ma
 %find_lang %{name} ../%{name}.lang
 
 %check
+# Generate machine-id using dbus
+%{_bindir}/dbus-uuidgen --ensure=%{_sysconfdir}/machine-id
+sudo su
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
 meson test -C build
 
 # Enable default systemd units.
@@ -287,6 +297,11 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Sun Dec 17 2023 Rakshaa Viswanathan <rviswanathan@microsoft.com> - 250.3-20
+- Add BR: dbus, mariner-release, tzdata, sudo to systemd.spec
+- Generate machine-id using dbus-uuidgen
+- Set UTF8 encoding in %check section of systemd.spec
+
 * Thu Nov 02 2023 Chris Co <chrco@microsoft.com> - 250.3-19
 - Add zstd-libs as a requires to ensure libzstd.so.1 is present
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -188,10 +188,6 @@ install -D -m 0644 %{SOURCE4} %{buildroot}%{_libdir}/systemd/system-preset/99-ma
 %check
 # Generate machine-id using dbus
 %{_bindir}/dbus-uuidgen --ensure=%{_sysconfdir}/machine-id
-sudo su
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
-export LANGUAGE=en_US.UTF-8
 meson test -C build
 
 # Enable default systemd units.


### PR DESCRIPTION
<!--
-ccCOMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Fix 17 ptests out of 23 failures for systemd

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add BR: dbus, mariner-release, tzdata, sudo to systemd.spec
- Generate machine-id using dbus-uuidgen
- Set UTF8 encoding in %check section of systemd.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=430931&view=results
