### PR TITLE
Add automatic mode for DAILY_BUILD_ID

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -141,68 +141,8 @@ include $(SCRIPTS_DIR)/utils.mk
 
 ######## DAILY BUILD AND PREVIEW REPO SUPPORT ########
 
-##help:var:DAILY_BUILD_ID:{'lkg','lkg-force',<build_id>}='lkg' will auto select latest daily build repo. Unless LKG_MANIFESTS='n' is used, unmodifed manifests will be udpated to match. 'lkg-force' will overwrite changes. An explicit ID of the daily build repo can also be used.
-DAILY_BUILD_ID ?=
+include $(SCRIPTS_DIR)/daily_build.mk
 
-##help:var:LKG_MANIFESTS:{y,n}='y' will auto update the manifests to the latest daily build if used in conjunction with DAILY_BUILD_ID='lkg' or 'lkg-force'.
-LKG_MANIFESTS ?= y
-skip_manifest_updates = $(if $(filter y,$(LKG_MANIFESTS)),,--skip-manifest-updates)
-
-ifneq ($(DAILY_BUILD_ID),)
-   # If DAILY_BUILD_ID is set to "lkg" or "lkg-force" we should attempt to auto select the best daily build
-   ifeq ($(DAILY_BUILD_ID),lkg)
-      $(warning Auto detecting DAILY_BUILD_ID based on the latest known good build)
-      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id $(skip_manifest_updates))
-      ifneq ($(.SHELLSTATUS),0)
-         $(error Failed to auto detect DAILY_BUILD_ID... try DAILY_BUILD_ID=lkg-force to overwrite manifests)
-      endif
-   endif
-   ifeq ($(DAILY_BUILD_ID),lkg-force)
-      # lkg-force is incompatible with LKG_MANIFESTS=n
-      ifneq ($(LKG_MANIFESTS),y)
-         $(error DAILY_BUILD_ID=lkg-force requires LKG_MANIFESTS=y)
-      endif
-      $(info Auto detecting DAILY_BUILD_ID based on the latest known good build AND overwriting manifests)
-      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id --force $(skip_manifest_updates))
-      ifneq ($(.SHELLSTATUS),0)
-         $(error Failed to auto detect DAILY_BUILD_ID and update manifests)
-      endif
-   endif
-
-   $(warning Using Daily Build $(DAILY_BUILD_ID))
-   # Ensure build_arch is set
-   ifeq ($(build_arch),)
-      $(error build_arch must be set when using DAILY_BUILD_ID)
-   endif
-   # build_arch cannot be directly used because Azure storage do not support container names with '_' char
-   ifeq ($(build_arch),x86_64)
-      # The actual repo is found at <URL>/, while a duplicate copy of all the rpms can be found at <URL>/built_rpms_all/
-      # Include both so that the tools that expect a valid repo work, while the tools that expect a basic URL also work.
-      override PACKAGE_URL_LIST   := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-x86-64/built_rpms_all \
-                                       https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-x86-64
-      override SRPM_URL_LIST      := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-x86-64/SRPMS
-   else
-      override PACKAGE_URL_LIST   := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-aarch64/built_rpms_all \
-                                       https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-aarch64
-      override SRPM_URL_LIST      := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-aarch64/SRPMS
-   endif
-else
-   ifeq ($(USE_PREVIEW_REPO),y)
-      override PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/$(build_arch)
-      override PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/debuginfo/$(build_arch)
-      override PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/Microsoft/$(build_arch)
-      override SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/srpms
-      ifneq ($(wildcard $(PREVIEW_REPO)),)
-         override REPO_LIST += $(PREVIEW_REPO)
-      else
-         $(warning )
-         $(warning ######################### WARNING #########################)
-         $(warning 'USE_PREVIEW_REPO=y' set but '$(PREVIEW_REPO)' is missing. Regenerate toolkit's 'repos' directory. Remove 'USE_PREVIEW_REPO' for core builds.)
-         $(warning ######################### WARNING #########################)
-         $(warning )
-      endif
-   endif
-endif
 
 ######## REMAINING BUILD FLAGS ########
 

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -139,21 +139,31 @@ SRPM_URL_LIST      ?= https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR
 # Variable prerequisite tracking
 include $(SCRIPTS_DIR)/utils.mk
 
-######## REMAINING BUILD FLAGS ########
+######## DAILY BUILD AND PREVIEW REPO SUPPORT ########
 
-##help:var:DAILY_BUILD_ID:{lkg,lkg-force,<build_id>}='lkg' will auto select latest daily build repo, 'lkg-force' will also replace the toolchain manifest files. An explicit ID of the daily build repo can also be used.
+##help:var:DAILY_BUILD_ID:{'lkg','lkg-force',<build_id>}='lkg' will auto select latest daily build repo. Unless LKG_MANIFESTS='n' is used, unmodifed manifests will be udpated to match. 'lkg-force' will overwrite changes. An explicit ID of the daily build repo can also be used.
+DAILY_BUILD_ID ?=
+
+##help:var:LKG_MANIFESTS:{y,n}='y' will auto update the manifests to the latest daily build if used in conjunction with DAILY_BUILD_ID='lkg' or 'lkg-force'.
+LKG_MANIFESTS ?= y
+skip_manifest_updates = $(if $(filter y,$(LKG_MANIFESTS)),,--skip-manifest-updates)
+
 ifneq ($(DAILY_BUILD_ID),)
    # If DAILY_BUILD_ID is set to "lkg" or "lkg-force" we should attempt to auto select the best daily build
    ifeq ($(DAILY_BUILD_ID),lkg)
       $(warning Auto detecting DAILY_BUILD_ID based on the latest known good build)
-      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id)
+      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id $(skip_manifest_updates))
       ifneq ($(.SHELLSTATUS),0)
          $(error Failed to auto detect DAILY_BUILD_ID... try DAILY_BUILD_ID=lkg-force to overwrite manifests)
       endif
    endif
    ifeq ($(DAILY_BUILD_ID),lkg-force)
+      # lkg-force is incompatible with LKG_MANIFESTS=n
+      ifneq ($(LKG_MANIFESTS),y)
+         $(error DAILY_BUILD_ID=lkg-force requires LKG_MANIFESTS=y)
+      endif
       $(info Auto detecting DAILY_BUILD_ID based on the latest known good build AND overwriting manifests)
-      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id --force)
+      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id --force $(skip_manifest_updates))
       ifneq ($(.SHELLSTATUS),0)
          $(error Failed to auto detect DAILY_BUILD_ID and update manifests)
       endif
