### PR TITLE
Add cpupower systemd unit file

### DIFF
--- a/SPECS/kernel/cpupower
+++ b/SPECS/kernel/cpupower
@@ -1,0 +1,2 @@
+CPUPOWER_START_OPTS="frequency-set -g performance"
+CPUPOWER_STOP_OPTS=""

--- a/SPECS/kernel/cpupower.service
+++ b/SPECS/kernel/cpupower.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Configure CPU power related settings
+After=syslog.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/etc/sysconfig/cpupower
+ExecStart=/usr/bin/cpupower $CPUPOWER_START_OPTS
+ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
+
+[Install]
+WantedBy=multi-user.target

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -4,6 +4,8 @@
     "config": "5aac865f894b53ebc1cd94dc6763ed8a5c07c0e2834e6a43fcc8a84fe0ce2c98",
     "config_aarch64": "f060e00880f85bb8222dac3db4419659a522e54c36eff4b2f322ec81e847da85",
     "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f",
-    "kernel-5.15.131.1.tar.gz": "79e6f96e5e9b0e920336dc5c2da0d5b65c3d77f9568b15ae6c4517164aace0a4"
+    "kernel-5.15.131.1.tar.gz": "79e6f96e5e9b0e920336dc5c2da0d5b65c3d77f9568b15ae6c4517164aace0a4",
+    "cpupower.service": "b057fe9e5d0e8c36f485818286b80e3eba8ff66ff44797940e99b1fd5361bb98",
+    "cpupower":  "0d6993742297527ff875b394449305f4eb9a739f5057cced9bcac4c52ea05e10"
   }
 }

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -229,8 +229,8 @@ install -vdm 755 %{buildroot}%{_defaultdocdir}/linux-%{uname_r}
 install -vdm 755 %{buildroot}%{_prefix}/src/linux-headers-%{uname_r}
 install -vdm 755 %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}
 
-install -d -m 755 %{buildroot}%{_libexecdir}/%{_sysconfdir}/sysconfig
-install -c -m 644 %{SOURCE5} %{buildroot}%{_libexecdir}/%{_sysconfdir}/sysconfig/cpupower
+install -d -m 755 %{buildroot}%{_sysconfdir}/sysconfig
+install -c -m 644 %{SOURCE5} %{buildroot}/%{_sysconfdir}/sysconfig/cpupower
 install -d -m 755 %{buildroot}%{_unitdir}
 install -c -m 644 %{SOURCE6} %{buildroot}%{_unitdir}/cpupower.service
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -28,7 +28,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.15.131.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -39,6 +39,8 @@ Source1:        config
 Source2:        config_aarch64
 Source3:        sha512hmac-openssl.sh
 Source4:        cbl-mariner-ca-20211013.pem
+Source5:        cpupower
+Source6:        cpupower.service
 Patch0:         nvme_multipath_default_false.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
@@ -61,6 +63,7 @@ BuildRequires:  pam-devel
 BuildRequires:  procps-ng-devel
 BuildRequires:  python3-devel
 BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
 %ifarch x86_64
 BuildRequires:  pciutils-devel
 %endif
@@ -225,6 +228,12 @@ install -vdm 700 %{buildroot}/boot
 install -vdm 755 %{buildroot}%{_defaultdocdir}/linux-%{uname_r}
 install -vdm 755 %{buildroot}%{_prefix}/src/linux-headers-%{uname_r}
 install -vdm 755 %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}
+
+install -d -m 755 %{buildroot}%{_libexecdir}/%{_sysconfdir}/sysconfig
+install -c -m 644 %{SOURCE5} %{buildroot}%{_libexecdir}/%{_sysconfdir}/sysconfig/cpupower
+install -d -m 755 %{buildroot}%{_unitdir}
+install -c -m 644 %{SOURCE6} %{buildroot}%{_unitdir}/cpupower.service
+
 make INSTALL_MOD_PATH=%{buildroot} modules_install
 
 %ifarch x86_64
@@ -278,6 +287,7 @@ find arch/%{archdir}/include Module.symvers include scripts -type f | xargs  sh 
 install -vsm 755 tools/objtool/objtool %{buildroot}%{_prefix}/src/linux-headers-%{uname_r}/tools/objtool/
 install -vsm 755 tools/objtool/fixdep %{buildroot}%{_prefix}/src/linux-headers-%{uname_r}/tools/objtool/
 %endif
+
 
 cp .config %{buildroot}%{_prefix}/src/linux-headers-%{uname_r} # copy .config manually to be where it's expected to be
 ln -sf "%{_prefix}/src/linux-headers-%{uname_r}" "%{buildroot}/lib/modules/%{uname_r}/build"
