### PR TITLE
Prevent -devel package inclusion in core images (from python-setuptools)

### DIFF
--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -6,7 +6,7 @@ Setuptools is a fully-featured, actively-maintained, and stable library designed
 Summary:        Easily build and distribute Python packages
 Name:           python-setuptools
 Version:        69.0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -19,7 +19,7 @@ Source0:        https://pypi.org/packages/source/s/setuptools/setuptools-%{versi
 %package -n python3-setuptools
 Summary:        %{summary}
 
-Requires:       python3-devel
+Requires:       python3
 # Early builds of Azure Linux 3.0 included python3-setuptools with the python3.spec. Obsolete to prevent build conflicts.
 Obsoletes:      python3-setuptools <= 3.9.14
 BuildArch:      noarch
@@ -57,6 +57,8 @@ EOF
 %{python3_sitelib}/setuptools-%{version}.dist-info/*
 
 %changelog
-* Tue Feb 13 2024 Andrew Phelps anphel@microsoft.com - 69.0.3-1
+* Mon Mar 11 2024 Andrew Phelps <anphel@microsoft.com> - 69.0.3-2
+- Change Requires to python3
+* Tue Feb 13 2024 Andrew Phelps <anphel@microsoft.com> - 69.0.3-1
 - License verified
 - Original version for CBL-Mariner

--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -59,7 +59,8 @@ EOF
 
 %changelog
 * Mon Mar 11 2024 Andrew Phelps <anphel@microsoft.com> - 69.0.3-2
-- Change Requires to python3
+- Change Requires from python3-devel to python3
+- Add BuildRequires to fix regular package build
 * Tue Feb 13 2024 Andrew Phelps <anphel@microsoft.com> - 69.0.3-1
 - License verified
 - Original version for CBL-Mariner

--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -19,7 +19,6 @@ Source0:        https://pypi.org/packages/source/s/setuptools/setuptools-%{versi
 %package -n python3-setuptools
 Summary:        %{summary}
 
-Requires:       python3
 # Early builds of Azure Linux 3.0 included python3-setuptools with the python3.spec. Obsolete to prevent build conflicts.
 Obsoletes:      python3-setuptools <= 3.9.14
 BuildArch:      noarch
@@ -28,6 +27,7 @@ BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-wheel
+Requires:       python3
 
 Provides:       python3dist(setuptools) = %{version}-%{release}
 Provides:       python%{python3_majmin}dist(setuptools) = %{version}-%{release}

--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -25,8 +25,9 @@ Obsoletes:      python3-setuptools <= 3.9.14
 BuildArch:      noarch
 
 # Note: these build requirements are only for the non-toolchain build environment (since they are already available in the toolchain environment)
-#BuildRequires:  python3-pip
-#BuildRequires:  python3-wheel
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-wheel
 
 Provides:       python3dist(setuptools) = %{version}-%{release}
 Provides:       python%{python3_majmin}dist(setuptools) = %{version}-%{release}

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -240,7 +240,7 @@ unzip-6.0-20.azl3.aarch64.rpm
 python3-3.12.0-2.azl3.aarch64.rpm
 python3-devel-3.12.0-2.azl3.aarch64.rpm
 python3-libs-3.12.0-2.azl3.aarch64.rpm
-python3-setuptools-69.0.3-1.azl3.noarch.rpm
+python3-setuptools-69.0.3-2.azl3.noarch.rpm
 python3-pygments-2.5.2-1.azl3.noarch.rpm
 which-2.21-8.azl3.aarch64.rpm
 libselinux-3.6-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -240,7 +240,7 @@ unzip-6.0-20.azl3.x86_64.rpm
 python3-3.12.0-2.azl3.x86_64.rpm
 python3-devel-3.12.0-2.azl3.x86_64.rpm
 python3-libs-3.12.0-2.azl3.x86_64.rpm
-python3-setuptools-69.0.3-1.azl3.noarch.rpm
+python3-setuptools-69.0.3-2.azl3.noarch.rpm
 python3-pygments-2.5.2-1.azl3.noarch.rpm
 which-2.21-8.azl3.x86_64.rpm
 libselinux-3.6-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -545,7 +545,7 @@ python3-pip-24.0-1.azl3.noarch.rpm
 python3-pygments-2.5.2-1.azl3.noarch.rpm
 python3-rpm-4.18.1-4.azl3.aarch64.rpm
 python3-rpm-generators-14-11.azl3.noarch.rpm
-python3-setuptools-69.0.3-1.azl3.noarch.rpm
+python3-setuptools-69.0.3-2.azl3.noarch.rpm
 python3-test-3.12.0-2.azl3.aarch64.rpm
 python3-tools-3.12.0-2.azl3.aarch64.rpm
 python3-wheel-0.33.6-7.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -551,7 +551,7 @@ python3-pip-24.0-1.azl3.noarch.rpm
 python3-pygments-2.5.2-1.azl3.noarch.rpm
 python3-rpm-4.18.1-4.azl3.x86_64.rpm
 python3-rpm-generators-14-11.azl3.noarch.rpm
-python3-setuptools-69.0.3-1.azl3.noarch.rpm
+python3-setuptools-69.0.3-2.azl3.noarch.rpm
 python3-test-3.12.0-2.azl3.x86_64.rpm
 python3-tools-3.12.0-2.azl3.x86_64.rpm
 python3-wheel-0.33.6-7.azl3.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Prevent *-devel packages from being pulled into core images. These should not be needed in the core images, and they increase the disk usage.
Reduces core EFI VHDX by ~2MB.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Modify `python-setuptools` to Require `python3` instead of `python3-devel` at runtime.
This prevents `python3-devel` (and `expat-devel`) from being included in the core images. 
Reduces core image size by ~2MB.
Add BuildRequires to fix buddybuild/regular package build for `python-setuptools`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=526144&view=results
- Local build. Built core VHDX before and after this change. Confirm that `-devel` packages are no longer in image.
`time sudo make image CONFIG_FILE=./imageconfigs/core-efi.json REBUILD_TOOLS=y SRPM_PACK_LIST="" DAILY_BUILD_ID=3-0-20240311 REBUILD_PACKAGES=n`
Boot the VHDX in Hyper-V and run "df -h" to compare disk usage, and diff the `build/logs/imggen/imager.log` file to compare the packages pulled into the image.
