### PR TITLE
Replace the mariner-vm default localhost name with azurelinux-vm

### DIFF
--- a/toolkit/resources/assets/meta-user-data/meta-data
+++ b/toolkit/resources/assets/meta-user-data/meta-data
@@ -1,5 +1,5 @@
 # instance-id: cloud-host-0
-local-hostname: mariner-vm
+local-hostname: azurelinux-vm
 # ----------------------------------------------------------
 # eth0 is the default network interface enabled in the image
 # ----------------------------------------------------------


### PR DESCRIPTION
This purely a rebranding change in a sample resource file.