@@ -193,6 +203,9 @@ else
       endif
    endif
 endif
+
+######## REMAINING BUILD FLAGS ########
+
 
 CA_CERT     ?=
 TLS_CERT    ?=

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -141,7 +141,24 @@ include $(SCRIPTS_DIR)/utils.mk
 
 ######## REMAINING BUILD FLAGS ########
 
+##help:var:DAILY_BUILD_ID:{lkg,lkg-force,<build_id>}='lkg' will auto select latest daily build repo, 'lkg-force' will also replace the toolchain manifest files. An explicit ID of the daily build repo can also be used.
 ifneq ($(DAILY_BUILD_ID),)
+   # If DAILY_BUILD_ID is set to "lkg" or "lkg-force" we should attempt to auto select the best daily build
+   ifeq ($(DAILY_BUILD_ID),lkg)
+      $(warning Auto detecting DAILY_BUILD_ID based on the latest known good build)
+      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id)
+      ifneq ($(.SHELLSTATUS),0)
+         $(error Failed to auto detect DAILY_BUILD_ID... try DAILY_BUILD_ID=lkg-force to overwrite manifests)
+      endif
+   endif
+   ifeq ($(DAILY_BUILD_ID),lkg-force)
+      $(info Auto detecting DAILY_BUILD_ID based on the latest known good build AND overwriting manifests)
+      override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/setuplkgtoolchain.sh --auto-id --force)
+      ifneq ($(.SHELLSTATUS),0)
+         $(error Failed to auto detect DAILY_BUILD_ID and update manifests)
+      endif
+   endif
+
    $(warning Using Daily Build $(DAILY_BUILD_ID))
    # Ensure build_arch is set
    ifeq ($(build_arch),)

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -143,7 +143,6 @@ include $(SCRIPTS_DIR)/utils.mk
 
 include $(SCRIPTS_DIR)/daily_build.mk
 
