### PR TITLE
Add RAID TargetDisk struct

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -7,7 +7,16 @@ Image configuration consists of two sections - Disks and SystemConfigs - that de
 Disks entry specifies the disk configuration like its size (for virtual disks), partitions and partition table.
 
 ## TargetDisk
-Required when building unattended ISO installer. This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path.
+Required when building unattended ISO installer (`sudo make iso UNATTENDED_INSTALLER=y ...`). This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path. Each `Disk` requires its own `TargetDisk`.
+
+An example can be seen in [core-legacy-unattended-hyperv.json](/toolkit/imageconfigs/core-legacy-unattended-hyperv.json)
+
+``` json
+"TargetDisk": {
+    "Type": "path",
+    "Value": "/dev/sda"
+}
+```
 
 ### Artifacts
 Artifact (non-ISO image building only) defines the name, type and optional compression of the output CBL-Mariner image.

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -7,7 +7,10 @@ Image configuration consists of two sections - Disks and SystemConfigs - that de
 Disks entry specifies the disk configuration like its size (for virtual disks), partitions and partition table.
 
 ## TargetDisk
-Required when building unattended ISO installer (`sudo make iso UNATTENDED_INSTALLER=y ...`). This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path. Each `Disk` requires its own `TargetDisk`.
+Required when building unattended ISO installer (`sudo make iso UNATTENDED_INSTALLER=y ...`) or using RAID disks. This field defines the target disk to which Mariner should be installed. The `Type` field must be set to `path`, or `raid`.
+
+### Path
+Path targets are physical disks (`/dev/sda` etc.). The `Value` field must be set to the desired target disk path. Each `Disk` requires its own `TargetDisk`.
 
 An example can be seen in [core-legacy-unattended-hyperv.json](/toolkit/imageconfigs/core-legacy-unattended-hyperv.json)
 
@@ -16,6 +19,35 @@ An example can be seen in [core-legacy-unattended-hyperv.json](/toolkit/imagecon
     "Type": "path",
     "Value": "/dev/sda"
 }
