### PR TITLE
[3.0] dhcp/dhclient.conf: add option rfc3442-classless-static-route in dhclient.conf

### DIFF
--- a/SPECS/dhcp/dhcp.spec
+++ b/SPECS/dhcp/dhcp.spec
@@ -1,7 +1,7 @@
 Summary:        Dynamic host configuration protocol
 Name:           dhcp
 Version:        4.4.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MPLv2.0
 Url:            https://www.isc.org/dhcp/
 Source0:        ftp://ftp.isc.org/isc/dhcp/%{version}/%{name}-%{version}.tar.gz
@@ -70,6 +70,8 @@ cat > %{buildroot}/etc/dhcp/dhclient.conf << "EOF"
 # Begin /etc/dhcp/dhclient.conf
 #
 # Basic dhclient.conf(5)
+
+option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
 
 #prepend domain-name-servers 127.0.0.1;
 request subnet-mask, broadcast-address, time-offset, routers,
@@ -169,6 +171,9 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/dhclient/
 %{_mandir}/man8/dhclient.8.gz
 
 %changelog
+* Fri Mar 08 2024 Chris Patterson <cpatterson@microsoft.com> - 4.4.3-2
+- Add option for classless static route configuration in dhclient.conf
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 4.4.3-1
 - Auto-upgrade to 4.4.3 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
Add manual definition of RFC3442 classless static routes, to fix #8334 

This is the 3.0 version of #8318 