### PR TITLE
NewToolchain 009: Add multi-file hash, file compare

### DIFF
--- a/toolkit/tools/internal/file/file_test.go
+++ b/toolkit/tools/internal/file/file_test.go
@@ -4,8 +4,12 @@
 package file
 
 import (
+	"encoding/hex"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
@@ -42,4 +46,241 @@ func TestRemoveFileDoesNotExist(t *testing.T) {
 	fileName := testFileName(t)
 	err := RemoveFileIfExists(fileName)
 	assert.NoError(t, err)
+}
+func TestCompareFileByteStreams(t *testing.T) {
+	type args struct {
+		in1 io.Reader
+		in2 io.Reader
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "Same content",
+			args: args{
+				in1: strings.NewReader("Hello, world!"),
+				in2: strings.NewReader("Hello, world!"),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Different content",
+			args: args{
+				in1: strings.NewReader("Hello, world!"),
+				in2: strings.NewReader("Goodbye, world!"),
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Error reading from input 1",
+			args: args{
+				in1: &errorReader{},
+				in2: strings.NewReader("Hello, world!"),
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Error reading from input 2",
+			args: args{
+				in1: strings.NewReader("Hello, world!"),
+				in2: &errorReader{},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Same input longer than buff size",
+			args: args{
+				in1: strings.NewReader(strings.Repeat("a", compareBufferSize*1.5)),
+				in2: strings.NewReader(strings.Repeat("a", compareBufferSize*1.5)),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Different input longer than buff size",
+			args: args{
+				in1: strings.NewReader(strings.Repeat("a", compareBufferSize*1.5)),
+				in2: strings.NewReader(strings.Repeat("a", (compareBufferSize*1.5)-1) + "b"),
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Input longer than buff size, one shorter",
+			args: args{
+				in1: strings.NewReader(strings.Repeat("a", compareBufferSize*1.5)),
+				in2: strings.NewReader(strings.Repeat("a", compareBufferSize*0.5)),
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Input longer than buff size, one shorter - reversed",
+			args: args{
+				in1: strings.NewReader(strings.Repeat("a", compareBufferSize*0.5)),
+				in2: strings.NewReader(strings.Repeat("a", compareBufferSize*1.5)),
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := compareFileByteStreams(tt.args.in1, tt.args.in2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("compareFileByteStreams() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("compareFileByteStreams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type errorReader struct{}
+
+func (er *errorReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("error reading from input")
+}
+
+func TestGenerateSHA1String(t *testing.T) {
+	// Create a temporary file with some content
+	tmpFilePath := testFileName(t)
+	tmpFile, err := os.Create(tmpFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpFile.Close()
+
+	content := "Hello, world!"
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate the SHA256 hash of the temporary file
+	hash, err := GenerateSHA1String(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the generated hash matches the expected hash
+	expectedHash := "943a702d06f34599aee1f8da8ef9f7296031d699"
+	if hash != expectedHash {
+		t.Errorf("Generated hash does not match the expected hash. Got: %s, Expected: %s", hash, expectedHash)
+	}
+}
+
+func TestGenerateSHA1StringInvalidPath(t *testing.T) {
+	// Generate the SHA256 hash of a non-existent file
+	_, err := GenerateSHA256String("/path/to/nonexistent/file")
+	if err == nil {
+		t.Error("Expected an error, but got nil")
+	}
+}
+
+func TestGenerateSHA256String(t *testing.T) {
+	// Create a temporary file with some content
+	tmpFilePath := testFileName(t)
+	tmpFile, err := os.Create(tmpFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpFile.Close()
+
+	content := "Hello, world!"
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate the SHA256 hash of the temporary file
+	hash, err := GenerateSHA256String(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the generated hash matches the expected hash
+	expectedHash := "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+	if hash != expectedHash {
+		t.Errorf("Generated hash does not match the expected hash. Got: %s, Expected: %s", hash, expectedHash)
+	}
+}
+
+func TestGenerateSHA256StringInvalidPath(t *testing.T) {
+	// Generate the SHA256 hash of a non-existent file
+	_, err := GenerateSHA256String("/path/to/nonexistent/file")
+	if err == nil {
+		t.Error("Expected an error, but got nil")
+	}
+}
+
+func TestSHA1MultipleFiles(t *testing.T) {
+	// Create a temporary file with some content
+	tempFileNames := []string{}
+	for i := 'a'; i <= 'c'; i++ {
+		tmpFilePath := testFileName(t) + string(i)
+		tempFileNames = append(tempFileNames, tmpFilePath)
+		tmpFile, err := os.Create(tmpFilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tmpFile.Close()
+
+		content := string(i)
+		if _, err := tmpFile.WriteString(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Generate the SHA256 hash of the temporary file
+	rawHash, err := CalculateSHA1Bytes(tempFileNames)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := hex.EncodeToString(rawHash)
+	// Verify that the generated hash matches the expected hash
+	expectedHash := "a9993e364706816aba3e25717850c26c9cd0d89d"
+	if hash != expectedHash {
+		t.Errorf("Generated hash does not match the expected hash. Got: %s, Expected: %s", hash, expectedHash)
+	}
+}
+
+func TestSHA256MultipleFiles(t *testing.T) {
+	// Create a temporary file with some content
+	tempFileNames := []string{}
+	for i := 'a'; i <= 'c'; i++ {
+		tmpFilePath := testFileName(t) + string(i)
+		tempFileNames = append(tempFileNames, tmpFilePath)
+		tmpFile, err := os.Create(tmpFilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tmpFile.Close()
+
+		content := string(i)
+		if _, err := tmpFile.WriteString(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Generate the SHA256 hash of the temporary file
+	rawHash, err := CalculateSHA256Bytes(tempFileNames)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := hex.EncodeToString(rawHash)
+	// Verify that the generated hash matches the expected hash
+	expectedHash := "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	if hash != expectedHash {
+		t.Errorf("Generated hash does not match the expected hash. Got: %s, Expected: %s", hash, expectedHash)
+	}
 }

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -1009,7 +1009,7 @@ func validateSignature(path string, srcConfig sourceRetrievalConfiguration, curr
 		return
 	}
 
-	newSignature, err := file.GenerateSHA256(path)
+	newSignature, err := file.GenerateSHA256String(path)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([ ]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Part of https://github.com/microsoft/CBL-Mariner/pull/6892, related to https://github.com/microsoft/CBL-Mariner/issues/6788

This is part of a series of PRs for the new toolchain prototype. Some PRs are fundamental bug fixes for 2.0, some are new features better targeted at 3.0, and some are early prototypes/RFCs.

##### Destination
2.0 - Maybe
3.0 - Yes
RFC - Yes

##### Specific PR summary:
Add `ContentsAreSame()` and `CalculateSHA<1|256>Bytes()` functions to `file.go`. Contents are same compare the bytes of two files and returns true if they are the same. The `CalcuateSHA*Bytes()` functions take a series of files and calculate a hash over the contents of all files. Refactor the existing sha functions to use these new functions.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `ContentsAreSame()`, `CalculateSHA1Bytes()`, and `CalculateSHA256Bytes()` to `file.go`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/issues/6788

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Full tests TBD
