### PR TITLE
rsyslog: move snmp capabilities into subpackage

### DIFF
--- a/SPECS/rsyslog/rsyslog.spec
+++ b/SPECS/rsyslog/rsyslog.spec
@@ -3,7 +3,7 @@
 Summary:        Rocket-fast system for log processing
 Name:           rsyslog
 Version:        8.2308.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3+ AND ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -26,7 +26,6 @@ BuildRequires:  libgcrypt-devel
 BuildRequires:  liblognorm-devel
 BuildRequires:  librdkafka-devel
 BuildRequires:  librelp-devel
-BuildRequires:  net-snmp-devel
 BuildRequires:  postgresql-devel
 BuildRequires:  systemd-devel
 BuildRequires:  zlib-devel
@@ -62,6 +61,21 @@ BuildArch:      noarch
 
 %description    doc
 HTML documentation for %{name}
+
+%package mmsnmptrapd
+Summary: rsyslog support for snmptrapd
+Requires: %name = %version-%release
+
+%description mmsnmptrapd
+%{summary}
+
+%package snmp
+Summary: rsyslog support for SNMP
+Requires: %name = %version-%release
+BuildRequires: net-snmp-devel
+
+%description snmp
+%{summary}
 
 %prep
 # Unpack the code source tarball
@@ -166,6 +180,9 @@ fi
 %license COPYING
 %{_bindir}/rscryutil
 %{_sbindir}/*
+# Exclude libraries that are packaged separately
+%exclude %{_libdir}/rsyslog/mmsnmptrapd.so
+%exclude %{_libdir}/rsyslog/omsnmp.so
 %{_libdir}/rsyslog/*.so
 %{_mandir}/man5/*
 %{_mandir}/man8/*
@@ -178,7 +195,16 @@ fi
 %files doc
 %doc %{_docdir}/%{name}/html
 
+%files mmsnmptrapd
+%{_libdir}/rsyslog/mmsnmptrapd.so
+
+%files snmp
+%{_libdir}/rsyslog/omsnmp.so
+
 %changelog
+* Thu Feb 29 2024 Henry Beberman <henry.beberman@microsoft.com> - 8.2308.0-3
+- Move snmp libraries into subpackage to remove strict dependency on net-snmp-libs/perl
+
 * Thu Dec 14 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 8.2308.0-2
 - Fix resetting of passwd and group on package update
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Currently rsyslog has a strict dependency on net-snmp-libs which in-turn requires Perl. This is the only consumer of Perl in our standard Azure VM image and removing the dependency will remove the need for over 180 packages in the image.
The rsyslog snmp capabilities will still be available by installing the rsyslog-netsnmp and rsyslog-mmsnmptrapd subpackages.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add rsyslog-netsnmp and rsyslog-mmsnmptrapd subpackages to remove strict rsyslog dependency on Perl.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
