### PR TITLE
CVE-2023-41051: Upgrade vm-memory from 0.12.0 0.12.2 as dependency of package virtiofsd

### DIFF
--- a/SPECS/virtiofsd/CVE-2023-41051.patch
+++ b/SPECS/virtiofsd/CVE-2023-41051.patch
@@ -1,0 +1,91 @@
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..53eaa21
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,2 @@
++/target
++**/*.rs.bk
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+new file mode 100644
+index 0000000..838c112
+--- /dev/null
++++ b/.gitlab-ci.yml
+@@ -0,0 +1,48 @@
++workflow:
++  rules:
++    - if: $CI_MERGE_REQUEST_ID            # Execute jobs in merge request context
++    - if: $CI_COMMIT_BRANCH == 'main'     # Execute jobs when a new commit is pushed to main branch
++
++image: "rust:alpine"
++
++clippy:
++  before_script:
++    - apk add musl-dev
++    - rustup component add clippy
++  script:
++    - cargo clippy --verbose -- -Dwarnings
++
++fmt:
++  before_script:
++    - rustup component add rustfmt
++  script:
++    - cargo fmt -v -- --check
++
++test:
++  before_script:
++    - apk add libcap-ng-static libseccomp-static musl-dev
++  script:
++    - rustc --version && cargo --version  # Print version info for debugging
++    - RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes' LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=/usr/lib LIBCAPNG_LINK_TYPE=static LIBCAPNG_LIB_PATH=/usr/lib cargo build --verbose --target x86_64-unknown-linux-musl
++    - RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes' LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=/usr/lib LIBCAPNG_LINK_TYPE=static LIBCAPNG_LIB_PATH=/usr/lib cargo test --verbose --target x86_64-unknown-linux-musl
++  except:
++      # There is an equivalent job ('publish') that will run when code lands
++      # on the 'main' branch, except it will upload a built binary. These are
++      # kept separate to avoid accidentally uploading binaries when it's not
++      # necessary.
++    - main@virtio-fs/virtiofsd
++
++# Build a statically linked and optimized binary for publishing.
++#
++# This only runs when code is merged to the 'main' branch.
++publish:
++  before_script:
++    - apk add libcap-ng-static libseccomp-static musl-dev
++  script:
++    - RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes' LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=/usr/lib LIBCAPNG_LINK_TYPE=static LIBCAPNG_LIB_PATH=/usr/lib cargo build --release --target x86_64-unknown-linux-musl
++  artifacts:
++    name: "virtiofsd-$CI_COMMIT_SHORT_SHA"
++    paths:
++      - target/x86_64-unknown-linux-musl/release/virtiofsd
++  only:
++    - main@virtio-fs/virtiofsd
+diff --git a/Cargo.lock b/Cargo.lock
+index c451ee0..05dc30f 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -652,9 +652,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "vm-memory"
+-version = "0.12.0"
++version = "0.12.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a77c7a0891cbac53618f5f6eec650ed1dc4f7e506bbe14877aff49d94b8408b0"
++checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
+ dependencies = [
+  "arc-swap",
+  "libc",
+diff --git a/Cargo.toml b/Cargo.toml
+index 12b2804..f593f16 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -23,7 +23,7 @@ clap = { version = "4", features = ["derive"] }
+ vhost-user-backend = "0.10.1"
+ vhost = "0.8.1"
+ virtio-bindings = { version = "0.2", features = ["virtio-v5_0_0"] }
+-vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
++vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic"] }
+ virtio-queue = "0.9.0"
+ vmm-sys-util = "0.11.1"
+ syslog = "6.0"

--- a/SPECS/virtiofsd/CVE-2023-41051.patch
+++ b/SPECS/virtiofsd/CVE-2023-41051.patch
@@ -1,81 +1,12 @@
-diff --git a/.gitignore b/.gitignore
-new file mode 100644
-index 0000000..53eaa21
---- /dev/null
-+++ b/.gitignore
-@@ -0,0 +1,2 @@
-+/target
-+**/*.rs.bk
-diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
-new file mode 100644
-index 0000000..838c112
---- /dev/null
-+++ b/.gitlab-ci.yml
-@@ -0,0 +1,48 @@
-+workflow:
-+  rules:
-+    - if: $CI_MERGE_REQUEST_ID            # Execute jobs in merge request context
-+    - if: $CI_COMMIT_BRANCH == 'main'     # Execute jobs when a new commit is pushed to main branch
-+
-+image: "rust:alpine"
-+
-+clippy:
-+  before_script:
-+    - apk add musl-dev
-+    - rustup component add clippy
-+  script:
-+    - cargo clippy --verbose -- -Dwarnings
-+
-+fmt:
-+  before_script:
-+    - rustup component add rustfmt
-+  script:
-+    - cargo fmt -v -- --check
-+
-+test:
-+  before_script:
-+    - apk add libcap-ng-static libseccomp-static musl-dev
-+  script:
-+    - rustc --version && cargo --version  # Print version info for debugging
-+    - RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes' LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=/usr/lib LIBCAPNG_LINK_TYPE=static LIBCAPNG_LIB_PATH=/usr/lib cargo build --verbose --target x86_64-unknown-linux-musl
-+    - RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes' LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=/usr/lib LIBCAPNG_LINK_TYPE=static LIBCAPNG_LIB_PATH=/usr/lib cargo test --verbose --target x86_64-unknown-linux-musl
-+  except:
-+      # There is an equivalent job ('publish') that will run when code lands
-+      # on the 'main' branch, except it will upload a built binary. These are
-+      # kept separate to avoid accidentally uploading binaries when it's not
-+      # necessary.
-+    - main@virtio-fs/virtiofsd
-+
-+# Build a statically linked and optimized binary for publishing.
-+#
-+# This only runs when code is merged to the 'main' branch.
-+publish:
-+  before_script:
-+    - apk add libcap-ng-static libseccomp-static musl-dev
-+  script:
-+    - RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes' LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=/usr/lib LIBCAPNG_LINK_TYPE=static LIBCAPNG_LIB_PATH=/usr/lib cargo build --release --target x86_64-unknown-linux-musl
-+  artifacts:
-+    name: "virtiofsd-$CI_COMMIT_SHORT_SHA"
-+    paths:
-+      - target/x86_64-unknown-linux-musl/release/virtiofsd
-+  only:
-+    - main@virtio-fs/virtiofsd
-diff --git a/Cargo.lock b/Cargo.lock
-index c451ee0..05dc30f 100644
---- a/Cargo.lock
-+++ b/Cargo.lock
-@@ -652,9 +652,9 @@ dependencies = [
- 
- [[package]]
- name = "vm-memory"
--version = "0.12.0"
-+version = "0.12.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a77c7a0891cbac53618f5f6eec650ed1dc4f7e506bbe14877aff49d94b8408b0"
-+checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
- dependencies = [
-  "arc-swap",
-  "libc",
+From 5a1c5a20ca066abeacba6fea1172e0dcd32eda7e Mon Sep 17 00:00:00 2001
+From: Nadiia Dubchak <ndubchak@microsoft.com>
+Date: Thu, 25 Jan 2024 16:37:34 -0800
+Subject: [PATCH] Bump vm-memory version to 0.12.2
+
+---
+ Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/Cargo.toml b/Cargo.toml
 index 12b2804..f593f16 100644
 --- a/Cargo.toml
@@ -89,3 +20,6 @@ index 12b2804..f593f16 100644
  virtio-queue = "0.9.0"
  vmm-sys-util = "0.11.1"
  syslog = "6.0"
+-- 
+2.34.1
+

--- a/SPECS/virtiofsd/virtiofsd.signatures.json
+++ b/SPECS/virtiofsd/virtiofsd.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "virtiofsd-v1.8.0.tar.gz": "35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b",
   "virtiofsd-v1.8.0-cargo.tar.gz": "47a1595ccee910ddb2f786469ac2601b5e5e114a42796072aa03bfe9f3706fd7",
-  "virtiofsd-v1.8.0-cargo-CVE-2023-41051.tar.gz": "3941e2e51ff9d962dc2983a97912449ea1dc934d56cfc01bf0d1431a85d71dbb",
+  "virtiofsd-v1.8.0-cargo-CVE-2023-41051-patch.tar.gz": "2e0b1d20142b995d8e77c14936e943b5a940f2080976c8f4cd9359b7414af095",
   "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b"
  }
 }

