### PR TITLE
Fix: Signature check not handling files in subfolders

### DIFF
--- a/SPECS/dracut/20overlayfs/module-setup.sh
+++ b/SPECS/dracut/20overlayfs/module-setup.sh
@@ -16,5 +16,3 @@ installkernel() {
 install() {
     inst_hook pre-pivot 10 "$moddir/overlayfs-mount.sh"
 }
-
-

--- a/SPECS/dracut/20overlayfs/module-setup.sh
+++ b/SPECS/dracut/20overlayfs/module-setup.sh
@@ -17,5 +17,3 @@ install() {
     inst_hook pre-pivot 10 "$moddir/overlayfs-mount.sh"
 }
 
-
-

--- a/SPECS/dracut/20overlayfs/module-setup.sh
+++ b/SPECS/dracut/20overlayfs/module-setup.sh
@@ -16,3 +16,5 @@ installkernel() {
 install() {
     inst_hook pre-pivot 10 "$moddir/overlayfs-mount.sh"
 }
+
+

--- a/SPECS/dracut/20overlayfs/module-setup.sh
+++ b/SPECS/dracut/20overlayfs/module-setup.sh
@@ -16,3 +16,6 @@ installkernel() {
 install() {
     inst_hook pre-pivot 10 "$moddir/overlayfs-mount.sh"
 }
+
+
+

--- a/SPECS/dracut/20overlayfs/module-setup.sh
+++ b/SPECS/dracut/20overlayfs/module-setup.sh
@@ -16,4 +16,3 @@ installkernel() {
 install() {
     inst_hook pre-pivot 10 "$moddir/overlayfs-mount.sh"
 }
-

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -34,8 +34,8 @@ def find_file_and_check(path, filename, expected_signature) -> Optional[bool]:
         path_to_check = os.path.join(path, content)
         if os.path.isdir(path_to_check):
             result = find_file_and_check(path_to_check, filename, expected_signature)
-            if result is True:
-                return True
+            if result is not None:
+                return result
 
     return None
 

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -22,15 +22,11 @@ def getSignature(fileName) -> str:
             sha256sum.update(read_data)
     return sha256sum.hexdigest()
 
-def find_file(path, filename) -> Optional[str]:
-    return_value : Optional[str] = None
+def find_matching_files(path, filename) -> List[str]:
+    return_value : List[str] = []
     for matching_file in Path(path).glob(f"**/{filename}"):
         if os.path.exists(matching_file):
-            if return_value is not None:
-                print(f"ERROR: detected multiple {filename}: [{matching_files}]")
-                return None
-            
-            return_value = matching_file
+            return_value.append(str(matching_file))
 
     return return_value
 
@@ -50,11 +46,12 @@ def find_name_of_all_spec_and_signatures_json_pairs(path: str) -> List[str]:
 
 def find_spec_folder_ancestor(path: str) -> Optional[str]:
     # Assume that spec/signatures.json files are only found in
-    # SPECS/XX and SPECS-EXTENDED/XX.  Find an ancestor of path
-    # that adheres to this assuption.  Return None if not found.
-    regex = f".*SPECS(-EXTENDED)?{os.sep}[^{os.sep}]+"
+    # SPECS/XX, SPECS-EXTENDED/XX, or SPECS-SIGNED/XX.  Find an
+    # ancestor of path that adheres to this assuption.  Return
+    # None if not found.
+    regex = f".*(SPECS|SPECS-EXTENDED|SPECS-SIGNED){os.sep}[^{os.sep}]+"
     matching_path = re.search(regex, path)
-    if matching_path is not None:
+    if matching_path:
         return matching_path.group(0)
     return None
 
@@ -72,14 +69,16 @@ def check_folder(folder):
         with open(signature_path, "r") as f:
             signatures_json = json.load(f)
             for file_to_check, expected_signature in signatures_json["Signatures"].items():
-                file_to_check_path = find_file(path, file_to_check)
-                if file_to_check_path is not None:
-                    actual_signature = getSignature(file_to_check_path)
+                file_to_check_list = find_matching_files(path, file_to_check)
+                if not file_to_check_list:
+                    print(f"{file_to_check} is not found in CBL-Mariner, build to verify signature")
+                elif len(file_to_check_list) > 1:
+                    print(f"ERROR: Unsure which file to validate, detected multiple {file_to_check}: {file_to_check_list}")
+                else:
+                    actual_signature = getSignature(file_to_check_list[0])
                     if actual_signature != expected_signature:
                         print(f"ERROR: detected a mismatched signature for {file_to_check}, expected [{expected_signature}] does not equal actual [{actual_signature}]")
                         signatures_correct = False
-                else:
-                    print(f"{file_to_check} is not found in CBL-Mariner, build to verify signature")
 
     return signatures_correct
 

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -38,8 +38,24 @@ def find_file_and_check(path, filename, expected_signature) -> Optional[bool]:
             if result is True:
                 return True
 
-def check_folder(path):
+def find_spec_folder_with_signatures_json(path: str) -> Optional[str]:
+    current = Path(path)
+    if Path(os.path.join(path, f"{current.name}.spec")).is_file():
+        if Path(os.path.join(path, f"{current.name}.signatures.json")).is_file():
+            return path
+
+    parent = current.parent
+    if parent != current:
+        return find_spec_folder_with_signatures_json(f"{parent}")
+
+    return None
+
+def check_folder(folder):
     signatures_correct = True
+
+    # find YY (maybe ancestor of path) that has xx/YY/YY.spec
+    path = find_spec_folder_with_signatures_json(folder)
+
     for signature_path in Path(path).glob("*.signatures.json"):
         with open(signature_path, "r") as f:
             signatures_json = json.load(f)

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -39,22 +39,32 @@ def find_file_and_check(path, filename, expected_signature) -> Optional[bool]:
                 return True
 
 def find_spec_folder_with_signatures_json(path: str) -> Optional[str]:
+    print(f"what folder to use for {path}")
     current = Path(path)
     if Path(os.path.join(path, f"{current.name}.spec")).is_file():
         if Path(os.path.join(path, f"{current.name}.signatures.json")).is_file():
+            print(f"use {path}")
             return path
 
     parent = current.parent
     if parent != current:
         return find_spec_folder_with_signatures_json(f"{parent}")
 
+    print(f"do not use {path}")
     return None
 
 def check_folder(folder):
     signatures_correct = True
 
+    print(f"check {folder}")
+
     # find YY (maybe ancestor of path) that has xx/YY/YY.spec
     path = find_spec_folder_with_signatures_json(folder)
+    if path is None:
+        # no spec/signature files found in path or its ancestors
+        return signatures_correct
+
+    print(f"actually check {path}")
 
     for signature_path in Path(path).glob("*.signatures.json"):
         with open(signature_path, "r") as f:

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -43,10 +43,10 @@ def find_name_of_all_spec_and_signatures_json_pairs(path: str) -> List[str]:
     names: List[str] = []
     # Search for all spec files (XXX.spec)
     for spec_path in Path(path).glob("*.spec"):
-        with open(spec_path, "r") as f:
+        if os.path.exists(spec_path):
             name = Path(spec_path).stem
             signature_path = os.path.join(path, f"{name}.signatures.json")
-            with open(signature_path, "r") as ff:
+            if os.path.exists(signature_path):
                 # If there is a matching signature file (XXX.signatures.json),
                 # add it to list
                 names.append(name)

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -25,12 +25,11 @@ def find_file_and_check(path, filename, expected_signature) -> Optional[bool]:
     path_to_check = os.path.join(path, filename)
     if Path(path_to_check).is_file():
         actual_signature = getSignature(path_to_check)
-        if actual_signature != expected_signature:
-            print(f"ERROR: detected a mismatched signature for {filename}, expected [{expected_signature}] does not equal actual [{actual_signature}]")
-            return False
-        else:
+        if actual_signature == expected_signature:
             return True
-    
+        print(f"ERROR: detected a mismatched signature for {filename}, expected [{expected_signature}] does not equal actual [{actual_signature}]")
+        return False
+
     for content in os.listdir(path):
         path_to_check = os.path.join(path, content)
         if os.path.isdir(path_to_check):
@@ -38,19 +37,16 @@ def find_file_and_check(path, filename, expected_signature) -> Optional[bool]:
             if result is True:
                 return True
 
+    return None
+
 def find_spec_folder_with_signatures_json(path: str) -> Optional[str]:
-    print(f"what folder to use for {path}")
     current = Path(path)
     if Path(os.path.join(path, f"{current.name}.spec")).is_file():
         if Path(os.path.join(path, f"{current.name}.signatures.json")).is_file():
-            print(f"use {path}")
             return path
-
     parent = current.parent
     if parent != current:
         return find_spec_folder_with_signatures_json(f"{parent}")
-
-    print(f"do not use {path}")
     return None
 
 def check_folder(folder):

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -48,7 +48,7 @@ def find_name_of_all_spec_and_signatures_json_pairs(path: str) -> List[str]:
 
     return names
 
-def find_spec_folder_with_signatures_json(path: str) -> Optional[str]:
+def find_spec_folder_ancestor(path: str) -> Optional[str]:
     # Assume that spec/signatures.json files are only found in
     # SPECS/XX and SPECS-EXTENDED/XX.  Find an ancestor of path
     # that adheres to this assuption.  Return None if not found.
@@ -61,9 +61,8 @@ def find_spec_folder_with_signatures_json(path: str) -> Optional[str]:
 def check_folder(folder):
     signatures_correct = True
 
-    # get SPECS/XX ancestor of input
-    # find YY (maybe ancestor of path) that has xx/YY/YY.spec
-    path = find_spec_folder_with_signatures_json(folder)
+    # get SPECS/XX or SPECS-EXTENED/XX ancestor of input
+    path = find_spec_folder_ancestor(folder)
     if path is None:
         # no spec/signature files found in path or its ancestors
         return signatures_correct

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -26,15 +26,16 @@ def find_file_and_check(path, filename, expected_signature) -> Optional[bool]:
     if Path(path_to_check).is_file():
         actual_signature = getSignature(path_to_check)
         if actual_signature != expected_signature:
+            print(f"ERROR: detected a mismatched signature for {filename}, expected [{expected_signature}] does not equal actual [{actual_signature}]")
             return False
         else:
             return True
     
-    for content in os.listdir(path) :
+    for content in os.listdir(path):
         path_to_check = os.path.join(path, content)
         if os.path.isdir(path_to_check):
             result = find_file_and_check(path_to_check, filename, expected_signature)
-            if result == True:
+            if result is True:
                 return True
 
 def check_folder(path):
@@ -46,8 +47,7 @@ def check_folder(path):
                 result = find_file_and_check(path, file_to_check, expected_signature)
                 if result is None:
                     print(f"{file_to_check} is not found in CBL-Mariner, build to verify signature")
-                elif result == False:
-                    print(f"ERROR: detected a mismatched signature for {file_to_check}, expected [{expected_signature}] does not equal actual [{actual_signature}]")                    
+                elif result is False:
                     signatures_correct = False
     return signatures_correct
 

--- a/toolkit/scripts/check_signatures.py
+++ b/toolkit/scripts/check_signatures.py
@@ -52,15 +52,11 @@ def find_spec_folder_with_signatures_json(path: str) -> Optional[str]:
 def check_folder(folder):
     signatures_correct = True
 
-    print(f"check {folder}")
-
     # find YY (maybe ancestor of path) that has xx/YY/YY.spec
     path = find_spec_folder_with_signatures_json(folder)
     if path is None:
         # no spec/signature files found in path or its ancestors
         return signatures_correct
-
-    print(f"actually check {path}")
 
     for signature_path in Path(path).glob("*.signatures.json"):
         with open(signature_path, "r") as f:


### PR DESCRIPTION
Signature check was not handling PRs that changed files embedded in subfolders.

This BuidlRpms break (https://dev.azure.com/mariner-org/mariner/_build/results?buildId=526527&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=88a626d5-bd2d-5bcb-0f14-68ce5ab12667) happened because a .sh file had a mismatched signature.  The .sh file was not a file in the same folder as the signatures/spec file, it was in a subfolder.

The changes here:
* look for SPECS|SPECS-EXTENDED folder that have changed in PR to get signatures from, search all signatures.json with corresponding spec file.
* when finding files to check signatures for, search all subfolders for a file with the matching name
