### PR TITLE
specreaderutils: return error from FindSpecFiles after parsing full list

### DIFF
--- a/toolkit/tools/pkg/specreaderutils/specreaderutil.go
+++ b/toolkit/tools/pkg/specreaderutils/specreaderutil.go
@@ -190,7 +190,7 @@ func FindSpecFiles(specsDir string, specListSet map[string]bool) (specFiles []st
 
 			// If a SPEC is in the parse list, it should be parsed.
 			if err != nil {
-				specParseErrMsg += fmt.Sprintf("\nspec search failed on (%s):\n%w", specSearch, err)
+				specParseErrMsg += fmt.Sprintf("\nspec search failed on (%s):\n%v", specSearch, err)
 			} else if len(matchingSpecFiles) != 1 {
 				specParseErrMsg += fmt.Sprintf("\nunexpected number of matches (%d) for spec file (%s) in directory (%s)", len(matchingSpecFiles), specName, specsDir)
 			} else {

--- a/toolkit/tools/pkg/specreaderutils/specreaderutil.go
+++ b/toolkit/tools/pkg/specreaderutils/specreaderutil.go
@@ -83,13 +83,13 @@ func ParseSPECsWrapper(buildDir, specsDir, rpmsDir, srpmsDir, toolchainDir, dist
 		if targetArch == "" {
 			packageRepo, parseError = parseSPECs(specsDir, rpmsDir, srpmsDir, toolchainDir, distTag, buildArch, specListSet, toolchainRPMs, workers, runCheck)
 			if parseError != nil {
-				err := fmt.Errorf("failed to parse native specs (%w)", parseError)
+				err := fmt.Errorf("failed to parse native specs:\n%w", parseError)
 				return err
 			}
 		} else {
 			packageRepo, parseError = parseSPECs(specsDir, rpmsDir, srpmsDir, toolchainDir, distTag, targetArch, specListSet, toolchainRPMs, workers, runCheck)
 			if parseError != nil {
-				err := fmt.Errorf("failed to parse cross specs (%w)", parseError)
+				err := fmt.Errorf("failed to parse cross specs:\n%w", parseError)
 				return err
 			}
 		}
@@ -183,20 +183,22 @@ func FindSpecFiles(specsDir string, specListSet map[string]bool) (specFiles []st
 			return nil, err
 		}
 	} else {
+		var specParseErrMsg string
 		for specName := range specListSet {
 			specSearch := filepath.Join(specsDir, fmt.Sprintf("**/%s.spec", specName))
 			matchingSpecFiles, err := filepath.Glob(specSearch)
 
 			// If a SPEC is in the parse list, it should be parsed.
 			if err != nil {
-				err = fmt.Errorf("spec search failed on '%s'. Error:\n%w", specSearch, err)
-				return nil, err
+				specParseErrMsg += fmt.Sprintf("\nspec search failed on (%s):\n%w", specSearch, err)
+			} else if len(matchingSpecFiles) != 1 {
+				specParseErrMsg += fmt.Sprintf("\nunexpected number of matches (%d) for spec file (%s) in directory (%s)", len(matchingSpecFiles), specName, specsDir)
+			} else {
+				specFiles = append(specFiles, matchingSpecFiles[0])
 			}
-			if len(matchingSpecFiles) != 1 {
-				err = fmt.Errorf("unexpected number of matches '%d' for spec file '%s'", len(matchingSpecFiles), specName)
-				return nil, err
-			}
-			specFiles = append(specFiles, matchingSpecFiles[0])
+		}
+		if specParseErrMsg != "" {
+			return nil, fmt.Errorf("failed to parse specs: %s", specParseErrMsg)
 		}
 	}
 	return
@@ -214,7 +216,6 @@ func parseSPECs(specsDir, rpmsDir, srpmsDir, toolchainDir, distTag, arch string,
 
 	specFiles, err = FindSpecFiles(specsDir, specListSet)
 	if err != nil {
-		logger.Log.Errorf("Failed to find *.spec files. Check that %s is the correct directory. Error: %v", specsDir, err)
 		return
 	}
 

--- a/toolkit/tools/pkg/specreaderutils/specreaderutil.go
+++ b/toolkit/tools/pkg/specreaderutils/specreaderutil.go
@@ -197,7 +197,7 @@ func FindSpecFiles(specsDir string, specListSet map[string]bool) (specFiles []st
 				specFiles = append(specFiles, matchingSpecFiles[0])
 			}
 		}
-		if (specParseErrMsg.Len() != 0){
+		if specParseErrMsg.Len() != 0 {
 			return nil, fmt.Errorf("failed to parse specs: %s", specParseErrMsg.String())
 		}
 	}

--- a/toolkit/tools/pkg/specreaderutils/specreaderutil.go
+++ b/toolkit/tools/pkg/specreaderutils/specreaderutil.go
@@ -183,22 +183,22 @@ func FindSpecFiles(specsDir string, specListSet map[string]bool) (specFiles []st
 			return nil, err
 		}
 	} else {
-		var specParseErrMsg string
+		var specParseErrMsg strings.Builder
 		for specName := range specListSet {
 			specSearch := filepath.Join(specsDir, fmt.Sprintf("**/%s.spec", specName))
 			matchingSpecFiles, err := filepath.Glob(specSearch)
 
 			// If a SPEC is in the parse list, it should be parsed.
 			if err != nil {
-				specParseErrMsg += fmt.Sprintf("\nspec search failed on (%s):\n%v", specSearch, err)
+				specParseErrMsg.WriteString(fmt.Sprintf("\nspec search failed on (%s):\n%v", specSearch, err))
 			} else if len(matchingSpecFiles) != 1 {
-				specParseErrMsg += fmt.Sprintf("\nunexpected number of matches (%d) for spec file (%s) in directory (%s)", len(matchingSpecFiles), specName, specsDir)
+				specParseErrMsg.WriteString(fmt.Sprintf("\nunexpected number of matches (%d) for spec file (%s) in directory (%s)", len(matchingSpecFiles), specName, specsDir))
 			} else {
 				specFiles = append(specFiles, matchingSpecFiles[0])
 			}
 		}
-		if specParseErrMsg != "" {
-			return nil, fmt.Errorf("failed to parse specs: %s", specParseErrMsg)
+		if (specParseErrMsg.Len() != 0){
+			return nil, fmt.Errorf("failed to parse specs: %s", specParseErrMsg.String())
 		}
 	}
 	return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
specreaderutils: return error from FindSpecFiles after parsing full list

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Parse entire list of specs in `FindSpecFiles` before returning error
- Remove error logging in `parseSPECs` as the error message is misleading. Error caught from `FindSpecFiles` has required information for debug. Throw to caller.
- Fix error format in `ParseSPECsWrapper`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with command
` sudo make build-packages SRPM_PACK_LIST="invalid_spec_A invalid_spec_B grpc" REBUILD_TOOLS=y`

before:
Even if there are multiple incorrect specs listed in the make command, an execution would notify of only one error, as the function `FindSpecFiles` returns on first erroneous spec.
![before](https://github.com/microsoft/azurelinux/assets/58672330/a8e618e7-6b65-4ddf-9d8b-68b1f4b7fc84)


after:
`FindSpecFiles` parses through the entire list of specs to parse, and collects all errors to show at once. If there are no errors, it returns list of specs parsed as expected.
![after](https://github.com/microsoft/azurelinux/assets/58672330/d96f47a7-614a-4ec0-902e-6bfd2aa2716d)
