### PR TITLE
Use systemd-255 macros in systemd-bootstrap

### DIFF
--- a/SPECS/systemd-bootstrap/macros.sysusers
+++ b/SPECS/systemd-bootstrap/macros.sysusers
@@ -1,0 +1,10 @@
+# RPM macros for packages creating system accounts
+#
+# Turn a sysusers.d file into macros specified by
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/UsersAndGroups/#_dynamic_allocation
+
+%sysusers_requires_compat Requires(pre): shadow-utils
+
+%sysusers_create_compat() \
+%(%{_rpmconfigdir}/sysusers.generate-pre.sh %{?*}) \
+%{nil}

--- a/SPECS/systemd-bootstrap/systemd-bootstrap.signatures.json
+++ b/SPECS/systemd-bootstrap/systemd-bootstrap.signatures.json
@@ -3,7 +3,11 @@
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "99-mariner.preset": "84326fcef828f893827f3d5acdb7a6fe722a8c8e593b19dcc68b082a1c597c79",
+  "macros.sysusers": "b7c3941912208657b68a5890b8e320d626a6bc17290a223b46071e251b240160",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",
-  "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
+  "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9",
+  "sysusers.attr": "49cffe66a7a366272e9ebac212f50dc9bc8d55aa6b4ef092fc87cb230bd50520",
+  "sysusers.generate-pre.sh": "6d503de2db2374125cb5c3b6034636514b58a38dcff193550768c3c49c6d7419",
+  "sysusers.prov": "0dcc4b699030c11eccedb850d4d2c097ebdc725766e17db56f942ee445b93cf6"
  }
 }

--- a/SPECS/systemd-bootstrap/systemd-bootstrap.spec
+++ b/SPECS/systemd-bootstrap/systemd-bootstrap.spec
@@ -33,6 +33,20 @@ Patch4:         CVE-2022-45873.patch
 Patch5:         backport-helper-util-macros.patch
 Patch6:         CVE-2022-4415.patch
 Patch7:         update-cifs-for-kernel-headers-6.1.patch
+
+# Directions for refreshing systemd macros:
+#    1. Update Source21->24 from main systemd directory, currently they are taken un-modified.
+#    2. Take systemd and systemd-bootstrap .src.rpms, install and run rpmbuild -bp --nodeps --noclean <srpm>.
+#    3. Personal flow to create patch:
+#         cd BUILD/systemd-stable-250 && git init && git add -A && git commit -m "init"
+#         cp ../systemd-stable-255/src/rpm/macros.systemd.in src/rpm/macros.systemd.in
+#         # Adjust changes as needed (LIBEXECDIR->ROOTLIBEXECDIR, define USER_TMPFILES_DIR), possibly split each change into its own commit
+#         git add -A && git commit -m "use-255-macros"
+#         # Use -1 for a single commit, or -3 etc. for more
+#         git format-patch -1 --stdout > use-255-macros.patch
+#    4. Update patch, then rebuild to validate changes
+#    5. Repeat from 2. as needed until it builds
+#    6. Build both systemd and systemd-bootstrap, validate the contents of systemd-rpm-macros and system-bootstrap-rpm-macros are idential
 Patch8:         use-255-macros.patch
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl

--- a/SPECS/systemd-bootstrap/systemd-bootstrap.spec
+++ b/SPECS/systemd-bootstrap/systemd-bootstrap.spec
@@ -37,16 +37,16 @@ Patch7:         update-cifs-for-kernel-headers-6.1.patch
 # Directions for refreshing systemd macros:
 #    1. Update Source21->24 from main systemd directory, currently they are taken un-modified.
 #    2. Take systemd and systemd-bootstrap .src.rpms, install and run rpmbuild -bp --nodeps --noclean <srpm>.
-#    3. Personal flow to create patch:
+#    3. Create a patch:
 #         cd BUILD/systemd-stable-250 && git init && git add -A && git commit -m "init"
 #         cp ../systemd-stable-255/src/rpm/macros.systemd.in src/rpm/macros.systemd.in
