### PR TITLE
remove srpm_pack_list_file

### DIFF
--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Get toolchain spec list
         run: |
-          make -C toolkit toolchain_spec_list
+          toolchain_spec_list=$(make --no-print-directory -sC toolkit printvar-toolchain_spec_list)
 
       - name: Main branch checkout
         uses: actions/checkout@v4
@@ -61,4 +61,4 @@ jobs:
 
       - name: Verify .spec files
         if: ${{ env.updated-specs != '' }}
-        run: python3 toolkit/scripts/check_spec_guidelines.py build/toolchain/toolchain_specs.txt ${{ env.updated-specs }}
+        run: python3 toolkit/scripts/check_spec_guidelines.py toolchain_spec_list ${{ env.updated-specs }}

--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -61,4 +61,4 @@ jobs:
 
       - name: Verify .spec files
         if: ${{ env.updated-specs != '' }}
-        run: python3 toolkit/scripts/check_spec_guidelines.py --toolchain_specs  ${{ env.toolchain-spec-list }} --specs ${{ env.updated-specs }}
+        run: python3 toolkit/scripts/check_spec_guidelines.py --toolchain_specs  "${{ env.toolchain-spec-list }}" --specs ${{ env.updated-specs }}

--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Get toolchain spec list
         run: |
-          toolchain_spec_list=$(make --no-print-directory -sC toolkit printvar-toolchain_spec_list)
+          echo "toolchain-spec-list=$(make --no-print-directory -sC toolkit printvar-toolchain_spec_list)" >> $GITHUB_ENV
 
       - name: Main branch checkout
         uses: actions/checkout@v4
@@ -61,4 +61,4 @@ jobs:
 
       - name: Verify .spec files
         if: ${{ env.updated-specs != '' }}
-        run: python3 toolkit/scripts/check_spec_guidelines.py toolchain_spec_list ${{ env.updated-specs }}
+        run: python3 toolkit/scripts/check_spec_guidelines.py --toolchain_specs  ${{ env.toolchain-spec-list }} --specs ${{ env.updated-specs }}

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -2,7 +2,7 @@
 Summary:        Text editor
 Name:           vim
 Version:        9.0.2190
-Release:        10%{?dist}
+Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -197,9 +197,6 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
-* Wed Mar 20 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 9.0.2190-10
-- Test update release
-
 * Tue Jan 02 2024 Muhammad Falak <mwani@microsoft.com> - 9.0.2190-1
 - Upgrade version to 9.0.2190
 

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -2,7 +2,7 @@
 Summary:        Text editor
 Name:           vim
 Version:        9.0.2190
-Release:        1%{?dist}
+Release:        10%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -197,6 +197,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Wed Mar 20 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 9.0.2190-10
+- Test update release
+
 * Tue Jan 02 2024 Muhammad Falak <mwani@microsoft.com> - 9.0.2190-1
 - Upgrade version to 9.0.2190
 

--- a/toolkit/scripts/check_spec_guidelines.py
+++ b/toolkit/scripts/check_spec_guidelines.py
@@ -180,8 +180,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Tool for checking if an RPM spec file follows Azure Linux's guidelines.")
     parser.add_argument('toolchain_specs',
-                        type=argparse.FileType('r'),
-                        help='Path to a file containing a list of toolchain specs.')
+                        type=str,
+                        help='a list of toolchain specs')
     parser.add_argument('specs',
                         metavar='spec_path',
                         type=argparse.FileType('r'),
@@ -189,7 +189,7 @@ if __name__ == '__main__':
                         help='path to an RPM spec file')
     args = parser.parse_args()
     
-    toolchain_specs = set(args.toolchain_specs.read().splitlines())
+    toolchain_specs = set(args.toolchain_specs.split())
 
     specs_correct = True
     for spec in args.specs:

