### PR TITLE
Address kernel CVE-2014-3185, CVE-2022-2602, CVE-2023-46838, CVE-2023-5090, CVE-2023-5633, CVE-2023-6040, CVE-2024-0340, CVE-2024-0562, CVE-2024-0646, CVE-2024-23849, CVE-2024-23850, CVE-2024-23851

### DIFF
--- a/SPECS/kernel/CVE-2014-3185.nopatch
+++ b/SPECS/kernel/CVE-2014-3185.nopatch
@@ -1,0 +1,3 @@
+CVE-2014-3185 - patched in kernel version 5.15.150.1
+upstream commit ID 6817ae225cd650fb1c3295d769298c38b1eba818
+stable commit ID 6817ae225cd650fb1c3295d769298c38b1eba818 

--- a/SPECS/kernel/CVE-2022-2602.nopatch
+++ b/SPECS/kernel/CVE-2022-2602.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-2602 - patched in version 5.15.75.1
+upstream commit ID 0091bfc81741b8d3aeb3b7ab8636f911b2de6e80
+stable commit ID 813d8fe5d30388f73a21d3a2bf46b0a1fd72498c

--- a/SPECS/kernel/CVE-2023-46838.nopatch
+++ b/SPECS/kernel/CVE-2023-46838.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-46838 - patched in version 5.15.148.1
+upstream commit ID c7ec4f2d684e17d69bbdd7c4324db0ef5daac26a
+stable commit ID e03023fcdb5e959d4252b3a38e1b27afb6c1c23c

--- a/SPECS/kernel/CVE-2023-5090.nopatch
+++ b/SPECS/kernel/CVE-2023-5090.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-5090 - introducing patch not present in LTS 5.15.150.1
+Upstream introducing commit: 4d1d7942e36add0aa741a62d0c8e3aba2d5b3ab1
+Upstream fix commit: b65235f6e102354ccafda601eaa1c5bef5284d21

--- a/SPECS/kernel/CVE-2023-5633.nopatch
+++ b/SPECS/kernel/CVE-2023-5633.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-5633 - introducing patch not present in LTS 5.15.150.1
+Upstream introducing commit: a950b989ea29ab3b38ea7f6e3d2540700a3c54e8
+Upstream fix commit: 91398b413d03660fd5828f7b4abc64e884b98069

--- a/SPECS/kernel/CVE-2023-6040.nopatch
+++ b/SPECS/kernel/CVE-2023-6040.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-6040 - patched in version 5.15.147.1
+upstream commit ID f1082dd31fe461d482d69da2a8eccfeb7bf07ac2
+stable commit ID ab3a3aadb373b47a1f401c7626608b1b214cec9e

--- a/SPECS/kernel/CVE-2024-0340.nopatch
+++ b/SPECS/kernel/CVE-2024-0340.nopatch
@@ -1,0 +1,3 @@
+CVE-2024-0340 - patched in version 5.15.149.1
+upstream commit ID 4d8df0f5f79f747d75a7d356d9b9ea40a4e4c8a9
+stable commit ID be38f291fd4d106be66370debd23d625c576023e

--- a/SPECS/kernel/CVE-2024-0562.nopatch
+++ b/SPECS/kernel/CVE-2024-0562.nopatch
@@ -1,0 +1,3 @@
+CVE-2024-0562 - patched in version 5.15.64.1
+upstream commit ID f87904c075515f3e1d8f4a7115869d3b914674fd
+stable commit ID f96b9f7c1676923bce871e728bb49c0dfa5013cc

--- a/SPECS/kernel/CVE-2024-0646.nopatch
+++ b/SPECS/kernel/CVE-2024-0646.nopatch
@@ -1,0 +1,3 @@
+CVE-2024-0646 - patched in 5.15.147.1
+Upstream: c5a595000e2677e865a39f249c056bc05d6e55fd 
+Stable: ba5efd8544fa62ae85daeb36077468bf2ce974ab 

--- a/SPECS/kernel/CVE-2024-23849.nopatch
+++ b/SPECS/kernel/CVE-2024-23849.nopatch
@@ -1,0 +1,3 @@
+CVE-2024-23849 - patched in version 5.15.149.1
+upstream commit ID 13e788deb7348cc88df34bed736c3b3b9927ea52
+stable commit ID 00d1ee8e1d02194f7b7b433e904e04bbcd2cc0dc

--- a/SPECS/kernel/CVE-2024-23850.nopatch
+++ b/SPECS/kernel/CVE-2024-23850.nopatch
@@ -1,0 +1,3 @@
+CVE-2024-23850 - patched in version 5.15.149.1
+upstream commit ID e03ee2fe873eb68c1f9ba5112fee70303ebf9dfb
+stable commit ID e31546b0f34af21738c4ceac47d662c00ee6382f

--- a/SPECS/kernel/CVE-2024-23851.nopatch
+++ b/SPECS/kernel/CVE-2024-23851.nopatch
@@ -1,0 +1,3 @@
+CVE-2024-23851 - patched in version 5.15.149.1
+upstream commit ID bd504bcfec41a503b32054da5472904b404341a4
+stable commit ID 888a0a46b80fa37eacfe81faf47ba0b83876251d


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address kernel CVE-2014-3185, CVE-2022-2602, CVE-2023-46838, CVE-2023-5090, CVE-2023-5633, CVE-2023-6040, CVE-2024-0340, CVE-2024-0562, CVE-2024-0646, CVE-2024-23849, CVE-2024-23850, CVE-2024-23851

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Address kernel CVE-2014-3185, CVE-2022-2602, CVE-2023-46838, CVE-2023-5090, CVE-2023-5633, CVE-2023-6040, CVE-2024-0340, CVE-2024-0562, CVE-2024-0646, CVE-2024-23849, CVE-2024-23850, CVE-2024-23851

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2014-3185
- https://nvd.nist.gov/vuln/detail/CVE-2022-2602
- https://nvd.nist.gov/vuln/detail/CVE-2023-46838
- https://nvd.nist.gov/vuln/detail/CVE-2023-5090
- https://nvd.nist.gov/vuln/detail/CVE-2023-5633
- https://nvd.nist.gov/vuln/detail/CVE-2023-6040
- https://nvd.nist.gov/vuln/detail/CVE-2024-0340
- https://nvd.nist.gov/vuln/detail/CVE-2024-0562
- https://nvd.nist.gov/vuln/detail/CVE-2024-0646
- https://nvd.nist.gov/vuln/detail/CVE-2024-23849
- https://nvd.nist.gov/vuln/detail/CVE-2024-23850
- https://nvd.nist.gov/vuln/detail/CVE-2024-23851

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- NA