### PR TITLE
NewToolchain 005: Give logs to calling user

### DIFF
--- a/toolkit/tools/internal/logger/log.go
+++ b/toolkit/tools/internal/logger/log.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/marinertoolusers"
 	"github.com/sirupsen/logrus"
 )
 
@@ -63,6 +64,11 @@ func initLogFile(filePath string) (err error) {
 	}
 
 	file, err := os.Create(filePath)
+	if err != nil {
+		return
+	}
+
+	err = marinertoolusers.GiveSinglePathToUser(filePath, marinertoolusers.GetMarinerBuildUser())
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/internal/marinertoolusers/marinertoolsusers_test.go
+++ b/toolkit/tools/internal/marinertoolusers/marinertoolsusers_test.go
@@ -1,0 +1,354 @@
+package marinertoolusers
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+// Mariner builder user environment variable may be set or not, so we need to handle both cases
+// in all tests. Assume the user is not set, and if it is, save the current value and restore it
+
+var (
+	oldEnvValue string
+)
+
+// Skips tests if we don't have two users we can test with (we generally will be running as sudo, so we should have
+// 'root', 'nobody' and '$SUDO_USER' available)
+func checkIfTestUsersAvailable(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Fatal("Need a second user to transfer files, skipping since we aren't root and can't pretend to be other users")
+	}
+	sudoUser, err := getCurrentUserHelper(t)
+	if err != nil {
+		t.Fatalf("Failed to get current user: %v", err)
+	}
+	if sudoUser.Uid == "0" {
+		t.Fatal("Need a second user to transfer files, skipping since we are ACTUALLY root instead of using sudo")
+	}
+
+	_, err = getNobodyUserHelper(t)
+	if err != nil {
+		t.Fatalf("Failed to get nobody user: %v", err)
+	}
+}
+
+// Make sure that MARINER_BUILDER_USER is set to the current user (helps if running tests outside the makefile).
+// Will restore the environment variable to its original value after the test
+func prepEnv(t *testing.T, envName string) {
+	t.Helper()
+	t.Cleanup(func() {
+		t.Log("Cleaning up environment variable")
+		os.Setenv(envName, oldEnvValue)
+	})
+	oldEnvValue = os.Getenv(envName)
+	currentUser, err := getCurrentUserHelper(t)
+	if err != nil {
+		t.Fatalf("Failed to get current user: %v", err)
+	}
+	currentEnvName := currentUser.Username
+	os.Setenv(envName, currentEnvName)
+}
+
+func getCurrentUserHelper(t *testing.T) (currentUser *user.User, err error) {
+	t.Helper()
+	currentUser, err = user.Current()
+	if err != nil {
+		err = fmt.Errorf("unable to get current user:\n%w", err)
+		return
+	}
+	if currentUser == nil {
+		err = fmt.Errorf("unable to get current user")
+		return
+	}
+	// Try to find a non-root user if we are root
+	if currentUser.Uid == "0" {
+		// Check if we can pull SUDO_USER
+		sudoUser := os.Getenv("SUDO_USER")
+		if sudoUser != "" {
+			currentUser, err = user.Lookup(sudoUser)
+			if err != nil {
+				err = fmt.Errorf("unable to get current user:\n%w", err)
+				return
+			}
+		} else {
+			err = fmt.Errorf("unable to get current user")
+			return
+		}
+	}
+	return
+}
+
+func getNobodyUserHelper(t *testing.T) (nobodyUser *user.User, err error) {
+	t.Helper()
+	nobodyUser, err = user.Lookup("nobody")
+	if err != nil {
+		err = fmt.Errorf("unable to get nobody user:\n%w", err)
+		return
+	}
+	if nobodyUser == nil {
+		err = fmt.Errorf("unable to get nobody user")
+		return
+	}
+	return
+}
+
+func getIDsHelper(t *testing.T, user *user.User) (uid int, gid int) {
+	t.Helper()
+	if user == nil {
+		t.Fatalf("User is nil")
+	}
+	uid, err := strconv.Atoi(user.Uid)
+	if err != nil {
+		t.Fatalf("Failed to convert UID to int: %v", err)
+	}
+	gid, err = strconv.Atoi(user.Gid)
+	if err != nil {
+		t.Fatalf("Failed to convert GID to int: %v", err)
+	}
+	return
+}
+
+func getOwnerHelper(t *testing.T, file *os.File, info *fs.FileInfo) (uid int, gid int) {
+	// Sanity check that we set the ownership correctly
+	var err error
+	if info == nil {
+		if file == nil {
+			t.Fatalf("Both file and info are nil")
+		}
+		name := file.Name()
+		newInfo, err := os.Stat(name)
+		if err != nil {
+			t.Fatalf("Failed to stat file: %v", err)
+		}
+		info = &newInfo
+	}
+	stat, ok := (*info).Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("Failed to get syscall.Stat_t: %v", err)
+	}
+	uid = int(stat.Uid)
+	gid = int(stat.Gid)
+	return
+}
+
+func TestUnsetUser(t *testing.T) {
+	prepEnv(t, userEnvName)
+
+	// Override by unsetting the environment variable
+	os.Unsetenv(userEnvName)
+
+	user := GetMarinerBuildUser()
+	if user != nil {
+		t.Errorf("Expected nil user, but got %v", user)
+	}
+}
+
+func TestGetMarinerBuildUser(t *testing.T) {
+	prepEnv(t, userEnvName)
+
+	currentUser, err := getCurrentUserHelper(t)
+	if err != nil {
+		t.Fatalf("Failed to get current user: %v", err)
+	}
+
+	user := GetMarinerBuildUser()
+	if user == nil {
+		t.Errorf("Expected non-nil user, but got nil")
+	} else {
+		if user.Username != currentUser.Username {
+			t.Errorf("Expected username 'root', but got %s", user.Username)
+		}
+	}
+}
+
+func TestGiveSinglePathToUser(t *testing.T) {
+	prepEnv(t, userEnvName)
+	checkIfTestUsersAvailable(t)
+
+	// Create a temporary file
+	file, err := os.CreateTemp("", "testfile")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+
+	nobody, err := getNobodyUserHelper(t)
+	if err != nil {
+		t.Fatalf("Failed to get nobody user: %v", err)
+	}
+	nobodyUid, nobodyGid := getIDsHelper(t, nobody)
+
+	// Change ownership to nobody, we will change it back to the current user
+	err = os.Chown(file.Name(), nobodyUid, nobodyGid)
+	if err != nil {
+		t.Fatalf("Failed to change ownership to root: %v", err)
+	}
+
+	// Sanity check that we set the ownership correctly
+	actualUid, actualGid := getOwnerHelper(t, file, nil)
+	if actualUid != nobodyUid || actualGid != nobodyGid {
+		t.Fatalf("Expected ownership %s:%s, but got %d:%d", nobody.Uid, nobody.Gid, actualUid, actualGid)
+	}
+
+	// Change ownership to mariner builder user
+	user := GetMarinerBuildUser()
+	err = GiveSinglePathToUser(file.Name(), user)
+	if err != nil {
+		t.Fatalf("Failed to change ownership to mariner builder user: %v", err)
+	}
+
+	// Check ownership
+	actualUid, actualGid = getOwnerHelper(t, file, nil)
+	// User type uses strings for UID, GID
+	userUid, userGid := getIDsHelper(t, user)
+
+	if actualUid != userUid || actualGid != userGid {
+		t.Errorf("Expected ownership %s:%s, but got %d:%d", user.Uid, user.Gid, actualUid, actualGid)
+	}
+}
+
+func TestGiveDirToUserRecursive(t *testing.T) {
+	prepEnv(t, userEnvName)
+	checkIfTestUsersAvailable(t)
+
+	// Create a temporary directory
+	dir, err := os.MkdirTemp("", "testdir")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+
+	// Create a temporary file in the directory
+	file1, err := os.CreateTemp(dir, "testfile1")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+
+	// Create a temporary file in the directory
+	file2, err := os.CreateTemp(dir, "testfile2")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+
+	nobody, err := getNobodyUserHelper(t)
+	if err != nil {
+		t.Fatalf("Failed to get nobody user: %v", err)
+	}
+	nobodyUid, nobodyGid := getIDsHelper(t, nobody)
+
+	// Change ownership to nobody, we will change it back to the current user
+	err = os.Chown(dir, nobodyUid, nobodyGid)
+	if err != nil {
+		t.Fatalf("Failed to change ownership to nobody: %v", err)
+	}
+	err = os.Chown(file1.Name(), nobodyUid, nobodyGid)
+	if err != nil {
+		t.Fatalf("Failed to change ownership to nobody: %v", err)
+	}
+	err = os.Chown(file2.Name(), nobodyUid, nobodyGid)
+	if err != nil {
+		t.Fatalf("Failed to change ownership to nobody: %v", err)
+	}
+
+	// Sanity check that we set the ownership correctly
+	actualUid, actualGid := getOwnerHelper(t, file1, nil)
+	if actualUid != nobodyUid || actualGid != nobodyGid {
+		t.Fatalf("Expected ownership %s:%s, but got %d:%d", nobody.Uid, nobody.Gid, actualUid, actualGid)
+	}
+	// Sanity check that we set the ownership correctly
+	actualUid, actualGid = getOwnerHelper(t, file2, nil)
+	if actualUid != nobodyUid || actualGid != nobodyGid {
+		t.Fatalf("Expected ownership %s:%s, but got %d:%d", nobody.Uid, nobody.Gid, actualUid, actualGid)
+	}
+
+	// Change ownership to mariner builder user
+	user := GetMarinerBuildUser()
+	err = GiveDirToUserRecursive(dir, user)
+	if err != nil {
+		t.Fatalf("Failed to change ownership to mariner builder user: %v", err)
+	}
+
+	// User type uses strings for UID, GID
+	userUid, err := strconv.Atoi(user.Uid)
+	if err != nil {
+		t.Fatalf("Failed to convert UID to int: %v", err)
+	}
+	userGid, err := strconv.Atoi(user.Gid)
+	if err != nil {
+		t.Fatalf("Failed to convert GID to int: %v", err)
+	}
+
+	// Check ownership
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		actualUid, actualGid := getOwnerHelper(t, nil, &info)
+
+		if actualUid != userUid || actualGid != userGid {
+			t.Errorf("Expected ownership %s:%s, but got %d:%d", user.Uid, user.Gid, actualUid, actualGid)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk directory: %v", err)
+	}
+}
+
+func TestInvalidUserSingle(t *testing.T) {
+	prepEnv(t, userEnvName)
+
+	// Create a temporary file
+	file, err := os.CreateTemp("", "testfile")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+
+	// Change ownership to mariner builder user
+	user := &user.User{
+		Uid: "invalid",
+		Gid: "invalid",
+	}
+	err = GiveSinglePathToUser(file.Name(), user)
+	if err == nil {
+		t.Fatalf("Expected error, but got nil")
+	}
+}
+
+func TestInvalidUserDir(t *testing.T) {
+	prepEnv(t, userEnvName)
+
+	// Create a temporary directory
+	dir, err := os.MkdirTemp("", "testdir")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+
+	// Create a temporary file in the directory
+	_, err = os.CreateTemp(dir, "testfile1")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+
+	// Create a temporary file in the directory
+	_, err = os.CreateTemp(dir, "testfile2")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+
+	// Change ownership to mariner builder user
+	user := &user.User{
+		Uid: "invalid",
+		Gid: "invalid",
+	}
+	err = GiveDirToUserRecursive(dir, user)
+	if err == nil {
+		t.Fatalf("Expected error, but got nil")
+	}
+}