-
 ######## REMAINING BUILD FLAGS ########
 
 

--- a/toolkit/scripts/daily_build.mk
+++ b/toolkit/scripts/daily_build.mk
@@ -12,6 +12,12 @@ lkg_workdir = $(BUILD_DIR)/daily_build_id
 
 ######## CONFIGURE FLAGS ########
 
+# DAILY_BUILD_ID is the main point of entry. It can be one of 'lkg', 'lkg-force', or <build-id>. Based on this selection 'LKG_MANIFESTS' and 'FORCE_MANIFEST_UPDATES' are selected by default. They may be overwritten if desired.
+
+# LKG_MANIFESTS will update the manifest files to match the commit in the LKG file. This does not make sense for arbitrary build-ids however, so only default to 'y' for 'lkg' or 'lkg-force'
+
+# PKG_MANIFEST_OVERWRITE will ignore local changes to the manifests and replace them with the LKG version.
+
 ##help:var:DAILY_BUILD_ID:{'lkg','lkg-force',<build_id>}='lkg' will auto select latest daily build repo. Unless LKG_MANIFESTS='n' is used, unmodifed manifests will be udpated to match. 'lkg-force' will overwrite changes. An explicit ID of the daily build repo can also be used.
 DAILY_BUILD_ID ?=
 