--- a/SPECS/virtiofsd/virtiofsd.signatures.json
+++ b/SPECS/virtiofsd/virtiofsd.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "virtiofsd-v1.8.0.tar.gz": "35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b",
   "virtiofsd-v1.8.0-cargo.tar.gz": "47a1595ccee910ddb2f786469ac2601b5e5e114a42796072aa03bfe9f3706fd7",
-  "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b",
   "virtiofsd-v1.8.0-cargo-CVE-2023-41051.tar.gz": "3941e2e51ff9d962dc2983a97912449ea1dc934d56cfc01bf0d1431a85d71dbb",
+  "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b",
  }
 }

--- a/SPECS/virtiofsd/virtiofsd.signatures.json
+++ b/SPECS/virtiofsd/virtiofsd.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "virtiofsd-v1.8.0.tar.gz": "35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b",
   "virtiofsd-v1.8.0-cargo.tar.gz": "47a1595ccee910ddb2f786469ac2601b5e5e114a42796072aa03bfe9f3706fd7",
-  "virtiofsd-v1.8.0-cargo-CVE-2023-41051-vendor.tar.gz": "a3f4094b0a1f856af31a237d336c7d8c9b839cb5eb6e264f4dae77c0104f32ef",
+  "virtiofsd-v1.8.0-cargo-vendor-CVE-2023-41051.tar.gz": "5bc81466a983ec54bdf276c57b38d4c3dead52d63493095c55aa1840f51576b7",
   "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b"
  }
 }

