### PR TITLE
Image Customizer: Fix for when shrinking filesystem is NOP.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -105,7 +105,7 @@ func getStartSectors(imageLoopDevice string, partitionCount int) (matchStarts []
 func getFilesystemSizeInSectors(resize2fsStdout string, resize2fsStderr string, imageLoopDevice string,
 ) (filesystemSizeInSectors int, err error) {
 	if strings.Contains(resize2fsStderr, "Nothing to do!") {
-		return -1, err
+		return -1, nil
 	}
 
 	// Example resize2fs output first line: "Resizing the filesystem on /dev/loop44p2 to 21015 (4k) blocks."
@@ -168,7 +168,7 @@ func getNewPartitionEndInSectors(resize2fsStdout string, resize2fsStderr string,
 	}
 
 	if filesystemSizeInSectors < 0 {
-		return "", err
+		return "", nil
 	}
 
 	// Convert start sector string to int

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/consume-space.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/consume-space.yaml
@@ -1,0 +1,3 @@
+SystemConfig:
+  FinalizeImageScripts:
+  - Path: scripts/consume-space.sh

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/scripts/consume-space.sh
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/scripts/consume-space.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Write out a file that consumes the rest of the space on the rootfs partition.
+dd if=/dev/zero of=/bigfile bs=512 || true


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

When shrinking partitions, the image customizer tool gets confused when the `resize2fs -M` reports that the filesystem is already at its minimum size. This change fixes this.

In addition, some of the logging for shrinking filesystems is improved.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Fix for when shrinking filesystem is NOP.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually testing image customizer tool.