--- a/toolkit/scripts/daily_build.mk
+++ b/toolkit/scripts/daily_build.mk
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Contains:
+#	- Rules to update manifests
+#	- Mechanism to update DAILY_BUILD_ID
+
+TOOLCHAIN_MANIFEST ?= $(TOOLCHAIN_MANIFESTS_DIR)/toolchain_$(build_arch).txt
+WORKER_CHROOT_MANIFEST = $(TOOLCHAIN_MANIFESTS_DIR)/pkggen_core_$(build_arch).txt
+
+lkg_workdir = $(BUILD_DIR)/daily_build_id
+
+######## CONFIGURE FLAGS ########
+
+##help:var:DAILY_BUILD_ID:{'lkg','lkg-force',<build_id>}='lkg' will auto select latest daily build repo. Unless LKG_MANIFESTS='n' is used, unmodifed manifests will be udpated to match. 'lkg-force' will overwrite changes. An explicit ID of the daily build repo can also be used.
+DAILY_BUILD_ID ?=
+
+##help:var:LKG_MANIFESTS:{y,n}='y' will auto update the manifests to the latest daily build if used in conjunction with DAILY_BUILD_ID='lkg' or 'lkg-force'.
+ifneq (, $(filter $(DAILY_BUILD_ID),lkg lkg-force))
+LKG_MANIFESTS ?= y
+else
+LKG_MANIFESTS ?= n
+endif
+
+##help:var:FORCE_MANIFEST_UPDATES:{y,n}='n' will not overwrite the manifests if they have local changes. 'y' will overwrite the manifests. Defaults to 'y' if DAILY_BUILD_ID='lkg-force'.
+PKG_MANIFEST_OVERWRITE ?= $(if $(filter lkg-force,$(DAILY_BUILD_ID)),y,n)
+
+######## CALCULATE LKG ID ########
+
+ifneq (, $(filter $(DAILY_BUILD_ID),lkg lkg-force))
+$(warning Auto detecting DAILY_BUILD_ID based on the latest known good build)
+override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/get_lkg_id.sh $(lkg_workdir))
+ifneq ($(.SHELLSTATUS),0)
+$(error Failed to auto detect DAILY_BUILD_ID)
+endif
+endif
+
+######## MANIFEST UPDATE ########
+
+# Update the toolchain manifests
+.PHONY: update-toolchain-manifests
+ifeq ($(LKG_MANIFESTS),y)
+.PHONY: update_manifest_always_run_phony
+update-toolchain-manifests: $(TOOLCHAIN_MANIFEST) $(WORKER_CHROOT_MANIFEST)
+$(call create_folder,$(lkg_workdir))
+force_manifest_updates=$(if $(filter y,$(PKG_MANIFEST_OVERWRITE)),true,false)
+$(TOOLCHAIN_MANIFEST) $(WORKER_CHROOT_MANIFEST): update_manifest_always_run_phony
+	$(SCRIPTS_DIR)/update_manifest.sh $@ $(build_arch) $(lkg_workdir) $(force_manifest_updates)
+else # LKG_MANIFEST y
+update-toolchain-manifest:
+endif
+
+
+######## DAILY BUILD ID ########
+
+ifneq ($(DAILY_BUILD_ID),)
+   $(warning Using Daily Build $(DAILY_BUILD_ID))
+   # Ensure build_arch is set
+   ifeq ($(build_arch),)
+      $(error build_arch must be set when using DAILY_BUILD_ID)
+   endif
+   # build_arch cannot be directly used because Azure storage do not support container names with '_' char
+   ifeq ($(build_arch),x86_64)
+      # The actual repo is found at <URL>/, while a duplicate copy of all the rpms can be found at <URL>/built_rpms_all/
+      # Include both so that the tools that expect a valid repo work, while the tools that expect a basic URL also work.
+      override PACKAGE_URL_LIST   := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-x86-64/built_rpms_all \
+                                       https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-x86-64
+      override SRPM_URL_LIST      := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-x86-64/SRPMS
+   else
+      override PACKAGE_URL_LIST   := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-aarch64/built_rpms_all \
+                                       https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-aarch64
+      override SRPM_URL_LIST      := https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$(DAILY_BUILD_ID)-aarch64/SRPMS
+   endif
+else
+   ifeq ($(USE_PREVIEW_REPO),y)
+      override PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/$(build_arch)
+      override PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/debuginfo/$(build_arch)
+      override PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/Microsoft/$(build_arch)
+      override SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/srpms
+      ifneq ($(wildcard $(PREVIEW_REPO)),)
+         override REPO_LIST += $(PREVIEW_REPO)
+      else
+         $(warning )
+         $(warning ######################### WARNING #########################)
+         $(warning 'USE_PREVIEW_REPO=y' set but '$(PREVIEW_REPO)' is missing. Regenerate toolkit's 'repos' directory. Remove 'USE_PREVIEW_REPO' for core builds.)
+         $(warning ######################### WARNING #########################)
+         $(warning )
+      endif
+   endif
+endif

--- a/toolkit/scripts/daily_build.mk
+++ b/toolkit/scripts/daily_build.mk
@@ -34,28 +34,32 @@ PKG_MANIFEST_OVERWRITE ?= $(if $(filter lkg-force,$(DAILY_BUILD_ID)),y,n)
 ######## CALCULATE LKG ID ########
 
 ifneq (, $(filter $(DAILY_BUILD_ID),lkg lkg-force))
-$(warning Auto detecting DAILY_BUILD_ID based on the latest known good build)
-override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/get_lkg_id.sh $(lkg_workdir))
-ifneq ($(.SHELLSTATUS),0)
-$(error Failed to auto detect DAILY_BUILD_ID)
-endif # .SHELLSTATUS
+    $(warning Auto detecting DAILY_BUILD_ID based on the latest known good build)
+    override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/get_lkg_id.sh $(lkg_workdir))
+    ifneq ($(.SHELLSTATUS),0)
+        $(error Failed to auto detect DAILY_BUILD_ID)
+    endif # .SHELLSTATUS
 endif # DAILY_BUILD_ID
 
 ######## MANIFEST UPDATE ########
 
 # Update the toolchain manifests
 .PHONY: update-toolchain-manifests
+
 ifeq ($(LKG_MANIFESTS),y)
+
 .PHONY: update_manifest_always_run_phony
 update-toolchain-manifests: $(TOOLCHAIN_MANIFEST) $(WORKER_CHROOT_MANIFEST)
 $(call create_folder,$(lkg_workdir))
 force_manifest_updates=$(if $(filter y,$(PKG_MANIFEST_OVERWRITE)),true,false)
 $(TOOLCHAIN_MANIFEST) $(WORKER_CHROOT_MANIFEST): update_manifest_always_run_phony
 	$(SCRIPTS_DIR)/update_manifest.sh $@ $(build_arch) $(lkg_workdir) $(force_manifest_updates)
-else # LKG_MANIFEST y
-update-toolchain-manifest:
-endif
 
+else # LKG_MANIFEST y
+
+update-toolchain-manifest:
+
+endif
 
 ######## DAILY BUILD ID ########
 

--- a/toolkit/scripts/daily_build.mk
+++ b/toolkit/scripts/daily_build.mk
@@ -38,8 +38,8 @@ $(warning Auto detecting DAILY_BUILD_ID based on the latest known good build)
 override DAILY_BUILD_ID := $(shell $(SCRIPTS_DIR)/get_lkg_id.sh $(lkg_workdir))
 ifneq ($(.SHELLSTATUS),0)
 $(error Failed to auto detect DAILY_BUILD_ID)
-endif
-endif
+endif # .SHELLSTATUS
+endif # DAILY_BUILD_ID
 
 ######## MANIFEST UPDATE ########
 

--- a/toolkit/scripts/get_lkg_id.sh
+++ b/toolkit/scripts/get_lkg_id.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Prints to stdout the daily build id from the LKG file
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <temp_dir>" >&2
+    exit 1
+fi
+
+temp_dir="$1"
+
+LKG_FILENAME="lkg-3.0-dev.json"
+LKG_TEMP_FILENAME="$(mktemp -p "$temp_dir" "${LKG_FILENAME}.XXXXXX" )"
+
+cleanup() {
+    rm -f "$LKG_TEMP_MANIFEST_FILENAME"
+}
+trap cleanup EXIT
+
+get_lkg() {
+    wget -O $LKG_TEMP_FILENAME -nv https://mariner3dailydevrepo.blob.core.windows.net/lkg/$LKG_FILENAME
+    DAILY_BUILD_ID=$(jq -r .dailybuildid $LKG_TEMP_FILENAME | tr . -)
+}
+
+get_lkg
+
+if [ -z "$DAILY_BUILD_ID" ]; then
+    echo "Failed to get DAILY_BUILD_ID from https://mariner3dailydevrepo.blob.core.windows.net/lkg/$LKG_FILENAME" >&2
+    exit 1
+fi
+
+echo $DAILY_BUILD_ID
+
+exit 0

--- a/toolkit/scripts/setuplkgtoolchain.sh
+++ b/toolkit/scripts/setuplkgtoolchain.sh
@@ -6,18 +6,13 @@ set -e
 
 ROOT_FOLDER=$(git rev-parse --show-toplevel)
 LKG_FILENAME="lkg-3.0-dev.json"
-# Get SUDO_USER if set, USER otherwise
-CALLING_USER=${SUDO_USER:-$USER}
-echo "Running setuplkgtoolchain.sh as $CALLING_USER" 1>&2
 
 trap cleanup EXIT
 
 usage() {
-    echo "./setuplkgtoolchain.sh [--auto-id] [--force]"
+    echo "./setuplkgtoolchain.sh"
     echo " Syncs toolchain manifests to match LKG build"
     echo " WARNING: can overwrite local changes to 'toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt'"
-    echo "    --auto-id: Just prints the latest LKG build ID and commit hash but makes no changes to the local manifests"
-    echo "    --force: Overwrite local changes to manifests without prompting"
     exit 1
 }
 
@@ -28,85 +23,30 @@ get_lkg() {
 }
 
 check_for_modified_manifests() {
-    auto=$1
-    force=$2
     if git status --porcelain | grep -qP "(pkggen_core|toolchain)_$(uname -p).txt"; then
-        if $force; then
-            echo "Forcing overwrite of local changes to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt'" 1>&2
-        else
-            if $auto; then
-                echo "Local modifications to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt' detected, will not auto update without --force" 1>&2
-                exit 1
-            else
-                echo "Local modifications to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt' detected." 1>&2
-                echo -e "\nNOTE: Changes to manifests were detected, and these will be overwritten. Hit Ctrl+C within 10 seconds to cancel...\n" 1>&2
-                sleep 10s
-            fi
-        fi
+        echo "Local modifications to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt' detected."
+        echo -e "\nNOTE: Changes to manifests were detected, and these will be overwritten. Hit Ctrl+C within 10 seconds to cancel...\n"
+        sleep 10s
     fi
 }
 
-# We don't want to update the timestamps unless we actually change the file, so download to a temp file and then move it over
-# if the files are different
-# $1 - filename (e.g. toolchain_aarch64.txt)
-update_manifest() {
-    local filename
-    local url
-    local filepath
-    filename="$1"
-    url="https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/${filename}"
-    filepath="$ROOT_FOLDER/toolkit/resources/manifests/package/${filename}"
-    filepath_tmp="${filepath}.tmp"
-
-    echo "Downloading $filename manifest from $url" 1>&2
-
-    wget -nv "${url}" -O "${filepath_tmp}" 1>&2
-    # only update if the files are different
-    if ! cmp -s "${filepath_tmp}" "${filepath}"; then
-        echo "Manifests are different, updating ${filename}" 1>&2
-        mv "${filepath_tmp}" "${filepath}"
-        chown "$CALLING_USER:$CALLING_USER" "${filepath}"
-    else
-        rm -f "${filepath_tmp}"
-    fi
+update_manifests() {
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/toolchain_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/toolchain_$(uname -p).txt
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt
 }
 
 cleanup() {
     rm -f $LKG_FILENAME
 }
 
-auto_id=false
-force_manifests=false
-skip_manifest_updates=false
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        *auto-id)
-            auto_id=true
-            shift
-            ;;
-        *force)
-            force_manifests=true
-            shift
-            ;;
-        *skip-manifest-updates)
-            skip_manifest_updates=true
-            shift
-            ;;
-        *help | *)
-            usage
-            ;;
-    esac
-done
+[[ "$1" == "--help" || "$1" == "help" ]] && usage
 
 get_lkg
 
