### PR TITLE
NewToolchain 007: Harden shell terminate code, add ExecuteLiveWithCallbackInDirectory()

### DIFF
--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -479,7 +479,7 @@ func cleanupAllChroots() {
 	// Acquire and permanently hold the global inChrootMutex lock to ensure this application is not
 	// inside any Chroot.
 	logger.Log.Info("Waiting for outstanding chroot commands to finish")
-	shell.PermanentlyStopAllChildProcesses(stopSignal)
+	shell.PermanentlyStopAllChildProcesses(stopSignal, nil)
 	inChrootMutex.Lock()
 
 	// mount is only supported in regular pipeline

--- a/toolkit/tools/internal/shell/shell_test.go
+++ b/toolkit/tools/internal/shell/shell_test.go
@@ -1,0 +1,159 @@
+package shell
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	logger.InitStderrLog()
+	os.Exit(m.Run())
+}
+
+func resetState() {
+	activeCommandsMutex.Lock()
+	defer activeCommandsMutex.Unlock()
+	allowProcessCreation = true
+	for cmd := range activeCommands {
+		cmd.Process.Kill()
+	}
+	activeCommands = make(map[*exec.Cmd]bool)
+}
+
+// file package has a cyclic dependency on shell package, re-implement ReadLines here
+func readLinesHelper(t *testing.T, path string) (lines []string) {
+	t.Helper()
+	handle, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Failed to open file %s, error: %s", path, err)
+	}
+	defer handle.Close()
+
+	scanner := bufio.NewScanner(handle)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("Failed to read file %s, error: %s", path, err)
+	}
+
+	return lines
+}
+
+func TestPermanentlyStopAllChildProcesses(t *testing.T) {
+	tests := []struct {
+		name   string
+		signal syscall.Signal
+		script string
+	}{
+		{
+			name:   "SIGTERM",
+			signal: syscall.SIGTERM,
+			script: path.Join(".", "testdata", "will_exit.sh"),
+		},
+		{
+			name:   "SIGKILL",
+			signal: syscall.SIGKILL,
+			script: path.Join(".", "testdata", "will_exit.sh"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(resetState)
+			logger.Log.Warnf("Running test %s", tt.name)
+			// bash command that echos counting numbers to a temp file
+			tempFile := path.Join(t.TempDir(), "tempFile")
+			bashArgs := []string{t.Name(), tempFile}
+			cmd := exec.Command(tt.script, bashArgs...)
+
+			var trackError error = nil
+			go func() {
+				trackError = trackAndStartProcess(cmd)
+			}()
+
+			// Sleep for 2.2 seconds to allow the child process to start and write to the temp file
+			// It should write the name of the test and then the numbers 1,2,3 before being killed
+			time.Sleep(2200 * time.Millisecond)
+
+			// Call the function to stop all child processes
+			results := PermanentlyStopAllChildProcesses(tt.signal, nil)
+
+			// Get the exit code from  cmd
+			err := results[cmd]
+			logger.Log.Infof("Exit code: %v", err)
+			// Check if the child process was stopped by sending a signal
+			if err, ok := err.(*exec.ExitError); ok {
+				if status, ok := err.Sys().(syscall.WaitStatus); ok {
+					if !status.Signaled() || status.Signal() != tt.signal {
+						t.Errorf("Expected child process to be stopped with %s, but got signal: %v", tt.name, status.Signal())
+					}
+				}
+			}
+
+			// Check if the allowProcessCreation flag is set to false
+			if allowProcessCreation {
+				t.Error("Expected allowProcessCreation to be false, but it is true")
+			}
+
+			// Check if the trackAndStartProcess function returned an error
+			assert.NoError(t, trackError)
+
+			// Check if we wrote to the temp file as expected
+			expectedOutput := []string{t.Name(), "START", "MIDDLE"}
+			actualOutput := readLinesHelper(t, tempFile)
+			assert.Equal(t, expectedOutput, actualOutput)
+		})
+	}
+}
+
+func TestTimeoutAfterIgnoreSignal(t *testing.T) {
+	t.Cleanup(resetState)
+	// bash command that echos counting numbers to a temp file
+	script := path.Join(".", "testdata", "trap.sh")
+	tempFile := path.Join(t.TempDir(), "tempFile")
+	bashArgs := []string{t.Name(), tempFile}
+	cmd := exec.Command(script, bashArgs...)
+
+	var trackError error = nil
+	go func() {
+		trackError = trackAndStartProcess(cmd)
+	}()
+
+	// Timeout after 2.2 seconds.
+	delay := 200 * time.Millisecond
+	timeout := 2000 * time.Millisecond
+	// Give a bit of extra time for the child process to start and write to the file
+	time.Sleep(delay)
+	// Call the function to stop all child processes. Set timout to
+	results := PermanentlyStopAllChildProcesses(syscall.SIGTERM, &timeout)
+
+	// Get the exit code from  cmd
+	err := results[cmd]
+	logger.Log.Infof("Exit code: %v", err)
+
+	// We should see the timeout error wrapped here
+	assert.ErrorIs(t, err, ErrProcessTerminateTimeout)
+
+	// Check if the allowProcessCreation flag is set to false
+	if allowProcessCreation {
+		t.Error("Expected allowProcessCreation to be false, but it is true")
+	}
+
+	// Check if the trackAndStartProcess function returned an error
+	assert.NoError(t, trackError)
+
+	// Check if we wrote to the temp file as expected
+	expectedOutput := []string{t.Name(), "START", "MIDDLE"}
+	actualOutput := readLinesHelper(t, tempFile)
+	assert.Equal(t, expectedOutput, actualOutput)
+}

