### PR TITLE
Fix CVE 2023 5528 by upgrading kubernetes to version 1.28.4

### DIFF
--- a/SPECS/kubernetes/kubernetes.signatures.json
+++ b/SPECS/kubernetes/kubernetes.signatures.json
@@ -1,6 +1,6 @@
 {
-  "Signatures": {
-    "kubelet.service": "3be41509e18552113367252397cbd7a28e2c481de04ec54f09e232ffabda16d2",
-    "kubernetes-v1.28.3.tar.gz": "a6b7f6942c9d629b97c702a47c1bdf1140adf5c849aff288555a85e4c8a70cab"
-  }
+ "Signatures": {
+  "kubelet.service": "3be41509e18552113367252397cbd7a28e2c481de04ec54f09e232ffabda16d2",
+  "kubernetes-v1.28.4.tar.gz": "d3fc96eb011e8f1c89674ed0619cd0c2f0e679165477df3db3a57070fcd5df05"
+ }
 }

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -9,8 +9,8 @@
 %define container_image_components 'kube-proxy kube-apiserver kube-controller-manager kube-scheduler'
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
-Version:        1.28.3
-Release:        2%{?dist}
+Version:        1.28.4
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -263,6 +263,9 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Tue Nov 21 2023 Bala <bkannan@microsoft.com> - 1.28.3-1
+- Upgrade to 1.28.4 to fix CVE-2023-5528
+
 * Fri Nov 10 2023 Muhammad Falak <mwani@microsoft.com> - 1.28.3-2
 - Fix version subcommand for components
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8381,8 +8381,8 @@
         "type": "other",
         "other": {
           "name": "kubernetes",
-          "version": "1.28.3",
-          "downloadUrl": "https://dl.k8s.io/v1.28.3/kubernetes-src.tar.gz"
+          "version": "1.28.4",
+          "downloadUrl": "https://dl.k8s.io/v1.28.4#/kubernetes-src.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8382,7 +8382,7 @@
         "other": {
           "name": "kubernetes",
           "version": "1.28.4",
-          "downloadUrl": "https://dl.k8s.io/v1.28.4#/kubernetes-src.tar.gz"
+          "downloadUrl": "https://dl.k8s.io/v1.28.4/kubernetes-src.tar.gz#/kubernetes-v1.28.4.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8382,7 +8382,7 @@
         "other": {
           "name": "kubernetes",
           "version": "1.28.4",
-          "downloadUrl": "https://dl.k8s.io/v1.28.4/kubernetes-src.tar.gz#/kubernetes-v1.28.4.tar.gz"
+          "downloadUrl": "https://dl.k8s.io/v1.28.4/kubernetes-src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE 2023 5528 by upgrading kubernetes to version 1.28.4

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Fix CVE 2023 5528 by upgrading kubernetes to version 1.28.4

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-5528

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Pipeline build id: [456367](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=456367&view=results)