-if ! $skip_manifest_updates; then
-    check_for_modified_manifests $auto_id $force_manifests
-    update_manifest "toolchain_$(uname -p).txt"
-    update_manifest "pkggen_core_$(uname -p).txt"
-fi
+check_for_modified_manifests
 
-if ! $auto_id; then
+update_manifests
+
 cat << EOF
 ===
 === Current LKG:
@@ -114,11 +54,8 @@ cat << EOF
 === Commit='$GIT_COMMIT'
 ===
 EOF
-    echo -e "Finished syncing toolchain to LKG ('$DAILY_BUILD_ID' - '$GIT_COMMIT')"
-    echo -e "To download LKG toolchain, run:\n\tsudo make toolchain -j$(nproc) REBUILD_TOOLCHAIN=n REBUILD_TOOLS=y DAILY_BUILD_ID=$DAILY_BUILD_ID"
-else
-    # In auto mode, just print the LKG build ID so we can use it in the calling script
-    echo $DAILY_BUILD_ID
-fi
+
+echo -e "Finished syncing toolchain to LKG ('$DAILY_BUILD_ID' - '$GIT_COMMIT')"
+echo -e "To download LKG toolchain, run:\n\tsudo make toolchain -j$(nproc) REBUILD_TOOLCHAIN=n REBUILD_TOOLS=y DAILY_BUILD_ID=$DAILY_BUILD_ID"
 
 exit 0

