### PR TITLE
make install_dependencies more reslient to weirdness in different spec files

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -146,15 +146,36 @@ get_pkg_dependency() {
 
 # Install package dependencies listed as BuildRequires in spec
 install_dependencies() {
-    local PKG=("$@")
-    if [ -z "$PKG" ]; then echo "Please provide pkg name"; return; fi
+    # Accept a single argument, which is a pattern to find spec files.
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <pkg_pattern>"
+        return 1
+    fi
+
+    local PKG="$1"
+
     echo "-------- installing build dependencies ---------"
-    spec_file=$SPECS_DIR/$PKG/$PKG.spec
-    dep_list=$(grep "BuildRequires:" $spec_file | cut -d ':' -f 2)
-    for dependency in $dep_list
+
+    # Find all spec files for the package pattern given.
+    spec_file_pattern=$SPECS_DIR/$PKG/$PKG.spec
+    echo "using spec file pattern: '$spec_file_pattern'"
+    spec_files=($spec_file_pattern)
+
+    # Install dependencies for each spec file found, preserving tdnf error codes.
+    echo "found ${#spec_files[@]} spec files; installing dependencies for each spec file sequentially"
+    exit_code=0
+    for spec_file in "${spec_files[@]}"
     do
-        tdnf install -y $dependency 2>&1
+        echo "installing dependencies for spec file: '$spec_file'"
+
+        # Get the list of dependencies from the spec file.
+        mapfile -t dep_list < <(rpmspec -q --buildrequires $spec_file)
+
+        # Install all the dependencies.
+        tdnf install -y "${dep_list[@]}" || exit_code=$?
     done
+
+    return $exit_code
 }
 
 # use Mariner specific DEFINES


### PR DESCRIPTION
Make `install_dependencies` function in the `containerized-rpmbuild` environment work on more complex `Requires` statements.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
`install_dependencies` in the `containerized_rpmbuild` environment was initially done as a quick script to install multiple dependencies in spec files. This change makes it more robust to handle some cases it wouldn't handle. Notably:
- Dependencies with special characters in their names like `Perl(Digest::SHA)`
- Dependencies with macros in them like `%{name}-libs`
- Dependencies with version specifications

###### Change Log  <!-- REQUIRED -->
- Make `install_dependencies` use `rpmspec` to parse `Requires` statements in a spec file.
- Install all packages for a given spec at one time.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
Tested locally in a `containerized-rpmbuild` environment.