### PR TITLE
kata-containers-cc: Remove references to kernel-uvm-cvm from kata-containers-cc

### DIFF
--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -8,7 +8,7 @@
 
 Name:         kata-containers-cc
 Version:      0.6.1
-Release:      3%{?dist}
+Release:      4%{?dist}
 Summary:      Kata Confidential Containers
 License:      ASL 2.0
 Vendor:       Microsoft Corporation
@@ -41,18 +41,16 @@ BuildRequires:  fuse-devel
 
 # needed to build the tarfs module, see next comment - we currently build the tarfs module for both kernels
 BuildRequires:  kernel-uvm-devel
-BuildRequires:  kernel-uvm-cvm-devel
 
 # kernel-uvm is required for allowing to test the kata-cc handler w/o SEV SNP but with the
 # policy feature using kernel-uvm and the kata-cc shim/agent from this package with policy features
 Requires:  kernel-uvm
-Requires:  kernel-uvm-cvm
 Requires:  moby-containerd-cc
 
 %description
 Kata Confidential Containers.
 
-# This subpackage is used to build the uvm and therefore has dependencies on the kernel-uvm(-cvm) binaries
+# This subpackage is used to build the uvm and therefore has dependencies on the kernel-uvm binaries
 %package tools
 Summary:        Kata CC tools package for building UVM components
 Requires:       cargo
@@ -62,7 +60,6 @@ Requires:       curl
 Requires:       veritysetup
 Requires:       opa >= 0.50.2
 Requires:       kernel-uvm
-Requires:       kernel-uvm-cvm
 
 %description tools
 This package contains the UVM osbuilder files
@@ -105,33 +102,17 @@ cargo build --release
 popd
 
 # kernel modules