--- a/toolkit/scripts/setuplkgtoolchain.sh
+++ b/toolkit/scripts/setuplkgtoolchain.sh
@@ -10,9 +10,11 @@ LKG_FILENAME="lkg-3.0-dev.json"
 trap cleanup EXIT
 
 usage() {
-    echo "./setuplkgtoolchain.sh"
+    echo "./setuplkgtoolchain.sh [--auto-id] [--force]"
     echo " Syncs toolchain manifests to match LKG build"
     echo " WARNING: can overwrite local changes to 'toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt'"
+    echo "    --auto-id: Just prints the latest LKG build ID and commit hash but makes no changes to the local manifests"
+    echo "    --force: Overwrite local changes to manifests without prompting"
     exit 1
 }
 
@@ -23,30 +25,58 @@ get_lkg() {
 }
 
 check_for_modified_manifests() {
+    auto=$1
+    force=$2
     if git status --porcelain | grep -qP "(pkggen_core|toolchain)_$(uname -p).txt"; then
-        echo "Local modifications to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt' detected."
-        echo -e "\nNOTE: Changes to manifests were detected, and these will be overwritten. Hit Ctrl+C within 10 seconds to cancel...\n"
-        sleep 10s
+        if $force; then
+            echo "Forcing overwrite of local changes to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt'" 1>&2
+        else
+            if $auto; then
+                echo "Local modifications to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt' detected, will not auto update without --force" 1>&2
+                exit 1
+            else
+                echo "Local modifications to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt' detected." 1>&2
+                echo -e "\nNOTE: Changes to manifests were detected, and these will be overwritten. Hit Ctrl+C within 10 seconds to cancel...\n" 1>&2
+                sleep 10s
+            fi
+        fi
     fi
 }
 
 update_manifests() {
-    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/toolchain_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/toolchain_$(uname -p).txt
-    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/toolchain_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/toolchain_$(uname -p).txt 1>&2
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt 1>&2
 }
 
 cleanup() {
     rm -f $LKG_FILENAME
 }
 
