### PR TITLE
Restoring `azl` macro usage.

### DIFF
--- a/SPECS/azurelinux-repos/azurelinux-repos.spec
+++ b/SPECS/azurelinux-repos/azurelinux-repos.spec
@@ -1,6 +1,6 @@
 Summary:        AzureLinux repo files, gpg keys
 Name:           azurelinux-repos
-Version:        3.0
+Version:        %{azl}.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation

--- a/SPECS/azurelinux-rpm-macros/azurelinux-rpm-macros.spec
+++ b/SPECS/azurelinux-rpm-macros/azurelinux-rpm-macros.spec
@@ -6,7 +6,7 @@
 %global __brp_python_bytecompile %{nil}
 Summary:        Azure Linux specific rpm macro files
 Name:           azurelinux-rpm-macros
-Version:        3.0
+Version:        %{azl}.0
 Release:        1%{?dist}
 License:        GPL+ AND MIT
 Vendor:         Microsoft Corporation

--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -44,7 +44,7 @@ Name:           ca-certificates
 
 # When updating, "Epoch, "Version", AND "Release" tags must be updated in the "prebuilt-ca-certificates*" packages as well.
 Epoch:          1
-Version:        3.0.0
+Version:        %{azl}.0.0
 Release:        3%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -2,7 +2,7 @@ Summary:        Prebuilt version of ca-certificates-base package.
 Name:           prebuilt-ca-certificates-base
 # When updating, "Epoch, "Version", AND "Release" tags must be updated in the "ca-certificates" package as well.
 Epoch:          1
-Version:        3.0.0
+Version:        %{azl}.0.0
 Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -2,7 +2,7 @@ Summary:        Prebuilt version of ca-certificates package.
 Name:           prebuilt-ca-certificates
 # When updating, "Epoch, "Version", AND "Release" tags must be updated in the "ca-certificates" package as well.
 Epoch:          1
-Version:        3.0.0
+Version:        %{azl}.0.0
 Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -54,12 +54,21 @@ PARAM_BUILD_NUM=$MARINER_BUILD_NUMBER
 PARAM_RELEASE_VER=$MARINER_RELEASE_VERSION
 
 if [ "$RUN_CHECK" = "y" ]; then
-    export CHECK_SETTING=" "
-    export CHECK_DEFINE_NUM="1"
+    CHECK_SETTING=" "
+    CHECK_DEFINE_NUM="1"
 else
-    export CHECK_SETTING="--nocheck"
-    export CHECK_DEFINE_NUM="0"
+    CHECK_SETTING="--nocheck"
+    CHECK_DEFINE_NUM="0"
 fi
+
+SHARED_RPM_MACROS=(                                                         \
+    -D "$MARINER_DIST_MACRO"                                                \
+    -D "dist                    '$PARAM_DIST_TAG'"                          \
+    -D "distro_module_ldflags   -Wl,-dT,%{_topdir}/BUILD/module_info.ld"    \
+    -D "distro_release_version  '$PARAM_RELEASE_VER'"                       \
+    -D "mariner_build_number    '$PARAM_BUILD_NUM'"                         \
+    -D "with_check              '$CHECK_DEFINE_NUM'"                        \
+    )
 
 # Assumption: pipeline has copied file: build/toolchain/toolchain_from_container.tar.gz
 # Or, if toolchain-build-all was called, both of the following will exist:
@@ -201,8 +210,8 @@ chroot_and_install_rpms () {
         # This is a heuristic to find the associated RPMs. In theory we should instead use a more selective filtering like
         # we use for build_rpm_in_chroot_no_install by querying for exact RPMs that match $2 found in $1.spec however to
         # preserve the existing behavior we'll just copy all RPMs that match the name-version-release string.
-        #     e.g. matching_rpms=$(rpmspec -q $specPath --srpm --define="with_check $CHECK_DEFINE_NUM" --define="_sourcedir $specDir" --define="dist $PARAM_DIST_TAG" --builtrpms --queryformat '%{nvra}.rpm\n' | grep $2)
-        verrel=$(rpmspec -q $specPath --srpm --define="with_check $CHECK_DEFINE_NUM" --define="_sourcedir $specDir" --define="dist $PARAM_DIST_TAG" --define="$MARINER_DIST_MACRO" --queryformat %{VERSION}-%{RELEASE})
+        #     e.g. matching_rpms=$(rpmspec -q $specPath --srpm "${SHARED_RPM_MACROS[@]}" --define="_sourcedir $specDir" --builtrpms --queryformat '%{nvra}.rpm\n' | grep $2)
+        verrel=$(rpmspec -q $specPath --srpm "${SHARED_RPM_MACROS[@]}" --define="_sourcedir $specDir" --queryformat %{VERSION}-%{RELEASE})
         # Do not include any files with "debuginfo" in the name
         find $CHROOT_RPMS_DIR -name "$2*$verrel*" ! -name "*debuginfo*" -exec cp {} $CHROOT_INSTALL_RPM_DIR ';'
     else
@@ -230,17 +239,16 @@ chroot_and_run_rpmbuild () {
     echo "Will build spec for $1 in chroot"
     chroot_mount
 
-    chroot "$LFS" /usr/bin/env -i          \
-        HOME=/root                         \
-        TERM="$TERM"                       \
-        PS1='\u:\w\$ '                     \
-        PATH=/bin:/usr/bin:/sbin:/usr/sbin \
-        SHELL=/bin/bash                    \
-        rpmbuild --nodeps --rebuild --clean     \
-            $CHECK_SETTING                 \
-            --define "with_check $CHECK_DEFINE_NUM" --define "dist $PARAM_DIST_TAG" --define "$MARINER_DIST_MACRO" --define "mariner_build_number $PARAM_BUILD_NUM" \
-            --define "distro_release_version $PARAM_RELEASE_VER" $TOPDIR/SRPMS/$1 \
-            --define "distro_module_ldflags  -Wl,-dT,%{_topdir}/BUILD/module_info.ld" \
+    chroot "$LFS" /usr/bin/env -i           \
+        HOME=/root                          \
+        TERM="$TERM"                        \
+        PS1='\u:\w\$ '                      \
+        PATH=/bin:/usr/bin:/sbin:/usr/sbin  \
+        SHELL=/bin/bash                     \
+        rpmbuild --nodeps --rebuild --clean \
+            "$CHECK_SETTING"                \
+            "${SHARED_RPM_MACROS[@]}"       \
+            "$TOPDIR/SRPMS/$1"              \
             || echo "$1" >> "$TOOLCHAIN_FAILURES"
 
     chroot_unmount
@@ -255,7 +263,7 @@ build_rpm_in_chroot_no_install () {
 
     specPath=$(find $SPECROOT -name "$1.spec" -print -quit)
     specDir=$(dirname $specPath)
-    rpmMacros=(-D "with_check $CHECK_DEFINE_NUM" -D "_sourcedir $specDir" -D "dist $PARAM_DIST_TAG")
+    rpmMacros=("${SHARED_RPM_MACROS[@]}" -D "_sourcedir $specDir")
     builtRpms="$(rpmspec -q $specPath --builtrpms "${rpmMacros[@]}" --queryformat="%{nvra}.rpm\n")"
 
     # Find all the associated RPMs for the SRPM and check if they are in the chroot RPM directory


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Re-introducing the changes from #8232. They were breaking toolchain builds and had to be reverted in #8279. This PR restores the use of the `azl` macro but also addresses the toolchain build issues related to it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Restored the use of the `azl` macro to define major version number for specs tied to the system version.
- Updated toolchain builds to consistently use pass the `azl` macro into its RPM queries and build commands.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #8232
- #8279

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Full dev build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=522703&view=results).