### PR TITLE
containerized-rpmbuild: fix tdnf --enablerepo value for 3.0

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -25,8 +25,10 @@ TDNF_ARGS=(--releasever=$CONTAINERIZED_RPMBUILD_AZL_VERSION)
 
 # TODO Remove once PMC is available for 3.0
 if [[ $CONTAINERIZED_RPMBUILD_AZL_VERSION == "3.0" ]]; then
-    TDNF_ARGS+=("--disablerepo=*" "--enablerepo=mariner-3.0-daily-build")
-    mv /mariner_setup_dir/mariner-3_repo /etc/yum.repos.d/mariner-3.repo
+    repo_file_src="/mariner_setup_dir/mariner-3_repo"
+    repo_name=$(awk -F'[][]' '/^\[/{print $2}' "${repo_file_src}")
+    TDNF_ARGS+=("--disablerepo=*" "--enablerepo=${repo_name}")
+    mv "${repo_file_src}" /etc/yum.repos.d/mariner-3.repo
 fi
 
 ## Create $SOURCES_DIR


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
A recent rebranding change #8238 changed the repo name used by the `containerized-rpmbuild` container for mariner to `azl-3.0-daily-build`, but didn't change the default `tdnf` argument, which continued to use `mariner-3.0-daily-build`. This results in `tdnf` not working in the container.

This fix updates the `tdnf` argument, basing it on the string in the repo file, so we don't have to copy/paste it later.

###### Change Log  <!-- REQUIRED -->
- Updated the `--enablerepo` flag used by `tdnf` in the `containerized-rpmbuild` environment.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Tested locally