### PR TITLE
Bumping gdb to version 13.2

### DIFF
--- a/SPECS/gdb/gdb.signatures.json
+++ b/SPECS/gdb/gdb.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "gdb-11.2.tar.xz": "1497c36a71881b8671a9a84a0ee40faab788ca30d7ba19d8463c3cc787152e32"
+  "gdb-13.2.tar.xz": "fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
  }
 }

--- a/SPECS/gdb/gdb.signatures.json
+++ b/SPECS/gdb/gdb.signatures.json
@@ -1,5 +1,7 @@
 {
  "Signatures": {
-  "gdb-13.2.tar.xz": "fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
+  "gdb-13.2.tar.xz": "fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a",
+  "binutils-common.exp": "330e4911ff7fffdc1c520b9b421bcb0ad5bc606dbaee96f8252fe832a82a719b",
+  "ld-lib.exp": "05ad5e293758c45d3606babdc4dcdd8c0bb155d207a6ead9e520599076e30d3e",
  }
 }

--- a/SPECS/gdb/gdb.signatures.json
+++ b/SPECS/gdb/gdb.signatures.json
@@ -1,7 +1,5 @@
 {
  "Signatures": {
-  "gdb-13.2.tar.xz": "fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a",
-  "binutils-common.exp": "330e4911ff7fffdc1c520b9b421bcb0ad5bc606dbaee96f8252fe832a82a719b",
-  "ld-lib.exp": "05ad5e293758c45d3606babdc4dcdd8c0bb155d207a6ead9e520599076e30d3e",
+  "gdb-13.2.tar.xz": "fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
  }
 }

--- a/SPECS/gdb/gdb.spec
+++ b/SPECS/gdb/gdb.spec
@@ -86,7 +86,7 @@ rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
 %license COPYING
 %exclude %{_datadir}/locale
 %exclude %{_includedir}/*.h
-%{_libdir}/libsframe.a
+%exclude %{_libdir}/libsframe.a
 %{_includedir}/gdb/*.h
 %{_libdir}/*.so
 %{_infodir}/*.gz

--- a/SPECS/gdb/gdb.spec
+++ b/SPECS/gdb/gdb.spec
@@ -8,6 +8,9 @@ Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://www.gnu.org/software/gdb
 Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.xz
+Source1:        binutils-common.exp
+Source2:        ld-lib.exp
+Patch0:         gdb-libctf-test-common-lib-import.patch
 BuildRequires:  expat-devel
 BuildRequires:  gcc-c++
 BuildRequires:  gcc-gfortran
@@ -45,6 +48,7 @@ another program was doing at the moment it crashed.
     --with-system-zlib \
     --disable-sim \
     --with-python=%{python3}
+
 %make_build
 
 %install
@@ -68,6 +72,8 @@ rm -vf %{buildroot}%{_libdir}/libaarch64-unknown-linux-gnu-sim.a
 %endif
 
 %find_lang %{name} --all-name
+cp %{SOURCE1} %{_builddir}/gdb-13.2/libctf/testsuite/lib/binutils-common.exp
+cp %{SOURCE2} %{_builddir}/gdb-13.2/libctf/testsuite/lib/ld-lib.exp
 
 %check
 # disable security hardening for tests
@@ -96,6 +102,7 @@ rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
 
 * Wed Aug 16 2023 Andy Zaugg <azaugg@linkedin.com> - 13.2
 - Upgrade to gdb 13.2
+- Fix the make checks
 
 * Wed May 11 2022 Fanzhe Lyu <falyu@microsoft.com> - 11.2
 - Upgrade to gdb 11.2

--- a/SPECS/gdb/gdb.spec
+++ b/SPECS/gdb/gdb.spec
@@ -91,11 +91,11 @@ rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
 %{_mandir}/*/*
 
 %changelog
+* Wed Oct 23 2023 Andy Zaugg <azaugg@linkedin.com> - 13.2-1
+- Upgrade to gdb 13.2
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 11.2-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
-
-* Wed Aug 16 2023 Andy Zaugg <azaugg@linkedin.com> - 13.2
-- Upgrade to gdb 13.2
 
 * Wed May 11 2022 Fanzhe Lyu <falyu@microsoft.com> - 11.2
 - Upgrade to gdb 11.2