--- a/SPECS/virtiofsd/virtiofsd.signatures.json
+++ b/SPECS/virtiofsd/virtiofsd.signatures.json
@@ -1,8 +1,7 @@
 {
  "Signatures": {
   "virtiofsd-v1.8.0.tar.gz": "35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b",
-  "virtiofsd-v1.8.0-cargo.tar.gz": "47a1595ccee910ddb2f786469ac2601b5e5e114a42796072aa03bfe9f3706fd7",
-  "virtiofsd-v1.8.0-cargo-vendor-CVE-2023-41051.tar.gz": "5bc81466a983ec54bdf276c57b38d4c3dead52d63493095c55aa1840f51576b7",
+  "virtiofsd-v1.8.0-cargo-v2.tar.gz": "5bc81466a983ec54bdf276c57b38d4c3dead52d63493095c55aa1840f51576b7",
   "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b"
  }
 }

--- a/SPECS/virtiofsd/virtiofsd.signatures.json
+++ b/SPECS/virtiofsd/virtiofsd.signatures.json
@@ -2,6 +2,7 @@
  "Signatures": {
   "virtiofsd-v1.8.0.tar.gz": "35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b",
   "virtiofsd-v1.8.0-cargo.tar.gz": "47a1595ccee910ddb2f786469ac2601b5e5e114a42796072aa03bfe9f3706fd7",
-  "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b"
+  "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b",
+  "virtiofsd-v1.8.0-cargo-CVE-2023-41051.tar.gz": "3941e2e51ff9d962dc2983a97912449ea1dc934d56cfc01bf0d1431a85d71dbb",
  }
 }

