### PR TITLE
Image Customizer: Adding skippable frames with unique metadata to generated partitions

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -3,24 +3,21 @@ package imagecustomizerlib
 import (
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 )
 
-// Define global constants
 const (
-	MagicNumber uint32 = 0x184D2A50
-	FrameSize   uint32 = 16
+	SkippableFrameMagicNumber uint32 = 0x184D2A50
+	SkippableFrameSize        uint32 = 16
 )
 
 // Extract all partitions of connected image into separate files with specified format.
@@ -33,20 +30,17 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 	}
 
 	// Create skippable frame metadata defined as a random 128-Bit number
-	metadata, err := createSkippableFrameMetadata()
+	skippableFrameMetadata, err := createSkippableFrameMetadata()
 	if err != nil {
 		return err
 	}
-
-	// Encode metadata into a payload defined as a uint32 array
-	payload := Encode128BitLittleEndian(metadata)
 
 	for partitionNum := 0; partitionNum < len(diskPartitions); partitionNum++ {
 		if diskPartitions[partitionNum].Type == "part" {
 			rawFilename := basename + "_" + strconv.Itoa(partitionNum) + ".raw"
 			partitionLoopDevice := diskPartitions[partitionNum].Path
 
-			partitionFilePath, err := copyBlockDeviceToFile(outDir, partitionLoopDevice, rawFilename)
+			partitionFilepath, err := copyBlockDeviceToFile(outDir, partitionLoopDevice, rawFilename)
 			if err != nil {
 				return err
 			}
@@ -55,28 +49,28 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 			case "raw":
 				// Do nothing for "raw" case.
 			case "raw-zst":
-				partitionRawFilePath := partitionFilePath
-				partitionFilepath, err := compressWithZstd(partitionRawFilePath)
+				partitionRawFilepath := partitionFilepath
+				partitionFilepath, err := compressWithZstd(partitionRawFilepath)
 				if err != nil {
 					return err
 				}
-				// Create a skippable frame containing the metadata payload and prepend the frame to the partition file
-				err = addSkippableFrame(partitionFilepath, MagicNumber, FrameSize, payload)
+				// Create a skippable frame containing the metadata and prepend the frame to the partition file
+				err = addSkippableFrame(partitionFilepath, SkippableFrameMagicNumber, SkippableFrameSize, skippableFrameMetadata)
 				if err != nil {
 					return err
 				}
 				// Verify decompression with skippable frame
-				err = verifySkippableFrameDecompression(partitionRawFilePath, partitionFilepath)
+				err = verifySkippableFrameDecompression(partitionRawFilepath, partitionFilepath)
 				if err != nil {
 					return err
 				}
 				// Remove raw file since output partition format is raw-zst.
-				err = os.Remove(partitionRawFilePath)
+				err = os.Remove(partitionRawFilepath)
 				if err != nil {
-					return fmt.Errorf("failed to remove raw file %s:\n%w", partitionRawFilePath, err)
+					return fmt.Errorf("failed to remove raw file %s:\n%w", partitionRawFilepath, err)
 				}
 				// Verify skippable frame metadata
-				err = verifySkippableFrameMetadataFromFile(partitionFilepath, MagicNumber, FrameSize, metadata)
+				err = verifySkippableFrameMetadataFromFile(partitionFilepath, SkippableFrameMagicNumber, SkippableFrameSize, skippableFrameMetadata)
 				if err != nil {
 					return err
 				}
@@ -84,7 +78,7 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 			default:
 				return fmt.Errorf("unsupported partition format (supported: raw, raw-zst): %s", partitionFormat)
 			}
-			logger.Log.Infof("Partition file created: %s", partitionFilePath)
+			logger.Log.Infof("Partition file created: %s", partitionFilepath)
 		}
 	}
 	return nil
@@ -124,8 +118,8 @@ func compressWithZstd(partitionRawFilepath string) (partitionFilepath string, er
 	return partitionRawFilepath + ".zst", nil
 }
 
