### PR TITLE
Fix bug 48763270 Mariner's go downloader clobbers prev logs, making it hard to diagnose toolchain download errors

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -188,6 +188,7 @@ $(toolchain_rpms_rehydrated): $(TOOLCHAIN_MANIFEST) $(go-downloader)
 	@rpm_filename="$(notdir $@)" && \
 	rpm_dir="$(dir $@)" && \
 	log_file="$(toolchain_downloads_logs_dir)/$$rpm_filename.log" && \
+	> $$log_file && \
 	echo "Attempting to download toolchain RPM: $$rpm_filename" | tee -a "$$log_file" && \
 	mkdir -p $$rpm_dir && \
 	cd $$rpm_dir && \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -188,20 +188,17 @@ $(toolchain_rpms_rehydrated): $(TOOLCHAIN_MANIFEST) $(go-downloader)
 	@rpm_filename="$(notdir $@)" && \
 	rpm_dir="$(dir $@)" && \
 	log_file="$(toolchain_downloads_logs_dir)/$$rpm_filename.log" && \
-	> $$log_file && \
 	echo "Attempting to download toolchain RPM: $$rpm_filename" | tee -a "$$log_file" && \
 	mkdir -p $$rpm_dir && \
 	cd $$rpm_dir && \
-	for url in $(PACKAGE_URL_LIST); do \
-		$(go-downloader) --no-verbose --no-clobber $$url/$$rpm_filename \
-			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
-			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-			--log-file $$log_file 2>/dev/null && \
-		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
-		echo "$$rpm_filename" >> $(toolchain_downloads_manifest) | tee -a "$$log_file" && \
-		touch $@ && \
-		break; \
-	done || { \
+	$(go-downloader) --no-verbose --no-clobber \
+		$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
+		$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
+		--log-file $$log_file \
+		$$rpm_filename $(PACKAGE_URL_LIST) 2>/dev/null && \
+	echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
+	echo "$$rpm_filename" >> $(toolchain_downloads_manifest) | tee -a "$$log_file" && \
+	touch $@ || { \
 		echo "Could not find toolchain package in package repo: $$rpm_filename." | tee -a "$$log_file" && \
 		touch $@; \
 	}

--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -115,9 +115,9 @@ func main() {
 		err = downloadFile(srcUrl, localDstFile, caCerts, tlsCerts)
 		if err != nil {
 			if idx == len(*srcUrls)-1 {
-				logger.Log.Fatalf("Failed to download (%s) to (%s). Error:\n%s", srcUrl, *dstFile, err)
+				logger.Log.Fatalf("Failed to download (%s) to (%s). Error:\n%s", srcUrl, localDstFile, err)
 			} else {
-				logger.Log.Errorf("Failed to download (%s) to (%s). Error:\n%s", srcUrl, *dstFile, err)
+				logger.Log.Errorf("Failed to download (%s) to (%s). Error:\n%s", srcUrl, localDstFile, err)
 			}
 		} else {
 			break

--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -43,8 +43,6 @@ var (
 func main() {
 	app.Version(exe.ToolkitVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
-	// log-file is created in InitBestEffort and should be used for all log messages
-	// for all the URLs in srcURLs
 	logger.InitBestEffort(logFlags)
 	if *noVerbose {
 		logger.Log.SetLevel(logrus.WarnLevel)

--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -150,7 +150,3 @@ func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls
 	}
 	return
 }
-
-func getRpmUrl(url string, rpmFilename string) (result string, err error) {
-	return url + "/" + rpmFilename, nil
-}

--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -34,10 +34,10 @@ var (
 	tlsClientCert = app.Flag("certificate", "TLS client certificate to use when downloading files.").String()
 	tlsClientKey  = app.Flag("private-key", "TLS client key to use when downloading files.").String()
 
-	dstFile       = app.Flag("output-file", "Destination file to download to").Short('O').String()
-	prefixDir     = app.Flag("directory-prefix", "Directory to download to").Short('P').String()
-	rpmFilename   = app.Arg("rpm-filename", "RPM to download").Required().String()
-	srcUrls       = app.Arg("url-list", "URLs to download").Required().Strings()
+	dstFile     = app.Flag("output-file", "Destination file to download to").Short('O').String()
+	prefixDir   = app.Flag("directory-prefix", "Directory to download to").Short('P').String()
+	rpmFilename = app.Arg("rpm-filename", "RPM to download").Required().String()
+	srcUrls     = app.Arg("url-list", "URLs to download").Required().Strings()
 )
 
 func main() {
@@ -119,6 +119,8 @@ func main() {
 			} else {
 				logger.Log.Errorf("Failed to download (%s) to (%s). Error:\n%s", srcUrl, *dstFile, err)
 			}
+		} else {
+			break
 		}
 	}
 }

--- a/toolkit/tools/internal/logger/log.go
+++ b/toolkit/tools/internal/logger/log.go
@@ -86,7 +86,7 @@ func initLogFile(filePath string, color string) (err error) {
 		return
 	}
 
-	file, err := os.Create(filePath)
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/internal/logger/log.go
+++ b/toolkit/tools/internal/logger/log.go
@@ -86,7 +86,7 @@ func initLogFile(filePath string, color string) (err error) {
 		return
 	}
 
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.Create(filePath)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The for loop at line 187 of toolchain.mk is meant to write and keep the logs from all the iterations but the logs from the current iteration overwrites the previous one. For more detail please refer to work item BUG 48763270

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Every invocation of the target `toolchain_rpms_rehydrated` flushes the log file.
-  Move the for loop from the `toolchain.mk` to  the `downloader.go`, passing url list to the downloader.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- BUG 48763270 is an internal work item.

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- This affects QUICK_REBUILD_TOOLCHAIN=y in local build