--- a/SPECS/virtiofsd/virtiofsd.signatures.json
+++ b/SPECS/virtiofsd/virtiofsd.signatures.json
@@ -3,6 +3,6 @@
   "virtiofsd-v1.8.0.tar.gz": "35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b",
   "virtiofsd-v1.8.0-cargo.tar.gz": "47a1595ccee910ddb2f786469ac2601b5e5e114a42796072aa03bfe9f3706fd7",
   "virtiofsd-v1.8.0-cargo-CVE-2023-41051.tar.gz": "3941e2e51ff9d962dc2983a97912449ea1dc934d56cfc01bf0d1431a85d71dbb",
-  "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b",
+  "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b"
  }
 }

--- a/SPECS/virtiofsd/virtiofsd.signatures.json
+++ b/SPECS/virtiofsd/virtiofsd.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "virtiofsd-v1.8.0.tar.gz": "35a59628c44da64d72b25cbdea54fe2fa68ecd42482f34c4755f4020e6dc280b",
   "virtiofsd-v1.8.0-cargo.tar.gz": "47a1595ccee910ddb2f786469ac2601b5e5e114a42796072aa03bfe9f3706fd7",
-  "virtiofsd-v1.8.0-cargo-CVE-2023-41051-patch.tar.gz": "2e0b1d20142b995d8e77c14936e943b5a940f2080976c8f4cd9359b7414af095",
+  "virtiofsd-v1.8.0-cargo-CVE-2023-41051-vendor.tar.gz": "a3f4094b0a1f856af31a237d336c7d8c9b839cb5eb6e264f4dae77c0104f32ef",
   "config.toml": "77e9219c27274120197571fd165cbe4121963b5ad3bc0b20b383c86ef0ce6c2b"
  }
 }

--- a/SPECS/virtiofsd/virtiofsd.spec
+++ b/SPECS/virtiofsd/virtiofsd.spec
@@ -16,6 +16,9 @@ Source0:        https://gitlab.com/virtio-fs/virtiofsd/-/archive/v%{version}/%{n
 #   tar -czf ../%{name}-v%{version}-cargo.tar.gz vendor/
 Source1:        %{name}-v%{version}-cargo.tar.gz
 Source2:        config.toml
+# Updates vm-memory to 0.12.2. Remove once virtiofsd gets updated to a version >= 1.9.0: 
+# https://gitlab.com/virtio-fs/virtiofsd/-/blob/v1.9.0/Cargo.toml
+Patch0: CVE-2023-41051.patch
 
 ExclusiveArch:  x86_64
 
@@ -50,6 +53,9 @@ install -D -p -m 0755 target/release/virtiofsd %{buildroot}%{_libexecdir}/virtio
 %{_libexecdir}/virtiofsd-rs
 
 %changelog
+* Wed Jan 24 2024 Nadiia Dubchak <ndubchak@microsoft.com> - 1.8.0-2
+- Patch CVE-2023-41051
+
 * Tue Jan 9 2024 Aurélien Bombo <abombo@microsoft.com> - 1.8.0-1
 - Initial CBL-Mariner import from Fedora 39 (license: MIT).
 - License verified.

--- a/SPECS/virtiofsd/virtiofsd.spec
+++ b/SPECS/virtiofsd/virtiofsd.spec
@@ -16,7 +16,7 @@ Source0:        https://gitlab.com/virtio-fs/virtiofsd/-/archive/v%{version}/%{n
 #   tar -czf ../%{name}-v%{version}-cargo.tar.gz vendor/
 Source1:        %{name}-v%{version}-cargo.tar.gz
 Source2:        config.toml
-Source3:        %{name}-v%{version}-cargo-CVE-2023-41051-patch.tar.gz
+Source3:        %{name}-v%{version}-cargo-CVE-2023-41051-vendor.tar.gz
 # Updates vm-memory to 0.12.2. Remove once virtiofsd gets updated to a version >= 1.9.0: 
 # https://gitlab.com/virtio-fs/virtiofsd/-/blob/v1.9.0/Cargo.toml
 Patch0: CVE-2023-41051.patch

