### PR TITLE
Image Customizer: Improve/fix errors in getFilesystemSizeInSectors().

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -102,16 +102,16 @@ func getFilesystemSizeInSectors(resize2fsOutput string, imageLoopDevice string) 
 	// Get the block count and block size
 	match := re.FindStringSubmatch(resize2fsOutput)
 	if match == nil {
-		return 0, fmt.Errorf("failed to parse output of resize2fs")
+		return 0, fmt.Errorf("failed to parse output of resize2fs:\n%s", resize2fsOutput)
 	}
 
 	blockCount, err := strconv.Atoi(match[1]) // Example: 21015
 	if err != nil {
-		return 0, fmt.Errorf("failed to get block count:\n%w", err)
+		return 0, fmt.Errorf("failed to parse block count (%s):\n%w", match[1], err)
 	}
 	multiplier, err := strconv.Atoi(match[2]) // Example: 4
 	if err != nil {
-		return 0, fmt.Errorf("failed to get multiplier for block size:\n%w", err)
+		return 0, fmt.Errorf("failed to parse multiplier for block size (%s):\n%w", match[2], err)
 	}
 	unit := match[3] // Example: 'k'
 
@@ -122,7 +122,7 @@ func getFilesystemSizeInSectors(resize2fsOutput string, imageLoopDevice string) 
 	case "k":
 		blockSize = multiplier * KiB
 	default:
-		return 0, fmt.Errorf("unrecognized unit %s", unit)
+		return 0, fmt.Errorf("unrecognized unit (%s)", unit)
 	}
 
 	filesystemSizeInBytes := blockCount * blockSize
@@ -130,7 +130,7 @@ func getFilesystemSizeInSectors(resize2fsOutput string, imageLoopDevice string) 
 	// Get the sector size
 	logicalSectorSize, _, err := diskutils.GetSectorSize(imageLoopDevice)
 	if err != nil {
-		fmt.Errorf("failed to get sector size")
+		return 0, fmt.Errorf("failed to get sector size:\n%w", err)
 	}
 	sectorSizeInBytes := int(logicalSectorSize) // cast from uint64 to int
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Fix up some of the errors in `getFilesystemSizeInSectors()` to help make the function easier to debug.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Improve/fix errors in getFilesystemSizeInSectors().

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

