### PR TITLE
Add systemd-bootstrap-libs subpackage.

### DIFF
--- a/SPECS/systemd-bootstrap/systemd-bootstrap.spec
+++ b/SPECS/systemd-bootstrap/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -67,6 +67,7 @@ BuildRequires:  python3-jinja2
 BuildRequires:  util-linux-devel
 BuildRequires:  xz-devel
 Requires:       %{name}-rpm-macros = %{version}-%{release}
+Requires:       %{name}-libs = %{version}-%{release}
 Requires:       glib
 Requires:       kmod
 Requires:       libcap
@@ -78,6 +79,12 @@ AutoReq:        no
 
 %description
 Systemd is an init replacement with better process control and security
+
+%package libs
+Summary:        systemd libraries
+
+%description libs
+Systemd libraries
 
 %package rpm-macros
 Summary:        Macros that define paths and scriptlets related to systemd
@@ -245,7 +252,6 @@ fi
 /lib/security
 %{_libdir}/sysctl.d
 %{_libdir}/tmpfiles.d
-/lib/*.so*
 %{_libdir}/modprobe.d/systemd.conf
 %{_libdir}/sysusers.d/*
 %{_bindir}/*
@@ -260,6 +266,9 @@ fi
 %{_datadir}/systemd
 %{_datadir}/zsh/*
 %dir %{_localstatedir}/log/journal
+
+%files libs
+/lib/*.so*
 
 %files rpm-macros
 %{_libdir}/rpm
@@ -276,6 +285,9 @@ fi
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Mon Mar 11 2024 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-17
+- Split libs into their own subpackage to align with full systemd.
+
 * Tue Feb 27 2024 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-16
 - Take rpm-macros from the new systemd-255 package so they are interchangeable
 
@@ -298,7 +310,7 @@ fi
 * Wed Dec 14 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 250.3-10
 - Add patch for CVE-2022-45873
 
-* Wed Nov 29 2022 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-9
+* Wed Nov 30 2022 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-9
 - Conditionally run systemctl preset-all only when first installing systemd, not on upgrades
 
 * Fri Nov 18 2022 Sam Meluch <sammeluch@microsoft.com> - 250.3-8

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        7%{?dist}
+Release:        8%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -344,6 +344,7 @@ Obsoletes:      systemd-compat-libs < 230
 Obsoletes:      nss-myhostname < 0.4
 Provides:       nss-myhostname = 0.4
 Provides:       nss-myhostname%{_isa} = 0.4
+Obsoletes:      systemd-bootstrap-libs <= %{version}-%{release}
 
 %description libs
 Libraries for systemd and udev.
@@ -1186,6 +1187,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Mon Mar 11 2024 Daniel McIlvaney <damcilva@microsoft.com> - 255-8
+- Obsolete the new systemd-bootstrap-libs subpacakge.
+
 * Thu Feb 22 2024 Dan Streetman <ddstreet@microsoft.com> - 255-7
 - remove use of %%azure (or %%azl) macro
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -571,10 +571,11 @@ sqlite-devel-3.44.0-1.azl3.aarch64.rpm
 sqlite-libs-3.44.0-1.azl3.aarch64.rpm
 swig-4.1.1-1.azl3.aarch64.rpm
 swig-debuginfo-4.1.1-1.azl3.aarch64.rpm
-systemd-bootstrap-250.3-16.azl3.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-16.azl3.aarch64.rpm
-systemd-bootstrap-devel-250.3-16.azl3.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-16.azl3.noarch.rpm
+systemd-bootstrap-250.3-17.azl3.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-17.azl3.aarch64.rpm
+systemd-bootstrap-devel-250.3-17.azl3.aarch64.rpm
+systemd-bootstrap-libs-250.3-17.azl3.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-17.azl3.noarch.rpm
 tar-1.35-1.azl3.aarch64.rpm
 tar-debuginfo-1.35-1.azl3.aarch64.rpm
 tdnf-3.5.6-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -577,10 +577,11 @@ sqlite-devel-3.44.0-1.azl3.x86_64.rpm
 sqlite-libs-3.44.0-1.azl3.x86_64.rpm
 swig-4.1.1-1.azl3.x86_64.rpm
 swig-debuginfo-4.1.1-1.azl3.x86_64.rpm
-systemd-bootstrap-250.3-16.azl3.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-16.azl3.x86_64.rpm
-systemd-bootstrap-devel-250.3-16.azl3.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-16.azl3.noarch.rpm
+systemd-bootstrap-250.3-17.azl3.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-17.azl3.x86_64.rpm
+systemd-bootstrap-devel-250.3-17.azl3.x86_64.rpm
+systemd-bootstrap-libs-250.3-17.azl3.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-17.azl3.noarch.rpm
 tar-1.35-1.azl3.x86_64.rpm
 tar-debuginfo-1.35-1.azl3.x86_64.rpm
 tdnf-3.5.6-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The new systemd package includes a `systemd-libs` subpackage which some packages `Requires:`. If a system has `systemd-bootstrap` installed, and we go to install that package, it will cause conflicts. The main `systemd` package correctly obsoletes `systemd-bootstrap`, but `systemd-libs` does not. It is not sufficient to just add an obsoletes to `systemd-libs` for `systemd-bootstrap` since the new libs subpackage offers only the `*.so` files. It is cleaner to just split the `*.so` files into their own bootstrap version of the `-libs` subpackage.

In a more general sense additional `Obsoletes` should be added to `systemd-bootstrap-libs` so it can replace an older copy of `systemd-bootstrap` correctly, but since we have not published these packages yet this is not a critical issue. (probably would need `Obsoletes: systemd-bootstrap < 250.3-16` in `systemd-bootstrap-libs`).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add new `systemd-bootstrap-libs`
- Add `Obsoletes: systemd-bootstrap-libs` to `systemd-libs`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=526687&view=results
- Local builds, tested install in a container to observe replacing.
``` bash
tdnf  install --enablerepo=azl-3.0-daily-build --enablerepo=host_build_repo /mnt/RPMS/systemd-bootstrap-250.3-17.azl3.x86_64.rpm
tdnf  install --enablerepo=azl-3.0-daily-build --enablerepo=host_build_repo systemd-libs-255-7.azl3
# fails
tdnf  install --enablerepo=azl-3.0-daily-build --enablerepo=host_build_repo /mnt/RPMS/x86_64/systemd-libs-255-8.azl3.x86_64.rpm
# works by replacing all bootstrap bits

tdnf remove systemd systemd-libs systemd-rpm-macros
tdnf  install --enablerepo=azl-3.0-daily-build --enablerepo=host_build_repo /mnt/RPMS/systemd-bootstrap-250.3-17.azl3.x86_64.rpm

tdnf install --enablerepo=azl-3.0-daily-build --enablerepo=host_build_repo conmon
# conmon wants systemd-libs, correctly obsoletes bootstrap
```