--- a/SPECS/virtiofsd/virtiofsd.spec
+++ b/SPECS/virtiofsd/virtiofsd.spec
@@ -16,6 +16,7 @@ Source0:        https://gitlab.com/virtio-fs/virtiofsd/-/archive/v%{version}/%{n
 #   tar -czf ../%{name}-v%{version}-cargo.tar.gz vendor/
 Source1:        %{name}-v%{version}-cargo.tar.gz
 Source2:        config.toml
+Source3:        %{name}-v%{version}-cargo-CVE-2023-41051.tar.gz
 # Updates vm-memory to 0.12.2. Remove once virtiofsd gets updated to a version >= 1.9.0: 
 # https://gitlab.com/virtio-fs/virtiofsd/-/blob/v1.9.0/Cargo.toml
 Patch0: CVE-2023-41051.patch
@@ -33,7 +34,8 @@ Virtio-fs vhost-user device daemon (Rust version)
 %autosetup -p1 -n %{name}-v%{version}
 
 pushd %{_builddir}/%{name}-v%{version}
-tar -xf %{SOURCE1}
+# Updated vendor package in Source3 to fix CVE-2023-41051
+tar -xf %{SOURCE3}
 mkdir -p .cargo
 cp %{SOURCE2} .cargo/
 popd
@@ -53,8 +55,12 @@ install -D -p -m 0755 target/release/virtiofsd %{buildroot}%{_libexecdir}/virtio
 %{_libexecdir}/virtiofsd-rs
 
 %changelog
+* Fri Jan 26 2024 Nadiia Dubchak <ndubchak@microsoft.com> - 1.8.0-2
+- Update vendor tarball to include vm-memory version 0.12.2.
+- Set the new tarball as Source3 and use it in step %prep.
+
 * Wed Jan 24 2024 Nadiia Dubchak <ndubchak@microsoft.com> - 1.8.0-2
-- Patch CVE-2023-41051
+- Patch CVE-2023-41051.
 
 * Tue Jan 9 2024 Aurélien Bombo <abombo@microsoft.com> - 1.8.0-1
 - Initial CBL-Mariner import from Fedora 39 (license: MIT).

--- a/SPECS/virtiofsd/virtiofsd.spec
+++ b/SPECS/virtiofsd/virtiofsd.spec
@@ -14,9 +14,8 @@ Source0:        https://gitlab.com/virtio-fs/virtiofsd/-/archive/v%{version}/%{n
 #   cd %{name}-v%{version}
 #   cargo vendor > ../config.toml
 #   tar -czf ../%{name}-v%{version}-cargo.tar.gz vendor/
-Source1:        %{name}-v%{version}-cargo.tar.gz
+Source1:        %{name}-v%{version}-cargo-v2.tar.gz
 Source2:        config.toml
-Source3:        %{name}-v%{version}-cargo-vendor-CVE-2023-41051.tar.gz
 # Updates vm-memory to 0.12.2. Remove once virtiofsd gets updated to a version >= 1.9.0: 
 # https://gitlab.com/virtio-fs/virtiofsd/-/blob/v1.9.0/Cargo.toml
 Patch0: CVE-2023-41051.patch
@@ -34,8 +33,7 @@ Virtio-fs vhost-user device daemon (Rust version)
 %autosetup -p1 -n %{name}-v%{version}
 
 pushd %{_builddir}/%{name}-v%{version}
-# Updated vendor package in Source3 to fix CVE-2023-41051
-tar -xf %{SOURCE3}
+tar -xf %{SOURCE1}
 mkdir -p .cargo
 cp %{SOURCE2} .cargo/
 popd
@@ -55,12 +53,10 @@ install -D -p -m 0755 target/release/virtiofsd %{buildroot}%{_libexecdir}/virtio
 %{_libexecdir}/virtiofsd-rs
 
 %changelog
