### PR TITLE
Add pedantic mode flag for scheduler

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -190,6 +190,8 @@ LOG_COLOR          ?= auto
 STOP_ON_WARNING    ?= n
 STOP_ON_PKG_FAIL   ?= n
 STOP_ON_FETCH_FAIL ?= n
+##help:var:PEDANTIC:{y,n}=Set to 'y' to enable pedantic mode, which will stop the build on certain recoverable errors.
+PEDANTIC           ?= y
 
 ######## HIGH LEVEL TARGETS ########
 

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -317,6 +317,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(no_repo_acl) $(preprocessed_file) $(chroo
 		--max-cpu="$(MAX_CPU)" \
 		$(if $(PACKAGE_BUILD_TIMEOUT),--timeout="$(PACKAGE_BUILD_TIMEOUT)") \
 		$(logging_command) && \
+		$(if $(filter y,$(PEDANTIC)),--pedantic) &&\
 	touch $@
 
 ##help:target:compress-rpms=Compresses all RPMs in `../out/RPMS` into `../out/rpms.tar.gz`. See `hydrate-rpms` target.

--- a/toolkit/tools/internal/exe/exe.go
+++ b/toolkit/tools/internal/exe/exe.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pedantic"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -77,4 +78,9 @@ func SetupProfileFlags(k *kingpin.Application) *ProfileFlags {
 	p.MemProfFile = k.Flag("mem-prof-file", "File that stores Memory pprof data.").String()
 	p.TraceFile = k.Flag("trace-file", "File that stores trace data.").String()
 	return p
+}
+
+func SetupPedanticFlag(k *kingpin.Application) *bool {
+	enablePedanticMode := k.Flag(pedantic.PedanticErrorFlag, "Enable more strict error checking").Bool()
+	return enablePedanticMode
 }

--- a/toolkit/tools/internal/pedantic/pedantic.go
+++ b/toolkit/tools/internal/pedantic/pedantic.go
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Logic to enable/disable certain error cases
+
+package pedantic
+
+import (
+	"fmt"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+)
+
+var (
+	// EnablePedanticMode is a flag to enable/disable pedantic mode
+	enablePedanticMode bool
+	PedanticErrorFlag  = "pedantic"
+)
+
+// EnablePedanticMode sets the flag to enable/disable pedantic mode
+func EnablePedanticMode(enable bool) {
+	enablePedanticMode = enable
+}
+
+// IsPedanticModeEnabled returns the flag to enable/disable pedantic mode
+func IsPedanticModeEnabled() bool {
+	return enablePedanticMode
+}
+
+// PedanticError is a function to return an error if pedantic mode is enabled,
+// otherwise it returns nil
+func PedanticError(potentialError error) error {
+	if IsPedanticModeEnabled() {
+		return potentialError
+	}
+	return nil
+}
+
+// PedanticErrorWithWarning is a function to return an error if pedantic mode is enabled,
+// otherwise it returns a warning message and nil.
+func PedanticErrorWithWarning(potentialError error) error {
+	if IsPedanticModeEnabled() {
+		err := fmt.Errorf("'--pedantic' mode is enabled, treating potential error as fatal:\n%w", potentialError)
+		return err
+	} else if logger.Log != nil {
+		logger.Log.Warnf("Pedantic mode is disabled, but a potential error was encountered: %v", potentialError)
+	}
+	return nil
+}

