### PR TITLE
Add priority queuing to optimize implicit nodes

### DIFF
--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -386,7 +386,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 				allowLowPriorityNodes = true
 				nodesToBuild = schedulerutils.LeafNodes(pkgGraph, graphMutex, goalNode, buildState, useCachedImplicit)
 				// Check if any of the low priority nodes are still in the graph. If not, we can skip building them.
-				lowPriorityNodes = filterLowPriorityNodesAgainstGraph(pkgGraph, graphMutex, buildState, lowPriorityNodes)
+				lowPriorityNodes = filterNodesAgainstGraphState(pkgGraph, graphMutex, buildState, lowPriorityNodes)
 				nodesToBuild = append(nodesToBuild, lowPriorityNodes...)
 				// We should generate no more low priority nodes going forward.
 				lowPriorityNodes = nil
@@ -450,7 +450,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 
 						// If we are shrinking the graph we need to filter out any low priority nodes that are no longer in the graph.
 						// We may still have some low priority nodes, those will be handled as normal when we switch allowLowPriorityNodes=true
-						lowPriorityNodes = filterLowPriorityNodesAgainstGraph(pkgGraph, graphMutex, buildState, lowPriorityNodes)
+						lowPriorityNodes = filterNodesAgainstGraphState(pkgGraph, graphMutex, buildState, lowPriorityNodes)
 					}
 				}
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -364,7 +364,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 			//    resolve implicit provides if the scheduler is unable to find a provider for them.
 			switch buildState.GetNodePriority(req.Node) {
 			case schedulerutils.HighNodePriority:
-				logger.Log.Tracef("Priority priority request (%d) for node '%s'", buildState.GetNodePriority(req.Node), req.Node.FriendlyName())
+				logger.Log.Tracef("High priority request (%d) for node '%s'", buildState.GetNodePriority(req.Node), req.Node.FriendlyName())
 				channels.HighPriorityRequests <- req
 			case schedulerutils.MediumNodePriority:
 				logger.Log.Tracef("Medium priority request (%d) for node '%s'", buildState.GetNodePriority(req.Node), req.Node.FriendlyName())

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -43,11 +43,12 @@ var (
 // Unlike BuildChannels, schedulerChannels holds bidirectional channels that
 // only the top-level scheduler should have. BuildChannels contains directional channels.
 type schedulerChannels struct {
-	Requests         chan *schedulerutils.BuildRequest
-	PriorityRequests chan *schedulerutils.BuildRequest
-	Results          chan *schedulerutils.BuildResult
-	Cancel           chan struct{}
-	Done             chan struct{}
+	LowPriorityRequests    chan *schedulerutils.BuildRequest
+	MediumPriorityRequests chan *schedulerutils.BuildRequest
+	HighPriorityRequests   chan *schedulerutils.BuildRequest
+	Results                chan *schedulerutils.BuildResult
+	Cancel                 chan struct{}
+	Done                   chan struct{}
 }
 
 var (
@@ -273,20 +274,22 @@ func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, work
 // channelBufferSize controls how many entries in the channels can be buffered before blocking writes to them.
 func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, checkAttempts, channelBufferSize int, graphMutex *sync.RWMutex, ignoredPackages, ignoredTests []*pkgjson.PackageVer) (channels *schedulerChannels) {
 	channels = &schedulerChannels{
-		Requests:         make(chan *schedulerutils.BuildRequest, channelBufferSize),
-		PriorityRequests: make(chan *schedulerutils.BuildRequest, channelBufferSize),
-		Results:          make(chan *schedulerutils.BuildResult, channelBufferSize),
-		Cancel:           make(chan struct{}),
-		Done:             make(chan struct{}),
+		LowPriorityRequests:    make(chan *schedulerutils.BuildRequest, channelBufferSize),
+		MediumPriorityRequests: make(chan *schedulerutils.BuildRequest, channelBufferSize),
+		HighPriorityRequests:   make(chan *schedulerutils.BuildRequest, channelBufferSize),
+		Results:                make(chan *schedulerutils.BuildResult, channelBufferSize),
+		Cancel:                 make(chan struct{}),
+		Done:                   make(chan struct{}),
 	}
 
 	// Downcast the bidirectional scheduler channels into directional channels for the build workers.
 	directionalChannels := &schedulerutils.BuildChannels{
-		Requests:         channels.Requests,
-		PriorityRequests: channels.PriorityRequests,
-		Results:          channels.Results,
-		Cancel:           channels.Cancel,
-		Done:             channels.Done,
+		LowPriorityRequests:    channels.LowPriorityRequests,
+		MediumPriorityRequests: channels.MediumPriorityRequests,
+		HighPriorityRequests:   channels.HighPriorityRequests,
+		Results:                channels.Results,
+		Cancel:                 channels.Cancel,
+		Done:                   channels.Done,
 	}
 
 	// Start the workers now so they begin working as soon as a new job is queued.
@@ -322,19 +325,31 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 		// by using cached implicit provides to satisfy unresolved dynamic dependencies during the first pass of the optimizer.
 		useCachedImplicit bool
 		isGraphOptimized  bool
+
+		// allowLowPriorityNodes tracks if low priority nodes can be built. Ideally the scheduler will be able to build all
+		// medium and high priority nodes without needing to build any low priority nodes. However, if the scheduler is unable
+		// to resolve an implicit provide, it will need to fall back to building low priority nodes to try and find a provider.
+		allowLowPriorityNodes bool = false
 	)
 
 	// Start the build at the leaf nodes.
 	// The build will bubble up through the graph as it processes nodes.
-	buildState := schedulerutils.NewGraphBuildState(reservedFiles, maxCascadingRebuilds)
+	priorityBuildSet, err := schedulerutils.BuildNodeResolutionPriorityMap(pkgGraph, graphMutex)
+	if err != nil {
+		err = fmt.Errorf("error building implicit node resolution priority set:\n%w", err)
+		return
+	}
+	buildState := schedulerutils.NewGraphBuildState(reservedFiles, priorityBuildSet, maxCascadingRebuilds)
 	buildRunsTests := len(pkgGraph.AllTestNodes()) > 0
 	nodesToBuild := schedulerutils.LeafNodes(pkgGraph, graphMutex, goalNode, buildState, useCachedImplicit)
+	// As the build progresses, we will need to keep track of low priority nodes that were set aside.
+	lowPriorityNodes := make([]*pkggraph.PkgNode, 0)
 
 	for {
 		logger.Log.Debugf("Found %d unblocked nodes: %v.", len(nodesToBuild), nodesToBuild)
 
 		// Each node that is ready to build must be converted into a build request and submitted to the worker pool.
-		newRequests, requestError := schedulerutils.ConvertNodesToRequests(pkgGraph, graphMutex, nodesToBuild, packagesToRebuild, testsToRerun, buildState, canUseCache)
+		newRequests, requestError := schedulerutils.ConvertNodesToRequests(pkgGraph, graphMutex, nodesToBuild, packagesToRebuild, testsToRerun, buildState, canUseCache, allowLowPriorityNodes)
 		if requestError != nil {
 			err = fmt.Errorf("failed to convert nodes to requests:\n%w", requestError)
 			stopBuilding = true
@@ -342,42 +357,48 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 		}
 		for _, req := range newRequests {
 			buildState.RecordBuildRequest(req)
-			// Decide which priority the build should be. Generally we want to get any remote or prebuilt nodes out of the
-			// way as quickly as possible since they may help us optimize the graph early.
-			// Meta nodes may also be blocking something we want to examine and give higher priority (priority inheritance from
-			// the hypothetical high priority node hidden further into the tree)
-			switch req.Node.Type {
-			case pkggraph.TypePreBuilt:
-				channels.PriorityRequests <- req
-
-				// For now all build nodes are of equal priority
-			case pkggraph.TypeGoal:
-				fallthrough
-			case pkggraph.TypePureMeta:
-				fallthrough
-			case pkggraph.TypeLocalRun:
-				fallthrough
-			case pkggraph.TypeRemoteRun:
-				fallthrough
-			case pkggraph.TypeLocalBuild:
+			// Queue nodes based on how likely they are to help optimize the build.
+			// - High priority nodes are expected to resolve implicit provides that are needed to build other packages.
+			// - Medium priority nodes are our desired build goal.
+			// - Low priority nodes are packages that are not needed to build the desired goal, but may be needed to
+			//    resolve implicit provides if the scheduler is unable to find a provider for them.
+			switch buildState.GetNodePriority(req.Node) {
+			case schedulerutils.HighNodePriority:
+				logger.Log.Tracef("Priority priority request (%d) for node '%s'", buildState.GetNodePriority(req.Node), req.Node.FriendlyName())
+				channels.HighPriorityRequests <- req
+			case schedulerutils.MediumNodePriority:
+				logger.Log.Tracef("Medium priority request (%d) for node '%s'", buildState.GetNodePriority(req.Node), req.Node.FriendlyName())
+				channels.MediumPriorityRequests <- req
+			case schedulerutils.LowNodePriority:
 				fallthrough
 			default:
-				channels.Requests <- req
+				logger.Log.Tracef("Low priority request (%d) for node '%s'", buildState.GetNodePriority(req.Node), req.Node.FriendlyName())
+				channels.LowPriorityRequests <- req
 			}
 		}
 		nodesToBuild = nil
 
-		// If there are no active builds running or results waiting to check try enabling cached packages for unresolved
-		// dynamic dependencies to unblock more nodes. Otherwise, there is nothing left that can be built.
+		// If there are no active builds running or results waiting to check try enabling low priority nodes  to unblock
+		// more nodes, then cached packages for unresolved dynamic dependencies. Otherwise, there is nothing left that can be built.
 		if len(buildState.ActiveBuilds()) == 0 && len(channels.Results) == 0 {
-			if useCachedImplicit {
-				err = fmt.Errorf("could not build all packages")
-				break
-			} else {
+			if !allowLowPriorityNodes {
+				logger.Log.Warnf("Enabling low priority packages to satisfy unresolved dynamic dependencies.")
+				allowLowPriorityNodes = true
+				nodesToBuild = schedulerutils.LeafNodes(pkgGraph, graphMutex, goalNode, buildState, useCachedImplicit)
+				// Check if any of the low priority nodes are still in the graph. If not, we can skip building them.
+				lowPriorityNodes = filterLowPriorityNodesAgainstGraph(pkgGraph, graphMutex, buildState, lowPriorityNodes)
+				nodesToBuild = append(nodesToBuild, lowPriorityNodes...)
+				// We should generate no more low priority nodes going forward.
+				lowPriorityNodes = nil
+				continue
+			} else if !useCachedImplicit {
 				logger.Log.Warn("Enabling cached packages to satisfy unresolved dynamic dependencies.")
 				useCachedImplicit = true
 				nodesToBuild = schedulerutils.LeafNodes(pkgGraph, graphMutex, goalNode, buildState, useCachedImplicit)
 				continue
+			} else {
+				err = fmt.Errorf("could not build all packages")
+				break
 			}
 		}
 
@@ -426,10 +447,18 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 						// When querying their edges, the graph library will return an empty iterator (graph.Empty).
 						pkgGraph = newGraph
 						goalNode = newGoalNode
+
+						// If we are shrinking the graph we need to filter out any low priority nodes that are no longer in the graph.
+						// We may still have some low priority nodes, those will be handled as normal when we switch allowLowPriorityNodes=true
+						lowPriorityNodes = filterLowPriorityNodesAgainstGraph(pkgGraph, graphMutex, buildState, lowPriorityNodes)
 					}
 				}
 
-				nodesToBuild = schedulerutils.FindUnblockedNodesFromResult(res, pkgGraph, graphMutex, buildState)
+				// We may unblock some nodes which are low priority. We will need to keep track of these nodes so we can queue requests for them
+				// when we switch allowLowPriorityNodes=true.
+				var newLowPiorityNodes []*pkggraph.PkgNode
+				nodesToBuild, newLowPiorityNodes = schedulerutils.FindUnblockedNodesFromResult(res, pkgGraph, graphMutex, buildState, allowLowPriorityNodes)
+				lowPriorityNodes = append(lowPriorityNodes, newLowPiorityNodes...)
 			} else if stopOnFailure {
 				stopBuilding = true
 				err = res.Err
@@ -451,13 +480,15 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 		// There may still be outstanding builds if the graph was recently subgraphed
 		// due to an unresolved implicit provide being satisfied and nodes that are no
 		// longer in the graph are building.
-		if buildState.IsNodeAvailable(goalNode) {
-			logger.Log.Infof("All packages built")
-			stopBuilding = true
-		}
-
 		activeSRPMs := buildState.ActiveSRPMs()
 		activeSRPMsCount := len(activeSRPMs)
+		if buildState.IsNodeAvailable(goalNode) {
+			logger.Log.Infof("All packages built")
+			if activeSRPMsCount > 0 {
+				logger.Log.Infof("%d workers still running. Waiting for them to finish.", activeSRPMsCount)
+			}
+			stopBuilding = true
+		}
 		if stopBuilding && activeSRPMsCount == 0 {
 			break
 		}
@@ -487,6 +518,26 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 		err = fmt.Errorf("toolchain packages rebuilt. See build summary for details. Use 'ALLOW_TOOLCHAIN_REBUILDS=y' to suppress this error if rebuilds were expected")
 	}
 	return
+}
+
+// filterNodesAgainstGraphState will filter out nodes that are no longer in the graph, or have been proccessed already.
+func filterNodesAgainstGraphState(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, buildState *schedulerutils.GraphBuildState, nodes []*pkggraph.PkgNode) (filteredNodes []*pkggraph.PkgNode) {
+	graphMutex.RLock()
+	defer graphMutex.RUnlock()
+
+	filteredNodes = make([]*pkggraph.PkgNode, 0, len(nodes))
+	for _, node := range nodes {
+		inGraph := pkgGraph.HasNode(node)
+		processed := buildState.IsNodeProcessed(node)
+
+		if inGraph && !processed {
+			logger.Log.Debugf("Node '%s' in graph, keeping ", node)
+			filteredNodes = append(filteredNodes, node)
+		} else {
+			logger.Log.Debugf("Discarding node '%s' because: inGraph=%t, processed=%t", node, inGraph, processed)
+		}
+	}
+	return filteredNodes
 }
 
 // updateGraphWithImplicitProvides will update the graph with new implicit provides if available.
@@ -557,14 +608,18 @@ func drainChannels(channels *schedulerChannels, buildState *schedulerutils.Graph
 	// For any workers that are current parked with no buffered requests, close the
 	// requests channel to wake up any build workers waiting on a request to be buffered.
 	// Upon being woken up by a closed requests channel, the build worker will stop.
-	close(channels.Requests)
-	close(channels.PriorityRequests)
+	close(channels.LowPriorityRequests)
+	close(channels.MediumPriorityRequests)
+	close(channels.HighPriorityRequests)
 
 	// Drain the request buffers to sync the build state with the new number of outstanding builds.
-	for req := range channels.PriorityRequests {
+	for req := range channels.LowPriorityRequests {
 		buildState.RemoveBuildRequest(req)
 	}
-	for req := range channels.Requests {
+	for req := range channels.MediumPriorityRequests {
+		buildState.RemoveBuildRequest(req)
+	}
+	for req := range channels.HighPriorityRequests {
 		buildState.RemoveBuildRequest(req)
 	}
 }

--- a/toolkit/tools/scheduler/schedulerutils/depsolver.go
+++ b/toolkit/tools/scheduler/schedulerutils/depsolver.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 	"github.com/sirupsen/logrus"
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/path"

--- a/toolkit/tools/scheduler/schedulerutils/priority.go
+++ b/toolkit/tools/scheduler/schedulerutils/priority.go
@@ -134,14 +134,13 @@ func (s NodePriorityMap) GetPriority(node *pkggraph.PkgNode) (priority int) {
 // SetSubgraphPriority will increase the priority of the given node and all of its dependencies to the given priority.
 func (s NodePriorityMap) SetSubgraphPriority(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, priority int) {
 	search := traverse.BreadthFirst{}
-
 	// Walk the graph from the node and prioritize all its dependencies
-	search.Walk(pkgGraph, node, func(n graph.Node, d int) (stopSearch bool) {
+	search.Visit = func(n graph.Node) {
 		pkgNode := n.(*pkggraph.PkgNode)
 		logger.Log.Warnf("Setting %s to priority %d", pkgNode.FriendlyName(), priority)
 		s.IncreaseNodePriority(pkgNode, priority)
-		return
-	})
+	}
+	search.Walk(pkgGraph, node, nil)
 }
 
 // findMatchesForImplicit will try and find real packages that satisfies the implicit node. This is done through four methods:

--- a/toolkit/tools/scheduler/schedulerutils/priority.go
+++ b/toolkit/tools/scheduler/schedulerutils/priority.go
@@ -214,14 +214,22 @@ func findBuildNodesByPath(rpmPath string, pkgGraph *pkggraph.PkgGraph, stripVers
 	buildNodes = make([]*pkggraph.PkgNode, 0)
 	implicitRPMBaseName := filepath.Base(rpmPath)
 
+	var err error
 	if stripVersion {
-		implicitRPMBaseName = rpm.ExtractNameFromRPMPath(implicitRPMBaseName)
+		implicitRPMBaseName, err = rpm.ExtractNameFromRPMPath(implicitRPMBaseName)
+		if err != nil {
+			logger.Log.Warnf("Failed to extract name from RPM path: %s", err)
+			return nil
+		}
 	}
 
 	for _, node := range pkgGraph.AllBuildNodes() {
 		graphNodeRPMBaseName := filepath.Base(node.RpmPath)
 		if stripVersion {
-			graphNodeRPMBaseName = rpm.ExtractNameFromRPMPath(graphNodeRPMBaseName)
+			graphNodeRPMBaseName, err = rpm.ExtractNameFromRPMPath(graphNodeRPMBaseName)
+			if err != nil {
+				continue
+			}
 		}
 		if implicitRPMBaseName == graphNodeRPMBaseName {
 			buildNodes = append(buildNodes, node)

--- a/toolkit/tools/scheduler/schedulerutils/priority.go
+++ b/toolkit/tools/scheduler/schedulerutils/priority.go
@@ -1,0 +1,232 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package schedulerutils
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/rpm"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/timestamp"
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/traverse"
+)
+
+// The scheduler currently supports three different priority levels for nodes: low, medium, and high. These are used to
+// prioritize which jobs the workers will pick up first. The priority levels are used to optimize the build process by
+// prioritizing the packages that will bring the most benefit to the build process. The priority levels are as follows:
+//   - Low: These are packages that are not expected to be needed for the build process. These packages will be built
+//     after the medium and high priority packages only if the build is stuck.
+//   - Medium: These are packages that are set by PACKAGE_BUILD_LIST, CONFIG_FILE, etc., and all of their dependencies.
+//     This is the "normal" priority level for packages.
+//   - High: High priority is used for packages that may cause changes in the build goals. The earlier they are processed
+//     the more likely the build will be optimized. This is currently used for packages that satisfy implicit provides
+//     that are expected to be needed for the build process.
+const (
+	LowNodePriority    int = 0
+	MediumNodePriority int = 1
+	HighNodePriority   int = 2
+	MinPriority            = LowNodePriority
+	MaxPriority            = HighNodePriority
+)
+
+type NodePriorityMap struct {
+	priorities map[*pkggraph.PkgNode]int
+}
+
+// BuildNodeResolutionPriorityMap will build a map of node priorities for the given graph. The graph is expected to
+// contain a goal node named "PackagesToBuild" that lists the packages that should be built. A map of nodes will list
+// all nodes that do not have default (0) priority. Any node not in the map will be assumed to have the implicit default
+// priority of 0.
+func BuildNodeResolutionPriorityMap(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex) (nodePriorityMap *NodePriorityMap, err error) {
+	timestamp.StartEvent("generate priority map", nil)
+	defer timestamp.StopEvent(nil)
+
+	graphMutex.RLock()
+	defer graphMutex.RUnlock()
+
+	// Any node not found in the prioirty set will have an implicit default priority of 0. This should be the nodes in the graph
+	// that we do not expect to need.
+	nodePriorityMap = &NodePriorityMap{
+		priorities: make(map[*pkggraph.PkgNode]int),
+	}
+
+	// Create a fake optimized subgraph, this should be the bulk of the packages we expect to need.
+	// Set these to medium.
+	logger.Log.Debugf("Setting priority for requested build nodes")
+	buildGoalNode := pkgGraph.FindGoalNode(buildGoalNodeName)
+	if buildGoalNode == nil {
+		err = fmt.Errorf("could not find goal node %s", buildGoalNodeName)
+		return
+	}
+	subgraph, err := pkgGraph.CreateSubGraph(buildGoalNode)
+	if err != nil {
+		logger.Log.Warnf("Failed to create subgraph error: %s", err)
+		return
+	}
+	for _, node := range subgraph.AllNodes() {
+		nodePriorityMap.IncreaseNodePriority(node, MediumNodePriority)
+	}
+
+	// Finally, we want to prioritize resolving any implicit nodes in the subgraph. Implicit nodes are what blocks the
+	// scheduler from optimizing and getting a true copy of the above sub-grpah. This is done by finding a real
+	// package that should satisfy the implicit node and prioritizing that package and all of its dependencies above all
+	// else.
+	// This process is best-effort and does not guarantee that all implicit nodes will be satisfied, or that the
+	// predicted package will be the one that actually provides the implicit provide. If the prediction is incorrect
+	// the scheduler can still rely on the low-priority nodes to eventually provide the correct result.
+	logger.Log.Debugf("Setting priority for implicit provider nodes")
+	implicitNodes := subgraph.AllImplicitNodes()
+	satisfyingNodes := []*pkggraph.PkgNode{}
+	for _, implicitNode := range implicitNodes {
+		satisfyingNodesForImplicitNode, findErr := findMatchesForImplicit(implicitNode, pkgGraph)
+		if findErr != nil {
+			err = fmt.Errorf("failed to find match for implicit node (%s):\n%w", implicitNode.FriendlyName(), findErr)
+			return
+		}
+		if len(satisfyingNodesForImplicitNode) > 0 {
+			logger.Log.Debugf("For implicit (%s), we found (%v) that likely provides it.", implicitNode.FriendlyName(), satisfyingNodesForImplicitNode)
+			satisfyingNodes = append(satisfyingNodes, satisfyingNodesForImplicitNode...)
+		}
+	}
+
+	// For each real node we found, we want to prioritize it and all of its dependencies at high.
+	for _, realBuildNode := range satisfyingNodes {
+		nodePriorityMap.SetSubgraphPriority(pkgGraph, realBuildNode, HighNodePriority)
+	}
+
+	return
+}
+
+// IsElevatedPriority returns true if the given node is a medium or high priority node.
+func (s NodePriorityMap) IsElevatedPriority(node *pkggraph.PkgNode) bool {
+	pri := s.priorities[node]
+	return pri > LowNodePriority
+}
+
+// IncreaseNodePriority will increase the priority of the given node to the given priority. If the node already has a
+// higher priority, the priority will not be changed.
+func (s NodePriorityMap) IncreaseNodePriority(node *pkggraph.PkgNode, priority int) {
+	// Limit range of priority to MinPriority and MaxPriority
+	if priority < MinPriority {
+		priority = MinPriority
+	} else if priority > MaxPriority {
+		priority = MaxPriority
+	}
+
+	if s.priorities[node] < priority {
+		logger.Log.Tracef("Setting %s to priority %d", node.FriendlyName(), priority)
+		s.priorities[node] = priority
+	} else {
+		logger.Log.Tracef("Leaving %s at existing priority %d", node.FriendlyName(), s.priorities[node])
+	}
+}
+
+func (s NodePriorityMap) GetPriority(node *pkggraph.PkgNode) (priority int) {
+	return s.priorities[node]
+}
+
+// SetSubgraphPriority will increase the priority of the given node and all of its dependencies to the given priority.
+func (s NodePriorityMap) SetSubgraphPriority(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, priority int) {
+	search := traverse.BreadthFirst{}
+
+	// Walk the graph from the node and prioritize all its dependencies
+	search.Walk(pkgGraph, node, func(n graph.Node, d int) (stopSearch bool) {
+		pkgNode := n.(*pkggraph.PkgNode)
+		logger.Log.Warnf("Setting %s to priority %d", pkgNode.FriendlyName(), priority)
+		s.IncreaseNodePriority(pkgNode, priority)
+		return
+	})
+}
+
+// findMatchesForImplicit will try and find real packages that satisfies the implicit node. This is done through four methods:
+// 1. Find the best package node for the implicit node
+// 2. Try to find a local build node that is backed by the exact same RPM as the implicit node
+// 3. Try 1. again with the version information stripped
+// 4. Finally try 2. again, also with  the version information from the .rpm path removed
+func findMatchesForImplicit(implicitNode *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph) (matches []*pkggraph.PkgNode, err error) {
+	const (
+		stripVersion = true
+		matchVersion = false
+	)
+
+	matches, err = findBuildNodesByGraph(implicitNode, pkgGraph, matchVersion)
+	if err != nil {
+		err = fmt.Errorf("failed to find best package node for implicit node (%s):\n%w", implicitNode.FriendlyName(), err)
+		return
+	}
+	if len(matches) > 0 {
+		return
+	}
+
+	matches = findBuildNodesByPath(implicitNode.RpmPath, pkgGraph, matchVersion)
+	if len(matches) > 0 {
+		return
+	}
+
+	matches, err = findBuildNodesByGraph(implicitNode, pkgGraph, stripVersion)
+	if err != nil {
+		err = fmt.Errorf("failed to find best package node for implicit node (%s):\n%w", implicitNode.FriendlyName(), err)
+		return
+	}
+	if len(matches) > 0 {
+		return
+	}
+
+	// Exact match via RPM path
+	matches = findBuildNodesByPath(implicitNode.RpmPath, pkgGraph, stripVersion)
+	if len(matches) > 0 {
+		return
+	}
+
+	return
+}
+
+// findBuildNodesByGraph will try to find a build node that satisfies the implicit node by looking at the best package node. We don't want to search
+// for run nodes since those may pull in additional runtime dependencies we may not care about. Once the graph is optimized we will have an exhaustive
+// list of nodes and we can build any actual runtime dependencies we need at that point.
+func findBuildNodesByGraph(implicitNode *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph, stripVersion bool) (buildNodes []*pkggraph.PkgNode, err error) {
+	version := *implicitNode.VersionedPkg
+	if stripVersion {
+		version = pkgjson.PackageVer{
+			Name: implicitNode.VersionedPkg.Name,
+		}
+	}
+	lookup, err := pkgGraph.FindBestPkgNode(&version)
+	if err != nil {
+		err = fmt.Errorf("failed to find best package node for implicit node (%s):\n%w", implicitNode.FriendlyName(), err)
+		return
+	}
+	if lookup != nil && lookup.BuildNode != nil {
+		buildNodes = []*pkggraph.PkgNode{lookup.BuildNode}
+	}
+	return
+}
+
+// findBuildNodesByPath will try to find a build node that satisfies the implicit node by looking at the RPM path. This is a best-effort
+// approach that will try to find a build node that has the same RPM path as the implicit node.
+func findBuildNodesByPath(rpmPath string, pkgGraph *pkggraph.PkgGraph, stripVersion bool) (buildNodes []*pkggraph.PkgNode) {
+	buildNodes = make([]*pkggraph.PkgNode, 0)
+	implicitRPMBaseName := filepath.Base(rpmPath)
+
+	if stripVersion {
+		implicitRPMBaseName = rpm.ExtractNameFromRPMPath(implicitRPMBaseName)
+	}
+
+	for _, node := range pkgGraph.AllBuildNodes() {
+		graphNodeRPMBaseName := filepath.Base(node.RpmPath)
+		if stripVersion {
+			graphNodeRPMBaseName = rpm.ExtractNameFromRPMPath(graphNodeRPMBaseName)
+		}
+		if implicitRPMBaseName == graphNodeRPMBaseName {
+			buildNodes = append(buildNodes, node)
+			break
+		}
+	}
+	return
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add a priority based build queue such that implicit provides are resolved without wasted work.

The goal is to avoid building packages that aren't required for a given goal. Currently if the subgraph rooted at our goal (say the list of all packages that need to be built for an image config) contains a dynamic dependency (looks like `something(name)` or `/path/to/file/`) the scheduler can't optimize the build.

The scheduler will attempt to take the full graph that contains all packages defined locally, and prune to just the required subgraph. It does this every time it gets a build result back, until the graph is successfully optimized. The optimization will fail if we have a dynamic/implicit dependency. We can't optimize since we don't konw what package will actually end up supplying that dependncy, they generally won't have an explicit `Provides: /path/to/file` in the `.spec` which would allow the graph to encode that information. Instead, we have to wait until a package build is complete to scan the resulting `.rpm` to see if it provides anything extra beyond what the `.spec` claims.

In the current version, if the graph cannot be optimized the scheduler will affectively a random walk through the graph, operating on each leaf node it finds.  When a package is built it is "removed" from the graph (actually just marked as done) and new "leaf" nodes may be exposed. Each time a package is built, the rpms are scanned and the graph updated to remove any implicit nodes that are now satisfied. Once all implicit nodes are removed from the subgraph under the goal, the graph is pruned of all the non-essential nodes and the build is optimized.

Instead, we should try to prioritize reaching the nodes that provide the implicit dependencies. As above, it isn't possible to know with 100% confidence that a given package will still provide a given implicit dependency, but there is some information that can provide a decent guess.

When the package fetcher runs to populate the graph, it assumes that each implicit dependency may not be found in the local packages and queries the repo for a provider (99% of the time, we get the same package back as we have locally +- some version differences). It places this package into the cache as a backup incase the local packages can't provide the dependency. The scheduler has a global mode that tries to build as much as possible without using these cached copies. Only if the scheduler gets completely stuck will it enable the cached implicit nodes.

We can use this information to make an educated guess which nodes will end up providing the implicit dependency. Say we have `my-pkg-1.1.1-1` published on PMC, and `my-pkg-1.1.1-2` as a `.spec` file locally. We have another package `goal-pkg-1-1` that has the line `BuildRequires: /path/to/my-pkg/some-file`.  If we look at the `%files` section of `my-pkg` we might see:
```spec
%files
/path/to/%{name}/*
```
Clearly we won't know what files are available in `/path/to/my-pkg` until after we build the `.rpm`... But if we look at the cache we will see an implicit remote node pointing to `my-pkg-1.1.1-1` from PMC. So, if we assume nothing has changed, we can look at the remote node and guess that since we can get that file from `my-pkg-1.1.1-1`, we can probably expect it from `1.1.1-2` as well.

To this end, we can have three levels of priority for the scheduler:
- High: put `my-pkg` here. Check it as fast as possible so we can see if the implicit dependnecy is resolved or not. If it is, we can optimize the graph.
- Medium: put `goal-pkg` here. We know anything else under this subgraph will be required for the end goal and we always want to build it.
- Low: Everything else. We ideally don't want to build anything here, but in the case where the implicit dependencies aren't found based on our guess we need to fall back to the old mechanism (random builds)

An added complexity: The scheduler will queue all packages into the build channels in a greedy fashion. We need a mechanism to ignore the low priority channels, or avoid queuing low priority packages, until such time as we get stuck and failed to optimize.

Some test results:
```
# Prep build to remove variability from network
sudo make clean-build-packages &&  sudo make graph-preprocessed input-srpms go-tools  PRECACHE=y CONFIG_FILE=./imageconfigs/core-efi.json
# Build images needed for core-efi.json
time sudo make build-packages PRECACHE=y CONFIG_FILE=./imageconfigs/core-efi.json 2>&1 | tee log.txt
```
| Mode | Wall Time | Total packages built | Wasted builds |
|--------|------------|-----------------------|-----------------|
| New    | 57m (1hr) | 109                          |0                       |
| Old     | 144m (2.3hr) | 477                      | 368                  |

**tldr: We wasted over an hour building packages we ended up not using in the old flow.**

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
