### PR TITLE
Allow both CBL-Mariner and Azure Linux in spec source changelog entry

### DIFF
--- a/toolkit/scripts/spec_source_attributions.py
+++ b/toolkit/scripts/spec_source_attributions.py
@@ -7,22 +7,22 @@ from pyrpm.spec import Spec
 import re
 
 VALID_SOURCE_ATTRIBUTIONS = {
-    "Microsoft":                      r'\n-\s+(Original version for CBL-Mariner|Initial CBL-Mariner import from Azure)( \(license: MIT\))?(\.|\n|$)',
-    "CentOS":                         r'\n-\s+Initial CBL-Mariner import from CentOS \d+ \(license: MIT\)(\.|\n|$)',
-    "Ceph source":                    r'\n-\s+Initial CBL-Mariner import from Ceph source \(license: LGPLv2.1\)(\.|\n|$)',
-    "Debian":                         r'\n-\s+Initial CBL-Mariner import from Debian source package \(license: MIT\)(\.|\n|$)',
-    "Netplan source":                 r'\n-\s+Initial CBL-Mariner import from Netplan source \(license: GPLv3\)(\.|\n|$)',
-    "Fedora":                         r'\n-\s+Initial CBL-Mariner import from Fedora \d+ \(license: MIT\)(\.|\n|$)',
-    "Fedora (Copyright Remi Collet)": r'\n-\s+Initial CBL-Mariner import from Fedora \d+ \(license: CC-BY-SA\)(\.|\n|$)',
-    "Fedora (ISC)":                   r'\n-\s+Initial CBL-Mariner import from Fedora \d+ \(license: ISC\)(\.|\n|$)',
-    "Magnus Edenhill Open Source":    r'\n-\s+Initial CBL-Mariner import from Magnus Edenhill Open Source \(license: BSD\)(\.|\n|$)',
-    "NVIDIA":                         r'\n-\s+Initial CBL-Mariner import from NVIDIA \(license: (ASL 2\.0|GPLv2)\)(\.|\n|$)',
-    "OpenEuler":                      r'\n-\s+Initial CBL-Mariner import from OpenEuler \(license: BSD\)(\.|\n|$)',
-    "OpenMamba":                      r'\n-\s+Initial CBL-Mariner import from OpenMamba(\.|\n|$)',
-    "OpenSUSE":                       r'\n-\s+Initial CBL-Mariner import from openSUSE \w+ \(license: same as "License" tag\)(\.|\n|$)',
-    "Photon":                         r'\n-\s+Initial CBL-Mariner import from Photon \(license: Apache2\)(\.|\n|$)',
-    "Sysbench source":                r'\n-\s+Initial CBL-Mariner import from Sysbench source \(license: GPLv2\+\)(\.|\n|$)',
-    "RPM software management source": r'\n-\s+Initial CBL-Mariner import from RPM software management source \(license: GPLv2\+\)(\.|\n|$)'
+    "Microsoft":                      r'\n-\s+(Original version for (CBL-Mariner|Azure Linux)|Initial (CBL-Mariner|Azure Linux) import from Azure)( \(license: MIT\))?(\.|\n|$)',
+    "CentOS":                         r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from CentOS \d+ \(license: MIT\)(\.|\n|$)',
+    "Ceph source":                    r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Ceph source \(license: LGPLv2.1\)(\.|\n|$)',
+    "Debian":                         r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Debian source package \(license: MIT\)(\.|\n|$)',
+    "Netplan source":                 r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Netplan source \(license: GPLv3\)(\.|\n|$)',
+    "Fedora":                         r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Fedora \d+ \(license: MIT\)(\.|\n|$)',
+    "Fedora (Copyright Remi Collet)": r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Fedora \d+ \(license: CC-BY-SA\)(\.|\n|$)',
+    "Fedora (ISC)":                   r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Fedora \d+ \(license: ISC\)(\.|\n|$)',
+    "Magnus Edenhill Open Source":    r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Magnus Edenhill Open Source \(license: BSD\)(\.|\n|$)',
+    "NVIDIA":                         r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from NVIDIA \(license: (ASL 2\.0|GPLv2)\)(\.|\n|$)',
+    "OpenEuler":                      r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from OpenEuler \(license: BSD\)(\.|\n|$)',
+    "OpenMamba":                      r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from OpenMamba(\.|\n|$)',
+    "OpenSUSE":                       r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from openSUSE \w+ \(license: same as "License" tag\)(\.|\n|$)',
+    "Photon":                         r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Photon \(license: Apache2\)(\.|\n|$)',
+    "Sysbench source":                r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from Sysbench source \(license: GPLv2\+\)(\.|\n|$)',
+    "RPM software management source": r'\n-\s+Initial (CBL-Mariner|Azure Linux) import from RPM software management source \(license: GPLv2\+\)(\.|\n|$)'
 }
 
 KNOWN_SOURCE_ORIGINS = VALID_SOURCE_ATTRIBUTIONS.keys()


### PR DESCRIPTION
For new packages in 3.0, the changelog entry where we mention the source of the spec file should be allowed to contain either CBL-Mariner or Azure Linux. Updating the regex in spec file check to use that logic.