--- a/toolkit/tools/internal/marinertoolusers/marinertoolsusers_test.go
+++ b/toolkit/tools/internal/marinertoolusers/marinertoolsusers_test.go
@@ -56,6 +56,7 @@ func prepEnv(t *testing.T, envName string) {
 	os.Setenv(envName, currentEnvName)
 }
 
+// Get the current user we should test against. If we are root, try to get the user from SUDO_USER
 func getCurrentUserHelper(t *testing.T) (currentUser *user.User, err error) {
 	t.Helper()
 	currentUser, err = user.Current()
@@ -85,6 +86,7 @@ func getCurrentUserHelper(t *testing.T) (currentUser *user.User, err error) {
 	return
 }
 
+// Get the nobody user
 func getNobodyUserHelper(t *testing.T) (nobodyUser *user.User, err error) {
 	t.Helper()
 	nobodyUser, err = user.Lookup("nobody")
@@ -99,6 +101,7 @@ func getNobodyUserHelper(t *testing.T) (nobodyUser *user.User, err error) {
 	return
 }
 
+// Get the UID and GID from a user.User and convert them to ints
 func getIDsHelper(t *testing.T, user *user.User) (uid int, gid int) {
 	t.Helper()
 	if user == nil {
@@ -115,6 +118,7 @@ func getIDsHelper(t *testing.T, user *user.User) (uid int, gid int) {
 	return
 }
 
+// Find the owner of a file or directory and return the UID and GID
 func getOwnerHelper(t *testing.T, file *os.File, info *fs.FileInfo) (uid int, gid int) {
 	// Sanity check that we set the ownership correctly
 	var err error

--- a/toolkit/tools/internal/marinertoolusers/marinertoolusers.go
+++ b/toolkit/tools/internal/marinertoolusers/marinertoolusers.go
@@ -70,7 +70,7 @@ func GiveDirToUserRecursive(path string, user *user.User) (err error) {
 	return
 }
 
-// Get the mariner builder UID
+// convertUserUIDInt will convert a user.User UID to an int
 func convertUserUIDInt(user *user.User) (uid int, err error) {
 	if user == nil {
 		err = fmt.Errorf("user is nil")
@@ -83,7 +83,7 @@ func convertUserUIDInt(user *user.User) (uid int, err error) {
 	return
 }
 
-// Get the mariner builder GID
+// convertUserGIDInt will convert a user.User GID to an int
 func convertUserGIDInt(user *user.User) (gid int, err error) {
 	if user == nil {
 		err = fmt.Errorf("user is nil")

--- a/toolkit/tools/internal/marinertoolusers/marinertoolusers.go
+++ b/toolkit/tools/internal/marinertoolusers/marinertoolusers.go
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Defines functions for getting the mariner builder user, and changing ownership of files and directories to the user.
+// The file change functions are defined here since they are used in the logging package and will create circular dependencies
+// in the file package if defined there.
+package marinertoolusers
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+const userEnvName = "MARINER_BUILDER_USER"
+
+// GetMarinerBuildUser will return the mariner builder user if set, otherwise will return nil
+func GetMarinerBuildUser() (marinerBuilderUser *user.User) {
+	marinerBuilderUser = nil
+	userName := os.Getenv(userEnvName)
+	if userName != "" {
+		builderUser, err := user.Lookup(userName)
+		if err == nil {
+			marinerBuilderUser = builderUser
+		}
+	}
+	return
+}
+
+// GiveSinglePathToMarinerUser will change ownership of a file or directory to the calling user (MARINER_BUILDER_USER) instead of root, if
+// the user is set. Otherwise will do nothing.
+func GiveSinglePathToUser(path string, user *user.User) (err error) {
+	if user != nil {
+		var uid, gid int
+		uid, err = convertUserUIDInt(user)
+		if err != nil {
+			err = fmt.Errorf("unable to change ownership of path '%s':\n%w", path, err)
+			return
+		}
+		gid, err = convertUserGIDInt(user)
+		if err != nil {
+			err = fmt.Errorf("unable to change ownership of path '%s':\n%w", path, err)
+			return
+		}
+		err = os.Chown(path, uid, gid)
+		if err != nil {
+			err = fmt.Errorf("unable to change ownership of path '%s':\n%w", path, err)
+		}
+	}
+	return
+}
+
+// GiveDirToUserRecursive will change ownership of a directory to the calling user (MARINER_BUILDER_USER) instead of root, if
+// the user is set. Otherwise will do nothing.
+func GiveDirToUserRecursive(path string, user *user.User) (err error) {
+	// Walk the directory and change ownership of all files and directories
+	err = filepath.WalkDir(path, func(path string, info fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return GiveSinglePathToUser(path, user)
+	})
+
+	if err != nil {
+		err = fmt.Errorf("unable to recursively change ownership of directory '%s':\n%w", path, err)
+	}
+	return
+}
+
+// Get the mariner builder UID
+func convertUserUIDInt(user *user.User) (uid int, err error) {
+	if user == nil {
+		err = fmt.Errorf("user is nil")
+		return
+	}
+	uid, err = strconv.Atoi(user.Uid)
+	if err != nil {
+		err = fmt.Errorf("unable to convert UID to int:\n%w", err)
+	}
+	return
+}
+
+// Get the mariner builder GID
+func convertUserGIDInt(user *user.User) (gid int, err error) {
+	if user == nil {
+		err = fmt.Errorf("user is nil")
+		return
+	}
+	gid, err = strconv.Atoi(user.Gid)
+	if err != nil {
+		err = fmt.Errorf("unable to convert GID to int:\n%w", err)
+	}
+	return
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Part of https://github.com/microsoft/CBL-Mariner/pull/6892, related to https://github.com/microsoft/CBL-Mariner/issues/6788

This is part of a series of PRs for the new toolchain prototype. Some PRs are fundamental bug fixes for 2.0, some are new features better targeted at 3.0, and some are early prototypes/RFCs.

##### Destination
2.0 - Maybe
3.0 - Yes
RFC - Yes

##### Specific PR summary:
The caller owns the directories we make per #6963, the log files should also be owned by that user.

`GetMarinerBuildUser()` will load the environment variable `MARINER_BUILDER_USER` if it is set. That user may be passed to new functions that transfer ownership of files to that user. 

The log files are a fairly contained place to start, update the ownership when we create the file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `marinertoolusers.go` to manage the calling user
- Use this package in logger.go


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/issues/6788

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Full tests TBD