-#         # Adjust changes as needed (LIBEXECDIR->ROOTLIBEXECDIR, define USER_TMPFILES_DIR), possibly split each change into its own commit
+#         # Adjust changes as needed (LIBEXECDIR->ROOTLIBEXECDIR, define USER_TMPFILES_DIR), ideally split each change into its own commit for ease of review.
 #         git add -A && git commit -m "use-255-macros"
 #         # Use -1 for a single commit, or -3 etc. for more
 #         git format-patch -1 --stdout > use-255-macros.patch
 #    4. Update patch, then rebuild to validate changes
 #    5. Repeat from 2. as needed until it builds
-#    6. Build both systemd and systemd-bootstrap, validate the contents of systemd-rpm-macros and system-bootstrap-rpm-macros are idential
+#    6. Build both systemd and systemd-bootstrap, validate the contents of systemd-rpm-macros and system-bootstrap-rpm-macros are identical
 Patch8:         use-255-macros.patch
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl

--- a/SPECS/systemd-bootstrap/systemd-bootstrap.spec
+++ b/SPECS/systemd-bootstrap/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -12,6 +12,13 @@ Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
 Source4:        99-mariner.preset
+
+# Taken from systemd-255
+Source21:       macros.sysusers
+Source22:       sysusers.attr
+Source23:       sysusers.prov
+Source24:       sysusers.generate-pre.sh
+
 Patch0:         fix-journald-audit-logging.patch
 # Patch1 can be removed once we update systemd to a version containing the following commit:
 # https://github.com/systemd/systemd/commit/19193b489841a7bcccda7122ac0849cf6efe59fd
@@ -26,6 +33,7 @@ Patch4:         CVE-2022-45873.patch
 Patch5:         backport-helper-util-macros.patch
 Patch6:         CVE-2022-4415.patch
 Patch7:         update-cifs-for-kernel-headers-6.1.patch
+Patch8:         use-255-macros.patch
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
 BuildRequires:  gettext
@@ -147,6 +155,12 @@ install -dm 0755 %{buildroot}/%{_sysconfdir}/systemd/network
 install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
 install -D -m 0644 %{SOURCE4} %{buildroot}%{_libdir}/systemd/system-preset/99-mariner.preset
 
+# Taken from systemd-255
+install -m 0644 -D -t %{buildroot}%{_rpmconfigdir}/macros.d/ %{SOURCE21}
+install -m 0644 -D -t %{buildroot}%{_rpmconfigdir}/fileattrs/ %{SOURCE22}
+install -m 0755 -D -t %{buildroot}%{_rpmconfigdir}/ %{SOURCE23}
+install -m 0755 -D -t %{buildroot}%{_rpmconfigdir}/ %{SOURCE24}
+
 # Enable default systemd units.
 %post
 /sbin/ldconfig
@@ -248,6 +262,9 @@ fi
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Tue Feb 27 2024 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-16
+- Take rpm-macros from the new systemd-255 package so they are interchangeable
+
 * Tue Feb 06 2024 Dan Streetman <ddstreet@ieee.org> - 250.3-15
 - do not conflict with polkit dir
 

--- a/SPECS/systemd-bootstrap/sysusers.attr
+++ b/SPECS/systemd-bootstrap/sysusers.attr
@@ -1,0 +1,2 @@
+%__sysusers_provides	%{_rpmconfigdir}/sysusers.prov
+%__sysusers_path	^%{_sysusersdir}/.*\\.conf$

