### PR TITLE
Bugfix on Verity enabled images Remount service down.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -112,7 +112,7 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = enableVerityPartition(config.SystemConfig.Verity, imageChroot)
+	err = enableVerityPartition(buildDir, config.SystemConfig.Verity, imageChroot, imageConnection)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -29,7 +29,7 @@ const (
 )
 
 func doCustomizations(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	imageChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
+	imageConnection *ImageConnection, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
 ) error {
 	var err error
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -29,7 +29,7 @@ const (
 )
 
 func doCustomizations(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	imageConnection *ImageConnection, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
+	imageChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
 ) error {
 	var err error
 
@@ -112,7 +112,7 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = enableVerityPartition(buildDir, config.SystemConfig.Verity, imageChroot, imageConnection)
+	err = enableVerityPartition(buildDir, config.SystemConfig.Verity, imageChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -32,7 +32,7 @@ func enableVerityPartition(buildDir string, verity *imagecustomizerapi.Verity, i
 		return err
 	}
 
-	err = updateFstab(buildDir, imageChroot)
+	err = updateFstabForVerity(buildDir, imageChroot)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func buildDracutModule(dracutModuleName string, dracutDriverName string, imageCh
 	return nil
 }
 
-func updateFstab(buildDir string, imageChroot *safechroot.Chroot) error {
+func updateFstabForVerity(buildDir string, imageChroot *safechroot.Chroot) error {
 	var err error
 
 	fstabFile := filepath.Join(imageChroot.RootDir(), "etc", "fstab")

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -377,7 +377,7 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 
 	// Do the actual customizations.
 	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection.Chroot(), rpmsSources,
-		useBaseImageRpmRepos, partitionsCustomized, imageConnection)
+		useBaseImageRpmRepos, partitionsCustomized)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -376,7 +376,7 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	defer imageConnection.Close()
 
 	// Do the actual customizations.
-	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection.Chroot(), rpmsSources,
+	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection, rpmsSources,
 		useBaseImageRpmRepos, partitionsCustomized)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -376,8 +376,8 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	defer imageConnection.Close()
 
 	// Do the actual customizations.
-	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection, rpmsSources,
-		useBaseImageRpmRepos, partitionsCustomized)
+	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection.Chroot(), rpmsSources,
+		useBaseImageRpmRepos, partitionsCustomized, imageConnection)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -229,13 +229,13 @@ func fstabEntriesToMountPoints(fstabEntries []diskutils.FstabEntry, diskPartitio
 		if fstabEntry.Target == "/" {
 			mountPoint = safechroot.NewPreDefaultsMountPoint(
 				source, fstabEntry.Target, fstabEntry.FsType,
-				uintptr(fstabEntry.Options), fstabEntry.FsOptions)
+				uintptr(fstabEntry.VfsOptions), fstabEntry.FsOptions)
 
 			foundRoot = true
 		} else {
 			mountPoint = safechroot.NewMountPoint(
 				source, fstabEntry.Target, fstabEntry.FsType,
-				uintptr(fstabEntry.Options), fstabEntry.FsOptions)
+				uintptr(fstabEntry.VfsOptions), fstabEntry.FsOptions)
 		}
 
 		mountPoints = append(mountPoints, mountPoint)


### PR DESCRIPTION
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The PR is for bugfixing the Remount service down on Verity enabled image. This is due to fstab file not updated.

```
[FAILED] Failed to start Remount Root and Kernel File Systems.
Mar 04 05:04:49 mariner-image systemd-remount-fs[548]: mount: /: cannot remount /dev/sda3 read-write, is write-protected.
```

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local MIC image build -> boot up the image seeing this service is up and running.