--- a/toolkit/tools/internal/pedantic/pedantic_test.go
+++ b/toolkit/tools/internal/pedantic/pedantic_test.go
@@ -1,0 +1,42 @@
+package pedantic
+
+import (
+	"fmt"
+	"testing"
+)
+
+var errPendaticTest = fmt.Errorf("test error")
+
+func TestEnablePedanticMode(t *testing.T) {
+	EnablePedanticMode(true)
+	if !IsPedanticModeEnabled() {
+		t.Errorf("Expected pedantic mode to be enabled")
+	}
+	EnablePedanticMode(false)
+	if IsPedanticModeEnabled() {
+		t.Errorf("Expected pedantic mode to be disabled")
+	}
+}
+
+func TestPedanticError(t *testing.T) {
+	EnablePedanticMode(true)
+	// Make sure nil is ok
+	err := PedanticError(nil)
+	if err != nil {
+		t.Errorf("Expected no error")
+	}
+	// Should get error still
+	err = PedanticError(errPendaticTest)
+	if err != errPendaticTest {
+		t.Errorf("Expected pedantic error")
+	}
+	EnablePedanticMode(false)
+	err = PedanticError(nil)
+	if err != nil {
+		t.Errorf("Expected no error")
+	}
+	err = PedanticError(errPendaticTest)
+	if err != nil {
+		t.Errorf("Expected no error")
+	}
+}

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/ccachemanager"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pedantic"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
@@ -105,6 +106,7 @@ var (
 
 	logFlags      = exe.SetupLogFlags(app)
 	profFlags     = exe.SetupProfileFlags(app)
+	pedanticMode  = exe.SetupPedanticFlag(app)
 	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
@@ -118,6 +120,8 @@ func main() {
 		logger.Log.Warnf("Could not start profiling: %s", err)
 	}
 	defer prof.StopProfiler()
+
+	pedantic.EnablePedanticMode(*pedanticMode)
 
 	if *workers <= 0 {
 		*workers = runtime.NumCPU()

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pedantic"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
@@ -90,12 +91,12 @@ func buildNodesToRequests(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildSta
 
 		// Check if we already queued up this build node for building.
 		if buildState.IsSRPMBuildActive(defaultNode.SRPMFileName()) || buildState.IsNodeProcessed(defaultNode) {
-			err = fmt.Errorf("unexpected duplicate build for (%s)", defaultNode.SRPMFileName())
-			// Temporarily ignore the error, this state is unexpected but not fatal. Error return will be
-			// restored later once the underlying cause of this error is fixed.
-			logger.Log.Warnf(err.Error())
-			err = nil
-			continue
+			err = pedantic.PedanticErrorWithWarning(fmt.Errorf("unexpected duplicate build for (%s)", defaultNode.SRPMFileName()))
+			if err != nil {
+				return
+			} else {
+				continue
+			}
 		}
 
 		req := buildRequest(pkgGraph, buildState, packagesToRebuild, defaultNode, buildNodes, isCacheAllowed, hasADeltaNode)
@@ -198,12 +199,12 @@ func testNodesToRequests(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildStat
 
 		// Check if we already queued up this build node for building.
 		if buildState.IsSRPMBuildActive(srpmFileName) || buildState.IsNodeProcessed(defaultTestNode) {
-			err = fmt.Errorf("unexpected duplicate test for (%s)", srpmFileName)
-			// Temporarily ignore the error, this state is unexpected but not fatal. Error return will be
-			// restored later once the underlying cause of this error is fixed.
-			logger.Log.Warnf(err.Error())
-			err = nil
-			continue
+			err = pedantic.PedanticErrorWithWarning(fmt.Errorf("unexpected duplicate test for (%s)", srpmFileName))
+			if err != nil {
+				return
+			} else {
+				continue
+			}
 		}
 
 		buildUsedCache := buildState.IsSRPMCached(srpmFileName)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
As part of the fix in https://github.com/microsoft/CBL-Mariner/pull/7928 it is clear we probably want a mechanism to enable/disable more pedantic error checking. This will be useful for asserts we would generally like to enforce but are "recoverable" if needed.

The flags can be set via:
```golang
var pedanticMode  = exe.SetupPedanticFlag(app)
func main() {
	kingpin.MustParse(app.Parse(os.Args[1:]))
	pedantic.EnablePedanticMode(*pedanticMode)
	//...
}
```
At any point in the future it can be used via:
```golang
func maybeFails() (error) {
	// Will print a warning to console, or wrap a helpful message referencing '--pedantic' around the error.
	err := PedanticErrorWithWarning(fmt.Errorf("pednatic error"));
	if err != nil {
		return err
	}
	// Silently removes error
	err := PedanticError(fmt.Errorf("pednatic error"));
	if err != nil {
		return err
	}
}
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add a new flag that can be added to tools (`--pedantic`) 
- Add `pedantic` module which offers `PedanticError()` and `PedanticErrorWithWarning()`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
