### PR TITLE
Write fstab file in correct order.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -211,15 +211,20 @@ func createOverlayPartition(partitionSetting configuration.PartitionSetting, mou
 // - mountPointToFsTypeMap is the map of mountpoint to the file type
 // - mountPointToMountArgsMap is the map of mountpoint to the parameters sent to
 // - mountPointToOverlayMap is the map of mountpoint to the overlay structure containing the base image
-func CreateInstallRoot(installRoot string, mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, mountPointToOverlayMap map[string]*Overlay) (installMap map[string]string, err error) {
-	installMap = make(map[string]string)
+func CreateInstallRoot(installRoot string, mountPointMap, mountPointToFsTypeMap,
+	mountPointToMountArgsMap map[string]string, mountPointToOverlayMap map[string]*Overlay,
+) (mountList []string, err error) {
 	for _, mountPoint := range sortMountPoints(&mountPointMap, false) {
 		device := mountPointMap[mountPoint]
-		err = mountSingleMountPoint(installRoot, mountPoint, device, mountPointToFsTypeMap[mountPoint], mountPointToMountArgsMap[mountPoint], mountPointToOverlayMap[mountPoint])
+		err = mountSingleMountPoint(installRoot, mountPoint, device, mountPointToFsTypeMap[mountPoint],
+			mountPointToMountArgsMap[mountPoint], mountPointToOverlayMap[mountPoint])
 		if err != nil {
 			return
 		}
-		installMap[mountPoint] = device
+
+		// Add to the list 1-by-1 so that the we can safely unmount if mounting fails half-way through.
+		// Note: The order of 'mountList' dictates the order the /etc/fstab file is written in.
+		mountList = append(mountList, mountPoint)
 	}
 	return
 }
@@ -228,14 +233,19 @@ func CreateInstallRoot(installRoot string, mountPointMap, mountPointToFsTypeMap,
 // - installRoot is the path to the root where the mountpoints exist
 // - mountPointMap is the map of mountpoints to partition device paths
 // - mountPointToOverlayMap is the map of mountpoints to overlay devices
-func DestroyInstallRoot(installRoot string, mountPointMap map[string]string, mountPointToOverlayMap map[string]*Overlay) (err error) {
+func DestroyInstallRoot(installRoot string, mountList []string, mountPointMap map[string]string,
+	mountPointToOverlayMap map[string]*Overlay,
+) (err error) {
 	logger.Log.Trace("Destroying InstallRoot")
 
 	defer OverlayUnmount(mountPointToOverlayMap)
 
 	logger.Log.Trace("Destroying InstallRoot")
+
 	// Reverse order for unmounting
-	for _, mountPoint := range sortMountPoints(&mountPointMap, true) {
+	for i := len(mountList) - 1; i >= 0; i-- {
+		mountPoint := mountList[i]
+
 		err = diskutils.BlockOnDiskIO(mountPointMap[mountPoint])
 		if err != nil {
 			logger.Log.Errorf("DestroyInstallRoot flush IO Error: %s", err.Error())
@@ -408,7 +418,11 @@ func PackageNamesFromConfig(config configuration.Config) (packageList []*pkgjson
 // - partIDToFsTypeMap is a map of partition IDs to filesystem type
 // - encryptedRoot stores information about the encrypted root device if root encryption is enabled
 // - diffDiskBuild is a flag that denotes whether this is a diffdisk build or not
-func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild bool) (err error) {
+func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string,
+	config configuration.SystemConfig, mountList []string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap,
+	partIDToDevPathMap, partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice,
+	diffDiskBuild bool,
+) (err error) {
 	timestamp.StartEvent("populating install root", nil)
 	defer timestamp.StopEvent(nil)
 
@@ -495,7 +509,8 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 
 	if !config.IsRootFS() {
 		// Configure system files
-		err = configureSystemFiles(installChroot, hostname, config, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot)
+		err = configureSystemFiles(installChroot, hostname, config, mountList, installMap, mountPointToFsTypeMap,
+			mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot)
 		if err != nil {
 			return
 		}
@@ -645,7 +660,10 @@ func TdnfInstallWithProgress(packageName, installRoot string, currentPackagesIns
 	return
 }
 
-func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice) (err error) {
+func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, config configuration.SystemConfig,
+	mountList []string, mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap,
+	partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice,
+) (err error) {
 	// Update hosts file
 	err = updateHosts(installChroot.RootDir(), hostname)
 	if err != nil {
@@ -653,13 +671,14 @@ func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, con
 	}
 
 	// Update fstab
-	err = UpdateFstab(installChroot.RootDir(), config.PartitionSettings, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, config.EnableHidepid)
+	err = UpdateFstab(installChroot.RootDir(), config.PartitionSettings, mountList, mountPointMap,
+		mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, config.EnableHidepid)
 	if err != nil {
 		return
 	}
 
 	// Update crypttab
-	err = updateCrypttab(installChroot.RootDir(), installMap, encryptedRoot)
+	err = updateCrypttab(installChroot.RootDir(), mountPointMap, encryptedRoot)
 	if err != nil {
 		return
 	}
@@ -830,21 +849,21 @@ func updateInitramfsForEncrypt(installChroot *safechroot.Chroot) (err error) {
 	return
 }
 
-func UpdateFstab(installRoot string, partitionSettings []configuration.PartitionSetting, installMap,
-	mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string,
+func UpdateFstab(installRoot string, partitionSettings []configuration.PartitionSetting, mountList []string,
+	mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string,
 	hidepidEnabled bool,
 ) (err error) {
 	const fstabPath = "/etc/fstab"
 
 	fullFstabPath := filepath.Join(installRoot, fstabPath)
 
-	return UpdateFstabFile(fullFstabPath, partitionSettings, installMap,
+	return UpdateFstabFile(fullFstabPath, partitionSettings, mountList, mountPointMap,
 		mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap,
 		hidepidEnabled)
 }
 
-func UpdateFstabFile(fullFstabPath string, partitionSettings []configuration.PartitionSetting, installMap,
-	mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string,
+func UpdateFstabFile(fullFstabPath string, partitionSettings []configuration.PartitionSetting, mountList []string,
+	mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string,
 	hidepidEnabled bool,
 ) (err error) {
 	const (
@@ -852,14 +871,17 @@ func UpdateFstabFile(fullFstabPath string, partitionSettings []configuration.Par
 	)
 	ReportAction("Configuring fstab")
 
-	for mountPoint, devicePath := range installMap {
+	for _, mountPoint := range mountList {
+		devicePath := mountPointMap[mountPoint]
+
 		if mountPoint != "" && devicePath != NullDevice {
 			partSetting := configuration.FindMountpointPartitionSetting(partitionSettings, mountPoint)
 			if partSetting == nil {
 				err = fmt.Errorf("unable to find PartitionSetting for '%s", mountPoint)
 				return
 			}
-			err = addEntryToFstab(fullFstabPath, mountPoint, devicePath, mountPointToFsTypeMap[mountPoint], mountPointToMountArgsMap[mountPoint], partSetting.MountIdentifier, !doPseudoFsMount)
+			err = addEntryToFstab(fullFstabPath, mountPoint, devicePath, mountPointToFsTypeMap[mountPoint],
+				mountPointToMountArgsMap[mountPoint], partSetting.MountIdentifier, !doPseudoFsMount)
 			if err != nil {
 				return
 			}
@@ -989,7 +1011,7 @@ func addEntryToCrypttab(installRoot string, devicePath string, encryptedRoot dis
 
 func ConfigureDiskBootloader(bootType string, encryptionEnable bool, readOnlyVerityRootEnable bool,
 	partitionSettings []configuration.PartitionSetting, kernelCommandLine configuration.KernelCommandLine,
-	installChroot *safechroot.Chroot, diskDevPath string, installMap map[string]string,
+	installChroot *safechroot.Chroot, diskDevPath string, mountPointMap map[string]string,
 	encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice, enableGrubMkconfig bool,
 	includeLegacyGrubCfg bool,
 ) (err error) {
@@ -1002,15 +1024,15 @@ func ConfigureDiskBootloader(bootType string, encryptionEnable bool, readOnlyVer
 	var rootDevice string
 
 	// Add bootloader. Prefer a separate boot partition if one exists.
-	bootDevice, isBootPartitionSeparate := installMap[bootMountPoint]
+	bootDevice, isBootPartitionSeparate := mountPointMap[bootMountPoint]
 	bootPrefix := ""
 	if !isBootPartitionSeparate {
-		bootDevice = installMap[rootMountPoint]
+		bootDevice = mountPointMap[rootMountPoint]
 		// If we do not have a separate boot partition we will need to add a prefix to all paths used in the configs.
 		bootPrefix = "/boot"
 	}
 
-	if installMap[rootMountPoint] == NullDevice {
+	if mountPointMap[rootMountPoint] == NullDevice {
 		// In case of overlay device being mounted at root, no need to change the bootloader.
 		return
 	}
@@ -1037,7 +1059,7 @@ func ConfigureDiskBootloader(bootType string, encryptionEnable bool, readOnlyVer
 	rootMountIdentifier := rootPartitionSetting.MountIdentifier
 	if encryptionEnable {
 		// Encrypted devices don't currently support identifiers
-		rootDevice = installMap[rootMountPoint]
+		rootDevice = mountPointMap[rootMountPoint]
 	} else if readOnlyVerityRootEnable {
 		var partIdentifier string
 		partIdentifier, err = FormatMountIdentifier(rootMountIdentifier, readOnlyRoot.BackingDevice)
@@ -1048,7 +1070,7 @@ func ConfigureDiskBootloader(bootType string, encryptionEnable bool, readOnlyVer
 		rootDevice = fmt.Sprintf("verityroot:%v", partIdentifier)
 	} else {
 		var partIdentifier string
-		partIdentifier, err = FormatMountIdentifier(rootMountIdentifier, installMap[rootMountPoint])
+		partIdentifier, err = FormatMountIdentifier(rootMountIdentifier, mountPointMap[rootMountPoint])
 		if err != nil {
 			err = fmt.Errorf("failed to get partIdentifier: %s", err)
 			return

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -530,17 +530,17 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 		leaveChrootOnDisk = true
 	)
 
-	var installMap map[string]string
+	var mountList []string
 
 	// Only invoke CreateInstallRoot for a raw disk. This call will result in mount points being created from a raw disk
 	// into the install root. A rootfs will not have these.
 	if !systemConfig.IsRootFS() {
-		installMap, err = installutils.CreateInstallRoot(installRoot, mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, mountPointToOverlayMap)
+		mountList, err = installutils.CreateInstallRoot(installRoot, mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, mountPointToOverlayMap)
 		if err != nil {
 			err = fmt.Errorf("failed to create install root:\n%w", err)
 			return
 		}
-		defer installutils.DestroyInstallRoot(installRoot, installMap, mountPointToOverlayMap)
+		defer installutils.DestroyInstallRoot(installRoot, mountList, mountPointMap, mountPointToOverlayMap)
 	}
 
 	// Install any tools required for the setup root to function
@@ -591,7 +591,9 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 	timestamp.StopEvent(nil) // install chroot packages
 
 	// Populate image contents
-	err = installutils.PopulateInstallRoot(installChroot, packagesToInstall, systemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, diffDiskBuild)
+	err = installutils.PopulateInstallRoot(installChroot, packagesToInstall, systemConfig, mountList, mountPointMap,
+		mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot,
+		diffDiskBuild)
 	if err != nil {
 		err = fmt.Errorf("failed to populate image contents:\n%w", err)
 		return
@@ -601,7 +603,8 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 	if !systemConfig.IsRootFS() {
 		err = installutils.ConfigureDiskBootloader(systemConfig.BootType, systemConfig.Encryption.Enable,
 			systemConfig.ReadOnlyVerityRoot.Enable, systemConfig.PartitionSettings, systemConfig.KernelCommandLine,
-			installChroot, diskDevPath, installMap, encryptedRoot, readOnlyRoot, systemConfig.EnableGrubMkconfig, false)
+			installChroot, diskDevPath, mountPointMap, encryptedRoot, readOnlyRoot,
+			systemConfig.EnableGrubMkconfig, false)
 		if err != nil {
 			err = fmt.Errorf("failed to configure boot loader:\n%w", err)
 			return

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 )
 
 type installOSFunc func(imageChroot *safechroot.Chroot) error
@@ -100,11 +101,6 @@ func createNewImageHelper(filename string, diskConfig imagecustomizerapi.Disk,
 		return err
 	}
 
-	// Sort the partitions so that they are mounted in the correct oder.
-	sort.Slice(imagerPartitionSettings, func(i, j int) bool {
-		return imagerPartitionSettings[i].MountPoint < imagerPartitionSettings[j].MountPoint
-	})
-
 	// Create imager boilerplate.
 	mountPointMap, tmpFstabFile, err := createImageBoilerplate(imageConnection, filename, buildDir, chrootDirName, imagerDiskConfig,
 		imagerPartitionSettings)
@@ -186,8 +182,16 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 		partIDToDevPathMap, partIDToFsTypeMap, imagerPartitionSettings,
 	)
 
-	err = installutils.UpdateFstabFile(tmpFstabFile, imagerPartitionSettings, mountPointMap, mountPointToFsTypeMap,
-		mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, false, /*hidepidEnabled*/
+	mountList := sliceutils.MapToSlice(mountPointMap)
+
+	// Sort the mounts so that they are mounted in the correct oder.
+	sort.Slice(mountList, func(i, j int) bool {
+		return mountList[i] < mountList[j]
+	})
+
+	err = installutils.UpdateFstabFile(tmpFstabFile, imagerPartitionSettings, mountList, mountPointMap,
+		mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap,
+		false, /*hidepidEnabled*/
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to write temp fstab file:\n%w", err)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

When the /etc/fstab file is being written, the order in which it is written is determined by the hash function used by the map type. Since, the hash function is randomized (for security), this means the ordering of the fstab file changes every time.

This change ensures the fstab file is written in the correct order.

###### Change Log  <!-- REQUIRED -->

- Write fstab file in correct order.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image build.
- Manually ran image customizer.