--- a/SPECS/gdb/gdb.spec
+++ b/SPECS/gdb/gdb.spec
@@ -8,9 +8,6 @@ Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://www.gnu.org/software/gdb
 Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.xz
-Source1:        binutils-common.exp
-Source2:        ld-lib.exp
-Patch0:         gdb-libctf-test-common-lib-import.patch
 BuildRequires:  expat-devel
 BuildRequires:  gcc-c++
 BuildRequires:  gcc-gfortran
@@ -48,7 +45,6 @@ another program was doing at the moment it crashed.
     --with-system-zlib \
     --disable-sim \
     --with-python=%{python3}
-
 %make_build
 
 %install
@@ -72,8 +68,6 @@ rm -vf %{buildroot}%{_libdir}/libaarch64-unknown-linux-gnu-sim.a
 %endif
 
 %find_lang %{name} --all-name
-cp %{SOURCE1} %{_builddir}/gdb-13.2/libctf/testsuite/lib/binutils-common.exp
-cp %{SOURCE2} %{_builddir}/gdb-13.2/libctf/testsuite/lib/ld-lib.exp
 
 %check
 # disable security hardening for tests
@@ -102,7 +96,6 @@ rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
 
 * Wed Aug 16 2023 Andy Zaugg <azaugg@linkedin.com> - 13.2
 - Upgrade to gdb 13.2
-- Fix the make checks
 
 * Wed May 11 2022 Fanzhe Lyu <falyu@microsoft.com> - 11.2
 - Upgrade to gdb 11.2

--- a/SPECS/gdb/gdb.spec
+++ b/SPECS/gdb/gdb.spec
@@ -1,7 +1,7 @@
 Summary:        C debugger
 Name:           gdb
-Version:        11.2
-Release:        2%{?dist}
+Version:        13.2
+Release:        1%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,7 @@ BuildRequires:  python3-libs
 BuildRequires:  readline-devel
 BuildRequires:  xz-devel
 BuildRequires:  zlib-devel
+BuildRequires:  gmp-devel
 %if %{with_check}
 BuildRequires:  dejagnu
 BuildRequires:  systemtap-sdt-devel
@@ -71,6 +72,7 @@ rm -vf %{buildroot}%{_libdir}/libaarch64-unknown-linux-gnu-sim.a
 %check
 # disable security hardening for tests
 rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
+
 %make_build check TESTS="gdb.base/default.exp"
 
 %files -f %{name}.lang
