### PR TITLE
test

### DIFF
--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -22,6 +22,7 @@ parameters:
         maxCPUs: "$(($(nproc) / 3))"
         rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64)"
         rawToolchainExpectedHash: "65de43b3bdcfdaac71df1f11fd1f830a8109b1eb9d7cb6cbc2e2d0e929d0ef76"
+        
 
 resources:
   repositories:
@@ -59,7 +60,17 @@ extends:
                 variables:
                   ob_artifactBaseName: $(toolchainArtifactNameBase)_${{ configuration.name }}
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
+                  - template: .pipelines/templates/NightlyRepoVariables.yml@templates
                 steps:
+                  - template: .pipelines/templates/NightlyRepoDefineRepoURL.yml@self
+                    parameters:
+                      architecture: ${{ configuration.name }}
+                      lkgFilePath: "$(lkgFilePath)"
+                      nightlyRepoBaseURL: "$(nightlyRepoBaseURL)"
+                      nightlyRepoMetadataDir: "$(nightlyRepoMetadataDir)"
+                      nightlyRepoLastKnownGoodFile: "$(nightlyRepoLastKnownGoodFile)"
+                      repoFileLocation: "$(repoFileLocation)"
+
                   - template: .pipelines/templates/RawToolchainDownload.yml@self
                     parameters:
                       rawToolchainCacheURL: ${{ configuration.rawToolchainCacheURL }}
@@ -67,6 +78,7 @@ extends:
 
                   - template: .pipelines/templates/ToolchainBuild.yml@self
                     parameters:
+                      nightlyRepoURL: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['construct-nightly-repo-url.nightlyRepoURL'] ] 
                       outputArtifactsFolder: $(ob_outputDirectory)
                       selfRepoName: self
 
@@ -97,10 +109,21 @@ extends:
                   ob_artifactBaseName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
+                  - template: .pipelines/templates/NightlyRepoVariables.yml@templates
                 steps:
+                  - template: .pipelines/templates/NightlyRepoDefineRepoURL.yml@self
+                    parameters:
+                      architecture: ${{ configuration.name }}
+                      lkgFilePath: "$(lkgFilePath)"
+                      nightlyRepoBaseURL: "$(nightlyRepoBaseURL)"
+                      nightlyRepoMetadataDir: "$(nightlyRepoMetadataDir)"
+                      nightlyRepoLastKnownGoodFile: "$(nightlyRepoLastKnownGoodFile)"
+                      repoFileLocation: "$(repoFileLocation)"
+                  
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
                       customToolchainArtifactName: $(toolchainArtifactNameBase)_${{ configuration.name }}
+                      extraPackageRepos: "$(repoFileLocation)"
                       isCheckBuild: true
                       isQuickRebuildPackages: true
                       outputArtifactsFolder: $(ob_outputDirectory)
@@ -129,3 +152,5 @@ extends:
                   - template: .pipelines/templatesWithCheckout/SodiffCheck.yml@self
                     parameters:
                       inputArtifactName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}
+
+          # If we expanded this to also build an image, we could begin to run all of our tests with these artifacts. (We'd want to enable the setting that only runs this pipeline when a teammate comments on the PR, so as to limit who and when these tests can run for.)

--- a/.pipelines/templates/NightlyRepoDefineRepoURL.yml
+++ b/.pipelines/templates/NightlyRepoDefineRepoURL.yml
@@ -1,0 +1,72 @@
+parameters:
+  - name: architecture
+    type: string
+  - name: lkgFilePath
+    type: string
+  - name: nightlyRepoBaseURL
+    type: string
+  - name: nightlyRepoMetadataDir
+    type: string
+  - name: nightlyRepoLastKnownGoodFile
+    type: string
+  - name: repoFileLocation
+    type: string
+
+steps:
+  - bash: |
+      architecture=$(echo "${{ parameters.architecture }}" | tr '[:upper:]' '[:lower:]')
+      LAST_KNOWN_GOOD_ENDPOINT="${{ parameters.nightlyRepoBaseURL }}${{ parameters.nightlyRepoMetadataDir }}${{ parameters.nightlyRepoLastKnownGoodFile }}"
+      if ! wget --quiet --timeout=30 --continue "$LAST_KNOWN_GOOD_ENDPOINT" -O "$lkgFilePath"; then
+          echo "-- ERROR: failed to download last known good metadata from the provided nightly package repository." >&2
+          exit 1
+      fi
+
+      # Construct Nightly Repo URL expects the lkgFilePath to be a json file with the following format:
+      #
+      # lkg.json:
+      # {
+      #   "amd64": "amd-container-name",
+      #   "arm64": "arm-container-name"
+      # }
+      
+      if [[ "${architecture}" == "arm64" ]]; then
+          lkg_container_name=$(jq -r '.arm64' "$lkgFilePath")
+      else
+          lkg_container_name=$(jq -r '.amd64' "$lkgFilePath")
+      fi
+
+      nightlyRepoURL="${{ parameters.nightlyRepoBaseURL }}${container_name}/"
+      
+
+      # Construct Nightly Repo URL expects the commit id to be in a json file with the following format:
+      #
+      # commit.json:
+      # {
+      #   "id": "commit-id"
+      # }
+      
+      if ! wget --quiet --timeout=30 --continue "${nightlyRepoURL}/repodata/commit.json" -O "$(Build.SourcesDirectory)/commit.json"; then
+          echo "-- ERROR: failed to download repo's commit id from the provided nightly package repository." >&2
+          exit 1
+      fi
+
+      commit_id=$(jq -r '.id' "$(Build.SourcesDirectory)/commit.json")
+
+      # Ensure the last known good commit is an ancestor of the current commit.
+      if ! git merge-base --is-ancestor $commit_id HEAD; then
+          echo "The last known good commit is not an ancestor of the current commit. Failing out... Confirm the following: this branch is a child of the nightly repo's source branch, the correct LKG file name parameter is set, and the correct nightly repo base url is set."
+          exit 1
+      fi
+
+      # Note: Repos secured by SAS tokens are not supported yet.
+      cat << EOF > "${{ parameters.repoFileLocation }}"
+      [nightly]
+      name=nightly
+      baseurl=${nightlyRepoURL}
+      enabled=1
+      gpgcheck=0
+      EOF
+
+      echo "##vso[task.setvariable isOutput=true,variable=nightlyRepoURL]${nightlyRepoURL}"
+    displayName: Construct Nightly Repo URL
+    name: construct-nightly-repo-url

