### PR TITLE
Image Customizer: Fix bugs for ISO gen + kernel-mshv

### DIFF
--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -86,19 +86,7 @@ func Move(src, dst string) (err error) {
 // Copy copies a file from src to dst, creating directories for the destination if needed.
 // dst is assumed to be a file and not a directory. Will preserve permissions.
 func Copy(src, dst string) (err error) {
-	return copyWithPermissions(src, dst, os.ModePerm, false, os.ModePerm, false)
-}
-
-// CopyAndChangeMode copies a file from src to dst, creating directories with the given access rights for the destination if needed.
-// dst is assumed to be a file and not a directory. Will change the permissions to the given value.
-func CopyAndChangeMode(src, dst string, dirmode os.FileMode, filemode os.FileMode) (err error) {
-	return copyWithPermissions(src, dst, dirmode, true, filemode, false)
-}
-
-// CopyNoDereference copies a file from src to dst, creating directories for the destination if needed.
-// dst is assumed to be a file and not a directory. Will preserve permissions and symlinks.
-func CopyNoDereference(src, dst string) (err error) {
-	return copyWithPermissions(src, dst, os.ModePerm, false, os.ModePerm, true)
+	return NewFileCopyBuilder(src, dst).Run()
 }
 
 // Read reads a string from the file src.
@@ -280,58 +268,6 @@ func IsDirEmpty(path string) (bool, error) {
 
 	// Directory has at least 1 child.
 	return false, nil
-}
-
-// copyWithPermissions copies a file from src to dst, creating directories with the requested mode for the destination if needed.
-// Depending on the changeMode parameter, it may also change the file mode.
-func copyWithPermissions(src, dst string, dirmode os.FileMode, changeMode bool, filemode os.FileMode,
-	noDereference bool,
-) (err error) {
-	const squashErrors = false
-
-	logger.Log.Debugf("Copying (%s) -> (%s)", src, dst)
-
-	if noDereference {
-		isSrcFileOrSymlink, err := IsFileOrSymlink(src)
-		if err != nil {
-			return err
-		}
-		if !isSrcFileOrSymlink {
-			return fmt.Errorf("source (%s) is not a file or a symlink", src)
-		}
-	} else {
-		isSrcFile, err := IsFile(src)
-		if err != nil {
-			return err
-		}
-		if !isSrcFile {
-			return fmt.Errorf("source (%s) is not a file", src)
-		}
-	}
-
-	err = createDestinationDir(dst, dirmode)
-	if err != nil {
-		return
-	}
-
-	args := []string(nil)
-	if noDereference {
-		args = append(args, "--no-dereference")
-	}
-
-	args = append(args, "--preserve=mode", src, dst)
-
-	err = shell.ExecuteLive(squashErrors, "cp", args...)
-	if err != nil {
-		return
-	}
-
-	if changeMode {
-		logger.Log.Debugf("Calling chmod on (%s) with the mode (%v)", dst, filemode)
-		err = os.Chmod(dst, filemode)
-	}
-
-	return
 }
 
 func createDestinationDir(dst string, dirmode os.FileMode) (err error) {

--- a/toolkit/tools/internal/file/filecopybuilder.go
+++ b/toolkit/tools/internal/file/filecopybuilder.go
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package file
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+)
+
+type FileCopyBuilder struct {
+	Src            string
+	Dst            string
+	DirFileMode    os.FileMode
+	ChangeFileMode bool
+	FileMode       os.FileMode
+	NoDereference  bool
+}
+
+func NewFileCopyBuilder(src string, dst string) FileCopyBuilder {
+	return FileCopyBuilder{
+		Src:            src,
+		Dst:            dst,
+		DirFileMode:    os.ModePerm,
+		ChangeFileMode: false,
+		FileMode:       os.ModePerm,
+		NoDereference:  false,
+	}
+}
+
+func (b FileCopyBuilder) SetDirFileMode(dirFileMode os.FileMode) FileCopyBuilder {
+	b.DirFileMode = dirFileMode
+	return b
+}
+
+func (b FileCopyBuilder) SetFileMode(fileMode os.FileMode) FileCopyBuilder {
+	b.ChangeFileMode = true
+	b.FileMode = fileMode
+	return b
+}
+
+func (b FileCopyBuilder) SetNoDereference() FileCopyBuilder {
+	b.NoDereference = true
+	return b
+}
+
+func (b FileCopyBuilder) Run() (err error) {
+	const squashErrors = false
+
+	logger.Log.Debugf("Copying (%s) to (%s)", b.Src, b.Dst)
+
+	if b.NoDereference && b.ChangeFileMode {
+		return fmt.Errorf("cannot modify file permissions of symlinks")
+	}
+
+	if b.NoDereference {
+		isSrcFileOrSymlink, err := IsFileOrSymlink(b.Src)
+		if err != nil {
+			return err
+		}
+		if !isSrcFileOrSymlink {
+			return fmt.Errorf("source (%s) is not a file or a symlink", b.Src)
+		}
+	} else {
+		isSrcFile, err := IsFile(b.Src)
+		if err != nil {
+			return err
+		}
+		if !isSrcFile {
+			return fmt.Errorf("source (%s) is not a file", b.Src)
+		}
+	}
+
+	err = createDestinationDir(b.Dst, b.DirFileMode)
+	if err != nil {
+		return
+	}
+
+	args := []string(nil)
+	if b.NoDereference {
+		args = append(args, "--no-dereference")
+	}
+
+	args = append(args, "--preserve=mode", b.Src, b.Dst)
+
+	err = shell.ExecuteLive(squashErrors, "cp", args...)
+	if err != nil {
+		return
+	}
+
+	if b.ChangeFileMode {
+		logger.Log.Debugf("Calling chmod on (%s) with the mode (%v)", b.Dst, b.FileMode)
+		err = os.Chmod(b.Dst, b.FileMode)
+	}
+
+	return
+}

--- a/toolkit/tools/internal/file/filecopybuilder_test.go
+++ b/toolkit/tools/internal/file/filecopybuilder_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package file
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFileCopyBasic tests file copies with default settings.
+func TestFileCopyBasic(t *testing.T) {
+	tempDir := t.TempDir()
+	testString := "test string"
+	filePerm := fs.FileMode(0o600)
+
+	_, fileA, fileB := createTestEnv(t, tempDir, testString, filePerm)
+
+	dstDir := filepath.Join(tempDir, "dst")
+	fileADst := filepath.Join(dstDir, "a")
+	fileBDst := filepath.Join(dstDir, "b")
+
+	err := NewFileCopyBuilder(fileA, fileADst).
+		Run()
+	assert.NoError(t, err, "file copy (a)")
+
+	err = NewFileCopyBuilder(fileB, fileBDst).
+		Run()
+	assert.NoError(t, err, "file copy (b)")
+
+	checkPermissionsSubset(t, dstDir, os.ModePerm, "dst")
+
+	checkFile(t, fileADst, testString, false, "a")
+	checkPermissionsSame(t, fileA, fileADst, "a")
+
+	checkFile(t, fileBDst, testString, false, "b")
+}
+
+// TestFileCopySetPerm tests file copies with file permission override.
+func TestFileCopySetPerm(t *testing.T) {
+	tempDir := t.TempDir()
+	testString := "test string"
+	filePerm := fs.FileMode(0o744)
+	newFilePerm := fs.FileMode(0o600)
+	newDirPerm := fs.FileMode(0o700)
+
+	_, fileA, fileB := createTestEnv(t, tempDir, testString, filePerm)
+
+	dstDir := filepath.Join(tempDir, "dst")
+	fileADst := filepath.Join(dstDir, "a")
+	fileBDst := filepath.Join(dstDir, "b")
+
+	err := NewFileCopyBuilder(fileA, fileADst).
+		SetFileMode(newFilePerm).
+		SetDirFileMode(newDirPerm).
+		Run()
+	assert.NoError(t, err, "file copy (a)")
+
+	err = NewFileCopyBuilder(fileB, fileBDst).
+		SetFileMode(newFilePerm).
+		Run()
+	assert.NoError(t, err, "file copy (b)")
+
+	checkPermissionsSubset(t, dstDir, newDirPerm, "dst")
+
+	checkFile(t, fileADst, testString, false, "a")
+	checkPermissions(t, fileADst, newFilePerm, "a")
+
+	checkFile(t, fileBDst, testString, false, "b")
+	checkPermissions(t, fileBDst, newFilePerm, "b")
+}
+
+// TestFileCopySetNoDereference tests file copies with `--no-dereference` set.
+func TestFileCopySetNoDereference(t *testing.T) {
+	tempDir := t.TempDir()
+	testString := "test string"
+	filePerm := fs.FileMode(0o600)
+
+	_, fileA, fileB := createTestEnv(t, tempDir, testString, filePerm)
+
+	dstDir := filepath.Join(tempDir, "dst")
+	fileADst := filepath.Join(dstDir, "a")
+	fileBDst := filepath.Join(dstDir, "b")
+
+	err := NewFileCopyBuilder(fileA, fileADst).
+		SetNoDereference().
+		Run()
+	assert.NoError(t, err, "file copy (a)")
+
+	err = NewFileCopyBuilder(fileB, fileBDst).
+		SetNoDereference().
+		Run()
+	assert.NoError(t, err, "file copy (b)")
+
+	checkPermissionsSubset(t, dstDir, os.ModePerm, "dst")
+
+	checkFile(t, fileADst, testString, false, "a")
+	checkPermissionsSame(t, fileA, fileADst, "a")
+
+	checkFile(t, fileBDst, testString, true, "b")
+}
+
+// TestFileCopyNotFile tests trying to copy a directory.
+func TestFileCopyNotFile(t *testing.T) {
+	tempDir := t.TempDir()
+	testString := "test string"
+	filePerm := fs.FileMode(0o600)
+
+	srcDir, _, _ := createTestEnv(t, tempDir, testString, filePerm)
+
+	dstDir := filepath.Join(tempDir, "dst")
+
+	err := NewFileCopyBuilder(srcDir, dstDir).
+		Run()
+	assert.ErrorContains(t, err, "is not a file")
+
+	err = NewFileCopyBuilder(srcDir, dstDir).
+		SetNoDereference().
+		Run()
+	assert.ErrorContains(t, err, "is not a file or a symlink")
+}
+
+// TestFileCopyInvalidOptions tests invalid combinations of file copy options.
+func TestFileCopyInvalidOptions(t *testing.T) {
+	tempDir := t.TempDir()
+	testString := "test string"
+	filePerm := fs.FileMode(0o600)
+
+	_, fileA, _ := createTestEnv(t, tempDir, testString, filePerm)
+
+	dstDir := filepath.Join(tempDir, "dst")
+	fileADst := filepath.Join(dstDir, "a")
+
+	err := NewFileCopyBuilder(fileA, fileADst).
+		SetNoDereference().
+		SetFileMode(filePerm).
+		Run()
+	assert.ErrorContains(t, err, "cannot modify file permissions of symlinks")
+}
+
+func createTestEnv(t *testing.T, tempDir string, fileContents string, filePerm fs.FileMode) (string, string, string) {
+	srcDir := filepath.Join(tempDir, "src")
+
+	err := os.MkdirAll(srcDir, os.ModePerm)
+	assert.NoError(t, err, "create dir (src)")
+
+	fileA := filepath.Join(srcDir, "a")
+	fileB := filepath.Join(srcDir, "b")
+
+	err = os.WriteFile(fileA, []byte(fileContents), filePerm)
+	assert.NoError(t, err, "write test file (a)")
+
+	err = os.Symlink("./a", fileB)
+	assert.NoError(t, err, "write test file (b)")
+
+	return srcDir, fileA, fileB
+}
+
+func checkFile(t *testing.T, path string, expectedContent string, expectedIsSymlink bool,
+	debugName string,
+) {
+	fileInfo, err := os.Lstat(path)
+	assert.NoErrorf(t, err, "lstat file (%s)", debugName)
+
+	fileIsSymlink := fileInfo.Mode().Type() == os.ModeSymlink
+	assert.Equalf(t, expectedIsSymlink, fileIsSymlink, "check is symlink (%s)", debugName)
+
+	readContent, err := os.ReadFile(path)
+	assert.NoError(t, err, "read file copy (%s)", debugName)
+	assert.Equalf(t, expectedContent, string(readContent), "check file copy (%s) contents", debugName)
+}
+
+// When files and directories are created in Go, the permissions specified are subject to the umask.
+// So, the best we can do is ensure that the permissions are a subset.
+func checkPermissionsSubset(t *testing.T, path string, expectedPerms fs.FileMode, debugName string) {
+	fileInfo, err := os.Stat(path)
+	assert.NoErrorf(t, err, "lstat file (%s)", debugName)
+
+	perm := fileInfo.Mode().Perm()
+	isSubset := (expectedPerms | perm) == expectedPerms
+	assert.Truef(t, isSubset, "check permissions: %d subset of %d (%s)", perm, expectedPerms, debugName)
+}
+
+func checkPermissionsSame(t *testing.T, src string, dst string, debugName string) {
+	fileInfo, err := os.Stat(src)
+	assert.NoErrorf(t, err, "stat file (%s)", debugName)
+	checkPermissions(t, dst, fileInfo.Mode().Perm(), debugName)
+}
+
+func checkPermissions(t *testing.T, path string, expectedPerms fs.FileMode, debugName string) {
+	fileInfo, err := os.Stat(path)
+	assert.NoErrorf(t, err, "stat file (%s)", debugName)
+
+	perm := fileInfo.Mode().Perm()
+	assert.Equalf(t, expectedPerms, perm, "check permissions (%s)", debugName)
+}

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -31,6 +31,8 @@ type FileToCopy struct {
 	Src         string
 	Dest        string
 	Permissions *os.FileMode
+	// Set to true to copy symlinks as symlinks.
+	NoDereference bool
 }
 
 // MountPoint represents a system mount point used by a Chroot.
@@ -312,7 +314,9 @@ func AddFilesToDestination(destDir string, filesToCopy ...FileToCopy) error {
 		logger.Log.Debugf("Copying '%s' to '%s'", f.Src, dest)
 
 		var err error
-		if f.Permissions != nil {
+		if f.NoDereference {
+			err = file.CopyNoDereference(f.Src, dest)
+		} else if f.Permissions != nil {
 			err = file.CopyAndChangeMode(f.Src, dest, os.ModePerm, *f.Permissions)
 		} else {
 			err = file.Copy(f.Src, dest)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -326,7 +326,7 @@ func (b *LiveOSIsoBuilder) extractBootDirFiles(writeableRootfsDir string) error 
 			copiedByIsoMaker = true
 		}
 
-		err = file.Copy(sourcePath, targetPath)
+		err = file.CopyNoDereference(sourcePath, targetPath)
 		if err != nil {
 			return err
 		}
@@ -360,18 +360,36 @@ func (b *LiveOSIsoBuilder) extractBootDirFiles(writeableRootfsDir string) error 
 //   - the following is populated:
 //     b.artifacts.kernelVersion
 func (b *LiveOSIsoBuilder) findKernelVersion(writeableRootfsDir string) error {
-	kernelParentPath := filepath.Join(writeableRootfsDir, "/usr/lib/modules")
-	kernelPaths, err := os.ReadDir(kernelParentPath)
+	const kernelModulesDir = "/usr/lib/modules"
+
+	kernelParentPath := filepath.Join(writeableRootfsDir, kernelModulesDir)
+	kernelDirs, err := os.ReadDir(kernelParentPath)
 	if err != nil {
 		return fmt.Errorf("failed to enumerate kernels under (%s):\n%w", kernelParentPath, err)
 	}
-	if len(kernelPaths) == 0 {
-		return fmt.Errorf("did not find any kernels installed under (%s).", kernelParentPath)
+
+	// Filter out directories that are empty.
+	// Some versions of Azure Linux 2.0 don't cleanup properly when the kernel package is uninstalled.
+	filteredKernelDirs := []fs.DirEntry(nil)
+	for _, kernelDir := range kernelDirs {
+		kernelPath := filepath.Join(kernelParentPath, kernelDir.Name())
+		empty, err := file.IsDirEmpty(kernelPath)
+		if err != nil {
+			return err
+		}
+
+		if !empty {
+			filteredKernelDirs = append(filteredKernelDirs, kernelDir)
+		}
 	}
-	if len(kernelPaths) > 1 {
-		return fmt.Errorf("unsupported scenario. found more than one kernel under (%s).", kernelParentPath)
+
+	if len(filteredKernelDirs) == 0 {
+		return fmt.Errorf("did not find any kernels installed under (%s)", kernelModulesDir)
 	}
-	b.artifacts.kernelVersion = kernelPaths[0].Name()
+	if len(filteredKernelDirs) > 1 {
+		return fmt.Errorf("unsupported scenario: found more than one kernel under (%s)", kernelModulesDir)
+	}
+	b.artifacts.kernelVersion = filteredKernelDirs[0].Name()
 	logger.Log.Debugf("Found installed kernel version (%s)", b.artifacts.kernelVersion)
 	return nil
 }
@@ -634,8 +652,9 @@ func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileTo
 	// Add /boot/* files
 	for sourceFile, targetFile := range b.artifacts.bootDirFiles {
 		fileToCopy := safechroot.FileToCopy{
-			Src:  sourceFile,
-			Dest: targetFile,
+			Src:           sourceFile,
+			Dest:          targetFile,
+			NoDereference: true,
 		}
 		additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -326,7 +326,9 @@ func (b *LiveOSIsoBuilder) extractBootDirFiles(writeableRootfsDir string) error 
 			copiedByIsoMaker = true
 		}
 
-		err = file.CopyNoDereference(sourcePath, targetPath)
+		err = file.NewFileCopyBuilder(sourcePath, targetPath).
+			SetNoDereference().
+			Run()
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/mshvkernel-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/mshvkernel-config.yaml
@@ -1,0 +1,31 @@
+Disks:
+- PartitionTableType: gpt
+  MaxSize: 4096
+  Partitions:
+  - ID: efi
+    Flags:
+    - esp
+    - boot
+    Start: 1
+    End: 65
+    FsType: fat32
+
+  - ID: rootfs
+    Start: 65
+    FsType: ext4
+
+SystemConfig:
+  BootType: efi
+  PartitionSettings:
+  - ID: efi
+    MountPoint: /boot/efi
+    MountOptions: umask=0077
+
+  - ID: rootfs
+    MountPoint: /
+
+  PackagesRemove:
+  - kernel
+
+  PackagesInstall:
+  - kernel-mshv

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -574,6 +574,7 @@ func (im *IsoMaker) copyAndRenameConfigFiles() (err error) {
 // files can be used by custom initrd/LiveOS images that will look for them
 // on the iso media.
 func (im *IsoMaker) copyIsoAdditionalFiles() (err error) {
+	logger.Log.Debugf("Copying ISO additional files.")
 	return safechroot.AddFilesToDestination(im.buildDirPath, im.additionalIsoFiles...)
 }
 

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -574,7 +574,7 @@ func (im *IsoMaker) copyAndRenameConfigFiles() (err error) {
 // files can be used by custom initrd/LiveOS images that will look for them
 // on the iso media.
 func (im *IsoMaker) copyIsoAdditionalFiles() (err error) {
-	logger.Log.Debugf("Copying ISO additional files.")
+	logger.Log.Debugf("Copying ISO additional files")
 	return safechroot.AddFilesToDestination(im.buildDirPath, im.additionalIsoFiles...)
 }
 


### PR DESCRIPTION
Fix a couple of bugs related to taking image that uses the kernel-mshv package and turning it into an ISO.

Firstly, when uninstalling the kernel package, the /usr/lib/modules/<version> directory is emptied but it isn't removed. This confuses the image customizer's logic to discover the list of installed kernels. This change updates the logic to filter out empty directories.

Secondly, when generating the ISO, the files under the /boot directory are copied into the ISO. But this logic fails if it encounters a broken symlink. For example, a `mariner.cfg` file that wasn't removed when the `kernel` package was uninstalled. This change ensures that symlinks are copied as symlinks.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

