### PR TITLE
azl3: upgrade libvirt-python and enable mdevctl for arm

### DIFF
--- a/SPECS/libvirt-python/libvirt-python.signatures.json
+++ b/SPECS/libvirt-python/libvirt-python.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libvirt-python-7.10.0.tar.gz": "267774bbdf99d47515274542880499437dc94ae291771f5663c62020a62da975"
+  "libvirt-python-10.0.0.tar.gz": "a82588f0e7db53eda7b7dbcbc448b0ec43e00a8c77cac69644495299b410c20d"
  }
 }

--- a/SPECS/libvirt-python/libvirt-python.spec
+++ b/SPECS/libvirt-python/libvirt-python.spec
@@ -59,6 +59,7 @@ find examples -type f -exec chmod 0644 \{\} \;
 %py3_install
 
 %check
+pip3 install iniconfig
 %pytest
 
 %files -n python3-libvirt

--- a/SPECS/libvirt-python/libvirt-python.spec
+++ b/SPECS/libvirt-python/libvirt-python.spec
@@ -59,14 +59,10 @@ find examples -type f -exec chmod 0644 \{\} \;
 %py3_install
 
 %check
-pip3 install \
-    more-itertools \
-    pluggy
-python3 setup.py test
+%pytest
 
 %files -n python3-libvirt
-%license COPYING COPYING.LESSER
-%doc ChangeLog AUTHORS README examples/
+%doc ChangeLog AUTHORS README COPYING examples/
 %{python3_sitearch}/libvirt.py*
 %{python3_sitearch}/libvirtaio.py*
 %{python3_sitearch}/libvirt_qemu.py*

--- a/SPECS/libvirt-python/libvirt-python.spec
+++ b/SPECS/libvirt-python/libvirt-python.spec
@@ -3,7 +3,7 @@
 
 Summary:        The libvirt virtualization API python3 binding
 Name:           libvirt-python
-Version:        7.10.0
+Version:        10.0.0
 Release:        1%{?dist}
 License:        GPLv2+ and LGPLv2+
 Vendor:         Microsoft Corporation
@@ -79,6 +79,9 @@ python3 setup.py test
 %{python3_sitearch}/*egg-info
 
 %changelog
+* Wed Mar 06 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 10..00-1
+- Upgrade to 10.0.0.
+
 * Wed Jan 05 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 7.10.0-1
 - Initial CBL-Mariner import from Fedora 36 (license: MIT).
 - License verified.

--- a/SPECS/mdevctl/mdevctl.spec
+++ b/SPECS/mdevctl/mdevctl.spec
@@ -2,7 +2,7 @@
 
 Name:           mdevctl
 Version:        1.3.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A mediated device management utility for Linux
 
 License:        LGPL-2.1-only
@@ -14,8 +14,6 @@ BuildRequires:  cargo
 BuildRequires:  make
 BuildRequires:  python3-docutils
 BuildRequires:  systemd-rpm-macros
-
-ExclusiveArch:  x86_64
 
 %ifarch x86_64
 %define rust_def_target x86_64-unknown-linux-gnu
@@ -94,6 +92,9 @@ cargo test
 %{bashcompletiondir}/lsmdev
 
 %changelog
+* Wed Mar 06 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 1.3.0-3
+- Enable for other architectures.
+
 * Fri Jan 19 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 1.3.0-2
 - Initial CBL-Mariner import from Fedora 39 (license: MIT).
 - License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11401,8 +11401,8 @@
         "type": "other",
         "other": {
           "name": "libvirt-python",
-          "version": "7.10.0",
-          "downloadUrl": "https://libvirt.org/sources/python/libvirt-python-7.10.0.tar.gz"
+          "version": "10.0.0",
+          "downloadUrl": "https://libvirt.org/sources/python/libvirt-python-10.0.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
libvirt-python is a runtime dependency for libvirt
mdevctl is a dependency for libvirt that currently only builds for x86_64

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
- Update libvirt-python version and signature
- Add iniconfig install for libvirt-python check
- Remove mdevctl ExclusiveArch

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- [only arm qemu is stopping libvirt and libvirt-python from building in this buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=522515&view=results)
