### PR TITLE
Auto clean tdnf cache

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -324,6 +324,10 @@ By default the repo will only be used during ISO install, it may also be made av
 RemoveRpmDb triggers RPM database removal after the packages have been installed.
 Removing the RPM database may break any package managers inside the image.
 
+### PreserveTdnfCache
+
+PreserveTdnfCache leaves the `tdnf` cache intact after image generation. By default the cache will be cleaned via `tdnf clean all` to save space after installing packages and running `PostInstallScripts`.
+
 ### KernelOptions
 
 KernelOptions key consists of a map of key-value pairs, where a key is an identifier and a value is a name of the package (kernel) used in a scenario described by the identifier. During the build time, all kernels provided in KernelOptions will be built.

--- a/toolkit/imageconfigs/core-efi.json
+++ b/toolkit/imageconfigs/core-efi.json
@@ -49,11 +49,6 @@
                 "packagelists/core-packages-image.json",
                 "packagelists/cloud-init-packages.json"
             ],
-            "PostInstallScripts": [
-                {
-                    "Path": "postinstallscripts/remove-tdnf-cache.sh"
-                }
-            ],
             "KernelOptions": {
                 "default": "kernel"
             },

--- a/toolkit/imageconfigs/core-legacy.json
+++ b/toolkit/imageconfigs/core-legacy.json
@@ -47,11 +47,6 @@
                 "packagelists/core-packages-image.json",
                 "packagelists/cloud-init-packages.json"
             ],
-            "PostInstallScripts": [
-                {
-                    "Path": "postinstallscripts/remove-tdnf-cache.sh"
-                }
-            ],
             "KernelOptions": {
                 "default": "kernel"
             },