--- a/toolkit/tools/internal/shell/testdata/trap.sh
+++ b/toolkit/tools/internal/shell/testdata/trap.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# $1 name
+# $2 file to write to
+trap "echo trapped!" SIGTERM
+
+echo "$1" > "$2"
+echo "START"  >> "$2"
+sleep 1
+echo "MIDDLE"  >> "$2"
+sleep 6000
+echo "END"  >> "$2"

--- a/toolkit/tools/internal/shell/testdata/will_exit.sh
+++ b/toolkit/tools/internal/shell/testdata/will_exit.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# $1 name
+# $2 file to write to
+echo "$1" > "$2"
+echo "START"  >> "$2"
+sleep 1
+echo "MIDDLE"  >> "$2"
+sleep 10
+echo "END"  >> "$2"

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -236,7 +236,7 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmF
 	case err = <-results:
 	case <-time.After(timeout):
 		logger.Log.Errorf("Timeout after %v: killing all processes in chroot...", timeout)
-		shell.PermanentlyStopAllChildProcesses(unix.SIGKILL)
+		shell.PermanentlyStopAllChildProcesses(unix.SIGKILL, nil)
 		err = fmt.Errorf("build timed out after %s", timeout)
 	}
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -221,7 +221,7 @@ func cancelOutstandingBuilds(agent buildagents.BuildAgent) {
 	}
 
 	// Issue a SIGINT to all children processes to allow them to gracefully exit.
-	shell.PermanentlyStopAllChildProcesses(unix.SIGINT)
+	shell.PermanentlyStopAllChildProcesses(unix.SIGINT, nil)
 }
 
 // cancelBuildsOnSignal will stop any builds running on SIGINT/SIGTERM.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([ ]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Part of https://github.com/microsoft/CBL-Mariner/pull/6892, related to https://github.com/microsoft/CBL-Mariner/issues/6788

This is part of a series of PRs for the new toolchain prototype. Some PRs are fundamental bug fixes for 2.0, some are new features better targeted at 3.0, and some are early prototypes/RFCs.

##### Destination
2.0 - Maybe
3.0 - Yes
RFC - Maybe?

##### Specific PR summary:
The shell command termination code will sometimes get stuck. We should put a hard limit on how long we wait for a child process to exit. By default we will wait for 60 seconds for all commands to finish. If any take longer than that we will record them as 'failed' and exit regardless.

Also add a new function ExecuteLiveWithCallbackInDirectory() which will change the working directory of a shell command before running it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `ExecuteLiveWithCallbackInDirectory()`
- Add timeout to `PermanentlyStopAllChildProcesses()`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/issues/6788

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Full tests TBD
