### PR TITLE
Revert "fix pam_wrapper build (#8194)"

### DIFF
--- a/SPECS/pam_wrapper/pam_wrapper.spec
+++ b/SPECS/pam_wrapper/pam_wrapper.spec
@@ -1,6 +1,6 @@
 Name:           pam_wrapper
 Version:        1.1.5
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        A tool to test PAM applications and PAM modules
 License:        GPLv3+
 URL:            https://cwrap.org/
@@ -59,6 +59,17 @@ License:        GPLv3+
 
 %description -n libpamtest-doc
 Documentation for libpamtest development.
+
+%package -n python3-libpamtest
+Summary:        A python wrapper for libpamtest
+License:        GPLv3+
+Requires:       libpamtest = %{version}-%{release}
+Requires:       pam_wrapper = %{version}-%{release}
+
+%description -n python3-libpamtest
+If you plan to develop python tests for a PAM module you can use this
+library, which simplifies testing of modules. This subpackage includes
+the header files for libpamtest
 
 %prep
 %autosetup -S git
@@ -124,10 +135,10 @@ popd
 %license LICENSE
 %doc obj/doc/html
 
-%changelog
-* Thu Feb 29 2024 Andrew Phelps <anphel@microsoft.com> - 1.1.5-2
-- Temporarily remove python3-libpamtest subpackage, which is not building with python 3.12
+%files -n python3-libpamtest
+%{python3_sitearch}/pypamtest.so
 
+%changelog
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.1.5-1
 - Auto-upgrade to 1.1.5 - Azure Linux 3.0 - package upgrades
 
@@ -138,7 +149,7 @@ popd
 - Bumping version to 1.1.4.
 - Remove gpg signature verification
 - License verified
-
+ 
 * Tue Jun 08 2021 Thomas Crain <thcrain@microsoft.com> - 1.1.3-3
 - Remove python2 macros
 


### PR DESCRIPTION
This reverts commit abc4f4e5fe19ba774c52fb36aed8bd7adea78743.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Revert the temporary changes in PR #8194 related to pam_wrapper.
Now that cmake has been updated from version 3.21.4 to 3.28.2, our nightly builds are again compiling the pypamtest.so module. 
The new cmake seems to have resolved an issue finding PythonLibs, which allows pypamtest.so to build.

With cmake 3.21.4, when pypamtest.so was not built:
```
"-- Could NOT find PythonLibs (missing: PYTHON_LIBRARIES PYTHON_INCLUDE_DIRS) (Required is at least version \"3\")"
```

With cmake 3.28.2, when pypamtest.so is being built:
```
"CMake Warning (dev) at src/python/python3/CMakeLists.txt:11 (find_package):"
"  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules"
"  are removed.  Run \"cmake --help-policy CMP0148\" for policy details.  Use"
"  the cmake_policy command to set the policy and suppress this warning."

"This warning is for project developers.  Use -Wno-dev to suppress it."

"-- Found PythonLibs: /usr/lib/libpython3.12.so (found suitable version \"3.12.0\", minimum required is \"3\") "
"CMake Warning (dev) at src/python/python3/CMakeLists.txt:12 (find_package):"
"  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules"
"  are removed.  Run \"cmake --help-policy CMP0148\" for policy details.  Use"
"  the cmake_policy command to set the policy and suppress this warning."

"This warning is for project developers.  Use -Wno-dev to suppress it."

"-- Installing: /usr/src/azl/BUILDROOT/pam_wrapper-1.1.5-2.azl3.x86_64/usr/lib/python3.12/site-packages/pypamtest.so"

```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Revert changes to pam_wrapper

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=523026&view=results
