### PR TITLE
Used cached toolchain containers by default.

### DIFF
--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -503,11 +503,11 @@ If that is not desired all remote sources can be disabled by clearing the follow
 
 #### `CLEAN_TOOLCHAIN_CONTAINERS=...`
 
-##### `CLEAN_TOOLCHAIN_CONTAINERS=n`
+##### `CLEAN_TOOLCHAIN_CONTAINERS=`**`n`** *(default)*`
 
-> Leave the raw toolchain containers in docker when running `make clean`. If they match the configuration of the current build they will be re-used.
+> Leave the raw toolchain containers in docker when running `make clean`. If they match the configuration of the current build they will be re-used. Run `clean-toolchain-containers` to clean them manually.
 
-##### `CLEAN_TOOLCHAIN_CONTAINERS=`**`y`** *(default)*
+##### `CLEAN_TOOLCHAIN_CONTAINERS=y`
 
 > Delete all `marinertoolchain*` containers and images associated with this working directory when running `make clean`.
 

--- a/toolkit/scripts/incremental_building.mk
+++ b/toolkit/scripts/incremental_building.mk
@@ -8,7 +8,6 @@
 
 # The QUICK_REBUILD* flags are special flags that will try to build the toolchain and packages as quickly as possible. They will
 # automatically set REBUILD_TOOLS, REBUILD_TOOLCHAIN, DELTA_BUILD, INCREMENTAL_TOOLCHAIN, and ALLOW_TOOLCHAIN_DOWNLOAD_FAIL to 'y'.
-# It will also set CLEAN_TOOLCHAIN_CONTAINERS to 'n'
 ##help:var:QUICK_REBUILD:{y,n}=Optimize the build for speed by using existing published components and optimizing unimpactful package rebuilds (Implies QUICK_REBUILD_PACKAGES=y, QUICK_REBUILD_TOOLCHAIN=y).
 QUICK_REBUILD           ?= n
 ##help:var:QUICK_REBUILD_TOOLCHAIN:{y,n}=Rebuild the toolchain, but attempt to download components where possible.
@@ -47,7 +46,6 @@ ALLOW_TOOLCHAIN_DOWNLOAD_FAIL = y
 # Don't care if REBUILD_TOOLS or CLEAN_TOOLCHAIN_CONTAINERS is set or not, doesn't matter to the quickbuild. Just turn this
 # on to be friendly to the user unless they  have explicitly set it to off.
 REBUILD_TOOLS                ?= y
-CLEAN_TOOLCHAIN_CONTAINERS   ?= n
 endif
 
 ######## QUICK_REBUILD PACKAGES ########
@@ -76,7 +74,8 @@ ALLOW_TOOLCHAIN_DOWNLOAD_FAIL   ?= n
 ##help:var:REBUILD_TOOLS:{y,n}=Build the go tools locally instead of taking them from the SDK.
 REBUILD_TOOLS                   ?= n
 DELTA_BUILD                     ?= n
-CLEAN_TOOLCHAIN_CONTAINERS      ?= y
+##help:var:CLEAN_TOOLCHAIN_CONTAINERS:{y,n}=Clean the toolchain bootstrap container when running clean.
+CLEAN_TOOLCHAIN_CONTAINERS      ?= n
 MAX_CPU                         ?=
 PACKAGE_BUILD_TIMEOUT           ?= 8h
 DELTA_FETCH                     ?= n

--- a/toolkit/scripts/toolchain/create_toolchain_in_container.sh
+++ b/toolkit/scripts/toolchain/create_toolchain_in_container.sh
@@ -12,7 +12,17 @@ INCREMENTAL_TOOLCHAIN=$4
 ARCHIVE_TOOL=$5
 
 # Grab an identity for the raw toolchain components so we can avoid rebuilding it if it hasn't changed
-sha_component_tag=$(sha256sum ./container/toolchain-sha256sums ./container/toolchain_build_in_chroot.sh ./create_toolchain_in_container.sh | sha256sum | cut -d' ' -f1 )
+files_to_watch=( "./create_toolchain_in_container.sh" \
+                    "./container/toolchain-sha256sums" \
+                    "./container/Dockerfile" \
+                    "./container/mount_chroot_start_build.sh" \
+                    "./container/sanity_check.sh" \
+                    "./container/toolchain_build_in_chroot.sh" \
+                    "./container/toolchain_build_temp_tools.sh" \
+                    "./container/toolchain_initial_chroot_setup.sh" \
+                    "./container/unmount_chroot.sh" \
+                    "./container/version-check-container.sh" )
+sha_component_tag=$(sha256sum "${files_to_watch[@]}" | sha256sum | cut -d' ' -f1 )
 
 # Check if we already have a committed container with the same sha_component_tag
 if [ "$INCREMENTAL_TOOLCHAIN" != "y" ] || [ -z "$(docker images -q marinertoolchain_populated:${sha_component_tag} 2>/dev/null)" ]; then

--- a/toolkit/scripts/toolchain/create_toolchain_in_container.sh
+++ b/toolkit/scripts/toolchain/create_toolchain_in_container.sh
@@ -12,14 +12,15 @@ INCREMENTAL_TOOLCHAIN=$4
 ARCHIVE_TOOL=$5
 
 # Grab an identity for the raw toolchain components so we can avoid rebuilding it if it hasn't changed
-files_to_watch=( "./create_toolchain_in_container.sh" \
-                    "./container/toolchain-sha256sums" \
+files_to_watch=(    "./create_toolchain_in_container.sh" \
                     "./container/Dockerfile" \
                     "./container/mount_chroot_start_build.sh" \
                     "./container/sanity_check.sh" \
                     "./container/toolchain_build_in_chroot.sh" \
                     "./container/toolchain_build_temp_tools.sh" \
                     "./container/toolchain_initial_chroot_setup.sh" \
+                    "./container/toolchain-remote-wget-list" \
+                    "./container/toolchain-sha256sums" \
                     "./container/unmount_chroot.sh" \
                     "./container/version-check-container.sh" )
 sha_component_tag=$(sha256sum "${files_to_watch[@]}" | sha256sum | cut -d' ' -f1 )


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In 2.0 `CLEAN_TOOLCHAIN_CONTAINERS` defaults to `y` unless `QUICK_REBUILD_TOOLCHAIN=y` is set. This means that most of the time when running `make clean` we will remove all the build containers associated with the current checkout (they are identified via the docker variable `MARINER_BUILD_DIR` which is included in each image).

The containers are tagged with a hash of the interesting input components (`./container/toolchain-sha256sums` `./container/toolchain_build_in_chroot.sh` `./create_toolchain_in_container.sh`). This means if a branch changes any of these files the previous containers will not be valid and the bootstrap will be re-run.

The bootstrap container is generally extremely stable, which means this build should be a very uncommon event. Unfortunately, with the current behavior of `make clean` these containers are discarded very easily (you can use `make clean CLEAN_TOOLCHAIN_CONTAINERS=n`, but this feels unnatural). 

With his change, globally setting `QUICK_REBUILD=y` becomes a valid strategy for building (and maybe that can be set to on by default as well?). Prior to this using that flag would often result in several hours wasted rebuilding the bootstrap toolchain *even if we could have downloaded all the toolchain rpms*.

Now at least we will skip over the bootstrap quickly and the incremental toolchain can build very fast if all rpms are available in the repo.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Default `CLEAN_TOOLCHAIN_CONTAINERS=n` 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
