### PR TITLE
systemd: force coredump to use LZ4 compression

### DIFF
--- a/SPECS/systemd/mariner-2-force-use-of-lz4-for-coredump.patch
+++ b/SPECS/systemd/mariner-2-force-use-of-lz4-for-coredump.patch
@@ -1,0 +1,33 @@
+diff -urpN systemd-stable-250.3/src/coredump/coredump.c b/src/coredump/coredump.c
+--- systemd-stable-250.3/src/coredump/coredump.c	2024-03-15 15:10:52.619059443 -0400
++++ b/src/coredump/coredump.c	2024-03-15 15:10:05.255079220 -0400
+@@ -614,7 +614,8 @@ static int save_external_coredump(
+                 if (lseek(fd, 0, SEEK_SET) == (off_t) -1)
+                         return log_error_errno(errno, "Failed to seek on coredump %s: %m", fn);
+ 
+-                fn_compressed = strjoin(fn, COMPRESSED_EXT);
++                /* For Mariner 2, we are HARDCODING coredump compression to use LZ4 because Azure Watson can't handle ZSTD */
++                fn_compressed = strjoin(fn, ".lz4");
+                 if (!fn_compressed)
+                         return log_oom();
+ 
+@@ -622,7 +623,8 @@ static int save_external_coredump(
+                 if (fd_compressed < 0)
+                         return log_error_errno(fd_compressed, "Failed to create temporary file for coredump %s: %m", fn_compressed);
+ 
+-                r = compress_stream(fd, fd_compressed, max_size, &uncompressed_size);
++                /* For Mariner 2, we are HARDCODING coredump compression to use LZ4 because Azure Watson can't handle ZSTD */
++                r = compress_stream_lz4(fd, fd_compressed, max_size, &uncompressed_size);
+                 if (r < 0)
+                         return log_error_errno(r, "Failed to compress %s: %m", coredump_tmpfile_name(tmp_compressed));
+ 
+@@ -635,7 +637,8 @@ static int save_external_coredump(
+                         tmp = unlink_and_free(tmp);
+                         fd = safe_close(fd);
+ 
+-                        r = compress_stream(input_fd, fd_compressed, max_size, &partial_uncompressed_size);
++                        /* For Mariner 2, we are HARDCODING coredump compression to use LZ4 because Azure Watson can't handle ZSTD */
++                        r = compress_stream_lz4(input_fd, fd_compressed, max_size, &partial_uncompressed_size);
+                         if (r < 0)
+                                 return log_error_errno(r, "Failed to compress %s: %m", coredump_tmpfile_name(tmp_compressed));
+                         uncompressed_size += partial_uncompressed_size;

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -27,8 +27,9 @@ Patch5:         backport-helper-util-macros.patch
 Patch6:         CVE-2022-4415.patch
 Patch7:         serve-stale-0001-resolved-added-serve-stale-feature-implementation-of.patch
 Patch8:         serve-stale-0002-resolved-Initialize-until_valid-while-storing-negati.patch
-# Patch9 should be dropped for mariner 3
+# Patch9 and Patch10 should be dropped for mariner 3
 Patch9:         mariner-2-do-not-default-zstd-journal-files-for-backwards-compatibility.patch
+Patch10:        mariner-2-force-use-of-lz4-for-coredump.patch
 BuildRequires:  audit-devel
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
@@ -287,6 +288,9 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Thu Mar 14 2024 Dan Streetman <ddstreet@microsoft.com> - 250.3-20
+- force use of lz4 for coredump
+
 * Thu Nov 02 2023 Chris Co <chrco@microsoft.com> - 250.3-19
 - Add zstd-libs as a requires to ensure libzstd.so.1 is present
 


### PR DESCRIPTION
Azure Watson cannot handle ZSTD compression, so force Mariner 2 systemd-coredump to always use LZ4 compression.