--- a/SPECS/systemd-bootstrap/sysusers.generate-pre.sh
+++ b/SPECS/systemd-bootstrap/sysusers.generate-pre.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: true; tab-width: 4; -*-
+
+# This script turns sysuser.d files into scriptlets mandated by Fedora
+# packaging guidelines. The general idea is to define users using the
+# declarative syntax but to turn this into traditional scriptlets.
+
+user() {
+	user="$1"
+	uid="$2"
+	desc="$3"
+	group="$4"
+	home="$5"
+	shell="$6"
+
+	[ "$desc" = '-' ] && desc=
+	{ [ "$home" = '-' ] || [ "$home" = '' ]; } && home=/
+	{ [ "$shell" = '-' ] || [ "$shell" = '' ]; } && shell=/usr/sbin/nologin
+
+	if [ "$uid" = '-' ] || [ "$uid" = '' ]; then
+		cat <<-EOF
+		getent passwd '$user' >/dev/null || \\
+		    useradd -r -g ${group@Q} -d ${home@Q} -s ${shell@Q} -c ${desc@Q} ${user@Q} || :
+		EOF
+	else
+		cat <<-EOF
+		if ! getent passwd ${user@Q} >/dev/null; then
+		    if ! getent passwd ${uid@Q} >/dev/null; then
+		        useradd -r -u ${uid@Q} -g ${group@Q} -d ${home@Q} -s ${shell@Q} -c ${desc@Q} ${user@Q} || :
+		    else
+		        useradd -r -g ${group@Q} -d ${home@Q} -s ${shell@Q} -c ${desc@Q} ${user@Q} || :
+		    fi
+		fi
+
+		EOF
+	fi
+}
+
+group() {
+	group="$1"
+	gid="$2"
+
+	if [ "$gid" = '-' ]; then
+		cat <<-EOF
+		getent group ${group@Q} >/dev/null || groupadd -r ${group@Q} || :
+		EOF
+	else
+		cat <<-EOF
+		getent group ${group@Q} >/dev/null || groupadd -f -g ${gid@Q} -r ${group@Q} || :
+		EOF
+	fi
+}
+
+usermod() {
+	user="$1"
+	group="$2"
+
+	cat <<-EOF
+	if getent group ${group@Q} >/dev/null; then
+	    usermod -a -G ${group@Q} '$user' || :
+	fi
+	EOF
+}
+
+parse() {
+	while read -r line || [ -n "$line" ] ; do
+		{ [ "${line:0:1}" = '#' ] || [ "${line:0:1}" = ';' ]; } && continue
+		line="${line## *}"
+		[ -z "$line" ] && continue
+		eval "arr=( $line )"
+		case "${arr[0]}" in
+			('u')
+				if [[ "${arr[2]}" == *":"* ]]; then
+					user "${arr[1]}" "${arr[2]%:*}" "${arr[3]}" "${arr[2]#*:}" "${arr[4]}" "${arr[5]}"
+				else
+					group "${arr[1]}" "${arr[2]}"
+					user "${arr[1]}" "${arr[2]}" "${arr[3]}" "${arr[1]}" "${arr[4]}" "${arr[5]}"
+				fi
+				;;
+			('g')
+				group "${arr[1]}" "${arr[2]}"
+				;;
+			('m')
+				group "${arr[2]}" "-"
+				user "${arr[1]}" "-" "" "${arr[1]}" "" ""
+				usermod "${arr[1]}" "${arr[2]}"
+				;;
+		esac
+	done
+}
+
+for fn in "$@"; do
+	[ -e "$fn" ] || continue
+	echo "# generated from $(basename "$fn")"
+	parse <"$fn"
+done

--- a/SPECS/systemd-bootstrap/sysusers.prov
+++ b/SPECS/systemd-bootstrap/sysusers.prov
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+process_u() {
+    if [ ! -z "${2##*[!0-9]*}" ]; then
+        # Single shared static ID.
+        echo "user($1) = $2"
+        echo "group($1) = $2"
+    elif [[ $2 == *:* ]]; then
+        # UID:<group>.
+        uid=$(echo $2 | cut -d':' -f1 -)
+        group=$(echo $2 | cut -d':' -f2 -)
+        if [ ! -z "${group##*[!0-9]*}" ]; then
+            # UID:GID.
+            echo "user($1) = ${uid}"
+            echo "group($1) = ${group}"
+        else
+            # UID:<groupname>.
+            echo "user($1) = ${uid}"
+            echo "group(${group})"
+        fi
+    else
+        # Dynamic (or something else uninteresting).
+        echo "user($1)"
+        echo "group($1)"
+    fi
+}
+
+process_g() {
+    if [ ! -z "${2##*[!0-9]*}" ]; then
+        # Static GID.
+        echo "group($1) = $2"
+    else
+        # Dynamic (or something else uninteresting).
+        echo "group($1)"
+    fi
+}
+
+parse() {
+    while read line; do
+        [ "${line:0:1}" = '#' -o "${line:0:1}" = ';' ] && continue
+        line="${line## *}"
+        [ -z "$line" ] && continue
+        set -- $line
+        case "$1" in
+            ('u')
+                process_u "$2" "$3"
+                ;;
+            ('g')
+                process_g "$2" "$3"
+                ;;
+            ('m')
+                echo "user($2)"
+                echo "group($3)"
+                ;;
+        esac
+    done
+}
+
+while read fn; do
+    parse < "$fn"
+done

