### PR TITLE
Fix SELinux labelling image with multiple partitions - Take 2.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1766,6 +1766,7 @@ func selinuxRelabelFiles(installChroot *safechroot.Chroot, mountPointToFsTypeMap
 	fileContextPath := fmt.Sprintf(fileContextBasePath, selinuxType)
 
 	targetRootPath := "/mnt/_bindmountroot"
+	targetRootFullPath := filepath.Join(installChroot.RootDir(), targetRootPath)
 
 	for _, mountToLabel := range listOfMountsToLabel {
 		logger.Log.Debugf("Running setfiles to apply SELinux labels on mount points: %v", mountToLabel)
@@ -1819,7 +1820,7 @@ func selinuxRelabelFiles(installChroot *safechroot.Chroot, mountPointToFsTypeMap
 		// Cleanup the temporary directory.
 		// Note: This is intentionally done within the for loop to ensure the directory is always empty for the next
 		// mount. For example, if a parent directory mount is processed after a nested child directory mount.
-		err = os.RemoveAll(targetRootPath)
+		err = os.RemoveAll(targetRootFullPath)
 		if err != nil {
 			return fmt.Errorf("failed to remove temporary bind mount directory:\n%w", err)
 		}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

When applying SELinux labels, bind mounts are used to ensure all directories are labelled (even those used for nested mounts). However, the bind mount root directory cleanup was accidentally targeting a directory on the host system instead of in the image. This change fixes this.

###### Change Log  <!-- REQUIRED -->

- Fix SELinux labelling image with multiple partitions - Take 2.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

