### PR TITLE
golang: replace deprecated ioutil package references

### DIFF
--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +28,7 @@ func TestShouldSucceedValidatingDefaultConfigs(t *testing.T) {
 		configDirectory = "../../imageconfigs/"
 	)
 	checkedConfigs := 0
-	configFiles, err := ioutil.ReadDir(configDirectory)
+	configFiles, err := os.ReadDir(configDirectory)
 	assert.NoError(t, err)
 
 	for _, file := range configFiles {
@@ -81,7 +80,7 @@ func TestShouldFailDeeplyNestedParsingError(t *testing.T) {
 		configDirectory string = "../../imageconfigs/"
 		targetPackage          = "core-efi.json"
 	)
-	configFiles, err := ioutil.ReadDir(configDirectory)
+	configFiles, err := os.ReadDir(configDirectory)
 	assert.NoError(t, err)
 
 	// Pick the first config file and mess something up which is deeply
@@ -112,7 +111,7 @@ func TestShouldFailMissingVerityPackageWithVerityRoot(t *testing.T) {
 		targetPackage                = "read-only-root-efi.json"
 		roRootPackageListFile        = "read-only-root-packages.json"
 	)
-	configFiles, err := ioutil.ReadDir(configDirectory)
+	configFiles, err := os.ReadDir(configDirectory)
 	assert.NoError(t, err)
 
 	// Pick the read-only-root config file, but remove the dm-verity dracut package list
@@ -150,7 +149,7 @@ func TestShouldFailMissingVerityDebugPackageWithVerityDebug(t *testing.T) {
 		targetPackage              = "read-only-root-efi.json"
 		readOnlyPackageList        = "packagelists/read-only-root-packages.json"
 	)
-	configFiles, err := ioutil.ReadDir(configDirectory)
+	configFiles, err := os.ReadDir(configDirectory)
 	assert.NoError(t, err)
 
 	// Skip this test if the package list DOES include it, but print an error
@@ -194,7 +193,7 @@ func TestShouldFailMissingFipsPackageWithFipsCmdLine(t *testing.T) {
 		targetPackage              = "core-fips.json"
 		fipsPackageListFile        = "fips-packages.json"
 	)
-	configFiles, err := ioutil.ReadDir(configDirectory)
+	configFiles, err := os.ReadDir(configDirectory)
 	assert.NoError(t, err)
 
 	// Pick the core-fips config file, but remove the fips package list
@@ -232,7 +231,7 @@ func TestShouldFailMissingSELinuxPackageWithSELinux(t *testing.T) {
 		targetPackage     = "core-efi.json"
 		targetPackageList = "selinux.json"
 	)
-	configFiles, err := ioutil.ReadDir(configDirectory)
+	configFiles, err := os.ReadDir(configDirectory)
 	assert.NoError(t, err)
 
 	// Pick the core-efi config file, then enable SELinux
@@ -270,7 +269,7 @@ func TestShouldSucceedSELinuxPackageDefinedInline(t *testing.T) {
 		targetPackageList = "selinux.json"
 		selinuxPkgName    = "selinux-policy"
 	)
-	configFiles, err := ioutil.ReadDir(configDirectory)
+	configFiles, err := os.ReadDir(configDirectory)
 	assert.NoError(t, err)
 
 	// Pick the core-efi config file, then enable SELinux

--- a/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
+++ b/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
@@ -6,7 +6,7 @@ package attendedinstaller
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -125,7 +125,7 @@ func (ai *AttendedInstaller) Run() (config configuration.Config, installationQui
 	// with the TUI (terminal UI) and result in undefined behavior.
 	// The log hooks that enable file logging will remain intact and still record
 	// logs.
-	originalStderrWriter := logger.ReplaceStderrWriter(ioutil.Discard)
+	originalStderrWriter := logger.ReplaceStderrWriter(io.Discard)
 	defer func() {
 		logger.ReplaceStderrWriter(originalStderrWriter)
 	}()

--- a/toolkit/tools/imagegen/attendedinstaller/views/eulaview/eulaview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/eulaview/eulaview.go
@@ -5,7 +5,7 @@ package eulaview
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/gdamore/tcell"
@@ -120,7 +120,7 @@ func populateEULA(eulaFile string, text *tview.TextView) (err error) {
 	}
 	defer file.Close()
 
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/imagegen/diskutils/verity.go
+++ b/toolkit/tools/imagegen/diskutils/verity.go
@@ -7,7 +7,6 @@ package diskutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -75,7 +74,7 @@ func (v *VerityDevice) AddRootVerityFilesToInitramfs(workingFolder, initramfsPat
 		return fmt.Errorf("failed to open the initramfs:\n%w", err)
 	}
 
-	verityFiles, err := ioutil.ReadDir(verityWorkingDirectory)
+	verityFiles, err := os.ReadDir(verityWorkingDirectory)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/internal/ccachemanager/ccachemanager.go
+++ b/toolkit/tools/internal/ccachemanager/ccachemanager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -288,7 +287,7 @@ func (g *CCachePkgGroup) getLatestTag(azureBlobStorage *azureblobstorage.AzureBl
 		}
 	}
 
-	latestBuildTagData, err := ioutil.ReadFile(g.TagFile.LocalSourcePath)
+	latestBuildTagData, err := os.ReadFile(g.TagFile.LocalSourcePath)
 	if err != nil {
 		return "", fmt.Errorf("Unable to read ccache tag file contents:\n%w", err)
 	}
@@ -655,7 +654,7 @@ func (m *CCacheManager) UploadPkgGroupCCache() (err error) {
 
 		// Create the latest tag file...
 		logger.Log.Infof("  creating a tag file (%s) with content: (%s)...", m.CurrentPkgGroup.TagFile.LocalTargetPath, remoteStoreConfig.UploadFolder)
-		err = ioutil.WriteFile(m.CurrentPkgGroup.TagFile.LocalTargetPath, []byte(remoteStoreConfig.UploadFolder), 0644)
+		err = os.WriteFile(m.CurrentPkgGroup.TagFile.LocalTargetPath, []byte(remoteStoreConfig.UploadFolder), 0644)
 		if err != nil {
 			return fmt.Errorf("Unable to write tag information to temporary file:\n%w", err)
 		}

--- a/toolkit/tools/internal/directory/directory.go
+++ b/toolkit/tools/internal/directory/directory.go
@@ -5,7 +5,6 @@ package directory
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -53,7 +52,7 @@ func CopyContents(srcDir, dstDir string) (err error) {
 		return
 	}
 
-	fds, err := ioutil.ReadDir(srcDir)
+	fds, err := os.ReadDir(srcDir)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/internal/jsonutils/jsonutils.go
+++ b/toolkit/tools/internal/jsonutils/jsonutils.go
@@ -8,7 +8,7 @@ package jsonutils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
@@ -25,7 +25,7 @@ func ReadJSONDescriptor(jsonFile *os.File, data interface{}) error {
 		return fmt.Errorf("passed nil file descriptor to WriteJSONDescriptor()")
 	}
 
-	jsonData, err := ioutil.ReadAll(jsonFile)
+	jsonData, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return err
 	}
@@ -82,5 +82,5 @@ func WriteJSONFile(outputFilePath string, data interface{}) error {
 
 	logger.Log.Tracef("Writing %#x bytes of JSON data.", len(outputBytes))
 
-	return ioutil.WriteFile(outputFilePath, outputBytes, defaultJsonFilePermission)
+	return os.WriteFile(outputFilePath, outputBytes, defaultJsonFilePermission)
 }

--- a/toolkit/tools/repoquerywrapper/repoquerywrapper.go
+++ b/toolkit/tools/repoquerywrapper/repoquerywrapper.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -92,7 +91,7 @@ func main() {
 }
 
 func readFileLines(fileName string) (lines []string, err error) {
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		logger.Log.Errorf("Error reading file: %v", err)
 		return nil, err
@@ -103,7 +102,7 @@ func readFileLines(fileName string) (lines []string, err error) {
 
 func writeFileLines(lines []string, fileName string) (err error) {
 	content := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(fileName, []byte(content), 0644)
+	err = os.WriteFile(fileName, []byte(content), 0644)
 	if err != nil {
 		logger.Log.Errorf("Error writing file: %v", err)
 		return err

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -165,7 +164,7 @@ func main() {
 	templateSrcConfig.caCerts, err = x509.SystemCertPool()
 	logger.PanicOnError(err, "Received error calling x509.SystemCertPool(). Error: %v", err)
 	if *caCertFile != "" {
-		newCACert, err := ioutil.ReadFile(*caCertFile)
+		newCACert, err := os.ReadFile(*caCertFile)
 		if err != nil {
 			logger.Log.Panicf("Invalid CA certificate (%s), error: %s", *caCertFile, err)
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Remove and replace references to deprecated ioutil package.
https://pkg.go.dev/io/ioutil
"Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code."

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove all references in .go files of io/ioutil package
- Replace with their corresponding implementation io and os package, specifically:
ioutil.ReadDir -> os.ReadDir
ioutil.ReadFile -> os.ReadFile
ioutil.WriteFile -> os.WriteFile
ioutil.Discard -> io.Discard
ioutil.ReadAll -> io.ReadAll

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Searched through our github repo to find all the files using this package
- Used a golang code editor
- Other than [ReadDir()](https://cs.opensource.google/go/go/+/go1.22.1:src/io/ioutil/ioutil.go;l=69) everything is exactly the same implementation. ReadDir() has a different return type ie returns a list of [fs.DirEntry](https://pkg.go.dev/io/fs#DirEntry) instead of [fs.FileInfo](https://pkg.go.dev/io/fs#FileInfo)
Wherever ReadDir() is used we only call .IsDir() and .Name() on the files which are implemented in both object types, so we don't need the fs.FileInfo type.
Ran the imageconfigvalidator_test to verify:
sudo go test ./imageconfigvalidator/
ok      github.com/microsoft/azurelinux/toolkit/tools/imageconfigvalidator      0.036s