### PR TITLE
NewToolchain 011: Give ownership to user for scheduler, roast

### DIFF
--- a/toolkit/tools/roast/roast.go
+++ b/toolkit/tools/roast/roast.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/marinertoolusers"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/timestamp"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/pkg/profile"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/roast/formats"
@@ -257,7 +258,12 @@ func artifactConverterWorker(convertRequests chan *convertRequest, convertedResu
 			if err != nil {
 				logger.Log.Errorf("Failed to move (%s) to (%s). Error: %s", workingArtifactPath, finalFile, err)
 			} else {
-				result.convertedFile = finalFile
+				err = marinertoolusers.GiveSinglePathToUser(finalFile, marinertoolusers.GetMarinerBuildUser())
+				if err != nil {
+					logger.Log.Errorf("Failed to change ownership of (%s) to mariner builder user. Error: %s", finalFile, err)
+				} else {
+					result.convertedFile = finalFile
+				}
 			}
 		}
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	ccachemanagerpkg "github.com/microsoft/CBL-Mariner/toolkit/tools/internal/ccachemanager"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/marinertoolusers"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
@@ -388,6 +389,12 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 			stopBuilding = true
 		}
 
+		err = setOwnershipOfBuildResult(res)
+		if err != nil {
+			err = fmt.Errorf("error setting ownership of build result:\n%w", err)
+			stopBuilding = true
+		}
+
 		if !stopBuilding {
 			if res.Err == nil {
 				if res.Node.Type == pkggraph.TypeLocalBuild && res.WasDelta {
@@ -481,6 +488,19 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 	schedulerutils.RecordBuildSummary(builtGraph, graphMutex, buildState, *outputCSVFile)
 	if !allowToolchainRebuilds && (len(buildState.ConflictingRPMs()) > 0 || len(buildState.ConflictingSRPMs()) > 0) {
 		err = fmt.Errorf("toolchain packages rebuilt. See build summary for details. Use 'ALLOW_TOOLCHAIN_REBUILDS=y' to suppress this error if rebuilds were expected")
+	}
+	return
+}
+
+// SetOwnershipOfBuildResult will change ownership of a file or directory to the calling user (MARINER_BUILDER_USER) instead of root, if
+// the user is set. Otherwise will do nothing.
+func setOwnershipOfBuildResult(res *schedulerutils.BuildResult) (err error) {
+	for _, file := range res.BuiltFiles {
+		err = marinertoolusers.GiveSinglePathToUser(file, marinertoolusers.GetMarinerBuildUser())
+		if err != nil {
+			err = fmt.Errorf("unable to change ownership of file '%s':\n%w", file, err)
+			return
+		}
 	}
 	return
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([ ]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Part of https://github.com/microsoft/CBL-Mariner/pull/6892, related to https://github.com/microsoft/CBL-Mariner/issues/6788

This is part of a series of PRs for the new toolchain prototype. Some PRs are fundamental bug fixes for 2.0, some are new features better targeted at 3.0, and some are early prototypes/RFCs.

##### Destination
2.0 - Maybe
3.0 - Yes
RFC - Yes

##### Specific PR summary:
Take the new user defined in https://github.com/microsoft/CBL-Mariner/pull/6965 and give ownership of files created by roast and scheduler to this user.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Give ownership of .rpm and image files to the calling user.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/issues/6788

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Full tests TBD
