### PR TITLE
Switch qemu-guest base image to kernel instead of kernel-hci

### DIFF
--- a/toolkit/imageconfigs/qemu-guest.json
+++ b/toolkit/imageconfigs/qemu-guest.json
@@ -53,7 +53,7 @@
                 "ExtraCommandLine": "console=tty0 console=ttyS0"
             },
             "KernelOptions": {
-                "default": "kernel-hci"
+                "default": "kernel"
             },
             "FinalizeImageScripts": [
                 {


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Move all base images to use `kernel` by default. Customers who needs a different kernel can customize that through uninstalling & installing the desired kernel.
For 3.0, `kernel-hci` is going away so this is related prep work.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local testing.
