### PR TITLE
Fix build breaks with fio and cri-o

### DIFF
--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.28.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -60,7 +60,6 @@ BuildRequires:  glibc-devel
 BuildRequires:  golang
 BuildRequires:  golang-packaging
 BuildRequires:  gpgme-devel
-BuildRequires:  libapparmor-devel
 BuildRequires:  libassuan-devel
 BuildRequires:  libseccomp-devel
 BuildRequires:  sed
@@ -203,6 +202,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Mon Mar 11 2024 Andrew Phelps <anphel@microsoft.com> - 1.28.0-2
+- Remove BR on libapparmor-devel
+
 * Mon Nov 06 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.28.0-1
 - Auto-upgrade to 1.28.0 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/fio/fio.spec
+++ b/SPECS/fio/fio.spec
@@ -1,7 +1,7 @@
 Summary:        Multithreaded IO generation tool
 Name:           fio
 Version:        3.30
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -20,7 +20,6 @@ BuildRequires:  python3-devel
 BuildRequires:  zlib-devel
 %ifarch x86_64
 BuildRequires:  libpmem-devel
-BuildRequires:  libpmemblk-devel
 %endif
 %if 0%{?with_check}
 BuildRequires:  CUnit-devel
@@ -37,7 +36,6 @@ Recommends:     %{name}-engine-rbd
 Recommends:     %{name}-engine-rdma
 %ifarch x86-64
 Recommends:     %{name}-engine-dev-dax
-Recommends:     %{name}-engine-pmemblk
 Recommends:     %{name}-engine-libpmem
 %endif
 
@@ -79,17 +77,6 @@ Requires:       %{name} = %{version}-%{release}
 dev-dax engine for %{name}.
 Read and write using device DAX to a persistent memory device
 (e.g., /dev/dax0.0) through the PMDK libpmem library.
-%endif
-
-%ifarch x86_64
-%package engine-pmemblk
-Summary:        PMDK pmemblk engine for %{name}.
-Requires:       %{name} = %{version}-%{release}
-
-%description engine-pmemblk
-pmemblk engine for %{name}.
-Read and write using filesystem DAX to a file on a filesystem mounted with
-DAX on a persistent memory device through the PMDK libpmemblk library.
 %endif
 
 %ifarch x86_64
@@ -176,11 +163,6 @@ EXTFLAGS="$RPM_OPT_FLAGS" LDFLAGS="$RPM_LD_FLAGS" %make_build
 %files engine-nbd
 %{_libdir}/fio/fio-nbd.so
 
-%ifarch x86_64
-%files engine-pmemblk
-%{_libdir}/fio/fio-pmemblk.so
-%endif
-
 %files engine-rados
 %{_libdir}/fio/fio-rados.so
 
@@ -191,6 +173,9 @@ EXTFLAGS="$RPM_OPT_FLAGS" LDFLAGS="$RPM_LD_FLAGS" %make_build
 %{_libdir}/fio/fio-rdma.so
 
 %changelog
+* Mon Mar 11 2023 Andrew Phelps <anphel@microsoft.com> - 3.30-3
+- Remove engine-pmemblk subpackage and BR on libpmemblk-devel
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 3.30-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 
@@ -421,40 +406,40 @@ EXTFLAGS="$RPM_OPT_FLAGS" LDFLAGS="$RPM_LD_FLAGS" %make_build
 * Sat Aug 16 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.1.11-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_21_22_Mass_Rebuild
 
-* Tue Jul 15 2014 Eric Sandeen <sandeen@redhat.com> 2.1.11-1 
+* Tue Jul 15 2014 Eric Sandeen <sandeen@redhat.com> 2.1.11-1
 - New upstream version
 
-* Mon Jun 16 2014 Eric Sandeen <sandeen@redhat.com> 2.1.10-1 
+* Mon Jun 16 2014 Eric Sandeen <sandeen@redhat.com> 2.1.10-1
 - New upstream version
 
 * Sat Jun 07 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.1.9-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
 
-* Tue May 13 2014 Eric Sandeen <sandeen@redhat.com> 2.1.9-1 
+* Tue May 13 2014 Eric Sandeen <sandeen@redhat.com> 2.1.9-1
 - New upstream version
 
-* Mon Apr 14 2014 Eric Sandeen <sandeen@redhat.com> 2.1.8-1 
+* Mon Apr 14 2014 Eric Sandeen <sandeen@redhat.com> 2.1.8-1
 - New upstream version
 
-* Mon Apr 07 2014 Eric Sandeen <sandeen@redhat.com> 2.1.7-1 
+* Mon Apr 07 2014 Eric Sandeen <sandeen@redhat.com> 2.1.7-1
 - New upstream version
 
-* Wed Feb 12 2014 Eric Sandeen <sandeen@redhat.com> 2.1.5-1 
+* Wed Feb 12 2014 Eric Sandeen <sandeen@redhat.com> 2.1.5-1
 - New upstream version
 