--- a/toolkit/scripts/check_spec_guidelines.py
+++ b/toolkit/scripts/check_spec_guidelines.py
@@ -179,11 +179,13 @@ def check_spec(spec_path, toolchain_specs):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Tool for checking if an RPM spec file follows Azure Linux's guidelines.")
-    parser.add_argument('toolchain_specs',
-                        type=str,
+    parser.add_argument('--toolchain_specs',
+                        metavar='toolchain_specs',
+                        dest='toolchain_specs',
                         help='a list of toolchain specs')
-    parser.add_argument('specs',
+    parser.add_argument('--specs',
                         metavar='spec_path',
+                        dest='specs',
                         type=argparse.FileType('r'),
                         nargs='+',
                         help='path to an RPM spec file')

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -87,13 +87,12 @@ analyze-built-graph: $(go-graphanalytics)
 	fi
 
 # Parse specs in $(SPECS_DIR) and generate a specs.json file encoding all dependency information
-# We look at the same pack list as the srpmpacker tool via the target $(srpm_pack_list_file), which
-# is build from the contents of $(SRPM_PACK_LIST) if it is set. We only parse the spec files we will
-# actually pack.
-$(specs_file): $(chroot_worker) $(SPECS_DIR) $(build_specs) $(build_spec_dirs) $(go-specreader) $(depend_SPECS_DIR) $(srpm_pack_list_file) $(depend_RUN_CHECK)
+# We look at the same pack list as the srpmpacker tool via the target $(SRPM_PACK_LIST) if it is set.
+# We only parse the spec files we will actually pack.
+$(specs_file): $(chroot_worker) $(SPECS_DIR) $(build_specs) $(build_spec_dirs) $(go-specreader) $(depend_SPECS_DIR) $(depend_SRPM_PACK_LIST) $(depend_RUN_CHECK)
 	$(go-specreader) \
 		--dir $(SPECS_DIR) \
-		$(if $(SRPM_PACK_LIST),--spec-list=$(srpm_pack_list_file)) \
+		$(if $(SRPM_PACK_LIST),--spec-list="$(SRPM_PACK_LIST)") \
 		--build-dir $(parse_working_dir) \
 		--srpm-dir $(BUILD_SRPMS_DIR) \
 		--rpm-dir $(RPMS_DIR) \

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -79,7 +79,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(local_specs) $(local_spec_dirs) $(local_
 $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(STATUS_FLAGS_DIR)/build_srpms.flag
 	@touch $@
 else
-$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmpacker) $(local_spec_sources)
+$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmpacker) $(depend_SRPM_PACK_LIST) $(local_spec_sources)
 	GODEBUG=netdns=go $(go-srpmpacker) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -17,7 +17,6 @@ SRPM_BUILD_CHROOT_DIR = $(BUILD_DIR)/SRPM_packaging
 SRPM_BUILD_LOGS_DIR = $(LOGS_DIR)/pkggen/srpms
 
 toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
-srpm_pack_list_file = $(BUILD_SRPMS_DIR)/pack_list.txt
 
 # Configure the list of packages we want to process into SRPMs
 # Strip any whitespace from user input and reasign using override so we can compare it with the empty string
@@ -25,12 +24,8 @@ override SRPM_PACK_LIST := $(strip $(SRPM_PACK_LIST))
 
 ifneq ($(SRPM_PACK_LIST),) # Pack list has user entries in it, only build selected .spec files
 local_specs = $(wildcard $(addprefix $(SPECS_DIR)/*/,$(addsuffix .spec,$(SRPM_PACK_LIST))))
-$(srpm_pack_list_file): $(depend_SRPM_PACK_LIST)
-	@echo $(SRPM_PACK_LIST) | tr " " "\n" > $(srpm_pack_list_file)
 else # Empty pack list, build all under $(SPECS_DIR)
 local_specs = $(call shell_real_build_only, find $(SPECS_DIR)/ -type f -name '*.spec')
-$(srpm_pack_list_file): $(depend_SRPM_PACK_LIST)
-	@truncate -s 0 $@
 endif
 local_spec_dirs = $(foreach spec,$(local_specs),$(dir $(spec)))
 local_spec_sources = $(call shell_real_build_only, find $(local_spec_dirs) -type f -name '*')
@@ -84,7 +79,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(local_specs) $(local_spec_dirs) $(local_
 $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(STATUS_FLAGS_DIR)/build_srpms.flag
 	@touch $@
 else
-$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmpacker) $(srpm_pack_list_file) $(local_spec_sources)
+$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmpacker) $(local_spec_sources)
 	GODEBUG=netdns=go $(go-srpmpacker) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \
@@ -97,7 +92,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 		--worker-tar=$(chroot_worker) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
-		$(if $(SRPM_PACK_LIST),--pack-list=$(srpm_pack_list_file)) \
+		$(if $(SRPM_PACK_LIST),--pack-list="$(SRPM_PACK_LIST)") \
 		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmpacker.log \
 		--log-level=$(LOG_LEVEL) \
 		--log-color=$(LOG_COLOR) \

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -114,7 +114,7 @@ $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_files) $(go-srpmpack
 		--tls-key=$(TLS_KEY) \
 		--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
-		--pack-list=$(toolchain_spec_list) \
+		--pack-list="$(toolchain_spec_list)" \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/toolchain/srpms/toolchain_srpmpacker.log \
 		--log-level=$(LOG_LEVEL) \

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -16,8 +16,6 @@ SRPM_FILE_SIGNATURE_HANDLING ?= enforce
 SRPM_BUILD_CHROOT_DIR = $(BUILD_DIR)/SRPM_packaging
 SRPM_BUILD_LOGS_DIR = $(LOGS_DIR)/pkggen/srpms
 
-toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
-
 # Configure the list of packages we want to process into SRPMs
 # Strip any whitespace from user input and reasign using override so we can compare it with the empty string
 override SRPM_PACK_LIST := $(strip $(SRPM_PACK_LIST))
@@ -105,7 +103,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		--timestamp-file=$(TIMESTAMP_DIR)/srpm_packer.jsonl && \
 	touch $@
 
-$(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_list) $(go-srpmpacker)
+$(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_files) $(go-srpmpacker)
 	GODEBUG=netdns=go $(go-srpmpacker) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -20,7 +20,6 @@ toolchain_downloads_manifest = $(toolchain_downloads_logs_dir)/download_manifest
 toolchain_log_tail_length = 20
 populated_toolchain_chroot = $(toolchain_build_dir)/populated_toolchain
 populated_toolchain_rpms = $(populated_toolchain_chroot)/usr/src/azl/RPMS
-toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
 toolchain_actual_contents = $(toolchain_build_dir)/actual_archive_contents.txt
 toolchain_expected_contents = $(toolchain_build_dir)/expected_archive_contents.txt
 raw_toolchain = $(toolchain_build_dir)/toolchain_from_container.tar.gz
@@ -28,7 +27,7 @@ final_toolchain = $(toolchain_build_dir)/toolchain_built_rpms_all.tar.gz
 toolchain_files = \
 	$(call shell_real_build_only, find $(SCRIPTS_DIR)/toolchain -name '*.sh') \
 	$(SCRIPTS_DIR)/toolchain/container/Dockerfile
-
+toolchain_spec_list := $(call shell_real_build_only, $(SCRIPTS_DIR)/toolchain/list_toolchain_specs.sh $(SCRIPTS_DIR)/toolchain/build_official_toolchain_rpms.sh)
 TOOLCHAIN_MANIFEST ?= $(TOOLCHAIN_MANIFESTS_DIR)/toolchain_$(build_arch).txt
 # Find the *.rpm corresponding to each of the entries in the manifest
 # regex operation: (.*\.([^\.]+)\.rpm) extracts *.(<arch>).rpm" to determine
@@ -57,8 +56,6 @@ ifeq ($(REBUILD_TOOLCHAIN),y)
 # If we are rebuilding the toolchain, we also expect the built RPMs to end up in out/RPMS
 toolchain: $(toolchain_out_rpms)
 endif
-##help:target:toolchain_spec_list=Generate a file containing a list of toolchain specs.
-toolchain_spec_list: $(toolchain_spec_list)
 
 clean: clean-toolchain
 
@@ -99,7 +96,7 @@ copy-toolchain-rpms:
 
 # check that the manifest files only contain RPMs that could have been generated from toolchain specs.
 check-manifests: check-x86_64-manifests check-aarch64-manifests
-check-aarch64-manifests: $(toolchain_spec_list)
+check-aarch64-manifests: $(toolchain_files)
 	cd $(SCRIPTS_DIR)/toolchain && \
 		./check_manifests.sh \
 			"$(toolchain_spec_list)" \
@@ -108,7 +105,7 @@ check-aarch64-manifests: $(toolchain_spec_list)
 			"$(DIST_TAG)" \
 			"$(DIST_VERSION_MACRO)" \
 			"aarch64"
-check-x86_64-manifests: $(toolchain_spec_list)
+check-x86_64-manifests: $(toolchain_files)
 	cd $(SCRIPTS_DIR)/toolchain && \
 		./check_manifests.sh \
 			"$(toolchain_spec_list)" \
@@ -117,14 +114,6 @@ check-x86_64-manifests: $(toolchain_spec_list)
 			"$(DIST_TAG)" \
 			"$(DIST_VERSION_MACRO)" \
 			"x86_64"
-
-# Generate a list of a specs built as part of the toolchain.
-$(toolchain_spec_list): $(toolchain_files)
-	cd $(SCRIPTS_DIR)/toolchain && \
-		./list_toolchain_specs.sh \
-			$(SCRIPTS_DIR)/toolchain/build_official_toolchain_rpms.sh \
-			$(toolchain_spec_list)
-	@echo "Toolchain spec list created under '$(toolchain_spec_list)'."
 
 # To save toolchain artifacts use compress-toolchain and cache the tarballs
 # To restore toolchain artifacts use hydrate-toolchain and give the location of the tarballs on the command-line

--- a/toolkit/scripts/toolchain/check_manifests.sh
+++ b/toolkit/scripts/toolchain/check_manifests.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-TOOLCHAIN_SPEC_LIST_FILE=$1
+TOOLCHAIN_SPEC_LIST=$1
 SPECS_DIR=$2
 MANIFESTS_DIR=$3
 DIST_TAG=$4
@@ -36,8 +36,7 @@ write_rpms_from_spec () {
 
 write_rpms_from_toolchain () {
     # $1 = file to save to
-    specs=$(cat $TOOLCHAIN_SPEC_LIST_FILE)
-    for specName in $specs
+    for specName in $TOOLCHAIN_SPEC_LIST
     do
         if [[ "$specName" == *"msopenjdk"* ]]; then
             # special case to add msopenjdk-17 which is downloaded and does not have a SPEC

--- a/toolkit/scripts/toolchain/list_toolchain_specs.sh
+++ b/toolkit/scripts/toolchain/list_toolchain_specs.sh
@@ -5,7 +5,6 @@
 set -e
 
 TOOLCHAIN_BUILD_FILE=$1
-OUTPUT_FILE=$2
 
 # Extract the specs built from toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
 # Each spec that is built will be on its own line in the following formats:
@@ -14,9 +13,9 @@ OUTPUT_FILE=$2
 # build_rpm_in_chroot_no_install foo-spec-name qualified-foo-rpm-name
 #
 # In both cases, the first entry is the actual spec name to extract.
-# The below sed command will extract every spec name that follows the above pattern and place it in $OUTPUT_FILE.
+# The below sed command will extract every spec name that follows the above pattern and echo it.
 # `sort -u` is for eliminating duplicates- we don't actually care about the order
-sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' $TOOLCHAIN_BUILD_FILE | sort -u > $OUTPUT_FILE
+sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' $TOOLCHAIN_BUILD_FILE | sort -u
 
 # Special case to add msopenjdk-17 RPM which is downloaded instead of built
-echo "msopenjdk-17" >> $OUTPUT_FILE
+echo "msopenjdk-17"

--- a/toolkit/tools/internal/packlist/packagelist.go
+++ b/toolkit/tools/internal/packlist/packagelist.go
@@ -11,8 +11,8 @@ import (
 
 // ParsePackageList will parse a string of packages.
 // Duplicate entries in the string will be removed.
-// If no/empty string is given, nil will be returned.
-// A map of [package name] -> [true] will be returned.
+// If empty string is given, nil will be returned.
+// Else, a map of [package name] -> [true] will be returned.
 func ParsePackageList(packages string) (packageMap map[string]bool, err error) {
 	timestamp.StartEvent("parse list", nil)
 	defer timestamp.StopEvent(nil)

--- a/toolkit/tools/internal/packlist/packagelist.go
+++ b/toolkit/tools/internal/packlist/packagelist.go
@@ -4,44 +4,29 @@
 package packagelist
 
 import (
-	"bufio"
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/timestamp"
 )
 
-// ParsePackageListFile will parse a list of packages to pack or parse, if one is specified.
-// Duplicate list entries in the file will be removed.
-// If no path is specified, nil will be returned.
-// A set of [package name] -> [true] will be returned.
-func ParsePackageListFile(packageListFile string) (packageList map[string]bool, err error) {
+// ParsePackageList will parse a string of packages.
+// Duplicate entries in the string will be removed.
+// If no/empty string is given, nil will be returned.
+// A map of [package name] -> [true] will be returned.
+func ParsePackageList(packages string) (packageMap map[string]bool, err error) {
 	timestamp.StartEvent("parse list", nil)
 	defer timestamp.StopEvent(nil)
 
-	if packageListFile == "" {
+	if len(strings.TrimSpace(packages)) == 0 {
 		return
 	}
 
-	packageList = make(map[string]bool)
+	packageMap = make(map[string]bool)
+	packageList := strings.Fields(packages)
 
-	file, err := os.Open(packageListFile)
-	if err != nil {
-		return
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" {
-			packageList[line] = true
-		}
-	}
-
-	if len(packageList) == 0 {
-		err = fmt.Errorf("cannot have empty pack list (%s)", packageListFile)
+	for _, pkg := range packageList {
+		pkg = strings.TrimSpace(pkg)
+		packageMap[pkg] = true
 	}
 
 	return

--- a/toolkit/tools/internal/packlist/packagelist.go
+++ b/toolkit/tools/internal/packlist/packagelist.go
@@ -25,7 +25,6 @@ func ParsePackageList(packages string) (packageMap map[string]bool, err error) {
 	packageList := strings.Fields(packages)
 
 	for _, pkg := range packageList {
-		pkg = strings.TrimSpace(pkg)
 		packageMap[pkg] = true
 	}
 

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -27,7 +27,7 @@ const (
 var (
 	app                     = kingpin.New("specreader", "A tool to parse spec dependencies into JSON")
 	specsDir                = exe.InputDirFlag(app, "Directory to scan for SPECS")
-	specListFile            = app.Flag("spec-list", "Path to a list of SPECs to parse. If empty will parse all SPECs.").ExistingFile()
+	specList                = app.Flag("spec-list", "List of SPECs to parse. If empty will parse all SPECs.").Default("").String()
 	output                  = exe.OutputFlag(app, "Output file to export the JSON")
 	workers                 = app.Flag("workers", "Number of concurrent goroutines to parse with").Default(defaultWorkerCount).Int()
 	buildDir                = app.Flag("build-dir", "Directory to store temporary files while parsing.").String()
@@ -67,7 +67,7 @@ func main() {
 
 	// A parse list may be provided, if so only parse this subset.
 	// If none is provided, parse all specs.
-	specListSet, err := packagelist.ParsePackageListFile(*specListFile)
+	specListSet, err := packagelist.ParsePackageList(*specList)
 	logger.PanicOnError(err)
 
 	// Convert specsDir to an absolute path

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -107,7 +107,7 @@ var (
 
 	buildDir     = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
 	distTag      = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()
-	packListFile = app.Flag("pack-list", "Path to a list of SPECs to pack. If empty will pack all SPECs.").ExistingFile()
+	srpmPackList = app.Flag("pack-list", "List of SPECs to pack. If empty will pack all SPECs.").Default("").String()
 	runCheck     = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
 
 	workers          = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Uint()
@@ -185,7 +185,7 @@ func main() {
 
 	// A pack list may be provided, if so only pack this subset.
 	// If non is provided, pack all srpms.
-	packList, err := packagelist.ParsePackageListFile(*packListFile)
+	packList, err := packagelist.ParsePackageList(*srpmPackList)
 	logger.PanicOnError(err)
 
 	err = createAllSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *concurrentNetOps, *nestedSourcesDir, *repackAll, *runCheck, packList, templateSrcConfig)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
remove srpm_pack_list_file

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove srpm_pack_list_file
- Pass SRPM_PACK_LIST to specreader and srpmpacker
- This change will remove the a few file ops, remove unnecessary logic from makefile and thereby make go tools more independent in handling user input

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Locally built packages successfully:
   - without providing SRPM_PACK_LIST in make command : all packages in SPECS_DIR built
   - providing empty SRPM_PACK_LIST `SRPM_PACK_LIST=""` : all packages in SPECS_DIR built
   - providing empty SRPM_PACK_LIST with spaces `SRPM_PACK_LIST="        "` : all packages in SPECS_DIR built
   - providing one package `SRPM_PACK_LIST="vim"` : vim built
   - providing one package with leading/trailing spaces `SRPM_PACK_LIST="   vim   "` : vim built
   - providing multiple packages `SRPM_PACK_LIST="vim cracklib"` : vim and cracklib built
   - providing multiple packages with leading/trailing spaces `SRPM_PACK_LIST="    vim      cracklib    "` : vim and cracklib built
- Testing for pipeline:
   - test commit changed vim.spec and check_specs.yml ran correctly
   - arguments get correctly parsed
   - providing empty string ("") as toolchain_specs also gets parsed correctly
- Testing for toolchain_spec_list:
   - toolchain_spec_list gets populated correctly from Makefile
   - toolchain_spec_list gets parsed correctly in check-*-manifests targets using check_manifests.sh file
- Pipeline build:
   - buddy build successfully built vim https://dev.azure.com/mariner-org/mariner/_build/results?buildId=533637&view=results
   - Full build successful: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=533637&view=results