+```
+
+### Raid
+Raid targets are 'virtual' disks that are based on other disks to back them. A RAID target must have a `RaidConfig` filled out. Each entry in the `ComponentPartIDs` is a `Partition.ID` on another disk. These partitions will be passed to the `mdadm` tool to create a RAID array. `Level` can be one of `0`, `1`, `4`, `5`, `6`, `10`. Each RAID disk must also have a unique `RaidID` which will correspond to the device's path (`/dev/md/MyID`). Each RAID disk may have only one partition (while `mdadm` can support creating partitionable RAID disks, the Mariner tools only support single partition RAIDs)
+
+An example can be found in [raid.json](/toolkit/imageconfigs/raid.json)
+
+``` json
+{
+    "ID": "raidBoot",
+    "TargetDisk": {
+        "Type": "raid",
+        "RaidConfig": {
+            "ComponentPartIDs": [
+                "boot_1",
+                "boot_2",
+                "boot_3"
+            ],
+            "Level": 5,
+            "RaidID": "boot"
+        }
+    },
+    "Partitions": [
+        {
+            "ID": "boot",
+            "FsType": "ext4"
+        }
+    ]
+},
 ```
 
 ### Artifacts

--- a/toolkit/imageconfigs/packagelists/raid-tools.json
+++ b/toolkit/imageconfigs/packagelists/raid-tools.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "mdadm"
+    ]
+}

--- a/toolkit/imageconfigs/raid.json
+++ b/toolkit/imageconfigs/raid.json
@@ -1,0 +1,131 @@
+{
+    "Disks": [
+        {
+            "PartitionTableType": "gpt",
+            "MaxSize": 5300,
+            "Artifacts": [
+                {
+                    "Name": "coreA",
+                    "Type": "vhdx"
+                }
+            ],
+            "Partitions": [
+                {
+                    "ID": "efi",
+                    "Flags": [
+                        "esp",
+                        "boot"
+                    ],
+                    "Start": 1,
+                    "End": 9,
+                    "FsType": "fat32"
+                },
+                {
+                    "ID": "boot_1",
+                    "Start": 10,
+                    "End": 410
+                },
+                {
+                    "ID": "boot_2",
+                    "Start": 410,
+                    "End": 810
+                },
+                {
+                    "ID": "boot_3",
+                    "Start": 810,
+                    "End": 1210
+                },
+                {
+                    "ID": "rootfs_1",
+                    "Start": 1210,
+                    "End": 3210
+                },
+                {
+                    "ID": "rootfs_2",
+                    "Start": 3210,
+                    "End": 4210
+                },
+                {
+                    "ID": "rootfs_3",
+                    "Start": 4210,
+                    "End": 5210
+                }
+            ]
+        },
+        {
+            "ID": "raidBoot",
+            "TargetDisk": {
+                "Type": "raid",
+                "RaidConfig": {
+                    "ComponentPartIDs": [
+                        "boot_1",
+                        "boot_2",
+                        "boot_3"
+                    ],
+                    "Level": 5,
+                    "RaidID": "boot"
+                }
+            },
+            "Partitions": [
+                {
+                    "ID": "boot",
+                    "FsType": "ext4"
+                }
+            ]
+        },
+        {
+            "TargetDisk": {
+                "Type": "raid",
+                "RaidConfig": {
+                    "ComponentPartIDs": [
+                        "rootfs_1",
+                        "rootfs_2",
+                        "rootfs_3"
+                    ],
+                    "Level": 5,
+                    "RaidID": "rootfs"
+                }
+            },
+            "Partitions": [
+                {
+                    "ID": "rootfs",
+                    "FsType": "ext4"
+                }
+            ]
+        }
+    ],
+    "SystemConfigs": [
+        {
+            "Name": "raid_offline",
+            "BootType": "efi",
+            "PrimaryDisk": "raidBoot",
+            "PartitionSettings": [
+                {
+                    "ID": "efi",
+                    "MountPoint": "/boot/efi",
+                    "MountOptions" : "umask=0077"
+                },
+                {
+                    "ID": "boot",
+                    "MountPoint": "/boot",
+                    "MountIdentifier": "uuid"
+                },
+                {
+                    "ID": "rootfs",
+                    "MountPoint": "/",
+                    "MountIdentifier": "uuid"
+                }
+            ],
+            "PackageLists": [
+                "packagelists/hyperv-packages.json",
+                "packagelists/core-packages-image.json",
+                "packagelists/cloud-init-packages.json",
+                "packagelists/raid-tools.json"
+            ],
+            "KernelOptions": {
+                "default": "kernel"
+            },
+            "Hostname": "cbl-mariner"
+        }
+    ]
+}

--- a/toolkit/imageconfigs/raid.json
+++ b/toolkit/imageconfigs/raid.json
@@ -11,44 +11,69 @@
             ],
             "Partitions": [
                 {
-                    "ID": "efi",
-                    "Flags": [
-                        "esp",
-                        "boot"
-                    ],
+                    "ID": "efi_1",
                     "Start": 1,
-                    "End": 9,
-                    "FsType": "fat32"
+                    "End": 9
+                },
+                {
+                    "ID": "efi_2",
+                    "Start": 9,
+                    "End": 17
                 },
                 {
                     "ID": "boot_1",
-                    "Start": 10,
-                    "End": 410
+                    "Start": 20,
+                    "End": 420
                 },
                 {
                     "ID": "boot_2",
-                    "Start": 410,
-                    "End": 810
+                    "Start": 420,
+                    "End": 820
                 },
                 {
                     "ID": "boot_3",
-                    "Start": 810,
-                    "End": 1210
+                    "Start": 820,
+                    "End": 1220
                 },
                 {
                     "ID": "rootfs_1",
-                    "Start": 1210,
-                    "End": 3210
+                    "Start": 1220,
+                    "End": 3220
                 },
                 {
                     "ID": "rootfs_2",
-                    "Start": 3210,
-                    "End": 4210
+                    "Start": 3220,
+                    "End": 4220
                 },
                 {
                     "ID": "rootfs_3",
-                    "Start": 4210,
-                    "End": 5210
+                    "Start": 4220,
+                    "End": 5220
+                }
+            ]
+        },
+        {
+            "ID": "raidEfi",
+            "TargetDisk": {
+                "Type": "raid",
+                "RaidConfig": {
+                    "ComponentPartIDs": [
+                        "efi_1",
+                        "efi_2"
+                    ],
+                    "Level": 1,
+                    "RaidID": "efi",
+                    "LegacyMetadata": true
+                }
+            },
+            "Partitions": [
+                {
+                    "ID": "efi",
+                    "FsType": "fat32",
+                    "Flags": [
+                        "esp",
+                        "boot"
+                    ]
                 }
             ]
         },
@@ -103,7 +128,8 @@
                 {
                     "ID": "efi",
                     "MountPoint": "/boot/efi",
-                    "MountOptions" : "umask=0077"
+                    "MountOptions" : "umask=0077",
+                    "MountIdentifier": "uuid"
                 },
                 {
                     "ID": "boot",

--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
@@ -130,7 +130,7 @@ func (ap *AutoPartitionWidget) SelectedSystemDevice() int {
 
 func (ap *AutoPartitionWidget) mustUpdateConfiguration(sysConfig *configuration.SystemConfig, cfg *configuration.Config) {
 	const (
-		targetDiskType     = "path"
+		targetDiskType     = configuration.TargetDiskTypePath
 		partitionTableType = "gpt"
 
 		bootPartitionName     = "esp"

--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
@@ -520,7 +520,7 @@ func (mp *ManualPartitionWidget) mustRemovePartition() {
 
 func (mp *ManualPartitionWidget) unmarshalPartitionTable() (err error) {
 	const (
-		targetDiskType     = "path"
+		targetDiskType     = configuration.TargetDiskTypePath
 		partitionTableType = "gpt"
 
 		rootMountPoint     = "/"

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -33,13 +33,6 @@ type RawBinary struct {
 	Seek      uint64 `json:"Seek"`
 }
 
-// TargetDisk [kickstart-only] defines the physical disk, to which
-// Mariner should be installed.
-type TargetDisk struct {
-	Type  string `json:"Type"`
-	Value string `json:"Value"`
-}
-
 // InstallScript defines a script to be run before or after other installation
 // steps and provides a way to pass parameters to it.
 type InstallScript struct {

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -95,9 +95,6 @@ func (d *Disk) IsValid() (err error) {
 		return fmt.Errorf("invalid [Disk]: %w", err)
 	}
 
-	// if err = disk.PartitionTableType.IsValid(); err != nil {
-	// 	return
-	// }
 	// for _, artifact := range disk.Artifacts {
 	// 	if err = artifact.IsValid(); err != nil {
 	// 		return
@@ -113,6 +110,11 @@ func (d *Disk) IsValid() (err error) {
 	// 		return
 	// 	}
 	// }
+
+	if err = d.TargetDisk.IsValid(); err != nil {
+		return
+	}
+
 	return
 }
 

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -49,11 +49,8 @@ func checkOverlappingePartitions(disk *Disk) (err error) {
 // also confirms that the MaxSize defined is large enough to accomodate all partitions. No partition should have an
 // end position that exceeds the MaxSize
 func checkMaxSizeCorrectness(disk *Disk) (err error) {
-	const (
-		realDiskType = "path"
-	)
 	//MaxSize is not relevant if target disk is specified.
-	if disk.TargetDisk.Type != realDiskType {
+	if disk.TargetDisk.Type != TargetDiskTypePath {
 		//Complain about 0 maxSize only when partitions are defined.
 		if disk.MaxSize <= 0 && len(disk.Partitions) != 0 {
 			return fmt.Errorf("a configuration without a defined target disk must have a non-zero MaxSize")

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -85,6 +85,15 @@ func checkRaidDisk(disk *Disk) (err error) {
 		if disk.Partitions[0].Start != 0 || disk.Partitions[0].End != 0 {
 			return fmt.Errorf("RAID disk '%s' cannot have a [Partition] with a Start or End value", disk.ID)
 		}
+
+		if disk.Partitions[0].HasBootLoaderFlag() {
+			if !disk.TargetDisk.RaidConfig.LegacyMetadata {
+				return fmt.Errorf("RAID disk '%s' cannot have a [Partition] with a BootLoaderFlag set to true when the RAID config has LegacyMetadata set to false", disk.ID)
+			}
+			if disk.TargetDisk.RaidConfig.Level != 1 {
+				return fmt.Errorf("RAID disk '%s' cannot have a [Partition] with a BootLoaderFlag set to true without setting the RAID config has Level to '1'", disk.ID)
+			}
+		}
 	}
 	return
 }

--- a/toolkit/tools/imagegen/configuration/disk_test.go
+++ b/toolkit/tools/imagegen/configuration/disk_test.go
@@ -164,6 +164,23 @@ func TestShouldFailMaxSizeInsufficient_Disk(t *testing.T) {
 	assert.Equal(t, "failed to parse [Disk]: invalid [Disk]: the MaxSize of 512 is not large enough to accomodate defined partitions ending at 1024.", err.Error())
 }
 
+func TestShouldFailNoSizeSet_Disk(t *testing.T) {
+	var checkedDisk Disk
+	invalidDisk := validDisk
+
+	invalidDisk.MaxSize = 0
+	invalidDisk.TargetDisk.Type = ""
+	invalidDisk.TargetDisk.Value = ""
+	err := invalidDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [Disk]: a configuration without a defined target disk must have a non-zero MaxSize", err.Error())
+
+	// remarshal runs IsValid() on [SystemConfig] prior to running it on [Config], so we get a different error message here.
+	err = remarshalJSON(invalidDisk, &checkedDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Disk]: invalid [Disk]: a configuration without a defined target disk must have a non-zero MaxSize", err.Error())
+}
+
 func TestShouldFailInvalidTargetDisk_Disk(t *testing.T) {
 	var checkedDisk Disk
 	invalidDisk := validDisk

--- a/toolkit/tools/imagegen/configuration/parse_partition.go
+++ b/toolkit/tools/imagegen/configuration/parse_partition.go
@@ -170,7 +170,7 @@ func processDisk(inputDiskValue string) (err error) {
 		disks[latestDiskIndex].PartitionTableType = partitionTableType
 
 		// Set TargetDisk and TargetDiskType for unattended installation
-		disks[latestDiskIndex].TargetDisk.Type = "path"
+		disks[latestDiskIndex].TargetDisk.Type = TargetDiskTypePath
 		disks[latestDiskIndex].TargetDisk.Value = diskValue
 
 		diskInfo[diskValue] = latestDiskIndex

--- a/toolkit/tools/imagegen/configuration/partition.go
+++ b/toolkit/tools/imagegen/configuration/partition.go
@@ -47,6 +47,11 @@ func (p *Partition) HasFlag(flag PartitionFlag) bool {
 	return false
 }
 
+// HasBootLoaderFlag returns true if this partition is marked for use by a boot loader
+func (p *Partition) HasBootLoaderFlag() bool {
+	return p.HasFlag(PartitionFlagESP) || p.HasFlag(PartitionFlagGrub) || p.HasFlag(PartitionFlagBiosGrub) || p.HasFlag(PartitionFlagBiosGrubLegacy)
+}
+
 // nameCheck makes sure the Name can fit in the alloted space in the GPT, and since parted works best with ASCII we check
 // for any non-ASCII characters
 // header (72 bytes of UTF-16)

--- a/toolkit/tools/imagegen/configuration/raid.go
+++ b/toolkit/tools/imagegen/configuration/raid.go
@@ -22,6 +22,7 @@ type RaidConfig struct {
 	ComponentPartIDs []string `json:"ComponentPartIDs"` // PartIDs of the partitions to be used in the raid
 	Level            int      `json:"Level"`            // 0, 1, 4, 5, 6, 10
 	RaidID           string   `json:"RaidID"`           // ID of the raid device used for mdadm
+	LegacyMetadata   bool     `json:"LegacyMetadata"`   // Use legacy metadata for mdadm to support efi boot partitions
 }
 
 // IsEmpty returns true if the RaidConfig is empty

--- a/toolkit/tools/imagegen/configuration/raid.go
+++ b/toolkit/tools/imagegen/configuration/raid.go
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// RaidConfig holds the raid configuration information for a software raid disk
+// valid levels:
+// 0: No parity, striping only
+// 1: Mirror on two+ disks
+// 4: Parity with 1 dedicated parity disk
+// 5: Parity on three+ disks with distributed parity
+// 6: Raid 5 with additional parity blocks
+// 10: Four+ disks with striped mirrors
+type RaidConfig struct {
+	ComponentPartIDs []string `json:"ComponentPartIDs"` // PartIDs of the partitions to be used in the raid
+	Level            int      `json:"Level"`            // 0, 1, 4, 5, 6, 10
+	RaidID           string   `json:"RaidID"`           // ID of the raid device used for mdadm
+}
+
+// IsEmpty returns true if the RaidConfig is empty
+func (r *RaidConfig) IsEmpty() bool {
+	return len(r.ComponentPartIDs) == 0 && r.Level == 0 && len(r.RaidID) == 0
+}
+
+// IsValid returns an error if the RaidConfig is not valid
+func (r *RaidConfig) IsValid() (err error) {
+
+	switch r.Level {
+	case 0, 1, 4, 5, 6, 10:
+		// Valid
+	default:
+		return fmt.Errorf("invalid [RaidConfig]: Level must be one of 0, 1, 4, 5, 6, 10")
+	}
+
+	if !r.IsEmpty() && (len(r.ComponentPartIDs) == 0 || len(r.RaidID) == 0) {
+		return fmt.Errorf("invalid [RaidConfig]: Raid '%s' must have non-empty ComponentPartIDs and RaidID", r.RaidID)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON Unmarshals a RaidConfig entry
+func (r *RaidConfig) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypeRaidConfig RaidConfig
+	err = json.Unmarshal(b, (*IntermediateTypeRaidConfig)(r))
+	if err != nil {
+		return fmt.Errorf("failed to parse [RaidConfig]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = r.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [RaidConfig]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/raid_test.go
+++ b/toolkit/tools/imagegen/configuration/raid_test.go
@@ -1,0 +1,63 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//TestMain found in configuration_test.go.
+
+var (
+	validRaidConfig       RaidConfig = RaidConfig{RaidID: "MyRaidID", ComponentPartIDs: []string{"MyPartID1", "MyPartID2"}}
+	validRaidConfigJSON              = `{"RaidID": "MyRaidID", "ComponentPartIDs": ["MyPartID1", "MyPartID2"]}`
+	invalidRaidConfigJSON            = `{"RaidID": 0}`
+)
+
+func TestShouldSucceedParsingDefaultRaidConfig_RaidConfig(t *testing.T) {
+	var checkedRaidConfig RaidConfig
+	err := marshalJSONString("{}", &checkedRaidConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, RaidConfig{}, checkedRaidConfig)
+}
+
+func TestShouldSucceedParsingValidRaidConfig_RaidConfig(t *testing.T) {
+	var checkedRaidConfig RaidConfig
+	err := remarshalJSON(validRaidConfig, &checkedRaidConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, validRaidConfig, checkedRaidConfig)
+}
+
+func TestShouldSucceedParsingValidJSON_RaidConfig(t *testing.T) {
+	var checkedRaidConfig RaidConfig
+
+	err := marshalJSONString(validRaidConfigJSON, &checkedRaidConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, validRaidConfig, checkedRaidConfig)
+}
+
+func TestShouldFailParsingInvalidJSON_RaidConfig(t *testing.T) {
+	var checkedRaidConfig RaidConfig
+
+	err := marshalJSONString(invalidRaidConfigJSON, &checkedRaidConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [RaidConfig]: json: cannot unmarshal number into Go struct field IntermediateTypeRaidConfig.RaidID of type string", err.Error())
+}
+
+func TestShouldFailInvalidLevel_RaidConfig(t *testing.T) {
+	var checkedRaidConfig RaidConfig
+	invalidRaidConfig := validRaidConfig
+
+	invalidRaidConfig.Level = -1
+
+	err := invalidRaidConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [RaidConfig]: Level must be one of 0, 1, 4, 5, 6, 10", err.Error())
+
+	err = remarshalJSON(invalidRaidConfig, &checkedRaidConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [RaidConfig]: invalid [RaidConfig]: Level must be one of 0, 1, 4, 5, 6, 10", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/targetdisk.go
+++ b/toolkit/tools/imagegen/configuration/targetdisk.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TargetDisk [kickstart-only] defines the physical disk, to which
+// Mariner should be installed.
+type TargetDisk struct {
+	Type  TargetDiskType `json:"Type"`
+	Value string         `json:"Value"`
+}
+
+// IsValid returns an error if the RaidConfig is not valid
+func (t *TargetDisk) IsValid() (err error) {
+
+	// Validate TargetDiskType
+	if err = t.Type.IsValid(); err != nil {
+		return fmt.Errorf("invalid [TargetDisk]: %w", err)
+	}
+
+	// Path must include a path to a disk
+	if t.Type == TargetDiskTypePath {
+		if t.Value == "" {
+			return fmt.Errorf("invalid [TargetDisk]: Value must be specified for TargetDiskType of '%s'", TargetDiskTypePath)
+		}
+	}
+
+	// Only allow empty struct if target type is empty
+	if t.Type == TargetDiskTypeNone {
+		if t.Value != "" {
+			return fmt.Errorf("invalid [TargetDisk]: Value must be empty for TargetDiskType of '%s'", TargetDiskTypeNone)
+		}
+	}
+
+	return nil
+}
+
+// UnmarshalJSON Unmarshals a RaidConfig entry
+func (t *TargetDisk) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypeTargetDisk TargetDisk
+	err = json.Unmarshal(b, (*IntermediateTypeTargetDisk)(t))
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDisk]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = t.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDisk]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/targetdisk_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisk_test.go
@@ -1,0 +1,93 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//TestMain found in configuration_test.go.
+
+var (
+	validTargetDisk       TargetDisk = TargetDisk{}
+	invalidTargetDiskJSON            = `{"End": "abc"}`
+)
+
+func TestShouldSuccessParsingDefaultTargetDisk_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	err := marshalJSONString("{}", &checkedTargetDisk)
+	assert.NoError(t, err)
+	assert.Equal(t, TargetDisk{}, checkedTargetDisk)
+}
+
+func TestShouldSuccessParsingValidTargetDisk_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	err := remarshalJSON(validTargetDisk, &checkedTargetDisk)
+	assert.NoError(t, err)
+	assert.Equal(t, validTargetDisk, checkedTargetDisk)
+}
+
+func TestShouldPassTypePath_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	pathTargetDisk := validTargetDisk
+
+	pathTargetDisk.Type = "path"
+	pathTargetDisk.Value = "/dev/sda"
+
+	err := pathTargetDisk.IsValid()
+	assert.NoError(t, err)
+
+	err = remarshalJSON(pathTargetDisk, &checkedTargetDisk)
+	assert.NoError(t, err)
+	assert.Equal(t, pathTargetDisk, checkedTargetDisk)
+}
+
+func TestShouldFailTypePathNoValue_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	PathTargetDisk := validTargetDisk
+
+	PathTargetDisk.Type = "path"
+	PathTargetDisk.Value = ""
+
+	err := PathTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: Value must be specified for TargetDiskType of 'path'", err.Error())
+
+	err = remarshalJSON(PathTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: invalid [TargetDisk]: Value must be specified for TargetDiskType of 'path'", err.Error())
+}
+
+func TestShouldFailInvalidType_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	invalidTargetDisk := validTargetDisk
+
+	invalidTargetDisk.Type = "invalid"
+
+	err := invalidTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: invalid value for TargetDiskType (invalid)", err.Error())
+
+	err = remarshalJSON(invalidTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: failed to parse [TargetDiskType]: invalid value for TargetDiskType (invalid)", err.Error())
+}
+
+func TestShouldFailNonEmptyStructWithNoneType_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	invalidTargetDisk := validTargetDisk
+
+	invalidTargetDisk.Type = ""
+	invalidTargetDisk.Value = "/dev/sda"
+
+	err := invalidTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: Value must be empty for TargetDiskType of ''", err.Error())
+
+	err = remarshalJSON(invalidTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: invalid [TargetDisk]: Value must be empty for TargetDiskType of ''", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/targetdisk_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisk_test.go
@@ -34,7 +34,7 @@ func TestShouldPassTypePath_TargetDisk(t *testing.T) {
 	var checkedTargetDisk TargetDisk
 	pathTargetDisk := validTargetDisk
 
-	pathTargetDisk.Type = "path"
+	pathTargetDisk.Type = TargetDiskTypePath
 	pathTargetDisk.Value = "/dev/sda"
 
 	err := pathTargetDisk.IsValid()
@@ -49,7 +49,7 @@ func TestShouldFailTypePathNoValue_TargetDisk(t *testing.T) {
 	var checkedTargetDisk TargetDisk
 	PathTargetDisk := validTargetDisk
 
-	PathTargetDisk.Type = "path"
+	PathTargetDisk.Type = TargetDiskTypePath
 	PathTargetDisk.Value = ""
 
 	err := PathTargetDisk.IsValid()

--- a/toolkit/tools/imagegen/configuration/targetdisk_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisk_test.go
@@ -13,21 +13,29 @@ import (
 
 var (
 	validTargetDisk       TargetDisk = TargetDisk{}
-	invalidTargetDiskJSON            = `{"End": "abc"}`
+	invalidTargetDiskJSON            = `{"Type": "path", "Value": "/dev/sda", "RaidConfig": "invalid"}`
 )
 
-func TestShouldSuccessParsingDefaultTargetDisk_TargetDisk(t *testing.T) {
+func TestShouldSucceedParsingDefaultTargetDisk_TargetDisk(t *testing.T) {
 	var checkedTargetDisk TargetDisk
 	err := marshalJSONString("{}", &checkedTargetDisk)
 	assert.NoError(t, err)
 	assert.Equal(t, TargetDisk{}, checkedTargetDisk)
 }
 
-func TestShouldSuccessParsingValidTargetDisk_TargetDisk(t *testing.T) {
+func TestShouldSucceedParsingValidTargetDisk_TargetDisk(t *testing.T) {
 	var checkedTargetDisk TargetDisk
 	err := remarshalJSON(validTargetDisk, &checkedTargetDisk)
 	assert.NoError(t, err)
 	assert.Equal(t, validTargetDisk, checkedTargetDisk)
+}
+
+func TestShouldFailParsingInvalidJSON_TargetDisk(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+
+	err := marshalJSONString(invalidTargetDiskJSON, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: failed to parse [RaidConfig]: json: cannot unmarshal string into Go value of type configuration.IntermediateTypeRaidConfig", err.Error())
 }
 
 func TestShouldPassTypePath_TargetDisk(t *testing.T) {
@@ -80,14 +88,44 @@ func TestShouldFailNonEmptyStructWithNoneType_TargetDisk(t *testing.T) {
 	var checkedTargetDisk TargetDisk
 	invalidTargetDisk := validTargetDisk
 
+	// Start with bad path
 	invalidTargetDisk.Type = ""
 	invalidTargetDisk.Value = "/dev/sda"
 
 	err := invalidTargetDisk.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "invalid [TargetDisk]: Value must be empty for TargetDiskType of ''", err.Error())
+	assert.Equal(t, "invalid [TargetDisk]: Value and RaidConfig must be empty for TargetDiskType of ''", err.Error())
 
 	err = remarshalJSON(invalidTargetDisk, &checkedTargetDisk)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [TargetDisk]: invalid [TargetDisk]: Value must be empty for TargetDiskType of ''", err.Error())
+	assert.Equal(t, "failed to parse [TargetDisk]: invalid [TargetDisk]: Value and RaidConfig must be empty for TargetDiskType of ''", err.Error())
+
+	// Also check bad raid
+	invalidTargetDisk.Type = ""
+	invalidTargetDisk.Value = ""
+	invalidTargetDisk.RaidConfig = RaidConfig{ComponentPartIDs: []string{"1", "2"}, RaidID: "newRaidID"}
+
+	err = invalidTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: Value and RaidConfig must be empty for TargetDiskType of ''", err.Error())
+
+	err = remarshalJSON(invalidTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: invalid [TargetDisk]: Value and RaidConfig must be empty for TargetDiskType of ''", err.Error())
+}
+
+func TestShouldFailRaidConfigNoComponents(t *testing.T) {
+	var checkedTargetDisk TargetDisk
+	invalidTargetDisk := validTargetDisk
+
+	invalidTargetDisk.Type = TargetDiskTypeRaid
+	invalidTargetDisk.RaidConfig = RaidConfig{RaidID: "newRaidID", ComponentPartIDs: []string{}}
+
+	err := invalidTargetDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [TargetDisk]: Valid RaidConfig just be set for TargetDiskType of 'raid': invalid [RaidConfig]: Raid 'newRaidID' must have non-empty ComponentPartIDs and RaidID", err.Error())
+
+	err = remarshalJSON(invalidTargetDisk, &checkedTargetDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDisk]: failed to parse [RaidConfig]: invalid [RaidConfig]: Raid 'newRaidID' must have non-empty ComponentPartIDs and RaidID", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/targetdisktype.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype.go
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TargetDiskType sets the backing disk type for the disk
+type TargetDiskType string
+
+const (
+	// TargetDiskTypePath means this is a /dev/sda or similar disk that already exists
+	TargetDiskTypePath TargetDiskType = "path"
+	// TargetDiskTypeNone means there is no target disk
+	TargetDiskTypeNone TargetDiskType = ""
+)
+
+func (t TargetDiskType) String() string {
+	return fmt.Sprint(string(t))
+}
+
+// GetValidTargetDiskTypes returns a list of all the supported
+// disk types
+func (t *TargetDiskType) GetValidTargetDiskTypes() (types []TargetDiskType) {
+	return []TargetDiskType{
+		TargetDiskTypePath,
+		TargetDiskTypeNone,
+	}
+}
+
+// IsValid returns an error if the TargetDiskType is not valid
+func (t *TargetDiskType) IsValid() (err error) {
+	for _, valid := range t.GetValidTargetDiskTypes() {
+		if *t == valid {
+			return
+		}
+	}
+	return fmt.Errorf("invalid value for TargetDiskType (%s)", t)
+}
+
+// UnmarshalJSON Unmarshals an TargetDiskType entry
+func (t *TargetDiskType) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypeTargetDiskType TargetDiskType
+	err = json.Unmarshal(b, (*IntermediateTypeTargetDiskType)(t))
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDiskType]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = t.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [TargetDiskType]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/targetdisktype.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype.go
@@ -16,6 +16,8 @@ type TargetDiskType string
 const (
 	// TargetDiskTypePath means this is a /dev/sda or similar disk that already exists
 	TargetDiskTypePath TargetDiskType = "path"
+	// TargetDiskTypeRAID creates a RAID disk
+	TargetDiskTypeRaid TargetDiskType = "raid"
 	// TargetDiskTypeNone means there is no target disk
 	TargetDiskTypeNone TargetDiskType = ""
 )
@@ -29,6 +31,7 @@ func (t TargetDiskType) String() string {
 func (t *TargetDiskType) GetValidTargetDiskTypes() (types []TargetDiskType) {
 	return []TargetDiskType{
 		TargetDiskTypePath,
+		TargetDiskTypeRaid,
 		TargetDiskTypeNone,
 	}
 }

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -1,0 +1,76 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMain found in configuration_test.go.
+
+var (
+	validTargetDiskTypes = []TargetDiskType{
+		TargetDiskType("path"),
+		TargetDiskType(""),
+	}
+	invalidTargetDiskType     = TargetDiskType("not_a_disk_type")
+	validTargetDiskTypeJSON   = `"path"`
+	invalidTargetDiskTypeJSON = `1234`
+)
+
+func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
+	var vdt TargetDiskType
+	assert.Equal(t, len(validTargetDiskTypes), len(vdt.GetValidTargetDiskTypes()))
+
+	for _, TargetDiskType := range validTargetDiskTypes {
+		found := false
+		for _, validTargetDiskType := range vdt.GetValidTargetDiskTypes() {
+			if TargetDiskType == validTargetDiskType {
+				found = true
+			}
+		}
+		assert.True(t, found)
+	}
+}
+
+func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
+	for _, validPolicy := range validTargetDiskTypes {
+		var checkedPolicy TargetDiskType
+
+		assert.NoError(t, validPolicy.IsValid())
+		err := remarshalJSON(validPolicy, &checkedPolicy)
+		assert.NoError(t, err)
+		assert.Equal(t, validPolicy, checkedPolicy)
+	}
+}
+
+func TestShouldFailParsingInvalidPolicy_TargetDiskType(t *testing.T) {
+	var checkedPolicy TargetDiskType
+
+	err := invalidTargetDiskType.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid value for TargetDiskType (not_a_disk_type)", err.Error())
+
+	err = remarshalJSON(invalidTargetDiskType, &checkedPolicy)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDiskType]: invalid value for TargetDiskType (not_a_disk_type)", err.Error())
+}
+
+func TestShouldSucceedParsingValidJSON_TargetDiskType(t *testing.T) {
+	var checkedPolicy TargetDiskType
+
+	err := marshalJSONString(validTargetDiskTypeJSON, &checkedPolicy)
+	assert.NoError(t, err)
+	assert.Equal(t, validTargetDiskTypes[0], checkedPolicy)
+}
+
+func TestShouldFailParsingInvalidJSON_TargetDiskType(t *testing.T) {
+	var checkedPolicy TargetDiskType
+
+	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedPolicy)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [TargetDiskType]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypeTargetDiskType", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -37,17 +37,17 @@ func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
 }
 
 func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
-	for _, validPolicy := range validTargetDiskTypes {
+	for _, validTargetDiskType := range validTargetDiskTypes {
 		var checkedTargetDiskTyp TargetDiskType
 
-		assert.NoError(t, validPolicy.IsValid())
-		err := remarshalJSON(validPolicy, &checkedTargetDiskTyp)
+		assert.NoError(t, validTargetDiskType.IsValid())
+		err := remarshalJSON(validTargetDiskType, &checkedTargetDiskTyp)
 		assert.NoError(t, err)
-		assert.Equal(t, validPolicy, checkedTargetDiskTyp)
+		assert.Equal(t, validTargetDiskType, checkedTargetDiskTyp)
 	}
 }
 
-func TestShouldFailParsingInvalidPolicy_TargetDiskType(t *testing.T) {
+func TestShouldFailParsingInvalidTargetDiskType_TargetDiskType(t *testing.T) {
 	var checkedTargetDiskTyp TargetDiskType
 
 	err := invalidTargetDiskType.IsValid()

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -38,39 +38,39 @@ func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
 
 func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
 	for _, validPolicy := range validTargetDiskTypes {
-		var checkedPolicy TargetDiskType
+		var checkedTargetDiskTyp TargetDiskType
 
 		assert.NoError(t, validPolicy.IsValid())
-		err := remarshalJSON(validPolicy, &checkedPolicy)
+		err := remarshalJSON(validPolicy, &checkedTargetDiskTyp)
 		assert.NoError(t, err)
-		assert.Equal(t, validPolicy, checkedPolicy)
+		assert.Equal(t, validPolicy, checkedTargetDiskTyp)
 	}
 }
 
 func TestShouldFailParsingInvalidPolicy_TargetDiskType(t *testing.T) {
-	var checkedPolicy TargetDiskType
+	var checkedTargetDiskTyp TargetDiskType
 
 	err := invalidTargetDiskType.IsValid()
 	assert.Error(t, err)
 	assert.Equal(t, "invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 
-	err = remarshalJSON(invalidTargetDiskType, &checkedPolicy)
+	err = remarshalJSON(invalidTargetDiskType, &checkedTargetDiskTyp)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 }
 
 func TestShouldSucceedParsingValidJSON_TargetDiskType(t *testing.T) {
-	var checkedPolicy TargetDiskType
+	var checkedTargetDiskTyp TargetDiskType
 
-	err := marshalJSONString(validTargetDiskTypeJSON, &checkedPolicy)
+	err := marshalJSONString(validTargetDiskTypeJSON, &checkedTargetDiskTyp)
 	assert.NoError(t, err)
-	assert.Equal(t, validTargetDiskTypes[0], checkedPolicy)
+	assert.Equal(t, validTargetDiskTypes[0], checkedTargetDiskTyp)
 }
 
 func TestShouldFailParsingInvalidJSON_TargetDiskType(t *testing.T) {
-	var checkedPolicy TargetDiskType
+	var checkedTargetDiskTyp TargetDiskType
 
-	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedPolicy)
+	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedTargetDiskTyp)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypeTargetDiskType", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -38,39 +38,39 @@ func TestShouldSucceedValidTargetDiskTypesMatch_TargetDiskType(t *testing.T) {
 
 func TestShouldSucceedParsingValidPolicies_TargetDiskType(t *testing.T) {
 	for _, validTargetDiskType := range validTargetDiskTypes {
-		var checkedTargetDiskTyp TargetDiskType
+		var checkedTargetDiskType TargetDiskType
 
 		assert.NoError(t, validTargetDiskType.IsValid())
-		err := remarshalJSON(validTargetDiskType, &checkedTargetDiskTyp)
+		err := remarshalJSON(validTargetDiskType, &checkedTargetDiskType)
 		assert.NoError(t, err)
-		assert.Equal(t, validTargetDiskType, checkedTargetDiskTyp)
+		assert.Equal(t, validTargetDiskType, checkedTargetDiskType)
 	}
 }
 
 func TestShouldFailParsingInvalidTargetDiskType_TargetDiskType(t *testing.T) {
-	var checkedTargetDiskTyp TargetDiskType
+	var checkedTargetDiskType TargetDiskType
 
 	err := invalidTargetDiskType.IsValid()
 	assert.Error(t, err)
 	assert.Equal(t, "invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 
-	err = remarshalJSON(invalidTargetDiskType, &checkedTargetDiskTyp)
+	err = remarshalJSON(invalidTargetDiskType, &checkedTargetDiskType)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: invalid value for TargetDiskType (not_a_disk_type)", err.Error())
 }
 
 func TestShouldSucceedParsingValidJSON_TargetDiskType(t *testing.T) {
-	var checkedTargetDiskTyp TargetDiskType
+	var checkedTargetDiskType TargetDiskType
 
-	err := marshalJSONString(validTargetDiskTypeJSON, &checkedTargetDiskTyp)
+	err := marshalJSONString(validTargetDiskTypeJSON, &checkedTargetDiskType)
 	assert.NoError(t, err)
-	assert.Equal(t, validTargetDiskTypes[0], checkedTargetDiskTyp)
+	assert.Equal(t, validTargetDiskTypes[0], checkedTargetDiskType)
 }
 
 func TestShouldFailParsingInvalidJSON_TargetDiskType(t *testing.T) {
-	var checkedTargetDiskTyp TargetDiskType
+	var checkedTargetDiskType TargetDiskType
 
-	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedTargetDiskTyp)
+	err := marshalJSONString(invalidTargetDiskTypeJSON, &checkedTargetDiskType)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [TargetDiskType]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypeTargetDiskType", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/targetdisktype_test.go
+++ b/toolkit/tools/imagegen/configuration/targetdisktype_test.go
@@ -14,6 +14,7 @@ import (
 var (
 	validTargetDiskTypes = []TargetDiskType{
 		TargetDiskType("path"),
+		TargetDiskType("raid"),
 		TargetDiskType(""),
 	}
 	invalidTargetDiskType     = TargetDiskType("not_a_disk_type")

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -333,10 +333,7 @@ func setupRootFS(outputDir, installRoot string) (extraMountPoints []*safechroot.
 }
 
 func setupDisk(outputDir, diskName string, liveInstallFlag bool, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption, readOnlyRootConfig configuration.ReadOnlyVerityRoot) (diskDevPath string, partIDToDevPathMap, partIDToFsTypeMap map[string]string, isLoopDevice bool, encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice, err error) {
-	const (
-		realDiskType = "path"
-	)
-	if diskConfig.TargetDisk.Type == realDiskType {
+	if diskConfig.TargetDisk.Type == configuration.TargetDiskTypePath {
 		if liveInstallFlag {
 			diskDevPath = diskConfig.TargetDisk.Value
 			partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, readOnlyRoot, err = setupRealDisk(diskDevPath, diskConfig, rootEncryption, readOnlyRootConfig)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
**Note: based on top of #4959 and #4984**

Adds the groundwork to support RAID disks in the imageconfg.json format. Each RAID disk has a single partition which is backed by 2 or more real partitions on other disks. These RAID partitions may be referenced in a systemconfig the same way normal partitions are.

Added the `RaidConfig` struct to the configuration schema, as well as some validation at the level of a `Disk`. Future PRs will add validation at the full configuration level, and add code to create, mount, and remove RAID disks during a build.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `RaidConfig` struct to image config schema
- Add example raid image config
- Add basic validation of RAID disks

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds and HyperV VM testing