--- a/toolkit/imageconfigs/marketplace-gen1-fips.json
+++ b/toolkit/imageconfigs/marketplace-gen1-fips.json
@@ -67,9 +67,6 @@
             "PostInstallScripts": [
                 {
                     "Path": "additionalconfigs/configure-systemd-networkd.sh"
-                },
-                {
-                    "Path": "postinstallscripts/remove-tdnf-cache.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/marketplace-gen1.json
+++ b/toolkit/imageconfigs/marketplace-gen1.json
@@ -66,9 +66,6 @@
             "PostInstallScripts": [
                 {
                     "Path": "additionalconfigs/configure-systemd-networkd.sh"
-                },
-                {
-                    "Path": "postinstallscripts/remove-tdnf-cache.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64.json
@@ -69,9 +69,6 @@
             "PostInstallScripts": [
                 {
                     "Path": "additionalconfigs/configure-systemd-networkd.sh"
-                },
-                {
-                    "Path": "postinstallscripts/remove-tdnf-cache.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/marketplace-gen2-fips.json
+++ b/toolkit/imageconfigs/marketplace-gen2-fips.json
@@ -70,9 +70,6 @@
             "PostInstallScripts": [
                 {
                     "Path": "additionalconfigs/configure-systemd-networkd.sh"
-                },
-                {
-                    "Path": "postinstallscripts/remove-tdnf-cache.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -69,9 +69,6 @@
             "PostInstallScripts": [
                 {
                     "Path": "additionalconfigs/configure-systemd-networkd.sh"
-                },
-                {
-                    "Path": "postinstallscripts/remove-tdnf-cache.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/postinstallscripts/core-container/cleanup.sh
+++ b/toolkit/imageconfigs/postinstallscripts/core-container/cleanup.sh
@@ -7,7 +7,3 @@ rm -rf /boot/*
 rm -rf /usr/src/
 rm -rf /home/*
 rm -rf /var/log/*
-
-echo removing tdnf cache
-tdnf -y clean all
-rm -rf /var/cache/tdnf

--- a/toolkit/imageconfigs/postinstallscripts/remove-tdnf-cache.sh
+++ b/toolkit/imageconfigs/postinstallscripts/remove-tdnf-cache.sh
@@ -1,6 +1,0 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-
-echo removing tdnf cache
-tdnf -y clean all
-rm -rf /var/cache/tdnf

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -38,6 +38,7 @@ type SystemConfig struct {
 	Users                []User                    `json:"Users"`
 	Encryption           RootEncryption            `json:"Encryption"`
 	RemoveRpmDb          bool                      `json:"RemoveRpmDb"`
+	PreserveTdnfCache    bool                      `json:"PreserveTdnfCache"`
 	ReadOnlyVerityRoot   ReadOnlyVerityRoot        `json:"ReadOnlyVerityRoot"`
 	EnableHidepid        bool                      `json:"EnableHidepid"`
 }

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -2214,9 +2214,19 @@ func cleanupTdnfCache(installChroot *safechroot.Chroot) error {
 	// Remove all files and subdirectories in the tdnf cache directory, but leave
 	// the directory since it's owned by the tdnf package.
 	cacheDir := filepath.Join(installChroot.RootDir(), rpmCacheDirectory)
+	// Skip if directory is missing already
+	exists, err := file.DirExists(cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to check if tdnf cache directory exists (%s):\n%w", cacheDir, err)
+	}
+	if !exists {
+		logger.Log.Infof("Skipping tdnf cache cleanup since directory does not exist (%s)", cacheDir)
+		return nil
+	}
+
 	err = file.RemoveDirectoryContents(cacheDir)
 	if err != nil {
-		err = fmt.Errorf("failed to remove tdnf cache contents(%s/*):\n%w", cacheDir, err)
+		err = fmt.Errorf("failed to remove tdnf cache contents (%s/*):\n%w", cacheDir, err)
 		return err
 	}
 	return nil

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -177,6 +177,27 @@ func RemoveFileIfExists(path string) (err error) {
 	return
 }
 
+// RemoveDirectoryContents will delete the contents of a directory, but not the
+// directory itself.
+func RemoveDirectoryContents(path string) (err error) {
+	logger.Log.Debugf("Removing contents of directory (%s)", path)
+	dir, err := os.ReadDir(path)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range dir {
+		childPath := filepath.Join(path, entry.Name())
+		logger.Log.Debugf("Removing (%s)", childPath)
+		err = os.RemoveAll(childPath)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
 // GenerateSHA1 calculates a sha1 of a file
 func GenerateSHA1(path string) (hash string, err error) {
 	file, err := os.Open(path)

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -180,7 +180,6 @@ func RemoveFileIfExists(path string) (err error) {
 // RemoveDirectoryContents will delete the contents of a directory, but not the
 // directory itself. If the directory does not exist, it will return an error.
 func RemoveDirectoryContents(path string) (err error) {
-	logger.Log.Debugf("Removing contents of directory (%s)", path)
 	dir, err := os.ReadDir(path)
 	if err != nil {
 		return

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -178,7 +178,7 @@ func RemoveFileIfExists(path string) (err error) {
 }
 
 // RemoveDirectoryContents will delete the contents of a directory, but not the
-// directory itself.
+// directory itself. If the directory does not exist, it will return an error.
 func RemoveDirectoryContents(path string) (err error) {
 	logger.Log.Debugf("Removing contents of directory (%s)", path)
 	dir, err := os.ReadDir(path)

--- a/toolkit/tools/internal/file/file_test.go
+++ b/toolkit/tools/internal/file/file_test.go
@@ -43,3 +43,83 @@ func TestRemoveFileDoesNotExist(t *testing.T) {
 	err := RemoveFileIfExists(fileName)
 	assert.NoError(t, err)
 }
+func TestRemoveDirectoryContents(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create some files and directories inside the temporary directory
+	file1 := filepath.Join(tempDir, "file1.txt")
+	file2 := filepath.Join(tempDir, "file2.txt")
+	dir1 := filepath.Join(tempDir, "dir1")
+	dir2 := filepath.Join(tempDir, "dir2")
+	file3 := filepath.Join(dir1, "file3.txt")
+
+	// Create the files and directories
+	err := os.Mkdir(dir1, 0755)
+	assert.NoError(t, err)
+	err = os.Mkdir(dir2, 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(file1, []byte("test"), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(file2, []byte("test"), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(file3, []byte("test"), 0644)
+	assert.NoError(t, err)
+
+	// Call the function to remove the contents of the directory
+	err = RemoveDirectoryContents(tempDir)
+	assert.NoError(t, err)
+
+	// Check if the files and directories have been removed
+	exists, err := PathExists(file1)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = PathExists(file2)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = PathExists(dir1)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = PathExists(dir2)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = PathExists(file3)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	// Ensure the directory itself is not removed
+	exists, err = PathExists(tempDir)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestRemoveDirectoryContentsEmpty(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Call the function to remove the contents of the directory
+	err := RemoveDirectoryContents(tempDir)
+	assert.NoError(t, err)
+
+	// Ensure the directory itself is not removed
+	exists, err := PathExists(tempDir)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestRemoveDirectoryContentsNonExistent(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Remove the temporary directory
+	err := os.RemoveAll(tempDir)
+	assert.NoError(t, err)
+
+	// Call the function to remove the contents of the directory
+	err = RemoveDirectoryContents(tempDir)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The toolkit should be able to handle cleaning up the `tdnf` cache itself, no need to oblige users to call a post-install script for ever image.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- By default run `tdnf clean all` and remove `/var/cache/tdnf` at the end of image builds.
- Add `PreserveTdnfCache` to `systemconfig` to keep old behavior.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build of baremetal and core-efi