-[[ "$1" == "--help" || "$1" == "help" ]] && usage
+auto_id=false
+force_manifests=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        *auto-id)
+            auto_id=true
+            shift
+            ;;
+        *force)
+            force_manifests=true
+            shift
+            ;;
+        *help | *)
+            usage
+            ;;
+    esac
+done
 
 get_lkg
 
-check_for_modified_manifests
+check_for_modified_manifests $auto_id $force_manifests
 
 update_manifests
 
+if ! $auto_id; then
 cat << EOF
 ===
 === Current LKG:
@@ -54,8 +84,11 @@ cat << EOF
 === Commit='$GIT_COMMIT'
 ===
 EOF
-
-echo -e "Finished syncing toolchain to LKG ('$DAILY_BUILD_ID' - '$GIT_COMMIT')"
-echo -e "To download LKG toolchain, run:\n\tsudo make toolchain -j$(nproc) REBUILD_TOOLCHAIN=n REBUILD_TOOLS=y DAILY_BUILD_ID=$DAILY_BUILD_ID"
+    echo -e "Finished syncing toolchain to LKG ('$DAILY_BUILD_ID' - '$GIT_COMMIT')"
+    echo -e "To download LKG toolchain, run:\n\tsudo make toolchain -j$(nproc) REBUILD_TOOLCHAIN=n REBUILD_TOOLS=y DAILY_BUILD_ID=$DAILY_BUILD_ID"
+else
+    # In auto mode, just print the LKG build ID so we can use it in the calling script
+    echo $DAILY_BUILD_ID
+fi
 
 exit 0

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -30,7 +30,6 @@ toolchain_files = \
 	$(call shell_real_build_only, find $(SCRIPTS_DIR)/toolchain -name '*.sh') \
 	$(SCRIPTS_DIR)/toolchain/container/Dockerfile
 
