### PR TITLE
NewToolchain 003: Define a user to own directories we create in make

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -11,6 +11,10 @@
 toolkit_root := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 SCRIPTS_DIR  ?= $(toolkit_root)/scripts
 
+# If SUDO_USER is set, grab that, otherwise grab USER
+MARINER_BUILDER_USER := $(if $(SUDO_USER),$(SUDO_USER),$(USER))
+export MARINER_BUILDER_USER
+
 # Build targets
 ##help:var:CONFIG_FILE:<config_path>=Path to image configuration file to use. Will add package dependencies and define final image generated.
 CONFIG_FILE             ?=

--- a/toolkit/scripts/makedirs.sh
+++ b/toolkit/scripts/makedirs.sh
@@ -11,28 +11,6 @@
 DIR="${1}"
 USER="${2}"
 
-function make_dir_recursive {
-    local dir="${1}"
-    local user="${2}"
-    local parent_dir
-    parent_dir="$(dirname "${dir}")"
-
-    # If the parent directory also needs to be created, recurse
-    if [[ ! -d "${parent_dir}" ]]; then
-        make_dir_recursive "${parent_dir}" "${user}" || { echo "Failed to recursively create '${parent_dir}'" ; return 1 ; }
-    fi
-
-    if [[ -d "${dir}" ]]; then
-        return 0
-    fi
-
-    mkdir -p "${dir}" || { echo "Failed to create '${dir}'" ; return 1 ; }
-    chown "${user}" "${dir}" || { echo "Failed to chown '${dir}' to user '${user}'" ; return 1 ; }
-    touch -d @0 "${dir}" || { echo "Failed to reset timestamp on '${dir}'" ; return 1 ; }
-
-    return 0
-}
-
 if [[ -z "${DIR}" ]] || [[ -z "${USER}" ]]; then
     echo "mkdirs.sh: No directory or user specified (input: DIR: '${DIR}', USER: '${USER}')"
     exit 1
@@ -42,5 +20,5 @@ if [[ -d "${DIR}" ]]; then
     # Directory already exists, no need to do anything
     exit 0
 else
-    make_dir_recursive "${DIR}" "${USER}" || { echo "Failed to create '${DIR}'" ; exit 1 ; }
+    runuser -u "${USER}" -- mkdir -p "${DIR}" || { echo "Failed to create '${DIR}'" ; exit 1 ; }
 fi

--- a/toolkit/scripts/makedirs.sh
+++ b/toolkit/scripts/makedirs.sh
@@ -9,10 +9,10 @@
 # New directories will be created with timestamp 0.
 
 DIR="${1}"
-USER="${2}"
+MARINER_USER="${2}"
 
-if [[ -z "${DIR}" ]] || [[ -z "${USER}" ]]; then
-    echo "mkdirs.sh: No directory or user specified (input: DIR: '${DIR}', USER: '${USER}')"
+if [[ -z "${DIR}" ]] || [[ -z "${MARINER_USER}" ]]; then
+    echo "mkdirs.sh: No directory or user specified (input: DIR: '${DIR}', USER: '${MARINER_USER}')"
     exit 1
 fi
 
@@ -20,5 +20,15 @@ if [[ -d "${DIR}" ]]; then
     # Directory already exists, no need to do anything
     exit 0
 else
-    runuser -u "${USER}" -- mkdir -p "${DIR}" || { echo "Failed to create '${DIR}'" ; exit 1 ; }
+    if [[ "${USER}" == "root" ]]; then
+        # If the current user is root, use runuser to create the directory as the specified user
+        runuser -u "${MARINER_USER}" -- mkdir -p "${DIR}" || { echo "Failed to create '${DIR}'" ; exit 1 ; }
+    elif [[ "${MARINER_USER}" == "${USER}" ]]; then
+        # Otherwise check if the user is the same as the current user, and create the directory as the current user
+        mkdir -p "${DIR}" || { echo "Failed to create '${DIR}'" ; exit 1 ; }
+    else
+        # Otherwise, the user is not the current user, and not root, so we cannot create the directory
+        echo "mkdirs.sh: Mariner build user '${MARINER_USER}' is not the current user '${USER}', and not running with sudo, cannot create '${DIR}'"
+        exit 1
+    fi
 fi

