### PR TITLE
Address kernel CVE-2015-5157, CVE-2022-2585, CVE-2022-2586, CVE-2023-50431, CVE-2023-6200, CVE-2023-6560

### DIFF
--- a/SPECS/kernel/CVE-2015-5157.nopatch
+++ b/SPECS/kernel/CVE-2015-5157.nopatch
@@ -1,0 +1,3 @@
+CVE-2015-5157 - patched in version 5.15.150.1
+upstream commit ID 9b6e6a8334d56354853f9c255d1395c2ba570e0a
+stable commit ID 9b6e6a8334d56354853f9c255d1395c2ba570e0a

--- a/SPECS/kernel/CVE-2022-2585.nopatch
+++ b/SPECS/kernel/CVE-2022-2585.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-2585 - patched in 5.15.61.1
+Upstream: e362359ace6f87c201531872486ff295df306d13
+Stable: 9e255ed238fc67058df87b0388ad6d4b2ef3a2bd

--- a/SPECS/kernel/CVE-2022-2586.nopatch
+++ b/SPECS/kernel/CVE-2022-2586.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-2586 - patched in 5.15.61.1
+Upstream: 470ee20e069a6d05ae549f7d0ef2bdbcee6a81b2
+Stable: faafd9286f1355c76fe9ac3021c280297213330e

--- a/SPECS/kernel/CVE-2023-50431.nopatch
+++ b/SPECS/kernel/CVE-2023-50431.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-50431 - Introducing commit not present in LTS 5.15.150.1
+Upstream instroducing commit: 0c88760f8f5e13e32f624a1da71144b240b05125
+Upstream fix commit: a9f07790a4b2250f0140e9a61c7f842fd9b618c7

--- a/SPECS/kernel/CVE-2023-6200.nopatch
+++ b/SPECS/kernel/CVE-2023-6200.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-6200 - Introducing commit not present in LTS 5.15.150.1
+Upstream instroducing commit: 3dec89b14d37ee635e772636dad3f09f78f1ab87
+Upstream fix commit: dade3f6a1e4e35a5ae916d5e78b3229ec34c78ec

--- a/SPECS/kernel/CVE-2023-6560.nopatch
+++ b/SPECS/kernel/CVE-2023-6560.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-6560 - introducing commit not present in LTS 5.15.150.1
+Upstream introducing commit: 03d89a2de25bbc5c77e61a0cf77663978c4b6ea7
+Upstream fix commit: 820d070feb668aab5bc9413c285a1dda2a70e076


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address kernel CVE-2015-5157, CVE-2022-2585, CVE-2022-2586, CVE-2023-50431, CVE-2023-6200, CVE-2023-6560

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Address kernel CVE-2015-5157, CVE-2022-2585, CVE-2022-2586, CVE-2023-50431, CVE-2023-6200, CVE-2023-6560

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2015-5157
- https://nvd.nist.gov/vuln/detail/CVE-2022-2585
- https://nvd.nist.gov/vuln/detail/CVE-2022-2586
- https://nvd.nist.gov/vuln/detail/CVE-2023-50431
- https://nvd.nist.gov/vuln/detail/CVE-2023-6200
- https://nvd.nist.gov/vuln/detail/CVE-2023-6560