--- a/SPECS/systemd-bootstrap/use-255-macros.patch
+++ b/SPECS/systemd-bootstrap/use-255-macros.patch
@@ -1,0 +1,148 @@
+From 213d8e7bd3777c112ca36a5ddd7fe1d5ed081fc6 Mon Sep 17 00:00:00 2001
+From: Daniel McIlvaney <damcilva@microsoft.com>
+Date: Tue, 27 Feb 2024 16:08:02 -0800
+Subject: [PATCH 1/3] Take macros from 255
+
+---
+ src/rpm/macros.systemd.in | 30 +++++++++++++++++++++++++++---
+ 1 file changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/src/rpm/macros.systemd.in b/src/rpm/macros.systemd.in
+index caa2e45..241e4b9 100644
+--- a/src/rpm/macros.systemd.in
++++ b/src/rpm/macros.systemd.in
+@@ -5,7 +5,7 @@
+ 
+ # RPM macros for packages installing systemd unit files
+ 
+-%_systemd_util_dir {{ROOTLIBEXECDIR}}
++%_systemd_util_dir {{LIBEXECDIR}}
+ %_unitdir {{SYSTEM_DATA_UNIT_DIR}}
+ %_userunitdir {{USER_DATA_UNIT_DIR}}
+ %_presetdir {{SYSTEM_PRESET_DIR}}
+@@ -17,6 +17,7 @@
+ %_sysctldir {{SYSCTL_DIR}}
+ %_sysusersdir {{SYSUSERS_DIR}}
+ %_tmpfilesdir {{TMPFILES_DIR}}
++%_user_tmpfilesdir {{USER_TMPFILES_DIR}}
+ %_environmentdir {{ENVIRONMENT_DIR}}
+ %_modulesloaddir {{MODULESLOAD_DIR}}
+ %_modprobedir {{MODPROBE_DIR}}
+@@ -100,6 +101,29 @@ if [ $1 -ge 1 ] && [ -x "{{SYSTEMD_UPDATE_HELPER_PATH}}" ]; then \
+ fi \
+ %{nil}
+ 
++%systemd_postun_with_reload() \
++%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_postun_with_reload}} \
++if [ $1 -ge 1 ] && [ -x "{{SYSTEMD_UPDATE_HELPER_PATH}}" ]; then \
++    # Package upgrade, not uninstall \
++    {{SYSTEMD_UPDATE_HELPER_PATH}} mark-reload-system-units %{?*} || : \
++fi \
++%{nil}
++
++%systemd_user_postun_with_reload() \
++%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_postun_with_reload}} \
++if [ $1 -ge 1 ] && [ -x "{{SYSTEMD_UPDATE_HELPER_PATH}}" ]; then \
++    # Package upgrade, not uninstall \
++    {{SYSTEMD_UPDATE_HELPER_PATH}} mark-reload-user-units %{?*} || : \
++fi \
++%{nil}
++
++%systemd_user_daemon_reexec() \
++if [ $1 -ge 1 ] && [ -x "{{SYSTEMD_UPDATE_HELPER_PATH}}" ]; then \
++    # Package upgrade, not uninstall \
++    {{SYSTEMD_UPDATE_HELPER_PATH}} user-reexec || : \
++fi \
++%{nil}
++
+ %udev_hwdb_update() %{nil}
+ 
+ %udev_rules_update() %{nil}
+@@ -166,10 +190,10 @@ SYSTEMD_INLINE_EOF\
+ 
+ %sysctl_apply() \
+ %{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# sysctl_apply}} \
+-[ -x {{ROOTLIBEXECDIR}}/systemd-sysctl ] && {{ROOTLIBEXECDIR}}/systemd-sysctl %{?*} || : \
++[ -x {{LIBEXECDIR}}/systemd-sysctl ] && {{LIBEXECDIR}}/systemd-sysctl %{?*} || : \
+ %{nil}
+ 
+ %binfmt_apply() \
+ %{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# binfmt_apply}} \
+-[ -x {{ROOTLIBEXECDIR}}/systemd-binfmt ] && {{ROOTLIBEXECDIR}}/systemd-binfmt %{?*} || : \
++[ -x {{LIBEXECDIR}}/systemd-binfmt ] && {{LIBEXECDIR}}/systemd-binfmt %{?*} || : \
+ %{nil}
+-- 
+2.33.8
+
+
+From f419e848e60c2aaf16da857e5b68769082bcce92 Mon Sep 17 00:00:00 2001
+From: Daniel McIlvaney <damcilva@microsoft.com>
+Date: Tue, 27 Feb 2024 16:09:38 -0800
+Subject: [PATCH 2/3] Adjust to work on 250
+
+---
+ src/rpm/macros.systemd.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/rpm/macros.systemd.in b/src/rpm/macros.systemd.in
+index 241e4b9..8d5895e 100644
+--- a/src/rpm/macros.systemd.in
++++ b/src/rpm/macros.systemd.in
+@@ -5,7 +5,7 @@
+ 
+ # RPM macros for packages installing systemd unit files
+ 
+-%_systemd_util_dir {{LIBEXECDIR}}
++%_systemd_util_dir {{ROOTLIBEXECDIR}}
+ %_unitdir {{SYSTEM_DATA_UNIT_DIR}}
+ %_userunitdir {{USER_DATA_UNIT_DIR}}
+ %_presetdir {{SYSTEM_PRESET_DIR}}
+@@ -190,10 +190,10 @@ SYSTEMD_INLINE_EOF\
+ 
+ %sysctl_apply() \
+ %{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# sysctl_apply}} \
+-[ -x {{LIBEXECDIR}}/systemd-sysctl ] && {{LIBEXECDIR}}/systemd-sysctl %{?*} || : \
++[ -x {{ROOTLIBEXECDIR}}/systemd-sysctl ] && {{ROOTLIBEXECDIR}}/systemd-sysctl %{?*} || : \
+ %{nil}
+ 
+ %binfmt_apply() \
+ %{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# binfmt_apply}} \
+-[ -x {{LIBEXECDIR}}/systemd-binfmt ] && {{LIBEXECDIR}}/systemd-binfmt %{?*} || : \
++[ -x {{ROOTLIBEXECDIR}}/systemd-binfmt ] && {{ROOTLIBEXECDIR}}/systemd-binfmt %{?*} || : \
+ %{nil}
+-- 
+2.33.8
+
+
+From 3709bfb05e27e265a367f4cbe71fb1cf600b5551 Mon Sep 17 00:00:00 2001
+From: Daniel McIlvaney <damcilva@microsoft.com>
+Date: Tue, 27 Feb 2024 17:56:28 -0800
+Subject: [PATCH 3/3] Update meson.build
+
+---
+ meson.build | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index e07875a..254cc09 100644
+--- a/meson.build
++++ b/meson.build
+@@ -153,6 +153,7 @@ pkgsysconfdir = sysconfdir / 'systemd'
+ userunitdir = prefixdir / 'lib/systemd/user'
+ userpresetdir = prefixdir / 'lib/systemd/user-preset'
+ tmpfilesdir = prefixdir / 'lib/tmpfiles.d'
++usertmpfilesdir = prefixdir / 'share/user-tmpfiles.d'
+ sysusersdir = prefixdir / 'lib/sysusers.d'
+ sysctldir = prefixdir / 'lib/sysctl.d'
+ binfmtdir = prefixdir / 'lib/binfmt.d'
+@@ -278,6 +279,7 @@ conf.set_quoted('SYSTEM_SYSVINIT_PATH',                       sysvinit_path)
+ conf.set_quoted('SYSTEM_SYSVRCND_PATH',                       sysvrcnd_path)
+ conf.set_quoted('SYSUSERS_DIR',                               sysusersdir)
+ conf.set_quoted('TMPFILES_DIR',                               tmpfilesdir)
++conf.set_quoted('USER_TMPFILES_DIR',                          usertmpfilesdir)
+ conf.set_quoted('UDEVLIBEXECDIR',                             udevlibexecdir)
+ conf.set_quoted('UDEV_HWDB_DIR',                              udevhwdbdir)
+ conf.set_quoted('UDEV_RULES_DIR',                             udevrulesdir)
+-- 
+2.33.8
+

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -5,10 +5,7 @@
   "10-oomd-per-slice-defaults.conf": "3f0d6882312affecddfdc5a204a44c34b90c573839f2a4850a26b44f528520bd",
   "10-timeout-abort.conf": "ae6b234f92bc22f1201a7572b59b454c9809f33c80d13f361b9674e1801acc37",
   "20-yama-ptrace.conf": "f7881466bff200865ec2c6b5f989ed35855ac45420a55ae5ace805f9e5111828",
-  "26494.patch": "1242a0db037a2c8e5de3c8b676aad63caaae60d674227ec58d1ea11f085a996b",
-  "95-disable-systemd-oomd.preset": "f2cc3a853de7d56431644b3b54d9a850dd6db01b7f00b86e108f50a845fc8edc",
   "98-default-mac-none.link": "11efa1aee1d52e74b3ca5d1db903e9e1f3ca5e07498c25ea13e40452e2430e1a",
-  "fedora-use-system-auth-in-pam-systemd-user.patch": "b1c8206a0ca6d5283130ec01387b8277e1478d5f01a7beeaa77d350e71e6c5e4",
   "macros.sysusers": "b7c3941912208657b68a5890b8e320d626a6bc17290a223b46071e251b240160",
   "split-files.py": "ff2ace09f116028299f75ab1f81ca467a6dc4e7ad38c27c22d2e8dd1229ad0dd",
   "sysctl.conf.README": "51d16ee2e7eef12dd42e924af6b835861e8b79d11921ba0418d7d0aec7a2a93b",
@@ -20,7 +17,6 @@
   "sysusers.generate-pre.sh": "6d503de2db2374125cb5c3b6034636514b58a38dcff193550768c3c49c6d7419",
   "sysusers.prov": "0dcc4b699030c11eccedb850d4d2c097ebdc725766e17db56f942ee445b93cf6",
   "triggers.systemd": "ee7398bec872cc3717d396d201c0a9d4239b883d5f43cb609ab83b229119ceb6",
-  "use-bfq-scheduler.patch": "d47f3224b6c984ff7f4335c1e127f86380c45beadfaabc73f09dc993aac908ed",
   "yum-protect-systemd.conf": "5a5aa0a6cdfb432f890351ebd1f62d05f9a04d5aa58f57d0758686afaa8d3617"
  }
 }

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -565,10 +565,10 @@ sqlite-devel-3.44.0-1.azl3.aarch64.rpm
 sqlite-libs-3.44.0-1.azl3.aarch64.rpm
 swig-4.1.1-1.azl3.aarch64.rpm
 swig-debuginfo-4.1.1-1.azl3.aarch64.rpm
-systemd-bootstrap-250.3-15.azl3.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-15.azl3.aarch64.rpm
-systemd-bootstrap-devel-250.3-15.azl3.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-15.azl3.noarch.rpm
+systemd-bootstrap-.*250.3-16.azl3.aarch64.rpm
+systemd-bootstrap-.*250.3-16.azl3.aarch64.rpm
+systemd-bootstrap-.*250.3-16.azl3.aarch64.rpm
+systemd-bootstrap-.*250.3-16.azl3.noarch.rpm
 tar-1.35-1.azl3.aarch64.rpm
 tar-debuginfo-1.35-1.azl3.aarch64.rpm
 tdnf-3.5.2-3.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -565,10 +565,10 @@ sqlite-devel-3.44.0-1.azl3.aarch64.rpm
 sqlite-libs-3.44.0-1.azl3.aarch64.rpm
 swig-4.1.1-1.azl3.aarch64.rpm
 swig-debuginfo-4.1.1-1.azl3.aarch64.rpm
-systemd-bootstrap-.*250.3-16.azl3.aarch64.rpm
-systemd-bootstrap-.*250.3-16.azl3.aarch64.rpm
-systemd-bootstrap-.*250.3-16.azl3.aarch64.rpm
-systemd-bootstrap-.*250.3-16.azl3.noarch.rpm
+systemd-bootstrap-250.3-16.azl3.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-16.azl3.aarch64.rpm
+systemd-bootstrap-devel-250.3-16.azl3.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-16.azl3.noarch.rpm
 tar-1.35-1.azl3.aarch64.rpm
 tar-debuginfo-1.35-1.azl3.aarch64.rpm
 tdnf-3.5.2-3.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -571,10 +571,10 @@ sqlite-devel-3.44.0-1.azl3.x86_64.rpm
 sqlite-libs-3.44.0-1.azl3.x86_64.rpm
 swig-4.1.1-1.azl3.x86_64.rpm
 swig-debuginfo-4.1.1-1.azl3.x86_64.rpm
-systemd-bootstrap-250.3-15.azl3.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-15.azl3.x86_64.rpm
-systemd-bootstrap-devel-250.3-15.azl3.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-15.azl3.noarch.rpm
+systemd-bootstrap-.*250.3-16.azl3.x86_64.rpm
+systemd-bootstrap-.*250.3-16.azl3.x86_64.rpm
+systemd-bootstrap-.*250.3-16.azl3.x86_64.rpm
+systemd-bootstrap-.*250.3-16.azl3.noarch.rpm
 tar-1.35-1.azl3.x86_64.rpm
 tar-debuginfo-1.35-1.azl3.x86_64.rpm
 tdnf-3.5.2-3.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -571,10 +571,10 @@ sqlite-devel-3.44.0-1.azl3.x86_64.rpm
 sqlite-libs-3.44.0-1.azl3.x86_64.rpm
 swig-4.1.1-1.azl3.x86_64.rpm
 swig-debuginfo-4.1.1-1.azl3.x86_64.rpm
-systemd-bootstrap-.*250.3-16.azl3.x86_64.rpm
-systemd-bootstrap-.*250.3-16.azl3.x86_64.rpm
-systemd-bootstrap-.*250.3-16.azl3.x86_64.rpm
-systemd-bootstrap-.*250.3-16.azl3.noarch.rpm
+systemd-bootstrap-250.3-16.azl3.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-16.azl3.x86_64.rpm
+systemd-bootstrap-devel-250.3-16.azl3.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-16.azl3.noarch.rpm
 tar-1.35-1.azl3.x86_64.rpm
 tar-debuginfo-1.35-1.azl3.x86_64.rpm
 tdnf-3.5.2-3.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There is currently no quick path to upgrading systemd-bootstrap, but we need to align to the macros in the new systemd-255. Packages that use macros like `%systemd_requires` or `%systemd_post` use them statically, i.e., the macros are evaluated at `rpmbuild` time and encoded into the `.rpm`. This means that any package using `systemd-bootstrap-rpm-macros` to build would be left using outdated macros.

Until we can get `systemd-bootstrap` aligned with `systemd` we should at least make sure the macros and associated components are updated to match.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Port systemd-255's macros to systemd-250

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Full build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=516187&view=results