--- a/toolkit/scripts/makedirs.sh
+++ b/toolkit/scripts/makedirs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Usage: /path/to/dirs/to/make owner_user_name
+
+# Will recursively create all directories in the path, and chown them to the specified user
+# If the directory already exists, it will be skipped and no changes will be made.
+# New directories will be created with timestamp 0.
+
+DIR="${1}"
+USER="${2}"
+
+function make_dir_recursive {
+    local dir="${1}"
+    local user="${2}"
+    local parent_dir
+    parent_dir="$(dirname "${dir}")"
+
+    # If the parent directory also needs to be created, recurse
+    if [[ ! -d "${parent_dir}" ]]; then
+        make_dir_recursive "${parent_dir}" "${user}" || { echo "Failed to recursively create '${parent_dir}'" ; return 1 ; }
+    fi
+
+    if [[ -d "${dir}" ]]; then
+        return 0
+    fi
+
+    mkdir -p "${dir}" || { echo "Failed to create '${dir}'" ; return 1 ; }
+    chown "${user}" "${dir}" || { echo "Failed to chown '${dir}' to user '${user}'" ; return 1 ; }
+    touch -d @0 "${dir}" || { echo "Failed to reset timestamp on '${dir}'" ; return 1 ; }
+
+    return 0
+}
+
+if [[ -z "${DIR}" ]] || [[ -z "${USER}" ]]; then
+    echo "mkdirs.sh: No directory or user specified (input: DIR: '${DIR}', USER: '${USER}')"
+    exit 1
+fi
+
+if [[ -d "${DIR}" ]]; then
+    # Directory already exists, no need to do anything
+    exit 0
+else
+    make_dir_recursive "${DIR}" "${USER}" || { echo "Failed to create '${DIR}'" ; exit 1 ; }
+fi

--- a/toolkit/scripts/precache.mk
+++ b/toolkit/scripts/precache.mk
@@ -13,7 +13,6 @@ precache_chroot_dir = $(precache_state_dir)/chroot
 precache_logs_path = $(LOGS_DIR)/precache/precache.log
 
 $(call create_folder,$(precache_state_dir))
-$(call create_folder,$(remote_rpms_cache_dir))
 
 clean-cache: clean-precache
 clean: clean-precache

--- a/toolkit/scripts/toolkit.mk
+++ b/toolkit/scripts/toolkit.mk
@@ -42,8 +42,8 @@ toolkit_rpms_snapshot_file_relative_path = $(toolkit_rpms_snapshot_file:$(toolki
 toolkit_repos_dir = $(toolkit_prep_dir)/repos
 toolkit_tools_dir = $(toolkit_prep_dir)/tools/toolkit_bins
 
-$(call create_folder,"$(rpms_snapshot_build_dir)")
-$(call create_folder,"$(toolkit_prep_dir)")
+$(call create_folder,$(rpms_snapshot_build_dir))
+$(call create_folder,$(toolkit_prep_dir))
 
 # Outputs
 toolkit_archive_versioned_compressed   = $(OUT_DIR)/toolkit-$(toolkit_version).tar.gz

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -127,12 +127,12 @@ $(BUILD_DIR)/tools/internal.test_coverage: $(go_internal_files) $(go_imagegen_fi
 # downloaded the dependencies as root. The go build command will download the dependencies if they are missing (but as root).
 $(STATUS_FLAGS_DIR)/got_go_deps.flag:
 	@cd $(TOOLS_DIR)/ && \
-		if [ -z "$$SUDO_USER" ]; then \
-			echo "SUDO_USER is not set, running 'go get' as user '$$USER'"; \
+		if [ -z "$(MARINER_BUILDER_USER)" ]; then \
+			echo "MARINER_BUILDER_USER is not set, running 'go get' as user '$$USER'"; \
 			go get -d ./... || echo "Failed to run 'go get', falling back to 'go build' to pull modules" ; \
 		else \
-			echo "SUDO_USER is set, running 'go get' as user '$$SUDO_USER'"; \
-			sudo -u $$SUDO_USER go get -d ./... || echo "Failed to run 'go get', falling back to 'go build' to pull modules" ; \
+			echo "MARINER_BUILDER_USER is set, running 'go get' as user '$(MARINER_BUILDER_USER)'"; \
+			sudo -u $(MARINER_BUILDER_USER) go get -d ./... || echo "Failed to run 'go get', falling back to 'go build' to pull modules" ; \
 		fi && \
 		touch $@
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Part of https://github.com/microsoft/CBL-Mariner/pull/6892, related to https://github.com/microsoft/CBL-Mariner/issues/6788

This is part of a series of PRs for the new toolchain prototype. Some PRs are fundamental bug fixes for 2.0, some are new features better targeted at 3.0, and some are early prototypes/RFCs.

##### Destination
2.0 - Maybe
3.0 - Yes
RFC - 

##### Specific PR summary:
The calling user should probably own at least some of the files the tools generate. Lets start by defining the ideal owner, and making the directories we create be owned by that user.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Environment variable `MARINER_BUILDER_USER` will be set to either `$SUDO_USER` if defined, or the current `$USER` otherwise.
- Create `makedirs.sh` to replace the existing `create_folder` define in Make. The script will be called instead and may now report an error back if it fails.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/issues/6788

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Full tests TBD
