### PR TITLE
revert cleaning up log directories for base image

### DIFF
--- a/toolkit/imageconfigs/scripts/cleanup.sh
+++ b/toolkit/imageconfigs/scripts/cleanup.sh
@@ -12,11 +12,3 @@ if [ -L /srv ]; then
 else
   echo "/srv symlink does not exist"
 fi
-
-# cleanup any logs that may have been created during the build
-if [ -d /var/log ]; then
-  echo "Clearing /var/log"
-  rm -rf /var/log/*
-else
-  echo "/var/log does not exist"
-fi


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
A previous PR added log directory clean-up to the clean-up script. However, that leads to services like `auditd` failing due to missing directories and incorrect selinux labeling even if the directories are created later.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Tested locally.