### PR TITLE
fix iso files for calamares eula, add retention of GrubMkConfig for attended installer

### DIFF
--- a/SPECS/calamares/calamares.signatures.json
+++ b/SPECS/calamares/calamares.signatures.json
@@ -13,7 +13,7 @@
   "calamares-partition-3.0.1.tar.gz": "294712d27279cff760d778fc2edbb7660fc7a76b49f635fd28974df0071d7a96",
   "calamares-users-3.0.1.tar.gz": "0da9e01feb26be2567e2df40cbd5ecb0ecab2d688bb8e7ef64bb498280f112c0",
   "calamares-welcome-3.0.1.tar.gz": "2a6c6c1cca6600f51515093d0d4e6e1b025a1fe341d886dc948fadd4c1ebd280",
-  "license.conf": "47b82c94103300158821d6f519da994656cc79dfb7456ed056da4c8b41be279e",
+  "license.conf": "ce9a46032697b75deea72b43818de6b08ede48fe02cd70f2f9cad2e790d8eb56",
   "settings.conf": "bb033dc3dffbb31007b098445779a2b479f35ebd0f69e5f8e1f9edd7a9cca234",
   "show.qml": "2fbf20110c6385749ff836a93cddcbcd6e6f111fe4063f086a29892b588e99b5",
   "stylesheet.qss": "9707878d63c9591fd83096d1650ada773bf5e85797fd3fbfc19555ef39ffa30a"

--- a/SPECS/calamares/calamares.spec
+++ b/SPECS/calamares/calamares.spec
@@ -7,7 +7,7 @@ Summary:        Installer from a live CD/DVD/USB to disk
 # https://github.com/calamares/calamares/issues/1051
 Name:           calamares
 Version:        3.3.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -221,6 +221,9 @@ install -p -m 644 %{SOURCE53} %{buildroot}%{_sysconfdir}/calamares/azl-eula
 %{_libdir}/libcalamaresui.so
 
 %changelog
+* Tue Mar 12 2024 Sam Meluch <sammeluch@microsoft.com> - 3.3.1-4
+- update license.conf file path to use azl-eula
+
 * Fri Mar 08 2024 Sam Meluch <sammeluch@microsoft.com> - 3.3.1-3
 - Fix python macros for calamares
 

--- a/SPECS/calamares/license.conf
+++ b/SPECS/calamares/license.conf
@@ -24,5 +24,5 @@ entries:
   vendor: Microsoft
   type: software
   required: true
-  url: file:///etc/calamares/mariner-eula
+  url: file:///etc/calamares/azl-eula
   expand: true

--- a/toolkit/imageconfigs/full.json
+++ b/toolkit/imageconfigs/full.json
@@ -3,6 +3,7 @@
         {
             "Name": "Azure Linux Full",
             "PackageLists": [
+                "packagelists/grub2-mkconfig.json",
                 "packagelists/developer-packages.json",
                 "packagelists/virtualization-host-packages.json",
                 "packagelists/core-packages-image.json",
@@ -17,17 +18,20 @@
             },
             "KernelOptions": {
                 "default": "kernel"
-            }
+            },
+            "EnableGrubMkconfig": true
         },
         {
             "Name": "Azure Linux Core",
             "PackageLists": [
+                "packagelists/grub2-mkconfig.json",
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image.json"
             ],
             "KernelOptions": {
                 "default": "kernel"
-            }
+            },
+            "EnableGrubMkconfig": true
         }
     ]
 }

--- a/toolkit/imageconfigs/full.json
+++ b/toolkit/imageconfigs/full.json
@@ -18,8 +18,7 @@
             },
             "KernelOptions": {
                 "default": "kernel"
-            },
-            "EnableGrubMkconfig": true
+            }
         },
         {
             "Name": "Azure Linux Core",
@@ -30,8 +29,7 @@
             ],
             "KernelOptions": {
                 "default": "kernel"
-            },
-            "EnableGrubMkconfig": true
+            }
         }
     ]
 }

