### PR TITLE
update toolchain container bootstrap to 2.0.20240123

### DIFF
--- a/toolkit/scripts/toolchain/cgmanifest.json
+++ b/toolkit/scripts/toolchain/cgmanifest.json
@@ -5,8 +5,8 @@
                 "Type": "DockerImage",
                 "DockerImage": {
                     "Name": "mcr.microsoft.com/cbl-mariner/base/core",
-                    "Digest": "sha256:ca9eb22782f247189c15a4145dfde7f21bca25e545a6a3782a3fe2dbe3b128f0",
-                    "Tag": "2.0.20231004"
+                    "Digest": "sha256:82314abb594a695fd8817774e8b7f101934902cc1d99b3075e80acbc8b9b23ee",
+                    "Tag": "2.0.20240123"
                 }
             }
         }

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Dockerfile to build Mariner toolchain from scratch
 #
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20231004
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20240123
 
 # Tag the layers so we can clean up all the containers associated with a build directory
 ARG MARINER_BUILD_DIR


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Update toolchain container bootstrap to version 2.0.20240123. This contains an updated ca-certificates package, which seems to be required to accesss PMC. The previous version 2.0.20231004 recently started hitting the following errors during toolchain builds:
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=522720&view=logs&j=b8434940-6313-5e68-756c-eb07a355d9c5&t=47ceba65-52ed-50aa-b33b-d0e02de1d7d0
```
Refreshing metadata for: 'CBL-Mariner Official Microsoft 2.0 x86_64'
Error(1261) : SSL peer certificate or SSH remote key was not OK
Error: Failed to synchronize cache for repo 'CBL-Mariner Official Base 2.0 x86_64'
```


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change toolchain container bootstrap to 2.0.20240123
- Update cgmanifest.json digest and version

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=522776&view=results