-pushd /usr/src/linux-headers*cvm
-header_dir=$(basename $PWD)
-KERNEL_CVM_VER=${header_dir#"linux-headers-"}
-KERNEL_CVM_MODULE_VER=${KERNEL_CVM_VER%%-*}
-popd
-
-pushd /usr/src/$(ls /usr/src | grep linux-header | grep -v cvm)
+pushd /usr/src/linux-headers*
 header_dir=$(basename $PWD)
 KERNEL_VER=${header_dir#"linux-headers-"}
 KERNEL_MODULE_VER=${KERNEL_VER%%-*}
 popd
-
-# make a copy of the tarfs folder for cvm modules
-mkdir -p %{_builddir}/%{name}-%{version}/src/tarfs-cvm
-cp -aR %{_builddir}/%{name}-%{version}/src/tarfs/* %{_builddir}/%{name}-%{version}/src/tarfs-cvm/
 
 pushd %{_builddir}/%{name}-%{version}/src/tarfs
 make KDIR=/usr/src/linux-headers-${KERNEL_VER}
 make KDIR=/usr/src/linux-headers-${KERNEL_VER} install
 popd
 %global KERNEL_MODULES_DIR %{_builddir}/%{name}-%{version}/src/tarfs/_install/lib/modules/${KERNEL_MODULE_VER}
-
-pushd %{_builddir}/%{name}-%{version}/src/tarfs-cvm
-make KDIR=/usr/src/linux-headers-${KERNEL_CVM_VER}
-make KDIR=/usr/src/linux-headers-${KERNEL_CVM_VER} install
-popd
-%global KERNEL_CVM_MODULES_DIR %{_builddir}/%{name}-%{version}/src/tarfs-cvm/_install/lib/modules/${KERNEL_CVM_MODULE_VER}
 
 %install
 %define coco_path     /opt/confidential-containers
@@ -148,7 +129,6 @@ mkdir -p %{buildroot}%{osbuilder}/ci
 
 # kernel modules
 cp -aR %{KERNEL_MODULES_DIR} %{buildroot}%{osbuilder}
-cp -aR %{KERNEL_CVM_MODULES_DIR} %{buildroot}%{osbuilder}
 
 # osbuilder
 pushd %{_builddir}/%{name}-%{version}
@@ -175,7 +155,6 @@ mkdir -p %{buildroot}/etc/systemd/system/containerd.service.d/
 # for testing policy/snapshotter without SEV SNP we use CH (with kernel-uvm and initrd) instead of CH-CVM with IGVM
 # Note: our kata-containers config toml expects cloud-hypervisor and kernel under a certain path/name, so we align this through symlinks here
 ln -s /usr/bin/cloud-hypervisor               %{buildroot}%{coco_bin}/cloud-hypervisor
-ln -s /usr/bin/cloud-hypervisor-cvm           %{buildroot}%{coco_bin}/cloud-hypervisor-snp
 
 # this is again for testing without SEV SNP
 ln -s /usr/share/cloud-hypervisor/vmlinux.bin %{buildroot}%{share_kata}/vmlinux.container
@@ -290,6 +269,11 @@ install -D -m 0755 %{_builddir}/%{name}-%{version}/tools/osbuilder/image-builder
 %exclude %{osbuilder}/tools/osbuilder/rootfs-builder/ubuntu
 
 %changelog
+*   Tue Jan 30 2024 Archana Choudhary <archana1@microsoft.com> - 0.6.1-4
+-   Remove kernel-uvm-cvm(-devel) dependency
+-   Remove kernel-uvm-cvm modules/sources/files
+-   Remove instructions to build kernel-uvm-cvm related binaries
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.6.1-3
 - Bump release to rebuild with go 1.20.10
 

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -155,7 +155,7 @@ mkdir -p %{buildroot}/etc/systemd/system/containerd.service.d/
 # for testing policy/snapshotter without SEV SNP we use CH (with kernel-uvm and initrd) instead of CH-CVM with IGVM
 # Note: our kata-containers config toml expects cloud-hypervisor and kernel under a certain path/name, so we align this through symlinks here
 ln -s /usr/bin/cloud-hypervisor               %{buildroot}%{coco_bin}/cloud-hypervisor
-ln -s /usr/bin/cloud-hypervisor-cvm %{buildroot}%{coco_bin}/cloud-hypervisor-snp
+ln -s /usr/bin/cloud-hypervisor-cvm           %{buildroot}%{coco_bin}/cloud-hypervisor-snp
 
 # this is again for testing without SEV SNP
 ln -s /usr/share/cloud-hypervisor/vmlinux.bin %{buildroot}%{share_kata}/vmlinux.container

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -155,6 +155,7 @@ mkdir -p %{buildroot}/etc/systemd/system/containerd.service.d/
 # for testing policy/snapshotter without SEV SNP we use CH (with kernel-uvm and initrd) instead of CH-CVM with IGVM
 # Note: our kata-containers config toml expects cloud-hypervisor and kernel under a certain path/name, so we align this through symlinks here
 ln -s /usr/bin/cloud-hypervisor               %{buildroot}%{coco_bin}/cloud-hypervisor
+ln -s /usr/bin/cloud-hypervisor-cvm %{buildroot}%{coco_bin}/cloud-hypervisor-snp
 
 # this is again for testing without SEV SNP
 ln -s /usr/share/cloud-hypervisor/vmlinux.bin %{buildroot}%{share_kata}/vmlinux.container

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -269,7 +269,7 @@ install -D -m 0755 %{_builddir}/%{name}-%{version}/tools/osbuilder/image-builder
 %exclude %{osbuilder}/tools/osbuilder/rootfs-builder/ubuntu
 
 %changelog
-*   Tue Jan 30 2024 Archana Choudhary <archana1@microsoft.com> - 0.6.1-4
+*   Thu Feb 29 2024 Cameron Baird <cameronbaird@microsoft.com> - 0.6.1-4
 -   Remove kernel-uvm-cvm(-devel) dependency
 -   Remove kernel-uvm-cvm modules/sources/files
 -   Remove instructions to build kernel-uvm-cvm related binaries


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The kernel-uvm-cvm package was already removed on 2.0, but not for 3.0-dev. This PR drops references to kernel-uvm-cvm from kata-containers-cc in preparation for deprecation, similar to https://github.com/microsoft/azurelinux/pull/7455 

**Note:** This is likely a temporary PR. The package should be updated in 3.0 the proper way, following the proper history as present in 2.0. When porting all our latest Kata package changes from 2.0 into 3.0, we will likely revert this PR and apply proper commit history on top of the packages.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- remove references to kernel-uvm-cvm in kata-containers-cc

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