--- a/toolkit/resources/imageconfigs/iso_initrd.json
+++ b/toolkit/resources/imageconfigs/iso_initrd.json
@@ -29,7 +29,7 @@
                 "../../out/tools/imager": "/installer/imager",
                 "../../out/tools/liveinstaller": "/installer/liveinstaller",
                 "additionalfiles/iso_initrd/init": "/init",
-                "additionalfiles/iso_initrd/installer/calamares-EULA.txt": "/etc/calamares/mariner-eula",
+                "additionalfiles/iso_initrd/installer/calamares-EULA.txt": "/etc/calamares/azl-eula",
                 "additionalfiles/iso_initrd/installer/terminal-EULA.txt": "/installer/EULA.txt",
                 "additionalfiles/iso_initrd/root/asoundrc": "/root/.asoundrc",
                 "additionalfiles/iso_initrd/root/runliveinstaller": "/root/runliveinstaller",

--- a/toolkit/resources/imageconfigs/iso_initrd_arm64.json
+++ b/toolkit/resources/imageconfigs/iso_initrd_arm64.json
@@ -24,7 +24,7 @@
                 "../../out/tools/imager": "/installer/imager",
                 "../../out/tools/liveinstaller": "/installer/liveinstaller",
                 "additionalfiles/iso_initrd/init": "/init",
-                "additionalfiles/iso_initrd/installer/calamares-EULA.txt": "/etc/calamares/mariner-eula",
+                "additionalfiles/iso_initrd/installer/calamares-EULA.txt": "/etc/calamares/azl-eula",
                 "additionalfiles/iso_initrd/installer/terminal-EULA.txt": "/installer/EULA.txt",
                 "additionalfiles/iso_initrd/root/asoundrc": "/root/.asoundrc",
                 "additionalfiles/iso_initrd/root/runliveinstaller": "/root/runliveinstaller",

--- a/toolkit/resources/imageconfigs/packagelists/iso-initrd-packages.json
+++ b/toolkit/resources/imageconfigs/packagelists/iso-initrd-packages.json
@@ -1,6 +1,7 @@
 {
     "packages": [
         "pam",
+        "audit",
         "attr",
         "bash",
         "bzip2",

--- a/toolkit/tools/imagegen/attendedinstaller/views/installationview/installationview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/installationview/installationview.go
@@ -152,6 +152,7 @@ func (iv *InstallationView) applyConfiguration(sysConfig *configuration.SystemCo
 	sysConfig.AdditionalFiles = selectedConfig.AdditionalFiles
 	sysConfig.PostInstallScripts = selectedConfig.PostInstallScripts
 	sysConfig.FinalizeImageScripts = selectedConfig.FinalizeImageScripts
+	sysConfig.EnableGrubMkconfig = selectedConfig.EnableGrubMkconfig
 }
 
 func (iv *InstallationView) populateInstallOptions() (err error) {

--- a/toolkit/tools/imagegen/attendedinstaller/views/installerview/installerview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/installerview/installerview.go
@@ -63,7 +63,8 @@ func New(calamaresInstallFunc func()) *InstallerView {
 	if err != nil {
 		logger.Log.Debugf("Calamares not found, defaulting to terminal based installer")
 	} else {
-		iv.installerOptions = append(iv.installerOptions, uitext.InstallerGraphicalOption)
+		logger.Log.Debugf("Calamares found, but the gui installer is temporarily disabled until stabilized")
+		// iv.installerOptions = append(iv.installerOptions, uitext.InstallerGraphicalOption)
 	}
 
 	iv.needsToPrompt = (len(iv.installerOptions) != 1)


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add in a few fixes to the azl-3.0 iso to stabilize the environment for grub mk config and calamares file references.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- allow grub mk config flag retention for attended installer configs
- Add grub mk config flag to full.json configs
- calamares filename change mariner-eula > azl-eula
- add audit to iso_initrd to reduce kernel printk spew in iso environment

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local iso Builds
