### PR TITLE
add SymCrypt and SymCrypt-OpenSSL to images with openssl

### DIFF
--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -71,6 +71,8 @@ Requires:       rpm
 Requires:       rpm-libs
 Requires:       sed
 Requires:       sqlite-libs
+Requires:       SymCrypt
+Requires:       SymCrypt-OpenSSL
 Requires:       tdnf
 Requires:       tdnf-plugin-repogpgcheck
 Requires:       xz

--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -80,6 +80,7 @@ Requires:       zlib
 
 # TEMP: Add packages required to unblock partner team; remove before merging to 3.0-dev.
 Requires:       build-essential
+Requires:       grubby
 Requires:       openssh-server
 Requires:       openssl-devel
 Requires:       curl-devel

--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -78,6 +78,14 @@ Requires:       tdnf-plugin-repogpgcheck
 Requires:       xz
 Requires:       zlib
 
+# TEMP: Add packages required to unblock partner team; remove before merging to 3.0-dev.
+Requires:       build-essential
+Requires:       openssh-server
+Requires:       openssl-devel
+Requires:       curl-devel
+Requires:       kernel-devel
+Requires:       kernel-headers
+
 %description    container
 %{summary}
 

--- a/SPECS/distroless-packages/distroless-packages.spec
+++ b/SPECS/distroless-packages/distroless-packages.spec
@@ -38,6 +38,7 @@ Requires:       tzdata
 
 # TEMP: Add packages required to unblock partner team; remove before merging to 3.0-dev.
 Requires:       build-essential
+Requires:       grubby
 Requires:       openssh-server
 Requires:       openssl-devel
 Requires:       curl-devel

--- a/SPECS/distroless-packages/distroless-packages.spec
+++ b/SPECS/distroless-packages/distroless-packages.spec
@@ -36,6 +36,15 @@ Requires:       SymCrypt
 Requires:       SymCrypt-OpenSSL
 Requires:       tzdata
 
+# TEMP: Add packages required to unblock partner team; remove before merging to 3.0-dev.
+Requires:       build-essential
+Requires:       openssh-server
+Requires:       openssl-devel
+Requires:       curl-devel
+Requires:       kernel-devel
+Requires:       kernel-headers
+
+
 %description base
 %{summary}
 

--- a/SPECS/distroless-packages/distroless-packages.spec
+++ b/SPECS/distroless-packages/distroless-packages.spec
@@ -32,6 +32,8 @@ Requires:       libgcc
 Requires:       azurelinux-release
 Requires:       openssl
 Requires:       openssl-libs
+Requires:       SymCrypt
+Requires:       SymCrypt-OpenSSL
 Requires:       tzdata
 
 %description base

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -88,6 +88,9 @@ BuildRequires: perl(Test::More)
 
 Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 
+Recommends: SymCrypt
+Recommends: SymCrypt-OpenSSL
+
 %description
 The OpenSSL toolkit provides support for secure communications between
 machines. OpenSSL includes a certificate management tool and shared


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add `SymCrypt` and `SymCrypt-OpenSSL` as `Recommends` packages for `openssl` and add them to images with `openssl`.

Note that an initial version of this commit with incorrect capitalization on `SymCrypt-OpenSSL` was merged in #7977 and then reverted in #8001.

<!-- Quick explanation of the changes. -->
In AZL 3 `openssl` relies on `SymCrypt` for `FIPS` mode. As such, we want `SymCrypt` and the related `SymCrypt-OpenSSL` packages installed where `openssl` is installed. To accomplish this, we do two things:
1. Add these packages as `Recommends` in the `openssl` spec. This means that if the package manager can find these packages, it will install them when `openssl` is installed, but it won't refuse to install `openssl` if it can't find them.
2. Add these packages to any image that has `openssl`.

One may wonder why we didn't simply add these packages as `Requires` to `openssl`. The issue here is that `SymCrypt` has a `BuildRequires` on `python`, which in turn requires `openssl`, so there's a circular dependency.

###### Change Log  <!-- REQUIRED -->
- Add `SymCrypt` and `SymCrypt-OpenSSL` as `Recommends` in the `openssl` spec file.
- Add `SymCrypt` and `SymCrypt-OpenSSL` to any image that already has `openssl`
- 
###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
- Tested locally to make sure the relevant `Recommends` and `Requires` gets into the built rpms.
- Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=510542&view=results
