### PR TITLE
python-gevent: disable c-ares module and fix CVE-2021-22931

### DIFF
--- a/SPECS/python-gevent/python-gevent.spec
+++ b/SPECS/python-gevent/python-gevent.spec
@@ -1,7 +1,7 @@
 Summary:        Coroutine-based network library
 Name:           python-gevent
 Version:        21.1.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,6 +48,7 @@ Features include:
 %autosetup -p1 -n gevent-%{version}
 
 %build
+export GEVENTSETUP_DISABLE_ARES=1
 %py3_build
 
 %install
@@ -64,6 +65,9 @@ cp %{SOURCE1} src/gevent/tests/tests_to_ignore.txt
 %{python3_sitelib}/*
 
 %changelog
+* Thu Mar 07 2024 Saul Paredes <saulparedes@microsoft.com> - 21.1.2-3
+- Disable c-ares module and fix CVE-2021-22931
+
 * Wed Jan 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 21.1.2-2
 - Disable unreliable tests
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2021-22931. Nist mentions this is a CVE against nodejs, despite deep scan alerting about sources inside deps/c-ares.

![image](https://github.com/microsoft/azurelinux/assets/30801614/786eecd1-8fb3-4119-b494-39cddfe18af6)


Another link from nist clarifies this is really a CVE against c-ares https://security.gentoo.org/glsa/202401-02. 
Embedded c-ares is [set to 1.16.1](https://github.com/gevent/gevent/commits/21.1.2/deps/c-ares), but we'd need to upgrade to 1.19 to fix CVE. eg add all these commits as patches from https://github.com/gevent/gevent/commits/master/deps/c-ares
![image](https://github.com/microsoft/azurelinux/assets/30801614/c3b12118-f208-443a-b43f-41ddee4e1d5b)

It seems easier to disable the module, provided no clients depend on this functionality.

By setting `GEVENTSETUP_DISABLE_ARES=1`, the c-ares module is excluded from the build:

![image](https://github.com/microsoft/azurelinux/assets/30801614/c8119a94-54d2-4152-b143-6c3f1b28cbd3)


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2021-22931

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-22931

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=521862&view=results [pass]
- Built locally:
![image](https://github.com/microsoft/azurelinux/assets/30801614/5459f838-d4e2-4b88-be00-d838f8a7a3c2)

