### PR TITLE
procps-ng: suppress debug messages to console by default

### DIFF
--- a/SPECS/procps-ng/10-console-messages.conf
+++ b/SPECS/procps-ng/10-console-messages.conf
@@ -1,0 +1,2 @@
+# Suppress debug messages on console
+kernel.printk = 4 4 1 7

--- a/SPECS/procps-ng/procps-ng.signatures.json
+++ b/SPECS/procps-ng/procps-ng.signatures.json
@@ -1,5 +1,6 @@
 {
   "Signatures": {
+    "10-console-messages.conf": "6cfc12931ac75df710aa1d323cdb98592935692cd9d32260d6118f9ad03a42e2",
     "procps-ng-4.0.4.tar.xz": "22870d6feb2478adb617ce4f09a787addaf2d260c5a8aa7b17d889a962c5e42e"
   }
 }

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -50,9 +50,9 @@ bzip2-devel-1.0.8-1.azl3.aarch64.rpm
 bzip2-libs-1.0.8-1.azl3.aarch64.rpm
 sed-4.9-1.azl3.aarch64.rpm
 sed-lang-4.9-1.azl3.aarch64.rpm
-procps-ng-4.0.4-1.azl3.aarch64.rpm
-procps-ng-devel-4.0.4-1.azl3.aarch64.rpm
-procps-ng-lang-4.0.4-1.azl3.aarch64.rpm
+procps-ng-4.0.4-2.azl3.aarch64.rpm
+procps-ng-devel-4.0.4-2.azl3.aarch64.rpm
+procps-ng-lang-4.0.4-2.azl3.aarch64.rpm
 m4-1.4.19-2.azl3.aarch64.rpm
 grep-3.11-2.azl3.aarch64.rpm
 grep-lang-3.11-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -50,9 +50,9 @@ bzip2-devel-1.0.8-1.azl3.x86_64.rpm
 bzip2-libs-1.0.8-1.azl3.x86_64.rpm
 sed-4.9-1.azl3.x86_64.rpm
 sed-lang-4.9-1.azl3.x86_64.rpm
-procps-ng-4.0.4-1.azl3.x86_64.rpm
-procps-ng-devel-4.0.4-1.azl3.x86_64.rpm
-procps-ng-lang-4.0.4-1.azl3.x86_64.rpm
+procps-ng-4.0.4-2.azl3.x86_64.rpm
+procps-ng-devel-4.0.4-2.azl3.x86_64.rpm
+procps-ng-lang-4.0.4-2.azl3.x86_64.rpm
 m4-1.4.19-2.azl3.x86_64.rpm
 grep-3.11-2.azl3.x86_64.rpm
 grep-lang-3.11-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -515,10 +515,10 @@ popt-1.19-1.azl3.aarch64.rpm
 popt-debuginfo-1.19-1.azl3.aarch64.rpm
 popt-devel-1.19-1.azl3.aarch64.rpm
 popt-lang-1.19-1.azl3.aarch64.rpm
-procps-ng-4.0.4-1.azl3.aarch64.rpm
-procps-ng-debuginfo-4.0.4-1.azl3.aarch64.rpm
-procps-ng-devel-4.0.4-1.azl3.aarch64.rpm
-procps-ng-lang-4.0.4-1.azl3.aarch64.rpm
+procps-ng-4.0.4-2.azl3.aarch64.rpm
+procps-ng-debuginfo-4.0.4-2.azl3.aarch64.rpm
+procps-ng-devel-4.0.4-2.azl3.aarch64.rpm
+procps-ng-lang-4.0.4-2.azl3.aarch64.rpm
 pyproject-rpm-macros-1.12.0-2.azl3.noarch.rpm
 pyproject-srpm-macros-1.12.0-2.azl3.noarch.rpm
 python-markupsafe-debuginfo-2.1.3-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -521,10 +521,10 @@ popt-1.19-1.azl3.x86_64.rpm
 popt-debuginfo-1.19-1.azl3.x86_64.rpm
 popt-devel-1.19-1.azl3.x86_64.rpm
 popt-lang-1.19-1.azl3.x86_64.rpm
-procps-ng-4.0.4-1.azl3.x86_64.rpm
-procps-ng-debuginfo-4.0.4-1.azl3.x86_64.rpm
-procps-ng-devel-4.0.4-1.azl3.x86_64.rpm
-procps-ng-lang-4.0.4-1.azl3.x86_64.rpm
+procps-ng-4.0.4-2.azl3.x86_64.rpm
+procps-ng-debuginfo-4.0.4-2.azl3.x86_64.rpm
+procps-ng-devel-4.0.4-2.azl3.x86_64.rpm
+procps-ng-lang-4.0.4-2.azl3.x86_64.rpm
 pyproject-rpm-macros-1.12.0-2.azl3.noarch.rpm
 pyproject-srpm-macros-1.12.0-2.azl3.noarch.rpm
 python-markupsafe-debuginfo-2.1.3-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
During normal use, many low level debug messages are printing to the console which is causing usability issues for the user.

To deal with this, install a sysctl configuration to run on boot which will change the default kernel printk value to "4 4 1 7".

/etc/sysctl.d is supplied by systemd, so we need to also have a weak recommends on systemd. This is not a full requires because it would induce a circular dependency, and would pull in systemd in situations where it may not be truly required (i.e., inside minimal container images).

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: [524643](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=524643&view=results)
