### PR TITLE
fix: make default kdumpctl save_core behavior use makedumpfile rather than cp

### DIFF
--- a/SPECS/kexec-tools/kdumpctl
+++ b/SPECS/kexec-tools/kdumpctl
@@ -67,7 +67,7 @@ save_core()
 	coredir="/var/crash/`date +"%Y-%m-%d-%H:%M"`"
 
 	mkdir -p $coredir
-	cp --sparse=always /proc/vmcore $coredir/vmcore-incomplete
+	makedumpfile -c --message-level 1 -d 31
 	if [ $? == 0 ]; then
 		mv $coredir/vmcore-incomplete $coredir/vmcore
 		echo "saved a vmcore to $coredir"

--- a/SPECS/kexec-tools/kexec-tools.signatures.json
+++ b/SPECS/kexec-tools/kexec-tools.signatures.json
@@ -27,7 +27,7 @@
   "kdump.sysconfig.aarch64": "a829f3a0f88d983ccec2782b048f12a2eafca71aac4dd42acac2eaea8f7dd8d9",
   "kdump.sysconfig.i386": "1175bcc11be49841d4b8c3f9612e68bb7b2e0e8f00067ffa782fd9dba04f821d",
   "kdump.sysconfig.x86_64": "850b3be780165d0721edb8d34b2ba28aafc60b29850ff627daf04190369e359c",
-  "kdumpctl": "d511b5db0ea2de014fb06ec9fa0a6a4fdf508a3ba6c0d73344870f245ebd4c23",
+  "kdumpctl": "c58b5dadae5f1caa73aec97eb8a141e0e5bc5a4f9911ca2088ca779ae03f2ff7",
   "kdumpctl.8": "025a39d212eed0584da7c23c1bb50d6ab797a0fa3c686ac6b80391af875dbaec",
   "kexec-kdump-howto.txt": "e783390a9aa582a2b5e7981cd3277081385340b5873a3f0633c789811876eccb",
   "kexec-tools-2.0.27.tar.xz": "38d78bcfa33a88928324b57dc81f50c1dfc279eede45e80957ca18f4e84b8187",


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Make default kdumpctl save_core behavior use makedumpfile rather than cp.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change kdumpctl script behavior to use makedumpfile rather than cp --sparse

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/issues/6478 

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- running dev pipelines to produce image
  - manually test crash