-// Prepend a skippable frame with the metadata payload to the specified partition file.
-func addSkippableFrame(partitionFilepath string, magicNumber uint32, frameSize uint32, payload [4]uint32) (err error) {
+// Prepend a skippable frame with the metadata to the specified partition file.
+func addSkippableFrame(partitionFilepath string, magicNumber uint32, frameSize uint32, skippableFrameMetadata [SkippableFrameSize]byte) (err error) {
 	// Read existing data from the partition file.
 	existingData, err := os.ReadFile(partitionFilepath)
 	if err != nil {
@@ -133,7 +127,7 @@ func addSkippableFrame(partitionFilepath string, magicNumber uint32, frameSize u
 	}
 
 	// Create a skippable frame.
-	skippableFrame := createSkippableFrame(magicNumber, frameSize, payload)
+	skippableFrame := createSkippableFrame(magicNumber, frameSize, skippableFrameMetadata)
 
 	// Combine the skippable frame and existing data.
 	newData := append(skippableFrame, existingData...)
@@ -148,9 +142,9 @@ func addSkippableFrame(partitionFilepath string, magicNumber uint32, frameSize u
 }
 
 // Creates a skippable frame.
-func createSkippableFrame(magicNumber uint32, frameSize uint32, payload [4]uint32) (skippableFrame []byte) {
+func createSkippableFrame(magicNumber uint32, frameSize uint32, skippableFrameMetadata [SkippableFrameSize]byte) (skippableFrame []byte) {
 	// Calculate the length of the byte array
-	lengthOfByteArray := 4 + 4 + (4 * len(payload))
+	lengthOfByteArray := 4 + 4 + len(skippableFrameMetadata)
 	// Define the Skippable frame
 	skippableFrame = make([]byte, lengthOfByteArray)
 	// Magic_Number
@@ -158,10 +152,7 @@ func createSkippableFrame(magicNumber uint32, frameSize uint32, payload [4]uint3
 	// Frame_Size
 	binary.LittleEndian.PutUint32(skippableFrame[4:8], frameSize)
 	// User_Data
-	binary.LittleEndian.PutUint32(skippableFrame[8:12], payload[0])
-	binary.LittleEndian.PutUint32(skippableFrame[12:16], payload[1])
-	binary.LittleEndian.PutUint32(skippableFrame[16:20], payload[2])
-	binary.LittleEndian.PutUint32(skippableFrame[20:24], payload[3])
+	copy(skippableFrame[8:24], skippableFrameMetadata[:])
 
 	logger.Log.Infof("Skippable frame has been created with the following metadata: %d", skippableFrame[8:24])
 
@@ -169,18 +160,18 @@ func createSkippableFrame(magicNumber uint32, frameSize uint32, payload [4]uint3
 }
 
 // Create user metadata that will be inserted into the skippable frame.
-func createSkippableFrameMetadata() (metadata [16]byte, err error) {
-	// Set the metadata to be a random 128-Bit number
-	metadata, err = generateRandom128BitNumber()
+func createSkippableFrameMetadata() (skippableFrameMetadata [SkippableFrameSize]byte, err error) {
+	// Set the skippableFrameMetadata to be a random 128-Bit number
+	skippableFrameMetadata, err = generateRandom128BitNumber()
 	if err != nil {
-		return metadata, err
+		return skippableFrameMetadata, err
 	}
-	return metadata, nil
+	return skippableFrameMetadata, nil
 }
 
 // Generates a Random 128-Bit number.
-func generateRandom128BitNumber() ([16]byte, error) {
-	var randomBytes [16]byte
+func generateRandom128BitNumber() ([SkippableFrameSize]byte, error) {
+	var randomBytes [SkippableFrameSize]byte
 	_, err := rand.Read(randomBytes[:])
 	if err != nil {
 		return randomBytes, err
@@ -188,50 +179,21 @@ func generateRandom128BitNumber() ([16]byte, error) {
 	return randomBytes, nil
 }
 
-// Encodes a 128-Bit number into an array of uint32 in little-endian order.
-func Encode128BitLittleEndian(number [16]byte) [4]uint32 {
-	var encoded [4]uint32
-	for i := 0; i < 4; i++ {
-		offset := i * 4
-		encoded[i] = binary.LittleEndian.Uint32(number[offset : offset+4])
-	}
-	return encoded
-}
-
-// Calculates sha256sum hash for a given file
-func calculateSHA256(filePath string) (string, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return "", err
-	}
-
-	hashInBytes := hash.Sum(nil)
-	hashString := hex.EncodeToString(hashInBytes)
-
-	return hashString, nil
-}
-
 // Decompress the .raw.zst partition file and verifies the hash matches with the source .raw file
 func verifySkippableFrameDecompression(rawPartitionFilepath string, rawZstPartitionFilepath string) (err error) {
 	// Decompressing .raw.zst file
-	decompressedPartitionFilePath := "build/decompressed.raw"
-	err = shell.ExecuteLive(true, "zstd", "-d", rawZstPartitionFilepath, "-o", decompressedPartitionFilePath)
+	decompressedPartitionFilepath := "build/decompressed.raw"
+	err = shell.ExecuteLive(true, "zstd", "-d", rawZstPartitionFilepath, "-o", decompressedPartitionFilepath)
 	if err != nil {
 		return fmt.Errorf("failed to decompress %s with zstd:\n%w", rawZstPartitionFilepath, err)
 	}
 
 	// Calculating hashes
-	rawPartitionFileHash, err := calculateSHA256(rawPartitionFilepath)
+	rawPartitionFileHash, err := file.GenerateSHA256(rawPartitionFilepath)
 	if err != nil {
 		return fmt.Errorf("error: %w", err)
 	}
-	decompressedPartitionFileHash, err := calculateSHA256(decompressedPartitionFilePath)
+	decompressedPartitionFileHash, err := file.GenerateSHA256(decompressedPartitionFilepath)
 	if err != nil {
 		return fmt.Errorf("error: %w", err)
 	}
@@ -240,19 +202,19 @@ func verifySkippableFrameDecompression(rawPartitionFilepath string, rawZstPartit
 	if rawPartitionFileHash != decompressedPartitionFileHash {
 		return fmt.Errorf("decompressed partition file hash does not match source partition file hash: %s != %s", decompressedPartitionFileHash, rawPartitionFilepath)
 	}
-	logger.Log.Infof("Decompressed partition file hash matches source partition file hash!")
+	logger.Log.Debugf("Decompressed partition file hash matches source partition file hash!")
 
 	// Removing decompressed file
-	err = os.Remove(decompressedPartitionFilePath)
+	err = os.Remove(decompressedPartitionFilepath)
 	if err != nil {
-		return fmt.Errorf("failed to remove raw file %s:\n%w", decompressedPartitionFilePath, err)
+		return fmt.Errorf("failed to remove raw file %s:\n%w", decompressedPartitionFilepath, err)
 	}
 
 	return nil
 }
 
 // Verifies that the skippable frame has been correctly prepended to the partition file with the correct data
-func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber uint32, frameSize uint32, metadata [16]byte) (err error) {
+func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber uint32, frameSize uint32, skippableFrameMetadata [SkippableFrameSize]byte) (err error) {
 	// Read existing data from the partition file.
 	existingData, err := os.ReadFile(partitionFilepath)
 	if err != nil {
@@ -275,9 +237,9 @@ func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber 
 	}
 	logger.Log.Infof("Skippable frame frameSize field is correct...")
 
-	// verify that the skippable frame has the correct inserted metadata by validating metadata
-	if !bytes.Equal(existingData[8:8+frameSize], metadata[:]) {
-		return fmt.Errorf("skippable frame metadata does not match the inserted metadata:\n %d != %d", existingData[8:8+frameSize], metadata[:])
+	// verify that the skippable frame has the correct inserted metadata by validating skippableFrameMetadata
+	if !bytes.Equal(existingData[8:8+frameSize], skippableFrameMetadata[:]) {
+		return fmt.Errorf("skippable frame metadata does not match the inserted metadata:\n %d != %d", existingData[8:8+frameSize], skippableFrameMetadata[:])
 	}
 	logger.Log.Infof("Skippable frame is valid and contains the correct metadata!")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -195,6 +195,7 @@ func Encode128BitLittleEndian(number [16]byte) [4]uint32 {
 	return encoded
 }
 
+// Calculates sha256sum hash for a given file
 func calculateSHA256(filePath string) (string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -62,7 +62,7 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 
 // Extract raw-zst partition
 func extractRawZstPartition(partitionRawFilepath string, skippableFrameMetadata [SkippableFrameSize]byte) (partitionFilepath string, err error) {
-	// Compress raw partition with zstd and output it
+	// Compress raw partition with zstd
 	partitionFilepath, err = compressWithZstd(partitionRawFilepath)
 	if err != nil {
 		return "", err
@@ -72,7 +72,7 @@ func extractRawZstPartition(partitionRawFilepath string, skippableFrameMetadata 
 	if err != nil {
 		return "", err
 	}
-	// Remove raw file since output partition format is raw-zst.
+	// Remove raw file since output partition format is raw-zst
 	err = os.Remove(partitionRawFilepath)
 	if err != nil {
 		return "", fmt.Errorf("failed to remove raw file %s:\n%w", partitionRawFilepath, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -67,8 +67,10 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 
 // Extract raw-zst partition
 func extractRawZstPartition(partitionRawFilepath string, skippableFrameMetadata [SkippableFramePayloadSize]byte, partitionFilename string, outDir string) (partitionFilepath string, err error) {
+	// Define file path for temporary partition
+	tempPartitionFilepath := outDir + "/" + partitionFilename + "_temp.raw.zst"
 	// Compress raw partition with zstd
-	tempPartitionFilepath, err := compressWithZstd(partitionRawFilepath, partitionFilename, outDir)
+	tempPartitionFilepath, err = compressWithZstd(partitionRawFilepath, tempPartitionFilepath)
 	if err != nil {
 		return "", err
 	}
@@ -114,9 +116,7 @@ func copyBlockDeviceToFile(outDir, devicePath, name string) (filename string, er
 }
 
 // Compress file from .raw to .raw.zst format using zstd.
-func compressWithZstd(partitionRawFilepath string, partitionFilename string, outDir string) (partitionFilepath string, err error) {
-	// Define output file.
-	outputPartitionFilepath := outDir + "/" + partitionFilename + "_temp.raw.zst"
+func compressWithZstd(partitionRawFilepath string, outputPartitionFilepath string) (partitionFilepath string, err error) {
 	// Using -f to overwrite a file with same name if it exists.
 	err = shell.ExecuteLive(true, "zstd", "-f", "-9", "-T0", partitionRawFilepath, "-o", outputPartitionFilepath)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -39,8 +39,8 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 
 	for partitionNum := 0; partitionNum < len(diskPartitions); partitionNum++ {
 		if diskPartitions[partitionNum].Type == "part" {
-			partitionfileName := basename + "_" + strconv.Itoa(partitionNum)
-			rawFilename := partitionfileName + ".raw"
+			partitionFilename := basename + "_" + strconv.Itoa(partitionNum)
+			rawFilename := partitionFilename + ".raw"
 			partitionLoopDevice := diskPartitions[partitionNum].Path
 
 			partitionFilepath, err := copyBlockDeviceToFile(outDir, partitionLoopDevice, rawFilename)
@@ -52,7 +52,7 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 			case "raw":
 				// Do nothing for "raw" case.
 			case "raw-zst":
-				partitionFilepath, err = extractRawZstPartition(partitionFilepath, skippableFrameMetadata, partitionfileName, outDir)
+				partitionFilepath, err = extractRawZstPartition(partitionFilepath, skippableFrameMetadata, partitionFilename, outDir)
 				if err != nil {
 					return err
 				}
@@ -66,14 +66,14 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 }
 
 // Extract raw-zst partition
-func extractRawZstPartition(partitionRawFilepath string, skippableFrameMetadata [SkippableFramePayloadSize]byte, partitionfileName string, outDir string) (partitionFilepath string, err error) {
+func extractRawZstPartition(partitionRawFilepath string, skippableFrameMetadata [SkippableFramePayloadSize]byte, partitionFilename string, outDir string) (partitionFilepath string, err error) {
 	// Compress raw partition with zstd
 	tempPartitionFilepath, err := compressWithZstd(partitionRawFilepath)
 	if err != nil {
 		return "", err
 	}
 	// Create a skippable frame containing the metadata and prepend the frame to the partition file
-	partitionFilepath, err = addSkippableFrame(tempPartitionFilepath, skippableFrameMetadata, partitionfileName, outDir)
+	partitionFilepath, err = addSkippableFrame(tempPartitionFilepath, skippableFrameMetadata, partitionFilename, outDir)
 	if err != nil {
 		return "", err
 	}
@@ -125,7 +125,7 @@ func compressWithZstd(partitionRawFilepath string) (partitionFilepath string, er
 }
 
 // Prepend a skippable frame with the metadata to the specified partition file.
-func addSkippableFrame(tempPartitionFilepath string, skippableFrameMetadata [SkippableFramePayloadSize]byte, partitionfileName string, outDir string) (partitionFilepath string, err error) {
+func addSkippableFrame(tempPartitionFilepath string, skippableFrameMetadata [SkippableFramePayloadSize]byte, partitionFilename string, outDir string) (partitionFilepath string, err error) {
 	// Open tempPartitionFile for reading
 	tempPartitionFile, err := os.OpenFile(tempPartitionFilepath, os.O_RDWR, PartitionFilePermissions)
 	if err != nil {
@@ -134,7 +134,7 @@ func addSkippableFrame(tempPartitionFilepath string, skippableFrameMetadata [Ski
 	// Create a skippable frame
 	skippableFrame := createSkippableFrame(SkippableFrameMagicNumber, SkippableFramePayloadSize, skippableFrameMetadata)
 	// Define the final partition file path
-	partitionFilepath = outDir + "/" + partitionfileName + "_final" + ".raw.zst"
+	partitionFilepath = outDir + "/" + partitionFilename + "_final" + ".raw.zst"
 	// Create partition file
 	finalFile, err := os.Create(partitionFilepath)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -85,7 +85,7 @@ func extractRawZstPartition(partitionRawFilepath string, skippableFrameMetadata 
 	// Remove temp partition file
 	err = os.Remove(tempPartitionFilepath)
 	if err != nil {
-		return "", fmt.Errorf("failed to remove temp file %s:\n%w", partitionRawFilepath, err)
+		return "", fmt.Errorf("failed to remove temp file %s:\n%w", tempPartitionFilepath, err)
 	}
 	return partitionFilepath, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -138,7 +138,7 @@ func createSkippableFrame(payload [4]uint32) (skippableFrame []byte) {
 	// Magic_Number
 	binary.LittleEndian.PutUint32(skippableFrame, 0x184D2A50)
 	// Frame_Size
-	binary.LittleEndian.PutUint32(skippableFrame[4:8], 4)
+	binary.LittleEndian.PutUint32(skippableFrame[4:8], 16)
 	// User_Data
 	binary.LittleEndian.PutUint32(skippableFrame[8:12], payload[0])
 	binary.LittleEndian.PutUint32(skippableFrame[12:16], payload[1])

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -60,7 +60,7 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 	return nil
 }
 
-// Extract raw-zstd partition
+// Extract raw-zst partition
 func extractRawZstPartition(partitionRawFilepath string, skippableFrameMetadata [SkippableFrameSize]byte) (partitionFilepath string, err error) {
 	// Compress raw partition with zstd and output it
 	partitionFilepath, err = compressWithZstd(partitionRawFilepath)

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,8 +15,9 @@ import (
 )
 
 const (
-	SkippableFrameMagicNumber uint32 = 0x184D2A50
-	SkippableFrameSize        uint32 = 16
+	SkippableFrameMagicNumber uint32      = 0x184D2A50
+	SkippableFrameSize        uint32      = 16
+	PartitionFilePermissions  fs.FileMode = 0644
 )
 
 // Extract all partitions of connected image into separate files with specified format.
@@ -128,8 +130,8 @@ func addSkippableFrame(partitionFilepath string, magicNumber uint32, frameSize u
 	// Combine the skippable frame and existing data.
 	newData := append(skippableFrame, existingData...)
 
-	// Write the combined data back to the partition file.
-	err = os.WriteFile(partitionFilepath, newData, 0644)
+	// Write the combined data back to the partition file with the same permissions as the original partition file.
+	err = os.WriteFile(partitionFilepath, newData, PartitionFilePermissions)
 	if err != nil {
 		return fmt.Errorf("failed to write skippable frame to partition file %s:\n%w", partitionFilepath, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -26,7 +26,6 @@ func TestAddSkippableFrame(t *testing.T) {
 	// Compress to .raw.zst partition file
 	tempPartitionFilepath, err := compressWithZstd(partitionRawFilepath)
 	assert.NoError(t, err)
-	logger.Log.Infof("temp: %s", tempPartitionFilepath)
 
 	// Test adding the skippable frame
 	partitionFilepath, err := addSkippableFrame(tempPartitionFilepath, skippableFrameMetadata, partitionfileName, testDir)

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -48,30 +48,15 @@ func TestAddSkippableFrame(t *testing.T) {
 
 func createTestRawPartitionFile(filename string) (string, error) {
 	// Test data
-	data := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	testData := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
 
-	err := writeToFile(filename, data)
+	err := os.WriteFile(filename, testData, PartitionFilePermissions)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to write skippable frame to partition file %s:\n%w", filename, err)
 	} else {
 		logger.Log.Infof("Test raw partition file created: %s", filename)
 		return filename, nil
 	}
-}
-
-func writeToFile(filename string, data []byte) error {
-	file, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = file.Write(data)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Decompress the .raw.zst partition file and verify the hash matches with the source .raw file

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -19,16 +19,17 @@ func TestAddSkippableFrame(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create test raw partition file
-	partitionfileName := "test"
-	partitionRawFilepath, err := createTestRawPartitionFile(partitionfileName)
+	partitionFilename := "test"
+	partitionRawFilepath, err := createTestRawPartitionFile(partitionFilename)
 	assert.NoError(t, err)
 
 	// Compress to .raw.zst partition file
-	tempPartitionFilepath, err := compressWithZstd(partitionRawFilepath, partitionfileName, testDir)
+	tempPartitionFilepath := testDir + partitionFilename + "_temp.raw.zst"
+	tempPartitionFilepath, err = compressWithZstd(partitionRawFilepath, tempPartitionFilepath)
 	assert.NoError(t, err)
 
 	// Test adding the skippable frame
-	partitionFilepath, err := addSkippableFrame(tempPartitionFilepath, skippableFrameMetadata, partitionfileName, testDir)
+	partitionFilepath, err := addSkippableFrame(tempPartitionFilepath, skippableFrameMetadata, partitionFilename, testDir)
 	assert.NoError(t, err)
 
 	// Verify decompression with skippable frame

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -25,7 +25,7 @@ func TestAddSkippableFrame(t *testing.T) {
 
 	// Compress to .raw.zst partition file
 	tempPartitionFilepath := testDir + partitionFilename + "_temp.raw.zst"
-	tempPartitionFilepath, err = compressWithZstd(partitionRawFilepath, tempPartitionFilepath)
+	err = compressWithZstd(partitionRawFilepath, tempPartitionFilepath)
 	assert.NoError(t, err)
 
 	// Test adding the skippable frame
@@ -57,7 +57,7 @@ func createTestRawPartitionFile(filename string) (string, error) {
 	outputFilename := filename + ".raw"
 
 	// Write data to file
-	err := os.WriteFile(outputFilename, testData, PartitionFilePermissions)
+	err := os.WriteFile(outputFilename, testData, os.ModePerm)
 	if err != nil {
 		return "", fmt.Errorf("failed to write test data to partition file %s:\n%w", filename, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -47,7 +47,7 @@ func TestAddSkippableFrame(t *testing.T) {
 }
 
 func createTestRawPartitionFile(filename string) (string, error) {
-	// Dummy data
+	// Test data
 	data := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
 
 	err := writeToFile(filename, data)

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -1,0 +1,142 @@
+package imagecustomizerlib
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddSkippableFrame(t *testing.T) {
+	// Create a skippable frame containing the metadata and prepend the frame to the partition file
+	skippableFrameMetadata, err := createSkippableFrameMetadata()
+	assert.NoError(t, err)
+
+	// Create test raw partition file
+	partitionRawFilepath, err := createTestRawPartitionFile("test.raw")
+	assert.NoError(t, err)
+
+	// Compress to .raw.zst partition file
+	partitionFilepath, err := compressWithZstd(partitionRawFilepath)
+	assert.NoError(t, err)
+
+	// Test adding the skippable frame
+	err = addSkippableFrame(partitionFilepath, SkippableFrameMagicNumber, SkippableFrameSize, skippableFrameMetadata)
+	assert.NoError(t, err)
+
+	// Verify decompression with skippable frame
+	err = verifySkippableFrameDecompression(partitionRawFilepath, partitionFilepath)
+	assert.NoError(t, err)
+
+	// Verify skippable frame metadata
+	err = verifySkippableFrameMetadataFromFile(partitionFilepath, SkippableFrameMagicNumber, SkippableFrameSize, skippableFrameMetadata)
+	assert.NoError(t, err)
+
+	// Remove test partition files
+	err = os.Remove(partitionRawFilepath)
+	assert.NoError(t, err)
+
+	err = os.Remove(partitionFilepath)
+	assert.NoError(t, err)
+}
+
+func createTestRawPartitionFile(filename string) (string, error) {
+	// Dummy data
+	data := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+
+	err := writeToFile(filename, data)
+	if err != nil {
+		return "", err
+	} else {
+		logger.Log.Infof("File %s created successfully with dummy data.", filename)
+		return filename, nil
+	}
+}
+
+func writeToFile(fileName string, data []byte) error {
+	file, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Decompress the .raw.zst partition file and verifies the hash matches with the source .raw file
+func verifySkippableFrameDecompression(rawPartitionFilepath string, rawZstPartitionFilepath string) (err error) {
+	// Decompressing .raw.zst file
+	decompressedPartitionFilepath := "decompressed.raw"
+	err = shell.ExecuteLive(true, "zstd", "-d", rawZstPartitionFilepath, "-o", decompressedPartitionFilepath)
+	if err != nil {
+		return fmt.Errorf("failed to decompress %s with zstd:\n%w", rawZstPartitionFilepath, err)
+	}
+
+	// Calculating hashes
+	rawPartitionFileHash, err := file.GenerateSHA256(rawPartitionFilepath)
+	if err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
+	decompressedPartitionFileHash, err := file.GenerateSHA256(decompressedPartitionFilepath)
+	if err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
+
+	// Verifying hashes are equal
+	if rawPartitionFileHash != decompressedPartitionFileHash {
+		return fmt.Errorf("decompressed partition file hash does not match source partition file hash: %s != %s", decompressedPartitionFileHash, rawPartitionFilepath)
+	}
+	logger.Log.Debugf("Decompressed partition file hash matches source partition file hash!")
+
+	// Removing decompressed file
+	err = os.Remove(decompressedPartitionFilepath)
+	if err != nil {
+		return fmt.Errorf("failed to remove raw file %s:\n%w", decompressedPartitionFilepath, err)
+	}
+
+	return nil
+}
+
+// Verifies that the skippable frame has been correctly prepended to the partition file with the correct data
+func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber uint32, frameSize uint32, skippableFrameMetadata [SkippableFrameSize]byte) (err error) {
+	// Read existing data from the partition file.
+	existingData, err := os.ReadFile(partitionFilepath)
+	if err != nil {
+		return fmt.Errorf("failed to read partition file %s:\n%w", partitionFilepath, err)
+	}
+
+	// verify that the skippable frame has been prepended to the partition file by validating magicNumber
+	var magicNumberByteArray [4]byte
+	binary.LittleEndian.PutUint32(magicNumberByteArray[:], magicNumber)
+	if !bytes.Equal(existingData[0:4], magicNumberByteArray[:]) {
+		return fmt.Errorf("skippable frame has not been prepended to the partition file:\n %d != %d", existingData[0:4], magicNumberByteArray[:])
+	}
+	logger.Log.Infof("Skippable frame had been correctly prepended to the partition file...")
+
+	// verify that the skippable frame has the correct frame size by validating frameSize
+	var frameSizeByteArray [4]byte
+	binary.LittleEndian.PutUint32(frameSizeByteArray[:], frameSize)
+	if !bytes.Equal(existingData[4:8], frameSizeByteArray[:]) {
+		return fmt.Errorf("skippable frame frameSize field does not match the defined frameSize:\n %d != %d", existingData[4:8], frameSizeByteArray[:])
+	}
+	logger.Log.Infof("Skippable frame frameSize field is correct...")
+
+	// verify that the skippable frame has the correct inserted metadata by validating skippableFrameMetadata
+	if !bytes.Equal(existingData[8:8+frameSize], skippableFrameMetadata[:]) {
+		return fmt.Errorf("skippable frame metadata does not match the inserted metadata:\n %d != %d", existingData[8:8+frameSize], skippableFrameMetadata[:])
+	}
+	logger.Log.Infof("Skippable frame is valid and contains the correct metadata!")
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -54,13 +54,13 @@ func createTestRawPartitionFile(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	} else {
-		logger.Log.Infof("File %s created successfully with dummy data.", filename)
+		logger.Log.Infof("Test raw partition file created: %s", filename)
 		return filename, nil
 	}
 }
 
-func writeToFile(fileName string, data []byte) error {
-	file, err := os.Create(fileName)
+func writeToFile(filename string, data []byte) error {
+	file, err := os.Create(filename)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func writeToFile(fileName string, data []byte) error {
 	return nil
 }
 
-// Decompress the .raw.zst partition file and verifies the hash matches with the source .raw file
+// Decompress the .raw.zst partition file and verify the hash matches with the source .raw file
 func verifySkippableFrameDecompression(rawPartitionFilepath string, rawZstPartitionFilepath string) (err error) {
 	// Decompressing .raw.zst file
 	decompressedPartitionFilepath := "decompressed.raw"
@@ -86,11 +86,11 @@ func verifySkippableFrameDecompression(rawPartitionFilepath string, rawZstPartit
 	// Calculating hashes
 	rawPartitionFileHash, err := file.GenerateSHA256(rawPartitionFilepath)
 	if err != nil {
-		return fmt.Errorf("error: %w", err)
+		return fmt.Errorf("error generating SHA256:\n%w", err)
 	}
 	decompressedPartitionFileHash, err := file.GenerateSHA256(decompressedPartitionFilepath)
 	if err != nil {
-		return fmt.Errorf("error: %w", err)
+		return fmt.Errorf("error generating SHA256:\n%w", err)
 	}
 
 	// Verifying hashes are equal
@@ -110,13 +110,13 @@ func verifySkippableFrameDecompression(rawPartitionFilepath string, rawZstPartit
 
 // Verifies that the skippable frame has been correctly prepended to the partition file with the correct data
 func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber uint32, frameSize uint32, skippableFrameMetadata [SkippableFrameSize]byte) (err error) {
-	// Read existing data from the partition file.
+	// Read existing data from the partition file
 	existingData, err := os.ReadFile(partitionFilepath)
 	if err != nil {
 		return fmt.Errorf("failed to read partition file %s:\n%w", partitionFilepath, err)
 	}
 
-	// verify that the skippable frame has been prepended to the partition file by validating magicNumber
+	// Verify that the skippable frame has been prepended to the partition file by validating magicNumber
 	var magicNumberByteArray [4]byte
 	binary.LittleEndian.PutUint32(magicNumberByteArray[:], magicNumber)
 	if !bytes.Equal(existingData[0:4], magicNumberByteArray[:]) {
@@ -124,7 +124,7 @@ func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber 
 	}
 	logger.Log.Infof("Skippable frame had been correctly prepended to the partition file...")
 
-	// verify that the skippable frame has the correct frame size by validating frameSize
+	// Verify that the skippable frame has the correct frame size by validating frameSize
 	var frameSizeByteArray [4]byte
 	binary.LittleEndian.PutUint32(frameSizeByteArray[:], frameSize)
 	if !bytes.Equal(existingData[4:8], frameSizeByteArray[:]) {
@@ -132,7 +132,7 @@ func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber 
 	}
 	logger.Log.Infof("Skippable frame frameSize field is correct...")
 
-	// verify that the skippable frame has the correct inserted metadata by validating skippableFrameMetadata
+	// Verify that the skippable frame has the correct inserted metadata by validating skippableFrameMetadata
 	if !bytes.Equal(existingData[8:8+frameSize], skippableFrameMetadata[:]) {
 		return fmt.Errorf("skippable frame metadata does not match the inserted metadata:\n %d != %d", existingData[8:8+frameSize], skippableFrameMetadata[:])
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -24,7 +24,7 @@ func TestAddSkippableFrame(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Compress to .raw.zst partition file
-	tempPartitionFilepath, err := compressWithZstd(partitionRawFilepath)
+	tempPartitionFilepath, err := compressWithZstd(partitionRawFilepath, partitionfileName, testDir)
 	assert.NoError(t, err)
 
 	// Test adding the skippable frame


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When MIC customizes Mariner images, it produces multiple output image files (with the `.zst` extension) that correspond to different partitions on the system. Currently, combining partition images from multiple runs of MIC is not supported and has resulted in customer bugs. Today, we have no way to detect whether a user has accidentally mixed images from different runs.

Zstd has a concept of “skippable frames",  which are blocks of data that can be included in a compressed stream but do not impact the result of decompression (https://github.com/facebook/zstd/blob/release/doc/zstd_compression_format.md#skippable-frames). Given a zst compressed file, a skippable frame can be prepended to the start to produce an equivalent zst file carrying additional metadata. 

The proposal here is to have MIC write a skippable frame at the start of all partition images it produces. All partition images from the same run would carry the same skippable frame. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added functionality in MIC to write a skippable frame at the start of all the partition images it produces. 
- All partition images from the same run would carry the same skippable frame metadata and this is a unique identifier for that run.
- Added unit test with verification functions that validated that the outputted `.zst` files had the valid skippable frame with the correct metadata and that they could be decompressed correctly with the skippable frame added in

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Manually tested this functionality by locally running MIC tool with the `-output-split-partitions-format` flag set to  `raw-zst`
- Added unit test for this feature
![image](https://github.com/microsoft/azurelinux/assets/110563293/afc8c76e-2f90-4c3b-bbc9-41e27255ec9c)