-TOOLCHAIN_MANIFEST ?= $(TOOLCHAIN_MANIFESTS_DIR)/toolchain_$(build_arch).txt
 # Find the *.rpm corresponding to each of the entries in the manifest
 # regex operation: (.*\.([^\.]+)\.rpm) extracts *.(<arch>).rpm" to determine
 # the exact path of the required rpm

--- a/toolkit/scripts/update_manifest.sh
+++ b/toolkit/scripts/update_manifest.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 <manifest_file> <arch> <temp_dir> <force_update>"
+    exit 1
+fi
+
+manifest_file="$1"
+arch="$2"
+temp_dir="$3"
+force_update="$4"
+
+# Get SUDO_USER if set, USER otherwise
+CALLING_USER=${SUDO_USER:-$USER}
+echo "Running update_manifest.sh as $CALLING_USER"
+LKG_FILENAME="lkg-3.0-dev.json"
+LKG_TEMP_FILENAME="$(mktemp -p "$temp_dir" "${LKG_FILENAME}.XXXXXX" )"
+LKG_TEMP_MANIFEST_FILENAME="$(mktemp -p "$temp_dir" "$(basename "$manifest_file").XXXXXX" )"
+
+cleanup() {
+    rm -f "$LKG_TEMP_FILENAME"
+    rm -f "$LKG_TEMP_MANIFEST_FILENAME"
+}
+trap cleanup EXIT
+
+usage() {
+    echo "$0 <manifest_file> <arch> <temp_dir>"
+    exit 1
+}
+
+get_lkg() {
+    wget -O $LKG_TEMP_FILENAME -nv https://mariner3dailydevrepo.blob.core.windows.net/lkg/$LKG_FILENAME
+    GIT_COMMIT=$(jq -r .commit $LKG_TEMP_FILENAME)
+}
+
+check_for_modified_manifests() {
+    if git status --porcelain | grep -qP "$(basename $manifest_file)"; then
+        echo "    #### Local modifications to '$manifest_file' detected."
+        echo "           Use 'DAILY_BUILD_ID=lkg-force' or 'PKG_MANIFEST_OVERWRITE=y' to overwrite local changes. ####" >&2
+        exit 1
+    fi
+}
+
+# We don't want to update the timestamps unless we actually change the file, so download to a temp file and then move it over
+# if the files are different
+# $1 - filename (e.g. toolchain_aarch64.txt)
+update_manifest() {
+    local filepath
+    local arch
+    local url
+    filepath="$1"
+    arch="$2"
+    basename=$(basename $filepath)
+
+    url="https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/${basename}"
+
+    echo "Downloading $basename manifest from $url"
+
+    wget -nv "${url}" -O "${LKG_TEMP_MANIFEST_FILENAME}"
+    # only update if the files are different
+    if ! cmp -s "${LKG_TEMP_MANIFEST_FILENAME}" "${filepath}"; then
+        echo "Manifests are different, updating ${basename}"
+        mv "${LKG_TEMP_MANIFEST_FILENAME}" "${filepath}"
+        chown "$CALLING_USER:$CALLING_USER" "${filepath}"
+    else
+        echo "Manifests are the same, not updating ${basename}"
+    fi
+}
+
+if ! $force_update; then
+    check_for_modified_manifests
+fi
+
+get_lkg
+
+update_manifest "${manifest_file}" "${arch}"
+
+exit 0

--- a/toolkit/scripts/update_manifest.sh
+++ b/toolkit/scripts/update_manifest.sh
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Updates the requested manifest file based on the contents of the LKG json.
+
 set -e
 
 if [ "$#" -ne 4 ]; then


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update the `Makefile` to support `DAILY_BUILD_ID=lkg` and `DAILY_BUILD_ID=lkg-force`. These will automatically invoke `setuplkgtoolchain.sh` to find the most recent valid repo to use.

`lkg` will just set the repo, while `lkg-force` will also update the local manifests.

If the local toolchain manifests have been changed, `lkg` will result in an error. `lkg-force` or an explicit ID must be used.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enhance `DAILY_BUILD_ID` to take `lkg` and `lkg-force` as special case options.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local tests
- Full pipeline tbd.