--- a/.pipelines/templates/NightlyRepoVariables.yml
+++ b/.pipelines/templates/NightlyRepoVariables.yml
@@ -1,0 +1,28 @@
+
+variables:
+  - name: lkgFilePath
+    value: "$(Build.SourcesDirectory)/lkg.json"
+  - name: repoFileLocation
+    value: "$(Build.SourcesDirectory)/nightly.repo"
+
+
+  # NightlyRepo_{{targetbranch}} is a group variable that contains the following variables (with example values):
+  #   - name: nightlyRepoBaseURL
+  #     value: "https://testreposdou.blob.core.windows.net/20231220174055-preview-repo-local-test/"
+  #   - name: nightlyRepoMetadataDir
+  #     value: "lkg/"
+  #   - name: nightlyRepoLastKnownGoodFile
+  #     value: "lkg.json"
+  #
+  # NOTE: we expect the path values to have trailing '/' characters. This is because we use the values in the following way:
+  #   # The container_name variable in this example is set in the NightlyRepoDefineRepoURL.yml template and does not contain the trailing '/' because it is used outside of pathing.
+  #   "${{ parameters.nightlyRepoBaseURL }}${{ parameters.nightlyRepoMetadataDir }}${{ parameters.nightlyRepoLastKnownGoodFile }}"
+  #   "${{ parameters.nightlyRepoBaseURL }}${container_name}/"
+  #   "${{ parameters.nightlyRepoBaseURL }}${container_name}/repodata/commit.json"
+
+  ${{ if eq(variables.System.PullRequest.TargetBranch, "main")}}:
+    - group: NightlyRepo_main
+  ${{ elseif eq(variables.System.PullRequest.TargetBranch, "3.0") }}:
+    - group: NightlyRepo_3.0
+  ${{ else }}:
+    - group: NightlyRepo_main # For now, default to main... (Maybe we shouldn't default to something and instead fail the build?)

--- a/.pipelines/templates/ToolchainBuild.yml
+++ b/.pipelines/templates/ToolchainBuild.yml
@@ -22,13 +22,21 @@ parameters:
     type: string
     default: "CBL-Mariner"
 
+  - name: packageUrlList
+    type: string
+    default: ""
+
 steps:
   - template: ToolkitCheck.yml@${{ parameters.selfRepoName }}
     parameters:
       buildRepoRoot: ${{ parameters.buildRepoRoot }}
 
-  - bash: sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" "-j$(nproc)" toolchain QUICK_REBUILD=y
-    displayName: "Build toolchain"
+  ${{ if eq(parameters.packageUrlList, "") }}:
+    - bash: sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" "-j$(nproc)" toolchain QUICK_REBUILD=y
+      displayName: "Build toolchain (quick rebuild)"
+  ${{ else }}:
+    - bash: sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" "-j$(nproc)" toolchain PACKAGE_URL_LIST="${{ parameters.packageUrlList }}" INCREMENTAL_TOOLCHAIN=y ALLOW_TOOLCHAIN_DOWNLOAD_FAIL=y
+      displayName: "Build toolchain (nightly repo)"
 
   - bash: |
       failed_rpms_log="${{ parameters.buildRepoRoot }}/build/logs/toolchain/failures.txt"


### PR DESCRIPTION
DRAFT PR to prompt discussion

This PR introduces the `NightlyRepoDefineRepoURL.yml` job template and the `NightlyRepoVariables.yml` variable template and injects them into our package building PR-check pipeline. The goal of this change is to enable fast delta builds of incoming PRs so that we can use these artifacts shift left and begin testing/validation before a PR is merged.

This solution uses the metadata in a json file stored in the nightly repo storage account. This metadata is combined to compose the endpoint of the most recent Nightly package repository for `main` or for `3.0`. 

With this endpoint now in hand, we can rebuild the toolchain, any packages, and any images very quickly by leveraging the prebuilt nightly packages and only building packages that are net new since the last nightly build.

----------

Something I have been considering: Could we integrate these packages/images with the parallel test system?

_Because the package repo is created nightly, these builds will, at most, have to build the last 24 hours of changes._