### PR TITLE
NewToolchain 002: Filter toolchain srpms to local .specs only

### DIFF
--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -16,7 +16,6 @@ SRPM_FILE_SIGNATURE_HANDLING ?= enforce
 SRPM_BUILD_CHROOT_DIR = $(BUILD_DIR)/SRPM_packaging
 SRPM_BUILD_LOGS_DIR = $(LOGS_DIR)/pkggen/srpms
 
-toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
 srpm_pack_list_file = $(BUILD_SRPMS_DIR)/pack_list.txt
 
 # Configure the list of packages we want to process into SRPMs
@@ -109,7 +108,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		--timestamp-file=$(TIMESTAMP_DIR)/srpm_packer.jsonl && \
 	touch $@
 
-$(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_list) $(go-srpmpacker)
+$(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_buildable_list) $(go-srpmpacker)
 	GODEBUG=netdns=go $(go-srpmpacker) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \
@@ -120,7 +119,7 @@ $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_list) $(go-srpm
 		--tls-key=$(TLS_KEY) \
 		--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
-		--pack-list=$(toolchain_spec_list) \
+		--pack-list=$(toolchain_spec_buildable_list) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/toolchain/srpms/toolchain_srpmpacker.log \
 		--log-level=$(LOG_LEVEL) \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -22,6 +22,7 @@ populated_toolchain_chroot = $(toolchain_build_dir)/populated_toolchain
 toolchain_sources_dir = $(populated_toolchain_chroot)/usr/src/mariner/SOURCES
 populated_toolchain_rpms = $(populated_toolchain_chroot)/usr/src/mariner/RPMS
 toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
+toolchain_spec_buildable_list = $(toolchain_build_dir)/toolchain_specs_buildable.txt
 toolchain_actual_contents = $(toolchain_build_dir)/actual_archive_contents.txt
 toolchain_expected_contents = $(toolchain_build_dir)/expected_archive_contents.txt
 raw_toolchain = $(toolchain_build_dir)/toolchain_from_container.tar.gz
@@ -116,11 +117,20 @@ check-x86_64-manifests: $(toolchain_spec_list)
 			x86_64
 
 # Generate a list of a specs built as part of the toolchain.
-$(toolchain_spec_list): $(toolchain_files)
+$(toolchain_spec_list): $(toolchain_files) $(SCRIPTS_DIR)/toolchain/list_toolchain_specs.sh
 	cd $(SCRIPTS_DIR)/toolchain && \
 		./list_toolchain_specs.sh \
 			$(SCRIPTS_DIR)/toolchain/build_official_toolchain_rpms.sh \
+			$(SPECS_DIR) \
 			$(toolchain_spec_list)
+
+$(toolchain_spec_buildable_list): $(toolchain_files) $(SCRIPTS_DIR)/toolchain/list_toolchain_specs.sh
+	cd $(SCRIPTS_DIR)/toolchain && \
+		./list_toolchain_specs.sh \
+			$(SCRIPTS_DIR)/toolchain/build_official_toolchain_rpms.sh \
+			$(SPECS_DIR) \
+			$(toolchain_spec_buildable_list) \
+			--filter-buildable
 
 # To save toolchain artifacts use compress-toolchain and cache the tarballs
 # To restore toolchain artifacts use hydrate-toolchain and give the location of the tarballs on the command-line

--- a/toolkit/scripts/toolchain/list_toolchain_specs.sh
+++ b/toolkit/scripts/toolchain/list_toolchain_specs.sh
@@ -3,7 +3,13 @@
 set -e
 
 TOOLCHAIN_BUILD_FILE=$1
-OUTPUT_FILE=$2
+SPECS_DIR=$2
+OUTPUT_FILE=$3
+# --filter-buildable is used to filter out specs that are not built in the toolchain build
+DO_FILTER=false
+if [[ "$4" == "--filter-buildable" ]]; then
+    DO_FILTER=true
+fi
 
 # Extract the specs built from toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
 # Each spec that is built will be on its own line in the following formats:
@@ -14,7 +20,23 @@ OUTPUT_FILE=$2
 # In both cases, the first entry is the actual spec name to extract.
 # The below sed command will extract every spec name that follows the above pattern and place it in $OUTPUT_FILE.
 # `sort -u` is for eliminating duplicates- we don't actually care about the order
-sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' $TOOLCHAIN_BUILD_FILE | sort -u > $OUTPUT_FILE
+sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' $TOOLCHAIN_BUILD_FILE | sort -u > "${OUTPUT_FILE}.tmp"
 
 # Special case to add msopenjdk-11 RPM which is downloaded instead of built
-echo "msopenjdk-11" >> $OUTPUT_FILE
+echo "msopenjdk-11" >> "${OUTPUT_FILE}.tmp"
+
+# Only filter if the --filter-buildable flag is passed in
+if [[ "$DO_FILTER" == "true" ]]; then
+    # Only write to the list if the .spec file is available locally
+    rm -f $OUTPUT_FILE
+    while read -r spec; do
+        # Need to use find, since subdir might be different
+        if [[ -n $(find $SPECS_DIR -name "${spec}.spec") ]] ; then
+            echo $spec >> $OUTPUT_FILE
+        fi
+    done < "${OUTPUT_FILE}.tmp"
+else
+    mv "${OUTPUT_FILE}.tmp" $OUTPUT_FILE
+fi
+
+rm -f "${OUTPUT_FILE}.tmp"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Part of https://github.com/microsoft/CBL-Mariner/pull/6892, related to https://github.com/microsoft/CBL-Mariner/issues/6788

This is part of a series of PRs for the new toolchain prototype. Some PRs are fundamental bug fixes for 2.0, some are new features better targeted at 3.0, and some are early prototypes/RFCs.

##### Destination
2.0 - Maybe
3.0 - Yes
RFC - 

##### Specific PR summary:
Ideally the toolchain should be able to function in an environment where only some (or none) of the toolchain .spec files are defined. It should be able to mix/match local with versions from the upstream repos. Filter the list of toolchain rpms we want to build to those we have defined locally.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Pass toolchain packing list through optional filter mode of `list_toochain_specs.sh`
- Remove unused copy of `toolchain_spec_list` in  `srpm_pack.mk`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/issues/6788

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Full tests TBD