@@ -78,6 +80,7 @@ rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
 %license COPYING
 %exclude %{_datadir}/locale
 %exclude %{_includedir}/*.h
+%{_libdir}/libsframe.a
 %{_includedir}/gdb/*.h
 %{_libdir}/*.so
 %{_infodir}/*.gz
@@ -90,6 +93,9 @@ rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
 %changelog
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 11.2-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
+
+* Wed Aug 16 2023 Andy Zaugg <azaugg@linkedin.com> - 13.2
+- Upgrade to gdb 13.2
 
 * Wed May 11 2022 Fanzhe Lyu <falyu@microsoft.com> - 11.2
 - Upgrade to gdb 11.2

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4180,8 +4180,8 @@
         "type": "other",
         "other": {
           "name": "gdb",
-          "version": "11.2",
-          "downloadUrl": "https://ftp.gnu.org/gnu/gdb/gdb-11.2.tar.xz"
+          "version": "13.2",
+          "downloadUrl": "https://ftp.gnu.org/gnu/gdb/gdb-13.2.tar.xz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Updating gdb to version 13.2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump version of gdb to version 13


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Updated spec file and built through tool chain
```
azaugg@azaugg-ld77 [ ~/CBL-Mariner/toolkit ]$ sudo make build-packages -j$(nproc) REBUILD_TOOLS=y SRPM_PACK_LIST="gdb" PACKAGE_REBUILD_LIST="gdb" REFRESH_WORKER_CHROOT=y
Makefile:17: CONFIG_FILE is undefined, defaulting to toolkit's core-efi.json.
make: setfacl: No such file or directory
GODEBUG=netdns=go /home/azaugg/CBL-Mariner/toolkit/out/tools/srpmpacker \
	--dir=/home/azaugg/CBL-Mariner/SPECS \
	--output-dir=/home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS \
	--source-url=https://cblmarinerstorage.blob.core.windows.net/sources/core \
	--dist-tag=.cm2 \
	--ca-cert= \
	--tls-cert= \
	--tls-key= \
	--build-dir=/home/azaugg/CBL-Mariner/build/SRPM_packaging \
	--signature-handling=enforce \
	--worker-tar=/home/azaugg/CBL-Mariner/build/worker/worker_chroot.tar.gz \
	 \
	--pack-list=/home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS/pack_list.txt \
	--log-file=/home/azaugg/CBL-Mariner/build/logs/pkggen/srpms/srpmpacker.log \
	--log-level=info \
	--cpu-prof-file=/home/azaugg/CBL-Mariner/build/profile/srpm_packer.cpu.pprof \
	--mem-prof-file=/home/azaugg/CBL-Mariner/build/profile/srpm_packer.mem.pprof \
	--trace-file=/home/azaugg/CBL-Mariner/build/profile/srpm_packer.trace \
	 \
	 \
	 \
	--timestamp-file=/home/azaugg/CBL-Mariner/build/timestamp/srpm_packer.jsonl && \
touch /home/azaugg/CBL-Mariner/build/make_status/build_srpms.flag
INFO[0002][srpmpacker] Packing SRPMs inside a chroot environment
INFO[0002][srpmpacker] Finding all SPEC files
INFO[0003][srpmpacker] Calculating SPECs to repack
INFO[0003][srpmpacker] Packing 1/1 SPECs
INFO[0003][srpmpacker] Packed (gdb.spec) -> (gdb-13.2-1.cm2.src.rpm)
Finished updating /home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS
Extracting new or updated SRPMs from "/home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS".
Extracting "/home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS/gdb-13.2-1.cm2.src.rpm" to "/home/azaugg/CBL-Mariner/build/INTERMEDIATE_SPECS/gdb-13.2-1.cm2".
Finished updating /home/azaugg/CBL-Mariner/build/INTERMEDIATE_SPECS.
/home/azaugg/CBL-Mariner/toolkit/out/tools/specreader \
	--dir /home/azaugg/CBL-Mariner/build/INTERMEDIATE_SPECS \
	--build-dir /home/azaugg/CBL-Mariner/build/spec_parsing \
	--srpm-dir /home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS \
	--rpm-dir /home/azaugg/CBL-Mariner/out/RPMS \
	--toolchain-manifest="/home/azaugg/CBL-Mariner/toolkit/resources/manifests/package/toolchain_x86_64.txt" \
	--toolchain-rpms-dir="/home/azaugg/CBL-Mariner/build/toolchain_rpms" \
	--dist-tag .cm2 \
	--worker-tar /home/azaugg/CBL-Mariner/build/worker/worker_chroot.tar.gz \
	 \
	--log-file=/home/azaugg/CBL-Mariner/build/logs/pkggen/workplan/specs.json.log --log-level=info \
	--cpu-prof-file=/home/azaugg/CBL-Mariner/build/profile/specreader.cpu.pprof \
	--mem-prof-file=/home/azaugg/CBL-Mariner/build/profile/specreader.mem.pprof \
	--trace-file=/home/azaugg/CBL-Mariner/build/profile/specreader.trace \
	 \
	 \
	 \
	--timestamp-file=/home/azaugg/CBL-Mariner/build/timestamp/specreader.jsonl \
	 \
	--output /home/azaugg/CBL-Mariner/build/pkg_artifacts/specs.json
INFO[0002][specreader] Parsing SPECs inside a chroot environment
/home/azaugg/CBL-Mariner/toolkit/out/tools/grapher \
	--input /home/azaugg/CBL-Mariner/build/pkg_artifacts/specs.json \
	--log-file=/home/azaugg/CBL-Mariner/build/logs/pkggen/workplan/graph.dot.log --log-level=info \
	--cpu-prof-file=/home/azaugg/CBL-Mariner/build/profile/grapher.cpu.pprof \
	--mem-prof-file=/home/azaugg/CBL-Mariner/build/profile/grapher.mem.pprof \
	--trace-file=/home/azaugg/CBL-Mariner/build/profile/grapher.trace \
	 \
	 \
	 \
	--timestamp-file=/home/azaugg/CBL-Mariner/build/timestamp/grapher.jsonl \
	--output /home/azaugg/CBL-Mariner/build/pkg_artifacts/graph.dot
INFO[0000][grapher] Opening /home/azaugg/CBL-Mariner/build/pkg_artifacts/specs.json
INFO[0000][grapher] Adding all packages from /home/azaugg/CBL-Mariner/build/pkg_artifacts/specs.json
INFO[0000][grapher] 	Added 27 packages
INFO[0000][grapher] Adding all dependencies from /home/azaugg/CBL-Mariner/build/pkg_artifacts/specs.json
INFO[0000][grapher] Adding unresolved node /bin/sh--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node /usr/sbin/groupadd--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node /usr/sbin/groupdel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node /usr/sbin/useradd--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node /usr/sbin/userdel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node apr-util--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node libdb--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node lua--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node openldap--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node openssl--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node pcre--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node apr--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node apr-util-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node expat-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node libdb-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node libxml2-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node lua-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node openssl-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node pcre-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node systemd-rpm-macros--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node expat--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node ncurses--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node python3--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node readline--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node xz-libs--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node zlib--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node gcc-c++--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node gcc-gfortran--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node gmp-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node ncurses-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node python3-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node python3-libs--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node readline-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node xz-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node zlib-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node apr-devel--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node apr-util-ldap--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node /usr/sbin/nologin--REMOTE<Unresolved>
INFO[0000][grapher] Adding unresolved node sscg--REMOTE<Unresolved>
INFO[0000][grapher] 	Added 423 dependencies
INFO[0000][grapher] Running cycle resolution to fix any cycles in the dependency graph
INFO[0000][grapher] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/graph.dot
INFO[0000][grapher] Finished generating graph.
mkdir -p /home/azaugg/CBL-Mariner/build/rpm_cache/cache && \
/home/azaugg/CBL-Mariner/toolkit/out/tools/graphpkgfetcher \
	--input=/home/azaugg/CBL-Mariner/build/pkg_artifacts/graph.dot \
	--output-dir=/home/azaugg/CBL-Mariner/build/rpm_cache/cache \
	--rpm-dir=/home/azaugg/CBL-Mariner/out/RPMS \
	--toolchain-rpms-dir="/home/azaugg/CBL-Mariner/build/toolchain_rpms" \
	--tmp-dir=/home/azaugg/CBL-Mariner/build/pkg_artifacts/tdnf_cache_worker \
	--tdnf-worker=/home/azaugg/CBL-Mariner/build/worker/worker_chroot.tar.gz \
	--toolchain-manifest=/home/azaugg/CBL-Mariner/toolkit/resources/manifests/package/toolchain_x86_64.txt \
	--tls-cert= \
	--tls-key= \
	--repo-file=/home/azaugg/CBL-Mariner/toolkit/resources/manifests/package/local.repo  --repo-file=/home/azaugg/CBL-Mariner/toolkit/resources/manifests/package/fetcher.repo  \
	 \
	--log-file=/home/azaugg/CBL-Mariner/build/logs/pkggen/workplan/cached_graph.dot.log --log-level=info \
	--input-summary-file= \
	--output-summary-file=/home/azaugg/CBL-Mariner/build/pkg_artifacts/graph_external_deps.json \
	--cpu-prof-file=/home/azaugg/CBL-Mariner/build/profile/graphpkgfetcher.cpu.pprof \
	--mem-prof-file=/home/azaugg/CBL-Mariner/build/profile/graphpkgfetcher.mem.pprof \
	--trace-file=/home/azaugg/CBL-Mariner/build/profile/graphpkgfetcher.trace \
	 \
	 \
	 \
	--timestamp-file=/home/azaugg/CBL-Mariner/build/timestamp/graph_cache.jsonl \
	--output=/home/azaugg/CBL-Mariner/build/pkg_artifacts/cached_graph.dot && \
touch /home/azaugg/CBL-Mariner/build/pkg_artifacts/cached_graph.dot
INFO[0000][graphpkgfetcher] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/graph.dot
INFO[0000][graphpkgfetcher] Creating cloning environment to populate (/home/azaugg/CBL-Mariner/build/rpm_cache/cache)
INFO[0004][graphpkgfetcher] Initializing repository configurations
INFO[0004][graphpkgfetcher] Found unresolved packages to cache, downloading packages
INFO[0004][graphpkgfetcher] Cache progress 0%: choosing 'xz-libs-5.2.5-1.cm2.x86_64.rpm' to provide 'xz-libs'.
INFO[0006][graphpkgfetcher] Cache progress 2%: choosing 'systemd-rpm-macros-250.3-17.cm2.noarch.rpm' to provide 'systemd-rpm-macros'.
INFO[0006][graphpkgfetcher] Cache progress 5%: choosing 'gmp-devel-6.2.1-2.cm2.x86_64.rpm' to provide 'gmp-devel'.
INFO[0006][graphpkgfetcher] Cache progress 7%: choosing 'xz-devel-5.2.5-1.cm2.x86_64.rpm' to provide 'xz-devel'.
INFO[0007][graphpkgfetcher] Cache progress 10%: choosing 'apr-1.7.2-1.cm2.x86_64.rpm' to provide 'apr'.
INFO[0007][graphpkgfetcher] Cache progress 12%: choosing 'apr-util-1.6.3-1.cm2.x86_64.rpm' to provide 'apr-util'.
INFO[0007][graphpkgfetcher] Cache progress 15%: choosing 'libdb-devel-5.3.28-7.cm2.x86_64.rpm' to provide 'libdb-devel'.
INFO[0007][graphpkgfetcher] Cache progress 17%: choosing 'python3-libs-3.9.14-6.cm2.x86_64.rpm' to provide 'python3-libs'.
INFO[0008][graphpkgfetcher] Cache progress 20%: choosing 'openldap-2.4.57-8.cm2.x86_64.rpm' to provide 'openldap'.
WARN[0008][graphpkgfetcher] Discarding '>=' version constraint for: sscg:C:'>='V:'2.2.0',C2:''V2:''
INFO[0008][graphpkgfetcher] Cache progress 23%: choosing 'sscg-2.6.2-2.cm2.x86_64.rpm' to provide 'sscg'.
INFO[0008][graphpkgfetcher] Cache progress 25%: choosing 'readline-devel-8.1-1.cm2.x86_64.rpm' to provide 'readline-devel'.
INFO[0008][graphpkgfetcher] Cache progress 28%: choosing 'openssl-1.1.1k-23.cm2.x86_64.rpm' to provide 'openssl'.
INFO[0008][graphpkgfetcher] Cache progress 30%: choosing 'lua-devel-5.4.3-5.cm2.x86_64.rpm' to provide 'lua-devel'.
INFO[0009][graphpkgfetcher] Cache progress 33%: choosing 'apr-util-ldap-1.6.3-1.cm2.x86_64.rpm' to provide 'apr-util-ldap'.
INFO[0009][graphpkgfetcher] Cache progress 35%: choosing 'gfortran-11.2.0-4.cm2.x86_64.rpm' to provide 'gcc-gfortran'.
INFO[0009][graphpkgfetcher] Cache progress 38%: choosing 'bash-5.1.8-1.cm2.x86_64.rpm' to provide '/bin/sh'.
INFO[0009][graphpkgfetcher] Cache progress 41%: choosing 'ncurses-devel-6.3-2.cm2.x86_64.rpm' to provide 'ncurses-devel'.
INFO[0009][graphpkgfetcher] Cache progress 43%: choosing 'libdb-5.3.28-7.cm2.x86_64.rpm' to provide 'libdb'.
INFO[0010][graphpkgfetcher] Cache progress 46%: choosing 'apr-devel-1.7.2-1.cm2.x86_64.rpm' to provide 'apr-devel'.
INFO[0010][graphpkgfetcher] Cache progress 48%: choosing 'zlib-devel-1.2.12-2.cm2.x86_64.rpm' to provide 'zlib-devel'.
INFO[0010][graphpkgfetcher] Cache progress 51%: choosing 'shadow-utils-4.9-12.cm2.x86_64.rpm' to provide '/usr/sbin/groupdel'.
INFO[0010][graphpkgfetcher] Cache progress 53%: choosing 'libxml2-devel-2.10.3-1.cm2.x86_64.rpm' to provide 'libxml2-devel'.
INFO[0010][graphpkgfetcher] Cache progress 56%: choosing 'shadow-utils-4.9-12.cm2.x86_64.rpm' to provide '/usr/sbin/useradd'.
INFO[0011][graphpkgfetcher] Cache progress 58%: choosing 'openssl-devel-1.1.1k-23.cm2.x86_64.rpm' to provide 'openssl-devel'.
INFO[0011][graphpkgfetcher] Cache progress 61%: choosing 'expat-devel-2.5.0-1.cm2.x86_64.rpm' to provide 'expat-devel'.
INFO[0011][graphpkgfetcher] Cache progress 64%: choosing 'python3-3.9.14-6.cm2.x86_64.rpm' to provide 'python3'.
INFO[0011][graphpkgfetcher] Cache progress 66%: choosing 'gcc-c++-11.2.0-4.cm2.x86_64.rpm' to provide 'gcc-c++'.
INFO[0011][graphpkgfetcher] Cache progress 69%: choosing 'pcre-8.45-2.cm2.x86_64.rpm' to provide 'pcre'.
INFO[0011][graphpkgfetcher] Cache progress 71%: choosing 'zlib-1.2.12-2.cm2.x86_64.rpm' to provide 'zlib'.
INFO[0011][graphpkgfetcher] Cache progress 74%: choosing 'readline-8.1-1.cm2.x86_64.rpm' to provide 'readline'.
INFO[0011][graphpkgfetcher] Cache progress 76%: choosing 'shadow-utils-4.9-12.cm2.x86_64.rpm' to provide '/usr/sbin/nologin'.
INFO[0011][graphpkgfetcher] Cache progress 79%: choosing 'lua-5.4.3-5.cm2.x86_64.rpm' to provide 'lua'.
INFO[0011][graphpkgfetcher] Cache progress 82%: choosing 'python3-devel-3.9.14-6.cm2.x86_64.rpm' to provide 'python3-devel'.
INFO[0011][graphpkgfetcher] Cache progress 84%: choosing 'apr-util-devel-1.6.3-1.cm2.x86_64.rpm' to provide 'apr-util-devel'.
INFO[0012][graphpkgfetcher] Cache progress 87%: choosing 'shadow-utils-4.9-12.cm2.x86_64.rpm' to provide '/usr/sbin/userdel'.
INFO[0012][graphpkgfetcher] Cache progress 89%: choosing 'ncurses-6.3-2.cm2.x86_64.rpm' to provide 'ncurses'.
INFO[0012][graphpkgfetcher] Cache progress 92%: choosing 'pcre-devel-8.45-2.cm2.x86_64.rpm' to provide 'pcre-devel'.
INFO[0012][graphpkgfetcher] Cache progress 94%: choosing 'shadow-utils-4.9-12.cm2.x86_64.rpm' to provide '/usr/sbin/groupadd'.
INFO[0012][graphpkgfetcher] Cache progress 97%: choosing 'expat-2.5.0-1.cm2.x86_64.rpm' to provide 'expat'.
INFO[0012][graphpkgfetcher] Configuring downloaded RPMs as a local repository
INFO[0036][graphpkgfetcher] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/cached_graph.dot
/home/azaugg/CBL-Mariner/toolkit/out/tools/graphPreprocessor \
	--input=/home/azaugg/CBL-Mariner/build/pkg_artifacts/cached_graph.dot \
	 \
	--log-file=/home/azaugg/CBL-Mariner/build/logs/pkggen/workplan/preprocessed_graph.dot.log --log-level=info \
	--output=/home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot && \
touch /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][graphPreprocessor] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/cached_graph.dot
INFO[0000][graphPreprocessor] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
/home/azaugg/CBL-Mariner/toolkit/out/tools/scheduler \
	--input="/home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot" \
	--output="/home/azaugg/CBL-Mariner/build/pkg_artifacts/built_graph.dot" \
	--output-build-state-csv-file="/home/azaugg/CBL-Mariner/build/pkg_artifacts/build_state.csv" \
	--workers="0" \
	--work-dir="/home/azaugg/CBL-Mariner/build/worker/chroot" \
	--worker-tar="/home/azaugg/CBL-Mariner/build/worker/worker_chroot.tar.gz" \
	--repo-file="/home/azaugg/CBL-Mariner/toolkit/resources/manifests/package/local.repo" \
	--rpm-dir="/home/azaugg/CBL-Mariner/out/RPMS" \
	--toolchain-rpms-dir="/home/azaugg/CBL-Mariner/build/toolchain_rpms" \
	--srpm-dir="/home/azaugg/CBL-Mariner/out/SRPMS" \
	--cache-dir="/home/azaugg/CBL-Mariner/build/rpm_cache/cache" \
	--ccache-dir="/home/azaugg/CBL-Mariner/ccache" \
	--build-logs-dir="/home/azaugg/CBL-Mariner/build/logs/pkggen/rpmbuilding" \
	--dist-tag=".cm2" \
	--distro-release-version="2.0.20230823.0259" \
	--distro-build-number="abbaa19cb" \
	--rpmmacros-file="/home/azaugg/CBL-Mariner/toolkit/resources/manifests/package/macros.override" \
	--build-attempts="1" \
	--check-attempts="1" \
	--build-agent="chroot-agent" \
	--build-agent-program="/home/azaugg/CBL-Mariner/toolkit/out/tools/pkgworker" \
	--ignored-packages="" \
	--packages="" \
	--rebuild-packages="gdb" \
	--image-config-file="/home/azaugg/CBL-Mariner/toolkit/imageconfigs/core-efi.json" \
	--cpu-prof-file=/home/azaugg/CBL-Mariner/build/profile/scheduler.cpu.pprof \
	--mem-prof-file=/home/azaugg/CBL-Mariner/build/profile/scheduler.mem.pprof \
	--trace-file=/home/azaugg/CBL-Mariner/build/profile/scheduler.trace \
	 \
	 \
	 \
	--timestamp-file=/home/azaugg/CBL-Mariner/build/timestamp/scheduler.jsonl \
	--toolchain-manifest="/home/azaugg/CBL-Mariner/toolkit/resources/manifests/package/toolchain_x86_64.txt" \
	--base-dir="/home/azaugg/CBL-Mariner/toolkit/imageconfigs/" \
	 \
	 \
	 \
	 \
	 \
	 \
	 \
	--max-cpu="" \
	--log-file=/home/azaugg/CBL-Mariner/build/logs/pkggen/workplan/build-rpms.flag.log --log-level=info && \
touch /home/azaugg/CBL-Mariner/build/make_status/build-rpms.flag
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Successfully created solvable subgraph
INFO[0000][scheduler] Building 30 nodes with 8 workers
INFO[0000][scheduler] Building gdb-13.2-1.cm2.src.rpm
INFO[0236][scheduler] Built: gdb-13.2-1.cm2.src.rpm -> [/home/azaugg/CBL-Mariner/out/RPMS/x86_64/gdb-13.2-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/gdb-debuginfo-13.2-1.cm2.x86_64.rpm]
INFO[0236][scheduler] 0 currently active build(s): [].
INFO[0236][scheduler] All packages built
INFO[0237][scheduler] ---------------------------
INFO[0237][scheduler] --------- Summary ---------
INFO[0237][scheduler] ---------------------------
INFO[0237][scheduler] Number of built SRPMs:             1
INFO[0237][scheduler] Number of prebuilt SRPMs:          0
INFO[0237][scheduler] Number of prebuilt delta SRPMs:    0
INFO[0237][scheduler] Number of failed SRPMs:            0
INFO[0237][scheduler] Number of blocked SRPMs:           0
INFO[0237][scheduler] Number of unresolved dependencies: 0
INFO[0237][scheduler] Built SRPMs:
INFO[0237][scheduler] --> gdb-13.2-1.cm2.src.rpm
INFO[0237][scheduler] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/built_graph.dot
INFO[0237][scheduler] Waiting for outstanding processes to be created
Finished updating /home/azaugg/CBL-Mariner/out/RPMS
azaugg@azaugg-ld77 [ ~/CBL-Mariner/toolkit ]$
```

- Checked rpm
```
azaugg@azaugg-ld77 [ ~/CBL-Mariner/out ]$ rpm -ql ~/CBL-Mariner/out/RPMS/x86_64/gdb-13.2-1.cm2.x86_64.rpm
/usr/bin/gcore
/usr/bin/gdb
/usr/bin/gdb-add-index
/usr/bin/gdbserver
/usr/include/gdb/jit-reader.h
/usr/lib/libinproctrace.so
/usr/lib/libsframe.a
/usr/share/gdb/python/gdb
/usr/share/gdb/python/gdb/FrameDecorator.py
/usr/share/gdb/python/gdb/FrameIterator.py
/usr/share/gdb/python/gdb/__init__.py
/usr/share/gdb/python/gdb/command
```
