### PR TITLE
valgrind Disable ld-linux strlen checks

### DIFF
--- a/SPECS/valgrind/remove_strlen_checks.patch
+++ b/SPECS/valgrind/remove_strlen_checks.patch
@@ -1,0 +1,32 @@
+diff --git a/coregrind/m_redir.c b/coregrind/m_redir.c
+index cef241b4f..449e916cc 100644
+--- a/coregrind/m_redir.c
++++ b/coregrind/m_redir.c
+@@ -1372,9 +1372,6 @@ void VG_(redir_initialise) ( void )
+       add_hardwired_spec(
+          "ld-linux.so.2", "index",
+          (Addr)&VG_(x86_linux_REDIR_FOR_index), mandatory);
+-      add_hardwired_spec(
+-         "ld-linux.so.2", "strlen",
+-         (Addr)&VG_(x86_linux_REDIR_FOR_strlen), mandatory);
+    }
+ 
+ #  elif defined(VGP_amd64_linux)
+@@ -1399,17 +1396,6 @@ void VG_(redir_initialise) ( void )
+       add_hardwired_spec(
+          "ld-linux-x86-64.so.2", "index",
+          (Addr)&VG_(amd64_linux_REDIR_FOR_index), NULL);
+-      add_hardwired_spec(
+-         "ld-linux-x86-64.so.2", "strlen",
+-         (Addr)&VG_(amd64_linux_REDIR_FOR_strlen),
+-#        ifndef GLIBC_MANDATORY_STRLEN_REDIRECT
+-         NULL
+-#        else
+-         /* for glibc-2.10 and later, this is mandatory - can't sanely
+-            continue without it */
+-         complain_about_stripped_glibc_ldso
+-#        endif
+-      );   
+    }
+ 
+ #  elif defined(VGP_ppc32_linux)

--- a/SPECS/valgrind/valgrind.spec
+++ b/SPECS/valgrind/valgrind.spec
@@ -26,8 +26,7 @@ more stable. You can also perform detailed profiling to help speed up your
 programs.
 
 %prep
-%setup -q
-%patch0 -p1
+%autosetup -p1
 
 %build
 CFLAGS="`echo " %{build_cflags} " | sed 's/-fstack-protector-strong//'`"

--- a/SPECS/valgrind/valgrind.spec
+++ b/SPECS/valgrind/valgrind.spec
@@ -2,14 +2,16 @@
 Summary:        Memory Management Debugger.
 Name:           valgrind
 Version:        3.22.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Debuggers
 URL:            https://valgrind.org
 Source0:        https://sourceware.org/pub/%{name}/%{name}-%{version}.tar.bz2
-Requires:       glibc-debuginfo
+
+Patch0:         remove_strlen_checks.patch
+
 BuildRequires:  pkg-config
 %if %{with_check}
 BuildRequires:  docbook-dtd-xml
@@ -25,6 +27,7 @@ programs.
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 CFLAGS="`echo " %{build_cflags} " | sed 's/-fstack-protector-strong//'`"
@@ -50,6 +53,9 @@ make %{?_smp_mflags} -k check
 %{_libexecdir}/valgrind/*
 
 %changelog
+* Thu Mar 07 2024 Andy Zaugg <azaugg@linkedin.com> - 3.22.0-2
+- Remove ldlinux strlen checks to force valgrind to work without glibc debug symbols enabled
+
 * Thu Nov 16 2023 Sriram Nambakam <snambakam@microsoft.com> - 3.22.0-1
 - Update to 3.22.0
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
the valgrind binary does not work on Mariner, disable strleng checks to get it to work

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added a patch to remove strlng checks on valgrind start


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built package
```
INFO[0000][scheduler] Building 13 nodes with 16 workers
INFO[0000][scheduler] Building: valgrind-3.22.0-3.cm2.src.rpm
INFO[0157][scheduler] Built: valgrind-3.22.0-3.cm2.src.rpm -> [/home/azaugg/CBL-Mariner/out/RPMS/x86_64/valgrind-3.22.0-3.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/valgrind-debuginfo-3.22.0-3.cm2.x86_64.rpm]
INFO[0157][scheduler] 0 currently active build(s): [].
INFO[0157][scheduler] All packages built
INFO[0158][scheduler] ---------------------------
INFO[0158][scheduler] --------- Summary ---------
INFO[0158][scheduler] ---------------------------
INFO[0158][scheduler] Number of prebuilt SRPMs:           0
INFO[0158][scheduler] Number of prebuilt delta SRPMs:     0
INFO[0158][scheduler] Number of skipped SRPMs tests:      0
INFO[0158][scheduler] Number of built SRPMs:              1
INFO[0158][scheduler] Number of passed SRPMs tests:       0
INFO[0158][scheduler] Number of unresolved dependencies:  0
INFO[0158][scheduler] Number of blocked SRPMs:            0
INFO[0158][scheduler] Number of blocked SRPMs tests:      0
INFO[0158][scheduler] Number of failed SRPMs:             0
INFO[0158][scheduler] Number of failed SRPMs tests:       0
INFO[0158][scheduler] Number of toolchain RPM conflicts:  0
INFO[0158][scheduler] Number of toolchain SRPM conflicts: 0
INFO[0158][scheduler] Built SRPMs:
INFO[0158][scheduler] --> valgrind-3.22.0-3.cm2.src.rpm
INFO[0158][scheduler] ---------------------------
INFO[0158][scheduler] --------- Summary ---------
INFO[0158][scheduler] ---------------------------
INFO[0158][scheduler] Number of prebuilt SRPMs:           0
INFO[0158][scheduler] Number of prebuilt delta SRPMs:     0
INFO[0158][scheduler] Number of skipped SRPMs tests:      0
INFO[0158][scheduler] Number of built SRPMs:              1
INFO[0158][scheduler] Number of passed SRPMs tests:       0
INFO[0158][scheduler] Number of unresolved dependencies:  0
INFO[0158][scheduler] Number of blocked SRPMs:            0
INFO[0158][scheduler] Number of blocked SRPMs tests:      0
INFO[0158][scheduler] Number of failed SRPMs:             0
INFO[0158][scheduler] Number of failed SRPMs tests:       0
INFO[0158][scheduler] Number of toolchain RPM conflicts:  0
INFO[0158][scheduler] Number of toolchain SRPM conflicts: 0
INFO[0158][scheduler] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/built_graph.dot
INFO[0158][scheduler] Waiting for outstanding processes to be created
Finished updating /home/azaugg/CBL-Mariner/out/RPMS
```
- Ran new binary
```
azaugg@azaugg-ld1 [ ~/CBL-Mariner/toolkit ] [ main ] $ valgrind ls
==773866== Memcheck, a memory error detector
==773866== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==773866== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==773866== Command: ls
==773866==
Makefile  README.md  docs  imageconfigs  out  resources  scripts  tools
==773866==
==773866== HEAP SUMMARY:
==773866==     in use at exit: 21,969 bytes in 15 blocks
==773866==   total heap usage: 24 allocs, 9 frees, 57,503 bytes allocated
==773866==
==773866== LEAK SUMMARY:
==773866==    definitely lost: 0 bytes in 0 blocks
==773866==    indirectly lost: 0 bytes in 0 blocks
==773866==      possibly lost: 0 bytes in 0 blocks
==773866==    still reachable: 21,969 bytes in 15 blocks
==773866==         suppressed: 0 bytes in 0 blocks
==773866== Rerun with --leak-check=full to see details of leaked memory
==773866==
==773866== For lists of detected and suppressed errors, rerun with: -s
==773866== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
