### PR TITLE
Fix failure when SELinux labelling image with multiple partitions.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1815,12 +1815,14 @@ func selinuxRelabelFiles(installChroot *safechroot.Chroot, mountPointToFsTypeMap
 		if err != nil {
 			return err
 		}
-	}
 
-	// Cleanup temporary directory.
-	err = os.RemoveAll(targetRootPath)
-	if err != nil {
-		return fmt.Errorf("failed to remove temporary bind mount directory:\n%w", err)
+		// Cleanup the temporary directory.
+		// Note: This is intentionally done within the for loop to ensure the directory is always empty for the next
+		// mount. For example, if a parent directory mount is processed after a nested child directory mount.
+		err = os.RemoveAll(targetRootPath)
+		if err != nil {
+			return fmt.Errorf("failed to remove temporary bind mount directory:\n%w", err)
+		}
 	}
 
 	return

--- a/toolkit/tools/internal/safemount/safemount.go
+++ b/toolkit/tools/internal/safemount/safemount.go
@@ -122,7 +122,7 @@ func (m *Mount) close(async bool) error {
 		// (This is unlikely. But "belt and braces".)
 		err = os.Remove(m.target)
 		if err != nil {
-			return fmt.Errorf("failed to delete source rpms mount directory (%s):\n%w", m.target, err)
+			return fmt.Errorf("failed to delete mount directory (%s):\n%w", m.target, err)
 		}
 
 		m.dirCreated = false


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

When labelling SELinux volumes, we use bind mounts to ensure that the entire volume is correctly labeled, including directories that are being used for nested mounts. However, when labelling multiple volumes, the root directory used for the bind mount targets isn't emptied.

###### Change Log  <!-- REQUIRED -->

- Fix failure when SELinux labelling image with multiple partitions.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO


###### Test Methodology

- Manually ran image customizer tool.

