### PR TITLE
Factor out python3-libfdt subpackage

### DIFF
--- a/SPECS/dtc/dtc.spec
+++ b/SPECS/dtc/dtc.spec
@@ -1,7 +1,7 @@
 Summary:        Device Tree Compiler
 Name:           dtc
 Version:        1.7.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD OR GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -18,7 +18,6 @@ BuildRequires:  python3-setuptools_scm
 BuildRequires:  python3-wheel
 BuildRequires:  swig
 Provides:       libfdt = %{name}-%{version}
-Provides:       python3-libfdt = %{name}-%{version}
 
 %description
 Devicetree is a data structure for describing hardware. Rather than hard coding
@@ -27,6 +26,14 @@ can be described in a data structure that is passed to the operating system at
 boot time. The devicetree is used by OpenFirmware, OpenPOWER Abstraction Layer
 (OPAL), Power Architecture Platform Requirements (PAPR) and in the standalone
 Flattened Device Tree (FDT) form.
+
+%package -n python3-libfdt
+Summary:        Python3 bindings for libfdt
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+%{?python_provide:%python_provide python3-libfdt}
+
+%description -n python3-libfdt
+Python interface to libdft.
 
 %package        devel
 Summary:        Development headers for device tree library
@@ -70,6 +77,8 @@ make %{?_smp_mflags} check
 %{_bindir}/*
 %{_libdir}/libfdt-%{version}.so
 %{_libdir}/libfdt.so.*
+
+%files -n python3-libfdt
 %{python3_sitearch}/
 
 %files devel
@@ -78,6 +87,9 @@ make %{?_smp_mflags} check
 %{_includedir}/*
 
 %changelog
+* Fri Feb 23 2024 Reuben Olinsky <reubeno@microsoft.com> - 1.7.0-2
+- Factor python3 bindings to a separate subpackage.
+
 * Thu Feb 01 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.7.0-1
 - Update to version 1.7.0
 - Add %check section


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary
<!-- Quick explanation of the changes. -->
This PR factors `python3-libfdt` out of the `dtc` package to avoid pulling Python dependencies into images that only require the natively-compiled `dtc` tools. We've seen specific scenarios where that happened, unwittingly bloating the containing image as well as making the image subject to servicing for any issues in the Python runtime.

###### Change Log  <!-- REQUIRED -->
* Remove `python3-libfdt` as a `Provides` value from the main package and create a subpackage of that name. Packages or images that already depend on this will continue to get what they need. Note, however, that any image or package that depends solely on `dtc` and counts on the Python bindings to be pulled in will see a behavioral change.

* Follow the pattern of other specs in setting up the tags for this subpackage using python rpm macros.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
Local build + buddy pipeline run. When running %check test, 2 of 2098 test fail, but they're the same tests that fail in the 3.0-dev branch without this set of changes. 