-* Wed Sep 25 2013 Eric Sandeen <sandeen@redhat.com> 2.1.3-1 
+* Wed Sep 25 2013 Eric Sandeen <sandeen@redhat.com> 2.1.3-1
 - New upstream version
 
-* Thu Aug 08 2013 Eric Sandeen <sandeen@redhat.com> 2.1.2-1 
+* Thu Aug 08 2013 Eric Sandeen <sandeen@redhat.com> 2.1.2-1
 - New upstream version
 
 * Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.1-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
 
-* Wed May 15 2013 Eric Sandeen <sandeen@redhat.com> 2.1-1 
+* Wed May 15 2013 Eric Sandeen <sandeen@redhat.com> 2.1-1
 - New upstream version
 
-* Wed Apr 17 2013 Eric Sandeen <sandeen@redhat.com> 2.0.15-1 
+* Wed Apr 17 2013 Eric Sandeen <sandeen@redhat.com> 2.0.15-1
 - New upstream version
 
 * Wed Feb 13 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.0.13-2
@@ -466,16 +451,16 @@ EXTFLAGS="$RPM_OPT_FLAGS" LDFLAGS="$RPM_LD_FLAGS" %make_build
 * Tue Jan 01 2013 Dan Horák <dan[at]danny.cz> - 2.0.12.2-2
 - fix build on arches without ARCH_HAVE_CPU_CLOCK (arm, s390)
 
-* Fri Dec 21 2012 Eric Sandeen <sandeen@redhat.com> 2.0.12.2-1 
+* Fri Dec 21 2012 Eric Sandeen <sandeen@redhat.com> 2.0.12.2-1
 - New upstream version
 
-* Sat Nov 24 2012 Eric Sandeen <sandeen@redhat.com> 2.0.11-1 
+* Sat Nov 24 2012 Eric Sandeen <sandeen@redhat.com> 2.0.11-1
 - New upstream version
 
 * Thu Nov 15 2012 Peter Robinson <pbrobinson@fedoraproject.org> 2.0.10-2
 - Merge latest from F16 to master, bump release
 
-* Fri Oct 12 2012 Eric Sandeen <sandeen@redhat.com> 2.0.10-1 
+* Fri Oct 12 2012 Eric Sandeen <sandeen@redhat.com> 2.0.10-1
 - New upstream version
 
 * Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.0.8-2

--- a/SPECS/libnbd/libnbd.spec
+++ b/SPECS/libnbd/libnbd.spec
@@ -3,7 +3,7 @@
 Summary:        NBD client library in userspace
 Name:           libnbd
 Version:        1.12.1
-Release:        4%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -215,6 +215,7 @@ skip_test tests/connect-tcp6
 %{python3_sitearch}/libnbdmod*.so
 %{python3_sitearch}/nbd.py
 %{python3_sitearch}/nbdsh.py
+%{python3_sitearch}/__pycache__/nbd*.py*
 %{_bindir}/nbdsh
 %{_mandir}/man1/nbdsh.1*
 
@@ -231,9 +232,6 @@ skip_test tests/connect-tcp6
 
 
 %changelog
-* Fri Feb 23 2024 Andrew Phelps <anphel@microsoft.com> - 1.12.1-4
-- Fix python3.12 build issue
-
 * Thu Oct 19 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 1.12.1-3
 - Add patch to fix CVE-2023-5215
 

--- a/SPECS/libnbd/libnbd.spec
+++ b/SPECS/libnbd/libnbd.spec
@@ -3,7 +3,7 @@
 Summary:        NBD client library in userspace
 Name:           libnbd
 Version:        1.12.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -215,7 +215,6 @@ skip_test tests/connect-tcp6
 %{python3_sitearch}/libnbdmod*.so
 %{python3_sitearch}/nbd.py
 %{python3_sitearch}/nbdsh.py
-%{python3_sitearch}/__pycache__/nbd*.py*
 %{_bindir}/nbdsh
 %{_mandir}/man1/nbdsh.1*
 
@@ -232,6 +231,9 @@ skip_test tests/connect-tcp6
 
 
 %changelog
+* Fri Feb 23 2024 Andrew Phelps <anphel@microsoft.com> - 1.12.1-4
+- Fix python3.12 build issue
+
 * Thu Oct 19 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 1.12.1-3
 - Add patch to fix CVE-2023-5215
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix package build breaks with `fio` and `cri-o`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- crio-o: remove dependency on `apparmor-devel`, which was removed in #6966 
- fio: remove BuildRequires on `libpmemblk-devel` and remove related `engine-pmemblk` subpackage. When `nvml` was upgraded to version 2.0.1, it no longer produced the `libpmemblk-devel` subpackage. See #7562 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=525647&view=results
- Note that `crio-o` and `fio` cannot build in buddybuild due to `ceph` build errors