### PR TITLE
Image Customizer: Changes to bootloader reset.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -35,9 +35,12 @@ The Azure Linux Image Customizer is configured using a YAML (or JSON) file.
 
 10. Run post-install scripts. ([PostInstallScripts](#postinstallscripts-script))
 
-11. If [ResetBootLoaderType](#resetbootloadertype-string) is specified, then reset the
-    boot-loader.
-    Otherwise, append kernel command-line args to existing boot-loader config.
+11. If [ResetBootLoaderType](#resetbootloadertype-string) is set to `hard-reset`, then
+    reset the boot-loader.
+
+    If [ResetBootLoaderType](#resetbootloadertype-string) is not set, then
+    append the [ExtraCommandLine](#extracommandline-string) value to the existing
+    `grub.cfg` file.
 
 12. Change SELinux mode and, if SELinux is enabled, call `setfiles`.
 
@@ -328,8 +331,9 @@ Additional Linux kernel command line options to add to the image.
 
 If [ResetBootLoaderType](#resetbootloadertype-string) is set to `"hard-reset"`, then the
 `ExtraCommandLine` value will be appended to the new `grub.cfg` file.
-Otherwise, the `ExtraCommandLine` value will be appended to the existing `grub.cfg`
-file.
+
+If [ResetBootLoaderType](#resetbootloadertype-string) is not set, then the
+`ExtraCommandLine` value will be appended to the existing `grub.cfg` file.
 
 ### SELinux
 

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -4,8 +4,7 @@ The Azure Linux Image Customizer is configured using a YAML (or JSON) file.
 
 ### Operation ordering
 
-1. If partitions were specified in the config, customize the disk partitions and reset
-   the boot-loader.
+1. If partitions were specified in the config, customize the disk partitions.
 
 2. Override the `/etc/resolv.conf` file with the version from the host OS.
 
@@ -36,7 +35,9 @@ The Azure Linux Image Customizer is configured using a YAML (or JSON) file.
 
 10. Run post-install scripts. ([PostInstallScripts](#postinstallscripts-script))
 
-11. Apply kernel command-line args, if the partitions weren't customized.
+11. If [ResetBootLoaderType](#resetbootloadertype-string) is specified, then reset the
+    boot-loader.
+    Otherwise, append kernel command-line args to existing boot-loader config.
 
 12. Change SELinux mode and, if SELinux is enabled, call `setfiles`.
 
@@ -48,7 +49,7 @@ The Azure Linux Image Customizer is configured using a YAML (or JSON) file.
 
 And if the output format is set to `iso`:
 
-12. Copy additional iso media files ([Iso](#iso-type)).
+16. Copy additional iso media files ([Iso](#iso-type)).
 
 ### /etc/resolv.conf
 
@@ -100,6 +101,7 @@ SystemConfig:
         - [Permissions](#permissions-string)
   - [SystemConfig](#systemconfig-type)
     - [BootType](#boottype-string)
+    - [ResetBootLoaderType](#resetbootloadertype-string)
     - [Hostname](#hostname-string)
     - [KernelCommandLine](#kernelcommandline-type)
       - [ExtraCommandLine](#extracommandline-string)
@@ -171,7 +173,8 @@ Contains the options for provisioning disks and their partitions.
 If the Disks field isn't specified, then the partitions of the base image aren't
 changed.
 
-If Disks is specified, then [SystemConfig.BootType](#boottype-boottype) must also be
+If Disks is specified, then both [SystemConfig.BootType](#boottype-string) and
+[SystemConfig.ResetBootLoaderType](#resetbootloadertype-string) must also be
 specified.
 
 While Disks is a list, only 1 disk is supported at the moment.
@@ -323,12 +326,10 @@ Options for configuring the kernel.
 
 Additional Linux kernel command line options to add to the image.
 
-If the partitions are customized, then the `grub.cfg` file will be reset to handle the
-new partition layout.
-So, any existing ExtraCommandLine value in the base image will be replaced.
-
-If the partitions are not customized, then the `ExtraCommandLine` value will be appended
-to the existing `grub.cfg` file.
+If [ResetBootLoaderType](#resetbootloadertype-string) is set to `"hard-reset"`, then the
+`ExtraCommandLine` value will be appended to the new `grub.cfg` file.
+Otherwise, the `ExtraCommandLine` value will be appended to the existing `grub.cfg`
+file.
 
 ### SELinux
 
@@ -660,6 +661,18 @@ Supported options:
 
   When this option is specified, the partition layout must contain a partition with the
   `esp` flag.
+
+### ResetBootLoaderType [string]
+
+Specifies that the boot-loader configuration should be reset and how it should be reset.
+
+Supported options:
+
+- `hard-reset`: Fully reset the boot-loader and its configuration.
+  This includes removing any customized kernel command-line arguments that were added to
+  base image.
+
+This field can only be specified if [Disks](#disks-disk) is also specified.
 
 ### Hostname [string]
 

--- a/toolkit/tools/imagecustomizerapi/bootloaderresettype.go
+++ b/toolkit/tools/imagecustomizerapi/bootloaderresettype.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type ResetBootLoaderType string
+
+const (
+	ResetBootLoaderTypeDefault ResetBootLoaderType = ""
+	ResetBootLoaderTypeHard    ResetBootLoaderType = "hard-reset"
+)
+
+func (t ResetBootLoaderType) IsValid() error {
+	switch t {
+	case ResetBootLoaderTypeDefault, ResetBootLoaderTypeHard:
+		// All good.
+		return nil
+
+	default:
+		return fmt.Errorf("invalid ResetBootLoaderType value (%v)", t)
+	}
+}

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -48,9 +48,14 @@ func (c *Config) IsValid() (err error) {
 	hasDisks := c.Disks != nil
 	hasBootType := c.SystemConfig.BootType != BootTypeUnset
 	hasPartitionSettings := len(c.SystemConfig.PartitionSettings) > 0
+	hasResetBootLoader := c.SystemConfig.ResetBootLoaderType != ResetBootLoaderTypeDefault
 
 	if hasDisks != hasBootType {
 		return fmt.Errorf("SystemConfig.BootType and Disks must be specified together")
+	}
+
+	if hasDisks != hasResetBootLoader {
+		return fmt.Errorf("SystemConfig.ResetBootLoaderType and Disks must be specified together'")
 	}
 
 	if hasPartitionSettings && !hasDisks {

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -27,8 +27,9 @@ func TestConfigIsValid(t *testing.T) {
 			},
 		}},
 		SystemConfig: SystemConfig{
-			BootType: "efi",
-			Hostname: "test",
+			BootType:            "efi",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 			PartitionSettings: []PartitionSetting{
 				{
 					ID:         "esp",
@@ -59,8 +60,9 @@ func TestConfigIsValidLegacy(t *testing.T) {
 			},
 		}},
 		SystemConfig: SystemConfig{
-			BootType: "legacy",
-			Hostname: "test",
+			BootType:            "legacy",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 		},
 	}
 
@@ -82,13 +84,39 @@ func TestConfigIsValidNoBootType(t *testing.T) {
 			},
 		}},
 		SystemConfig: SystemConfig{
-			Hostname: "test",
+			Hostname:            "test",
+			ResetBootLoaderType: "hard-reset",
 		},
 	}
 
 	err := config.IsValid()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "BootType")
+	assert.ErrorContains(t, err, "Disks")
+}
+
+func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
+	config := &Config{
+		Disks: &[]Disk{{
+			PartitionTableType: "gpt",
+			MaxSize:            2,
+			Partitions: []Partition{
+				{
+					ID:     "a",
+					FsType: "ext4",
+					Start:  1,
+				},
+			},
+		}},
+		SystemConfig: SystemConfig{
+			Hostname: "test",
+			BootType: "efi",
+		},
+	}
+
+	err := config.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ResetBootLoaderType")
 	assert.ErrorContains(t, err, "Disks")
 }
 
@@ -105,7 +133,9 @@ func TestConfigIsValidMultipleDisks(t *testing.T) {
 			},
 		},
 		SystemConfig: SystemConfig{
-			Hostname: "test",
+			BootType:            "legacy",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 		},
 	}
 
@@ -163,8 +193,9 @@ func TestConfigIsValidMissingEsp(t *testing.T) {
 			Partitions:         []Partition{},
 		}},
 		SystemConfig: SystemConfig{
-			BootType: "efi",
-			Hostname: "test",
+			BootType:            "efi",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 		},
 	}
 
@@ -182,8 +213,9 @@ func TestConfigIsValidMissingBiosBoot(t *testing.T) {
 			Partitions:         []Partition{},
 		}},
 		SystemConfig: SystemConfig{
-			BootType: "legacy",
-			Hostname: "test",
+			BootType:            "legacy",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 		},
 	}
 
@@ -211,8 +243,9 @@ func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 			},
 		}},
 		SystemConfig: SystemConfig{
-			BootType: "efi",
-			Hostname: "test",
+			BootType:            "efi",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 			PartitionSettings: []PartitionSetting{
 				{
 					ID:         "esp",
@@ -246,8 +279,9 @@ func TestConfigIsValidInvalidPartitionId(t *testing.T) {
 			},
 		}},
 		SystemConfig: SystemConfig{
-			BootType: "efi",
-			Hostname: "test",
+			BootType:            "efi",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 			PartitionSettings: []PartitionSetting{
 				{
 					ID:         "boot",
@@ -285,8 +319,9 @@ func TestConfigIsValidPartitionSettingsMissingDisks(t *testing.T) {
 func TestConfigIsValidBootTypeMissingDisks(t *testing.T) {
 	config := &Config{
 		SystemConfig: SystemConfig{
-			Hostname: "test",
-			BootType: BootTypeEfi,
+			Hostname:            "test",
+			BootType:            BootTypeEfi,
+			ResetBootLoaderType: "hard-reset",
 			KernelCommandLine: KernelCommandLine{
 				ExtraCommandLine: "console=ttyS0",
 			},
@@ -315,8 +350,9 @@ func TestConfigIsValidKernelCLI(t *testing.T) {
 			},
 		}},
 		SystemConfig: SystemConfig{
-			BootType: "efi",
-			Hostname: "test",
+			BootType:            "efi",
+			ResetBootLoaderType: "hard-reset",
+			Hostname:            "test",
 			PartitionSettings: []PartitionSetting{
 				{
 					ID:         "esp",

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -12,31 +12,37 @@ import (
 
 // SystemConfig defines how each system present on the image is supposed to be configured.
 type SystemConfig struct {
-	BootType                BootType           `yaml:"BootType"`
-	Hostname                string             `yaml:"Hostname"`
-	UpdateBaseImagePackages bool               `yaml:"UpdateBaseImagePackages"`
-	PackageListsInstall     []string           `yaml:"PackageListsInstall"`
-	PackagesInstall         []string           `yaml:"PackagesInstall"`
-	PackageListsRemove      []string           `yaml:"PackageListsRemove"`
-	PackagesRemove          []string           `yaml:"PackagesRemove"`
-	PackageListsUpdate      []string           `yaml:"PackageListsUpdate"`
-	PackagesUpdate          []string           `yaml:"PackagesUpdate"`
-	KernelCommandLine       KernelCommandLine  `yaml:"KernelCommandLine"`
-	AdditionalFiles         AdditionalFilesMap `yaml:"AdditionalFiles"`
-	PartitionSettings       []PartitionSetting `yaml:"PartitionSettings"`
-	PostInstallScripts      []Script           `yaml:"PostInstallScripts"`
-	FinalizeImageScripts    []Script           `yaml:"FinalizeImageScripts"`
-	Users                   []User             `yaml:"Users"`
-	Services                Services           `yaml:"Services"`
-	Modules                 Modules            `yaml:"Modules"`
-	Verity                  *Verity            `yaml:"Verity"`
-	Overlays                *[]Overlay         `yaml:"Overlays"`
+	BootType                BootType            `yaml:"BootType"`
+	ResetBootLoaderType     ResetBootLoaderType `yaml:"ResetBootLoaderType"`
+	Hostname                string              `yaml:"Hostname"`
+	UpdateBaseImagePackages bool                `yaml:"UpdateBaseImagePackages"`
+	PackageListsInstall     []string            `yaml:"PackageListsInstall"`
+	PackagesInstall         []string            `yaml:"PackagesInstall"`
+	PackageListsRemove      []string            `yaml:"PackageListsRemove"`
+	PackagesRemove          []string            `yaml:"PackagesRemove"`
+	PackageListsUpdate      []string            `yaml:"PackageListsUpdate"`
+	PackagesUpdate          []string            `yaml:"PackagesUpdate"`
+	KernelCommandLine       KernelCommandLine   `yaml:"KernelCommandLine"`
+	AdditionalFiles         AdditionalFilesMap  `yaml:"AdditionalFiles"`
+	PartitionSettings       []PartitionSetting  `yaml:"PartitionSettings"`
+	PostInstallScripts      []Script            `yaml:"PostInstallScripts"`
+	FinalizeImageScripts    []Script            `yaml:"FinalizeImageScripts"`
+	Users                   []User              `yaml:"Users"`
+	Services                Services            `yaml:"Services"`
+	Modules                 Modules             `yaml:"Modules"`
+	Verity                  *Verity             `yaml:"Verity"`
+	Overlays                *[]Overlay          `yaml:"Overlays"`
 }
 
 func (s *SystemConfig) IsValid() error {
 	var err error
 
 	err = s.BootType.IsValid()
+	if err != nil {
+		return err
+	}
+
+	err = s.ResetBootLoaderType.IsValid()
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
@@ -204,14 +204,10 @@ func replaceKernelCommandLineArgumentValue(inputGrubCfgContent string, name stri
 	return outputGrubCfgContent, oldValue, nil
 }
 
-func handleKernelCommandLine(kernelExtraArguments imagecustomizerapi.KernelExtraArguments, imageChroot *safechroot.Chroot, partitionsCustomized bool) error {
+func addKernelCommandLine(kernelExtraArguments imagecustomizerapi.KernelExtraArguments,
+	imageChroot *safechroot.Chroot,
+) error {
 	var err error
-
-	if partitionsCustomized {
-		// ExtraCommandLine was handled when the new image was created and the grub.cfg file was regenerated from
-		// scatch.
-		return nil
-	}
 
 	extraCommandLine := strings.TrimSpace(string(kernelExtraArguments))
 	if extraCommandLine == "" {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -21,11 +21,6 @@ func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, co
 	}
 	defer existingImageConnection.Close()
 
-	currentSELinuxMode, err := getCurrentSELinuxMode(existingImageConnection.Chroot())
-	if err != nil {
-		return err
-	}
-
 	diskConfig := (*config.Disks)[0]
 
 	installOSFunc := func(imageChroot *safechroot.Chroot) error {
@@ -33,8 +28,7 @@ func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, co
 	}
 
 	err = createNewImage(newBuildImageFile, diskConfig, config.SystemConfig.PartitionSettings,
-		config.SystemConfig.BootType, config.SystemConfig.KernelCommandLine, buildDir, "newimageroot",
-		currentSELinuxMode, installOSFunc)
+		buildDir, "newimageroot", installOSFunc)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -376,7 +376,7 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	defer imageConnection.Close()
 
 	// Do the actual customizations.
-	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection.Chroot(), rpmsSources,
+	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection, rpmsSources,
 		useBaseImageRpmRepos, partitionsCustomized)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -318,7 +318,7 @@ func createFakeEfiImage(buildDir string) (string, error) {
 		return nil
 	}
 
-	err = createNewImage(rawDisk, diskConfig, partitionSettings, "efi",
+	err = createNewImageWithBootLoader(rawDisk, diskConfig, partitionSettings, "efi",
 		imagecustomizerapi.KernelCommandLine{}, buildDir, testImageRootDirName, imagecustomizerapi.SELinuxDisabled,
 		installOS)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -18,45 +18,28 @@ import (
 )
 
 var (
-	bootPartitionRegex   = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
-	rootfsPartitionRegex = regexp.MustCompile(`(?m)^set rootdevice=([A-Z]*)=([a-zA-Z0-9\-]+)$`)
+	bootPartitionRegex = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
 )
 
-func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot.MountPoint, error) {
+func findPartitions(buildDir string, diskDevice string) ([]*safechroot.MountPoint, error) {
 	var err error
 
 	diskPartitions, err := diskutils.GetDiskPartitions(diskDevice)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	systemBootPartition, err := findSystemBootPartition(diskPartitions)
+	rootfsPartition, err := findRootfsPartition(diskPartitions, buildDir)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	var rootfsPartition *diskutils.PartitionInfo
-
-	switch systemBootPartition.PartitionTypeUuid {
-	case diskutils.EfiSystemPartitionTypeUuid:
-		rootfsPartition, err = findRootfsPartitionFromEsp(systemBootPartition, diskPartitions, buildDir)
-		if err != nil {
-			return nil, nil, err
-		}
-
-	case diskutils.BiosBootPartitionTypeUuid:
-		rootfsPartition, err = findRootfsPartitionFromBiosBootPartition(systemBootPartition, diskPartitions, buildDir)
-		if err != nil {
-			return nil, nil, err
-		}
+		return nil, err
 	}
 
 	mountPoints, err := findMountsFromRootfs(rootfsPartition, diskPartitions, buildDir)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return nil, mountPoints, nil
+	return mountPoints, nil
 }
 
 func findSystemBootPartition(diskPartitions []diskutils.PartitionInfo) (*diskutils.PartitionInfo, error) {
@@ -79,25 +62,6 @@ func findSystemBootPartition(diskPartitions []diskutils.PartitionInfo) (*diskuti
 
 	bootPartition := bootPartitions[0]
 	return bootPartition, nil
-}
-
-func findRootfsPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, error) {
-	var bootPartition *diskutils.PartitionInfo
-	bootPartition, err := findBootPartitionFromEsp(efiSystemPartition, diskPartitions, buildDir)
-	if err != nil {
-		return nil, err
-	}
-
-	rootfsPartition, err := tryFindRootfsPartitionFromBootPartition(bootPartition, diskPartitions, buildDir)
-	if err != nil {
-		return nil, err
-	}
-
-	if rootfsPartition == nil {
-		return nil, fmt.Errorf("failed to find rootfs partition using boot partition (%s)", bootPartition.Name)
-	}
-
-	return rootfsPartition, nil
 }
 
 func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, error) {
@@ -148,34 +112,43 @@ func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskP
 	return bootPartition, nil
 }
 
-func findRootfsPartitionFromBiosBootPartition(biosBootLoaderPartition *diskutils.PartitionInfo,
-	diskPartitions []diskutils.PartitionInfo, buildDir string,
-) (*diskutils.PartitionInfo, error) {
-
-	// The BIOS boot parition is just an executable blob that is uniquely built for each system/disk.
-	// So, there is not much that can be done to reliably extract the boot loader partition from it.
-	// So, instead, find the boot partition through brute force.
+// Searches for the partition that contains the /etc/fstab file.
+// While technically it is possible to place /etc on a different partition, doing so is fairly difficult and requires
+// a custom initramfs module.
+func findRootfsPartition(diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, error) {
+	tmpDir := filepath.Join(buildDir, tmpParitionDirName)
 
 	var rootfsPartitions []*diskutils.PartitionInfo
 	for i := range diskPartitions {
 		diskPartition := diskPartitions[i]
 
-		switch diskPartition.FileSystemType {
-		case "ext4", "vfat", "xfs":
-
-		default:
-			// Skips file system types that aren't known to support the boot loader partition.
-			// (This list may be incomplete.)
+		if diskPartition.Type != "part" {
 			continue
 		}
 
-		rootfsPartition, err := tryFindRootfsPartitionFromBootPartition(&diskPartition, diskPartitions, buildDir)
+		// Temporarily mount the partition.
+		partitionMount, err := safemount.NewMount(diskPartition.Path, tmpDir, diskPartition.FileSystemType, 0,
+			"", true)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to mount partition (%s):\n%w", diskPartition.Path, err)
+		}
+		defer partitionMount.Close()
+
+		// Check if the /etc/fstab file exists.
+		fstabPath := filepath.Join(tmpDir, "/etc/fstab")
+		exists, err := file.PathExists(fstabPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if /etc/fstab file exists (%s):\n%w", diskPartition.Path, err)
 		}
 
-		if rootfsPartition != nil {
-			rootfsPartitions = append(rootfsPartitions, rootfsPartition)
+		if exists {
+			rootfsPartitions = append(rootfsPartitions, &diskPartition)
+		}
+
+		// Close the rootfs partition mount.
+		err = partitionMount.CleanClose()
+		if err != nil {
+			return nil, fmt.Errorf("failed to close partition mount (%s):\n%w", diskPartition.Path, err)
 		}
 	}
 
@@ -186,95 +159,6 @@ func findRootfsPartitionFromBiosBootPartition(biosBootLoaderPartition *diskutils
 	}
 
 	rootfsPartition := rootfsPartitions[0]
-	return rootfsPartition, nil
-}
-
-func tryFindRootfsPartitionFromBootPartition(bootPartition *diskutils.PartitionInfo,
-	diskPartitions []diskutils.PartitionInfo, buildDir string,
-) (*diskutils.PartitionInfo, error) {
-	tmpDir := filepath.Join(buildDir, tmpParitionDirName)
-
-	// Temporarily mount the partition.
-	partitionMount, err := safemount.NewMount(bootPartition.Path, tmpDir, bootPartition.FileSystemType, 0, "", true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to mount partition (%s):\n%w", bootPartition.Path, err)
-	}
-	defer partitionMount.Close()
-
-	// Check if grub exists on the file system.
-	var rootfsPartition *diskutils.PartitionInfo
-	for _, grubCfgPath := range []string{"boot/grub2/grub.cfg", "grub2/grub.cfg"} {
-		grubCfgFullPath := filepath.Join(tmpDir, grubCfgPath)
-
-		grubCfgExists, err := file.PathExists(grubCfgFullPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to stat file (%s):\n%w", grubCfgFullPath, err)
-		}
-
-		if grubCfgExists {
-			rootfsPartition, err = findRootfsPartitionFromGrubCfgFile(grubCfgFullPath, diskPartitions)
-			if err != nil {
-				return nil, err
-			}
-
-			break
-		}
-	}
-
-	err = partitionMount.CleanClose()
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmount partition (%s):\n%w", bootPartition.Path, err)
-	}
-
-	return rootfsPartition, nil
-}
-
-func findRootfsPartitionFromGrubCfgFile(grubCfgFilePath string, diskPartitions []diskutils.PartitionInfo) (*diskutils.PartitionInfo, error) {
-	// Read the grub.cfg file.
-	grubConfigFile, err := os.ReadFile(grubCfgFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read grub.cfg file:\n%w", err)
-	}
-
-	// Look for the root partition declaration line in the grub.cfg file.
-	match := rootfsPartitionRegex.FindStringSubmatch(string(grubConfigFile))
-	if match == nil {
-		return nil, fmt.Errorf("failed to find rootfs partition in grub.cfg file")
-	}
-
-	rootfsType := match[1]
-	rootfsId := match[2]
-
-	// Search for the partition in the list of partitions.
-	var rootfsPartition *diskutils.PartitionInfo
-	for i := range diskPartitions {
-		diskPartition := diskPartitions[i]
-
-		var found bool
-		switch rootfsType {
-		case "UUID":
-			found = diskPartition.Uuid == rootfsId
-
-		case "PARTUUID":
-			found = diskPartition.PartUuid == rootfsId
-
-		case "PARTLABEL":
-			found = diskPartition.PartLabel == rootfsId
-
-		default:
-			return nil, fmt.Errorf("unknown rootdevice target type (%s) in grub.cfg (%s)", rootfsType, grubConfigFile)
-		}
-
-		if found {
-			rootfsPartition = &diskPartition
-			break
-		}
-	}
-
-	if rootfsPartition == nil {
-		return nil, fmt.Errorf("failed to find rootfs partition (%s=%s)", rootfsType, rootfsId)
-	}
-
 	return rootfsPartition, nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
@@ -15,8 +15,12 @@ Disks:
 
 SystemConfig:
   BootType: legacy
+  ResetBootLoaderType: hard-reset
   PartitionSettings:
   - ID: boot
 
   - ID: rootfs
     MountPoint: /
+    
+  PackagesInstall:
+  - grub2

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
@@ -26,6 +26,7 @@ Disks:
 
 SystemConfig:
   BootType: efi
+  ResetBootLoaderType: hard-reset
   PartitionSettings:
   - ID: esp
     MountPoint: /boot/efi


### PR DESCRIPTION
The change does two things.

Firstly, it moves bootloader reset operation so that it is done after package installation. If a new partition layout requires additional dependencies (e.g. the grub2 package), this allows those dependencies to be easily installed before the bootloader is reset.

Secondly, a new config field called `ResetBootLoaderType` has been added. This field doesn't add any additional logic. Instead, it used to make the user explicitly acknowledge that the bootloader must be reset when partitions are customized.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

