### PR TITLE
Cherry-pick: Write fstab file in correct order. (#8217)

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 )
 
 type installOSFunc func(imageChroot *safechroot.Chroot) error
@@ -102,11 +103,6 @@ func createNewImageHelper(filename string, diskConfig imagecustomizerapi.Disk,
 		return err
 	}
 
-	// Sort the partitions so that they are mounted in the correct oder.
-	sort.Slice(imagerPartitionSettings, func(i, j int) bool {
-		return imagerPartitionSettings[i].MountPoint < imagerPartitionSettings[j].MountPoint
-	})
-
 	// Create imager boilerplate.
 	mountPointMap, tmpFstabFile, err := createImageBoilerplate(imageConnection, filename, buildDir, chrootDirName, imagerDiskConfig,
 		imagerPartitionSettings)
@@ -188,8 +184,16 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 		partIDToDevPathMap, partIDToFsTypeMap, imagerPartitionSettings,
 	)
 
-	err = installutils.UpdateFstabFile(tmpFstabFile, imagerPartitionSettings, mountPointMap, mountPointToFsTypeMap,
-		mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, false, /*hidepidEnabled*/
+	mountList := sliceutils.MapToSlice(mountPointMap)
+
+	// Sort the mounts so that they are mounted in the correct oder.
+	sort.Slice(mountList, func(i, j int) bool {
+		return mountList[i] < mountList[j]
+	})
+
+	err = installutils.UpdateFstabFile(tmpFstabFile, imagerPartitionSettings, mountList, mountPointMap,
+		mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap,
+		false, /*hidepidEnabled*/
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to write temp fstab file:\n%w", err)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Backporting #8217 to 2.0.

###### Change Log  <!-- REQUIRED -->

- Cherry-pick: Write fstab file in correct order. (#8217)

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran imager tool.
