### PR TITLE
Upgrade libnotify from 0.7.9 to 0.8.3

### DIFF
--- a/SPECS/libnotify/disable-gtk.patch
+++ b/SPECS/libnotify/disable-gtk.patch
@@ -26,24 +26,3 @@ index 088b7ed..bafeb7d 100644
  
  conf = configuration_data()
  conf.set_quoted('VERSION', meson.project_version())
-diff --git a/meson_options.txt b/meson_options.txt
-index c57b364..c4b9c0c 100644
---- a/meson_options.txt
-+++ b/meson_options.txt
-@@ -1,6 +1,6 @@
- option('tests',
-   type: 'boolean',
--  value: true,
-+  value: false,
-   description: 'Build tests')
- option('introspection',
-   type: 'feature',
-@@ -12,7 +12,7 @@ option('man',
-   description: 'Enable generating the manual page (depends on xsltproc)')
- option('gtk_doc',
-   type: 'boolean',
--  value: true,
-+  value: false,
-   description: 'Enable generating the API reference (depends on GTK-Doc)')
- option('docbook_docs',
-   type: 'feature',

--- a/SPECS/libnotify/libnotify.signatures.json
+++ b/SPECS/libnotify/libnotify.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libnotify-0.7.9.tar.xz": "66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761"
+  "libnotify-0.8.3.tar.xz": "ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0"
  }
 }

--- a/SPECS/libnotify/libnotify.spec
+++ b/SPECS/libnotify/libnotify.spec
@@ -2,8 +2,8 @@
 %define majmin %(echo %{version} | cut -d. -f1-2)
 Summary:        Desktop notification library
 Name:           libnotify
-Version:        0.7.9
-Release:        4%{?dist}
+Version:        0.8.3
+Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -14,7 +14,6 @@ BuildRequires:  %{_bindir}/xsltproc
 BuildRequires:  gdk-pixbuf2-devel
 BuildRequires:  glib2-devel >= %{glib2_version}
 BuildRequires:  gobject-introspection-devel
-BuildRequires:  gtk-doc
 BuildRequires:  meson
 BuildRequires:  pkg-config
 BuildRequires:  xmlto
@@ -38,10 +37,10 @@ development of programs using %{name}.
 
 %prep
 %setup -q
-%patch0 -p1
+%patch 0 -p1
 
 %build
-%meson -Dman=false
+%meson -Dman=false -Dgtk_doc=false -Dtests=false
 %meson_build
 
 %install
@@ -54,16 +53,21 @@ development of programs using %{name}.
 %doc NEWS AUTHORS
 %{_bindir}/notify-send
 %{_libdir}/libnotify.so.*
-%{_libdir}/girepository-1.0/Notify-%{majmin}.typelib
+%{_libdir}/girepository-1.0/Notify-0.7.typelib
 
 %files devel
 %dir %{_includedir}/libnotify
 %{_includedir}/libnotify/*
 %{_libdir}/libnotify.so
 %{_libdir}/pkgconfig/libnotify.pc
-%{_datadir}/gir-1.0/Notify-%{majmin}.gir
+%{_datadir}/gir-1.0/Notify-0.7.gir
 
 %changelog
+* Wed Feb 28 2024 Sindhu Karri <lakarri@microsoft.com> - 0.8.3-1
+- Upgrade to 0.8.3
+- Update patch to use meson options to disable tests and gtk_doc
+- Remove build dependency on gtk-doc
+
 * Wed Dec 08 2021 Thomas Crain <thcrain@microsoft.com> - 0.7.9-4
 - License verified
 - Lint spec

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -10231,8 +10231,8 @@
         "type": "other",
         "other": {
           "name": "libnotify",
-          "version": "0.7.9",
-          "downloadUrl": "https://ftp.gnome.org/pub/GNOME/sources/libnotify/0.7/libnotify-0.7.9.tar.xz"
+          "version": "0.8.3",
+          "downloadUrl": "https://ftp.gnome.org/pub/GNOME/sources/libnotify/0.8/libnotify-0.8.3.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrade libnotify from 0.7.9 to 0.8.3 for Mariner 3.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade to 0.8.3
- Update patch to use meson options to disable tests and gtk_doc
- Remove build dependency on gtk-doc

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=515489&view=results
