### PR TITLE
add signature check

### DIFF
--- a/.github/workflows/check-signatures.yml
+++ b/.github/workflows/check-signatures.yml
@@ -48,42 +48,4 @@ jobs:
           changed_folders=$(dirname $(git diff-tree --diff-filter=d --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }}) | sort --unique)
           echo "Folders to validate: '${changed_folders}'"
           
-          for DIR in $changed_folders
-          do
-            echo "check $DIR"
-            for SIGNATURE_FILE in $(pwd)/$DIR/*.signatures.json
-            do
-              echo "check $SIGNATURE_FILE"
-              if [[ -f "$SIGNATURE_FILE" ]]
-              then
-                echo  "$SIGNATURE_FILE exists"
-                cat $SIGNATURE_FILE
-                echo  "$SIGNATURE_FILE files: [$(jq -r '.Signatures | keys[]' $SIGNATURE_FILE)]"
-                echo  "$SIGNATURE_FILE signatures: [$(jq -r '.Signatures[]' $SIGNATURE_FILE)]"
-
-                keys=$(jq -r '.Signatures | keys[]' $SIGNATURE_FILE)
-                for KEY in $keys
-                do
-                  file_to_test="$(pwd)/$DIR/$KEY"
-                  echo "check $file_to_test"
-
-                  if [[ -e $file_to_test ]]
-                  then
-                    echo "$file_to_test exists"
-
-                    echo  "$KEY: expect $(jq -r ".Signatures[\"$KEY\"]" $SIGNATURE_FILE)"
-                    echo  "$KEY: actual $(sha256sum $file_to_test  | awk '{print $1}')"
-
-                    expected_signature=$(jq -r ".Signatures[\"$KEY\"]" $SIGNATURE_FILE)
-                    actual_signature=$(sha256sum $file_to_test  | awk '{print $1}')
-                    if [[ "$actual_signature" != "$expected_signature" ]]
-                    then
-                      echo "Mismatched signatures for $file_to_test: expeceted=$expected_signature actual=$actual_signature"
-                      exit 1
-                    fi
-                  fi
-                done
-              fi
-            done
-          done
-
+          python3 toolkit/scripts/check_signatures.py ${changed_folders}

--- a/.github/workflows/check-signatures.yml
+++ b/.github/workflows/check-signatures.yml
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Signature files check
+
+on:
+  push:
+    branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
+  pull_request:
+    branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
+
+jobs:
+  spec-check:
+    name: Signature files check
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the branch of our repo that triggered this action
+      - name: Workflow trigger checkout
+        uses: actions/checkout@v4
+
+      # For consistency, we use the same major/minor version of Python that CBL-Mariner ships
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Get Python dependencies
+        run: python3 -m pip install -r toolkit/scripts/requirements.txt
+
+      - name: Get base commit for PRs
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          echo "base_sha=$(git rev-parse origin/${{ github.base_ref }})" >> $GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.base_ref }}"
+
+      - name: Get base commit for Pushes
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          git fetch origin ${{ github.event.before }}
+          echo "base_sha=${{ github.event.before }}" >> $GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
+
+      - name: Check the signatures
+        run: |
+          echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
+          changed_folders=$(dirname $(git diff-tree --diff-filter=d --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }}) | sort --unique)
+          echo "Folders to validate: '${changed_folders}'"
+          
+          for DIR in $changed_folders
+          do
+            echo "check $DIR"
+            for SIGNATURE_FILE in $(pwd)/$DIR/*.signatures.json
+            do
+              echo "check $SIGNATURE_FILE"
+              if [[ -f "$SIGNATURE_FILE" ]]
+              then
+                echo  "$SIGNATURE_FILE exists"
+                cat $SIGNATURE_FILE
+                echo  "$SIGNATURE_FILE files: [$(jq -r '.Signatures | keys[]' $SIGNATURE_FILE)]"
+                echo  "$SIGNATURE_FILE signatures: [$(jq -r '.Signatures[]' $SIGNATURE_FILE)]"
+
+                keys=$(jq -r '.Signatures | keys[]' $SIGNATURE_FILE)
+                for KEY in $keys
+                do
+                  file_to_test="$(pwd)/$DIR/$KEY"
+                  echo "check $file_to_test"
+
+                  if [[ -e $file_to_test ]]
+                  then
+                    echo "$file_to_test exists"
+
+                    echo  "$KEY: expect $(jq -r ".Signatures[\"$KEY\"]" $SIGNATURE_FILE)"
+                    echo  "$KEY: actual $(sha256sum $file_to_test  | awk '{print $1}')"
+
+                    expected_signature=$(jq -r ".Signatures[\"$KEY\"]" $SIGNATURE_FILE)
+                    actual_signature=$(sha256sum $file_to_test  | awk '{print $1}')
+                    if [[ "$actual_signature" != "$expected_signature" ]]
+                    then
+                      echo "Mismatched signatures for $file_to_test: expeceted=$expected_signature actual=$actual_signature"
+                      exit 1
+                    fi
+                  fi
+                done
+              fi
+            done
+          done
+

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from os.path import join
+from pathlib import Path
+
+import argparse
+import hashlib
+import json
+import sys
+
+def getSignature(fileName) -> str:
+    with open(fileName, "rb") as tarballFile:
+        sha256sum = hashlib.sha256()
+        while True:
+            read_data = tarballFile.read()
+            if not read_data:
+                break
+            sha256sum.update(read_data)
+    return sha256sum.hexdigest()
+
+def check_folder(path):
+    for signature_path in Path(path).glob("*.signatures.json"):
+        with open(signature_path, "r") as f:
+            signatures_json = json.load(f)
+            for file_to_check, expected_signature in signatures_json["Signatures"].items():
+                path_to_check = join(path, file_to_check)
+                if Path(path_to_check).is_file():
+                    actual_signature = getSignature(path_to_check)
+                    if actual_signature != expected_signature:
+                        print(f"ERROR: detected a mismatched signature for {file_to_check}, expected [{expected_signature}] does not equal actual [{actual_signature}]")
+                        return False
+                else:
+                    print(f"{file_to_check} is not found in CBL-Mariner, build to verify signature")
+        return True
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Tool for checking if a folder containing a signatures.json file contains files with matching signatures.")
+    parser.add_argument('folders',
+                        metavar='folder_path',
+                        nargs='+',
+                        help='path to check for signature correctness')
+    args = parser.parse_args()
+
+    signatures_correct = True
+    for folder in args.folders:
+        if not check_folder(folder):
+            signatures_correct = False
+
+    if signatures_correct:
+        print("====================== Signatures verification PASSED ======================")
+    else:
+        print("""====================== Signatures verification FAILED ======================
+
+Please update the mismatched files listed above.
+""")
+        sys.exit(1)

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -21,6 +21,7 @@ def getSignature(fileName) -> str:
     return sha256sum.hexdigest()
 
 def check_folder(path):
+    signatures_correct = True
     for signature_path in Path(path).glob("*.signatures.json"):
         with open(signature_path, "r") as f:
             signatures_json = json.load(f)
@@ -30,10 +31,10 @@ def check_folder(path):
                     actual_signature = getSignature(path_to_check)
                     if actual_signature != expected_signature:
                         print(f"ERROR: detected a mismatched signature for {file_to_check}, expected [{expected_signature}] does not equal actual [{actual_signature}]")
-                        return False
+                        signatures_correct = False
                 else:
                     print(f"{file_to_check} is not found in CBL-Mariner, build to verify signature")
-    return True
+    return signatures_correct
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -33,7 +33,7 @@ def check_folder(path):
                         return False
                 else:
                     print(f"{file_to_check} is not found in CBL-Mariner, build to verify signature")
-        return True
+    return True
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -45,9 +45,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     signatures_correct = True
-    for folder in args.folders:
-        if not check_folder(folder):
-            signatures_correct = False
+    for folder_arg in args.folders:
+        split_folders = folder_arg.split()
+        for folder in split_folders:
+            if not check_folder(folder):
+                signatures_correct = False
 
     if signatures_correct:
         print("====================== Signatures verification PASSED ======================")


### PR DESCRIPTION
add signature check to list of other checks.  validation of files (that exist in this repo, not downloaded src tarballs) that show up in *.signatures.json for directories included in a given PR.

ways to make this better:
* check downloaded tarballs as well