-* Fri Jan 26 2024 Nadiia Dubchak <ndubchak@microsoft.com> - 1.8.0-2
-- Update vendor tarball to include vm-memory version 0.12.2.
-- Set the new tarball as Source3 and use it in step %prep.
-
-* Wed Jan 24 2024 Nadiia Dubchak <ndubchak@microsoft.com> - 1.8.0-2
+* Mon Jan 29 2024 Nadiia Dubchak <ndubchak@microsoft.com> - 1.8.0-2
 - Patch CVE-2023-41051.
+- Update vendor tarball to include vm-memory version 0.12.2.
+- Update Source1 to the new vendor tarball, virtiofsd-v1.8.0-cargo-v2.tar.gz.
 
 * Tue Jan 9 2024 Aurélien Bombo <abombo@microsoft.com> - 1.8.0-1
 - Initial CBL-Mariner import from Fedora 39 (license: MIT).

--- a/SPECS/virtiofsd/virtiofsd.spec
+++ b/SPECS/virtiofsd/virtiofsd.spec
@@ -16,7 +16,7 @@ Source0:        https://gitlab.com/virtio-fs/virtiofsd/-/archive/v%{version}/%{n
 #   tar -czf ../%{name}-v%{version}-cargo.tar.gz vendor/
 Source1:        %{name}-v%{version}-cargo.tar.gz
 Source2:        config.toml
-Source3:        %{name}-v%{version}-cargo-CVE-2023-41051-vendor.tar.gz
+Source3:        %{name}-v%{version}-cargo-vendor-CVE-2023-41051.tar.gz
 # Updates vm-memory to 0.12.2. Remove once virtiofsd gets updated to a version >= 1.9.0: 
 # https://gitlab.com/virtio-fs/virtiofsd/-/blob/v1.9.0/Cargo.toml
 Patch0: CVE-2023-41051.patch

--- a/SPECS/virtiofsd/virtiofsd.spec
+++ b/SPECS/virtiofsd/virtiofsd.spec
@@ -16,7 +16,7 @@ Source0:        https://gitlab.com/virtio-fs/virtiofsd/-/archive/v%{version}/%{n
 #   tar -czf ../%{name}-v%{version}-cargo.tar.gz vendor/
 Source1:        %{name}-v%{version}-cargo.tar.gz
 Source2:        config.toml
-Source3:        %{name}-v%{version}-cargo-CVE-2023-41051.tar.gz
+Source3:        %{name}-v%{version}-cargo-CVE-2023-41051-patch.tar.gz
 # Updates vm-memory to 0.12.2. Remove once virtiofsd gets updated to a version >= 1.9.0: 
 # https://gitlab.com/virtio-fs/virtiofsd/-/blob/v1.9.0/Cargo.toml
 Patch0: CVE-2023-41051.patch


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR creates a patch to upgrade the version of vm-memory from 0.12.0 to 0.12.2 to fix an associated CVE linked below. This is needed because vm-memory is a dependency of virtiofsd, a new package whose version cannot be upgraded from the current version of 1.8.0 since that version is being used by the upstream Kata: [kata-containers/versions.yaml at 3.2.0 · kata-containers/kata-containers (github.com)](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fkata-containers%2Fkata-containers%2Fblob%2F3.2.0%2Fversions.yaml%23L316&data=05%7C02%7Cndubchak%40microsoft.com%7C641f66e68de5452f5a0808dc1c47be1e%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638416341661742056%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=hsmQfsHGBqHg4nNjqEd7zzJ555qAno46YNbrPuk4%2BcI%3D&reserved=0)). Upgrading virtiofsd could break our kata-containers package.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Mon Jan 29 2024 Nadiia Dubchak <ndubchak@microsoft.com> - 1.8.0-2
- Patch CVE-2023-41051.
- Update vendor tarball to include vm-memory version 0.12.2.
- Update Source1 to the new vendor tarball, virtiofsd-v1.8.0-cargo-v2.tar.gz.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
N/A

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-41051

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 492064
- Link: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=492064&view=results