### PR TITLE
fix libcgroup and leveldb

### DIFF
--- a/SPECS/leveldb/leveldb.spec
+++ b/SPECS/leveldb/leveldb.spec
@@ -1,7 +1,7 @@
 Summary:        A fast and lightweight key/value database library by Google
 Name:           leveldb
 Version:        1.23
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD
 URL:            https://github.com/google/leveldb
 Vendor:         Microsoft Corporation
@@ -69,7 +69,7 @@ Libs: -l%{name}
 EOF
 
 %build
-%cmake
+%cmake -DCMAKE_CXX_STANDARD=14
 %make_build
 
 %install
@@ -102,7 +102,10 @@ ctest -V %{?_smp_mflags}
 %{_libdir}/cmake/%{name}/
 
 %changelog
-* Thu Apr 06 2023 Bala <balakumaran.kannan@microsoft.com> 1.23.3
+* Fri Mar 01 2024 Andrew Phelps <anphel@microsoft.com> - 1.23.3-4
+- Fix build by forcing C++ 14 standard
+
+* Thu Apr 06 2023 Bala <balakumaran.kannan@microsoft.com> 1.23.3-3
 - Remove __cmake_in_source_build macro undefine to match make_build with cmake
 
 * Wed Mar 23 2022 Nicolas Guibourge <nicolasg@microsoft.com> 1.23-2

--- a/SPECS/libcgroup/libcgroup.spec
+++ b/SPECS/libcgroup/libcgroup.spec
@@ -1,7 +1,7 @@
 Summary:        Library to control and monitor control groups
 Name:           libcgroup
 Version:        3.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,8 @@ autoreconf -vif
            --disable-daemon
 
 # build libcgroup
+export CXXFLAGS="$CXXFLAGS -std=c++14"
+
 make %{?_smp_mflags}
 
 # build test
@@ -194,6 +196,9 @@ getent group cgred >/dev/null || groupadd -r cgred
 /tests/gunit/.libs/lt-gtest
 
 %changelog
+* Fri Mar 01 2024 Andrew Phelps <anphel@microsoft.com> - 3.1.0-2
+- Fix build by forcing C++ 14 standard
+
 * Thu Feb 22 2024 Henry Li <lihl@microsoft.com> - 3.1.0-1
 - Upgrade to version 3.1.0
 - Add systemd-rpm-macros as BR


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix build breaks in libcgroup and leveldb by using C++ 14 standard

Errors seen in nightly builds:
leveldb-1.23-3.azl3.src.rpm
```
"/usr/include/gtest/internal/gtest-port.h:279:2: error: #error C++ versions less than C++14 are not supported."
```

libcgroup-3.1.0-1.azl3.src.rpm.log
```
"/usr/include/gtest/internal/gtest-port.h:279:2: error: #error C++ versions less than C++14 are not supported."
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix build breaks in libcgroup and leveldb by using C++14 standard

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- leveldb buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=520352&view=results
- libcgroup buddy build: (unable to run due to separate buddybuild issue, but I validated the build locally)
