### PR TITLE
Bump version of golang to 1.19.6 to fix CVE-2022-41722, CVE-2022-4172…

### DIFF
--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -1,6 +1,6 @@
 {
-  "Signatures": {
-    "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52",
-    "go1.19.5.src.tar.gz": "8e486e8e85a281fc5ce3f0bedc5b9d2dbf6276d7db0b25d3ec034f313da0375f"
-  }
+ "Signatures": {
+  "go1.19.6.src.tar.gz": "d7f0013f82e6d7f862cc6cb5c8cdb48eef5f2e239b35baa97e2f1a7466043767",
+  "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
+ }
 }

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -12,7 +12,7 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.19.5
+Version:        1.19.6
 Release:        1%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
@@ -117,6 +117,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Mar 14 2023 Rakshaa Viswanathan <rviswanathan@microsoft.com> - 1.19.6-1
+- Upgrade to 1.19.6 (fixes CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723)
+
 * Fri Feb 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.19.5-1
 - Auto-upgrade to 1.19.5 - upgrade to latest
 

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -1,15 +1,3 @@
-%global goroot          %{_libdir}/golang
-%global gopath          %{_datadir}/gocode
-%ifarch aarch64
-%global gohostarch      arm64
-%else
-%global gohostarch      amd64
-%endif
-%define debug_package %{nil}
-%define __strip /bin/true
-# rpmbuild magic to keep from having meta dependency on libc.so.6
-%define _use_internal_dependency_generator 0
-%define __find_requires %{nil}
 Summary:        Go
 Name:           golang
 Version:        1.19.6
@@ -22,6 +10,18 @@ URL:            https://golang.org
 Source0:        https://golang.org/dl/go%{version}.src.tar.gz
 Source1:        https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
+%global goroot          %{_libdir}/golang
+%global gopath          %{_datadir}/gocode
+%ifarch aarch64
+%global gohostarch      arm64
+%else
+%global gohostarch      amd64
+%endif
+%define debug_package %{nil}
+%define __strip /bin/true
+# rpmbuild magic to keep from having meta dependency on libc.so.6
+%define _use_internal_dependency_generator 0
+%define __find_requires %{nil}
 Obsoletes:      %{name} < %{version}
 Provides:       %{name} = %{version}
 Provides:       go = %{version}-%{release}

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4570,8 +4570,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.19.5",
-          "downloadUrl": "https://golang.org/dl/go1.19.5.src.tar.gz"
+          "version": "1.19.6",
+          "downloadUrl": "https://golang.org/dl/go1.19.6.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
…4, CVE-2022-41725, CVE-2022-41723

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump golang from 1.19.5 to 1.19.6 to fix CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-41722
- https://nvd.nist.gov/vuln/detail/CVE-2022-41724
- https://nvd.nist.gov/vuln/detail/CVE-2022-41725
- https://nvd.nist.gov/vuln/detail/CVE-2022-41723

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
