### PR TITLE
fix libselinux and kernel-headers spec issues

### DIFF
--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -78,7 +78,7 @@ done
 * Tue Feb 27 2024 Chris Gunn <chrisgun@microsoft.com> - 6.6.14.1-3
 - Bump release to match kernel
 
-* Thu Feb 22 30 2024 Cameron Baird <cameronbaird@microsoft.com> - 6.6.14.1-2
+* Thu Feb 22 2024 Cameron Baird <cameronbaird@microsoft.com> - 6.6.14.1-2
 - Bump release to match kernel
 
 * Fri Feb 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.14.1-1

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -78,7 +78,7 @@ done
 * Tue Feb 27 2024 Chris Gunn <chrisgun@microsoft.com> - 6.6.14.1-3
 - Bump release to match kernel
 
-* Tue Jan 30 2024 Cameron Baird <cameronbaird@microsoft.com> - 6.6.14.1-2
+* Thu Feb 22 30 2024 Cameron Baird <cameronbaird@microsoft.com> - 6.6.14.1-2
 - Bump release to match kernel
 
 * Fri Feb 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.14.1-1

--- a/SPECS/libselinux/libselinux.spec
+++ b/SPECS/libselinux/libselinux.spec
@@ -11,11 +11,11 @@ Source0:        https://github.com/SELinuxProject/selinux/releases/download/%{ve
 BuildRequires:  libsepol-devel
 BuildRequires:  pcre2-devel
 BuildRequires:  swig
-BuildRequires:  python3
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+# python3-wheel (non-toolchain package) cannot be added as a BR to libselinux (since it is a toolchain package)
+#BuildRequires:  python3-wheel
 Requires:       pcre2
 Requires:       libsepol
 
@@ -119,7 +119,7 @@ echo "d %{_localstatedir}/run/setrans 0755 root root" > %{buildroot}/%{_libdir}/
 
 * Fri Aug 13 2021 Thomas Crain <thcrain@microsoft.com> - 3.2-1
 - Upgrade to latest upstream version
-- Add -fno-semantic-interposition to CFLAGS as recommended by upstream 
+- Add -fno-semantic-interposition to CFLAGS as recommended by upstream
 - License verified
 - Remove manual pkgconfig provides
 - Update source URL to new format

--- a/SPECS/libselinux/libselinux.spec
+++ b/SPECS/libselinux/libselinux.spec
@@ -15,6 +15,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
 # python3-wheel (non-toolchain package) cannot be added as a BR to libselinux (since it is a toolchain package)
+# The raw toolchain environment does already provide python3-wheel
 #BuildRequires:  python3-wheel
 Requires:       pcre2
 Requires:       libsepol


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
fix libselinux and kernel-headers spec issues

The bogus changelog date in kernel-headers causes:
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=519508&view=logs&j=db98f19e-da46-5e4d-a4ba-372cf3771a92&t=8831c5ce-9476-5d69-9bf5-bfd7485723f1&l=226074
```
++ rpmspec -q /mnt/vss/_work/1/s/SPECS/kernel-headers/kernel-headers.spec --srpm -D 'with_check 0' -D '_sourcedir /mnt/vss/_work/1/s/SPECS/kernel-headers' -D 'dist .azl3' --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.src.rpm' 
error: %changelog not in descending chronological order
```

The BR from a toolchain package (libselinux) to a non-toolchain package (python3-wheel) is causing toolchain packages to incorrectly (re)-build in the pkggen pipelines. All toolchain package dependencies must be contained in the toolchain.
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=519566&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=96d12790-e2a0-56cb-1f4c-4eb56738aded&l=1616
```
"Number of toolchain RPM conflicts:  116"
"Number of toolchain SRPM conflicts: 38"
```

Not bumping the release since we haven't published either of these packages yet.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change kernel-headers
- Change libselinux

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full build (along with unrelated changes) - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=519559&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=96d12790-e2a0-56cb-1f4c-4eb56738aded