@@ -408,6 +418,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/examples/bpf/*
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
+%{_unitdir}/cpupower.service
+%{_sysconfdir}/sysconfig/cpupower
 
 %files -n python3-perf
 %{python3_sitearch}/*
@@ -422,6 +434,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Fri Sep 15 2023 Andy Zaugg <azaugg@linkedin.com> - 5.15.131.1-2
+- Include a  cpupower systemd unit file, allowing cpupower service to start on boot
+
 * Fri Sep 08 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.131.1-1
 - Auto-upgrade to 5.15.131.1
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-15.cm2.aarch64.rpm
-kernel-headers-5.15.131.1-1.cm2.noarch.rpm
+kernel-headers-5.15.131.1-2.cm2.noarch.rpm
 glibc-2.35-4.cm2.aarch64.rpm
 glibc-devel-2.35-4.cm2.aarch64.rpm
 glibc-i18n-2.35-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-15.cm2.x86_64.rpm
-kernel-headers-5.15.131.1-1.cm2.noarch.rpm
+kernel-headers-5.15.131.1-2.cm2.noarch.rpm
 glibc-2.35-4.cm2.x86_64.rpm
 glibc-devel-2.35-4.cm2.x86_64.rpm
 glibc-i18n-2.35-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -136,7 +136,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.131.1-1.cm2.noarch.rpm
+kernel-headers-5.15.131.1-2.cm2.noarch.rpm
 kmod-29-1.cm2.aarch64.rpm
 kmod-debuginfo-29-1.cm2.aarch64.rpm
 kmod-devel-29-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -136,7 +136,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-headers-5.15.131.1-1.cm2.noarch.rpm
+kernel-headers-5.15.131.1-2.cm2.noarch.rpm
 kmod-29-1.cm2.x86_64.rpm
 kmod-debuginfo-29-1.cm2.x86_64.rpm
 kmod-devel-29-1.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Allow cpupower to be started as a systemd service, include a systemd unit file with an associated default config file, bringing the cpu governor to performance mode by default.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add cpupower systemd unit file


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built package and confirmed that new files were included in package
```
azaugg@azaugg-ld77 [ ~/CBL-Mariner/toolkit ]$ sudo make build-packages -j$(nproc) REBUILD_TOOLS=y SRPM_PACK_LIST="kernel" PACKAGE_REBUILD_LIST="kernel" REFRESH_WORKER_CHROOT=y RUN_CHECK=y
[sudo] password for azaugg:
Sorry, try again.
[sudo] password for azaugg:
Makefile:17: CONFIG_FILE is undefined, defaulting to toolkit's core-efi.json.
/home/azaugg/CBL-Mariner/toolkit/out/tools/specreader \
	--dir /home/azaugg/CBL-Mariner/SPECS \
	--spec-list=/home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS/pack_list.txt \
	--build-dir /home/azaugg/CBL-Mariner/build/spec_parsing \
	--srpm-dir /home/azaugg/CBL-Mariner/build/INTERMEDIATE_SRPMS \
...
...
...
INFO[0000][scheduler] Building: kernel-5.15.126.1-2.cm2.src.rpm

INFO[1395][scheduler] Built: kernel-5.15.126.1-2.cm2.src.rpm -> [/home/azaugg/CBL-Mariner/out/RPMS/x86_64/bpftool-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-5.15.126.1-2.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-debuginfo-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-devel-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-docs-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-drivers-accessibility-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-drivers-gpu-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-drivers-sound-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/kernel-tools-5.15.126.1-1.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/python3-perf-5.15.126.1-1.cm2.x86_64.rpm]
INFO[1395][scheduler] 0 currently active build(s): [].
INFO[1395][scheduler] All packages built
INFO[1396][scheduler] ---------------------------
INFO[1396][scheduler] --------- Summary ---------
INFO[1396][scheduler] ---------------------------
INFO[1396][scheduler] Number of built SRPMs:             1
INFO[1396][scheduler] Number of tested SRPMs:            0
INFO[1396][scheduler] Number of prebuilt SRPMs:          0
INFO[1396][scheduler] Number of prebuilt delta SRPMs:    0
INFO[1396][scheduler] Number of skipped SRPMs tests:     0
INFO[1396][scheduler] Number of failed SRPMs:            0
INFO[1396][scheduler] Number of failed SRPMs tests:      0
INFO[1396][scheduler] Number of blocked SRPMs:           0
INFO[1396][scheduler] Number of blocked SRPMs tests:     0
INFO[1396][scheduler] Number of unresolved dependencies: 0
INFO[1396][scheduler] Built SRPMs:
INFO[1396][scheduler] --> kernel-5.15.126.1-2.cm2.src.rpm
INFO[1396][scheduler] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/built_graph.dot
INFO[1396][scheduler] Waiting for outstanding processes to be created
Finished updating /home/azaugg/CBL-Mariner/out/RPMS

```
```
azaugg@azaugg-ld77 [ ~/CBL-Mariner/out/RPMS/x86_64 ]$ rpm -ql kernel-tools-5.15.126.1-2.cm2.x86_64.rpm|grep cpupower |grep -v share
/usr/bin/cpupower
/usr/lib/systemd/system/cpupower.service # <<<
/usr/lib64/libcpupower.so
/usr/lib64/libcpupower.so.0
/usr/lib64/libcpupower.so.0.0.1
/etc/sysconfig/cpupower                      # <<<
azaugg@azaugg-ld77 [ ~/CBL-Mariner/out/RPMS/x86_64 ]$ ^C
```
