### PR TITLE
Attempt to use real macros when using rpmops.sh

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -169,11 +169,11 @@ do
   # Removing trailing comments from "Source" tags.
   sed -Ei "s/^(\s*Source[0-9]*:.*)#.*/\1/" "$spec"
 
-  name=$(mariner_rpmspec --srpm --qf "%{NAME}" -q "$spec" 2>/dev/null)
+  name=$(azl_rpmspec --srpm --qf "%{NAME}" -q "$spec" 2>/dev/null)
   if [[ -z $name ]]
   then
     echo "Failed to get name from '$original_spec'. Please update the spec or the macros from the 'defines' variable in this script. Error:" >> bad_registrations.txt
-    mariner_rpmspec --srpm --qf "%{NAME}" -q "$spec" &>> bad_registrations.txt
+    azl_rpmspec --srpm --qf "%{NAME}" -q "$spec" &>> bad_registrations.txt
     continue
   fi
 
@@ -184,15 +184,15 @@ do
     continue
   fi
 
-  version=$(mariner_rpmspec --srpm --qf "%{VERSION}" -q "$spec" 2>/dev/null )
+  version=$(azl_rpmspec --srpm --qf "%{VERSION}" -q "$spec" 2>/dev/null )
   if [[ -z $version ]]
   then
     echo "Failed to get version from '$original_spec'. Please update the spec or the macros from the 'defines' variable in this script. Error:" >> bad_registrations.txt
-    mariner_rpmspec --srpm --qf "%{VERSION}" -q "$spec" &>> bad_registrations.txt
+    azl_rpmspec --srpm --qf "%{VERSION}" -q "$spec" &>> bad_registrations.txt
     continue
   fi
 
-  parsed_spec="$(mariner_rpmspec --parse "$spec" 2>/dev/null)"
+  parsed_spec="$(azl_rpmspec --parse "$spec" 2>/dev/null)"
 
   # Reading the source0 file/URL.
   source0=$(echo "$parsed_spec" | grep -P "^\s*Source0?:" | cut -d: -f2- | xargs)

--- a/SPECS/nano/nano.spec
+++ b/SPECS/nano/nano.spec
@@ -11,9 +11,6 @@ Source0:        http://www.nano-editor.org/dist/v6/%{name}-%{version}.tar.xz
 BuildRequires:  ncurses-devel
 Requires:       ncurses
 
-# TEST UPDATE TO TRIGGER CGMANFIEST PR GATE
-%bcond test 0
-
 %description
 The Nano package contains a small, simple text editor
 

--- a/SPECS/nano/nano.spec
+++ b/SPECS/nano/nano.spec
@@ -12,6 +12,7 @@ BuildRequires:  ncurses-devel
 Requires:       ncurses
 
 # TEST UPDATE TO TRIGGER CGMANFIEST PR GATE
+%bcond test 0
 
 %description
 The Nano package contains a small, simple text editor

--- a/SPECS/nano/nano.spec
+++ b/SPECS/nano/nano.spec
@@ -11,6 +11,8 @@ Source0:        http://www.nano-editor.org/dist/v6/%{name}-%{version}.tar.xz
 BuildRequires:  ncurses-devel
 Requires:       ncurses
 
+# TEST UPDATE TO TRIGGER CGMANFIEST PR GATE
+
 %description
 The Nano package contains a small, simple text editor
 

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -86,7 +86,7 @@ cp "$REPO_ROOT/SPECS/cmake/macros.cmake" "$cmake_macros_file_path"
 sed -i -e "s|@@CMAKE_VERSION@@|$cmake_spec_version|" -e "s|@@CMAKE_MAJOR_VERSION@@|$cmake_spec_major_version|" "$cmake_macros_file_path"
 
 # Add all macro files we know about to the list of macros to load, except cmake where we need to use the custom one.
-for macro_file in $rpm_package_macros_file_path $cmake_macros_file_path $(find ../SPECS/ -name 'macros.*' ! -name 'macros.cmake')
+for macro_file in $rpm_package_macros_file_path $cmake_macros_file_path $(find $REPO_ROOT/SPECS/ -name 'macros.*' ! -name 'macros.cmake')
 do
   MACROS+=("--load=$macro_file")
 done

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -76,7 +76,7 @@ then
     MACROS+=("--macros=''")
 fi
 
-# Add all macro files we know about to the list of macros to load, except cmake where we need to use the custom one.
+# Add all macro files we would have in the chroot.
 for macro_file in $rpm_package_macros_file_path "$SPECS_DIR"/azurelinux-rpm-macros/macros* "$SPECS_DIR"/pyproject-rpm-macros/macros.pyproject "$SPECS_DIR"/perl/macros.perl
 do
   MACROS+=("--load=$macro_file")

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -86,7 +86,7 @@ cp "$REPO_ROOT/SPECS/cmake/macros.cmake" "$cmake_macros_file_path"
 sed -i -e "s|@@CMAKE_VERSION@@|$cmake_spec_version|" -e "s|@@CMAKE_MAJOR_VERSION@@|$cmake_spec_major_version|" "$cmake_macros_file_path"
 
 # Add all macro files we know about to the list of macros to load, except cmake where we need to use the custom one.
-for macro_file in $rpm_package_macros_file_path $cmake_macros_file_path $(find $REPO_ROOT/SPECS/ -name 'macros.*' ! -name 'macros.cmake')
+for macro_file in $rpm_package_macros_file_path $cmake_macros_file_path "$SPECS_DIR"/azurelinux-rpm-macros/macros* "$SPECS_DIR"/pyproject-rpm-macros/macros.pyproject "$SPECS_DIR"/perl/macros.perl
 do
   MACROS+=("--load=$macro_file")
 done

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -76,17 +76,8 @@ then
     MACROS+=("--macros=''")
 fi
 
-# The CMAKE macro is problematic, it needs to be adjusted based on the CMAKE_MAJOR_VERSION variable.
-# This is based on %version from the specfile, so grab that.
-cmake_spec_version=$(rpmspec --query --qf "%{version}" $REPO_ROOT/SPECS/cmake/cmake.spec)
-# Major version is defined via %global major_version #, can't use rpmspec to read that...
-cmake_spec_major_version=$(grep -E '^%global major_version' $REPO_ROOT/SPECS/cmake/cmake.spec | awk '{print $3}')
-cmake_macros_file_path="$RPM_OPS_MACROS_DIRECTORY/macros.cmake$cmake_spec_version"
-cp "$REPO_ROOT/SPECS/cmake/macros.cmake" "$cmake_macros_file_path"
-sed -i -e "s|@@CMAKE_VERSION@@|$cmake_spec_version|" -e "s|@@CMAKE_MAJOR_VERSION@@|$cmake_spec_major_version|" "$cmake_macros_file_path"
-
 # Add all macro files we know about to the list of macros to load, except cmake where we need to use the custom one.
-for macro_file in $rpm_package_macros_file_path $cmake_macros_file_path "$SPECS_DIR"/azurelinux-rpm-macros/macros* "$SPECS_DIR"/pyproject-rpm-macros/macros.pyproject "$SPECS_DIR"/perl/macros.perl
+for macro_file in $rpm_package_macros_file_path "$SPECS_DIR"/azurelinux-rpm-macros/macros* "$SPECS_DIR"/pyproject-rpm-macros/macros.pyproject "$SPECS_DIR"/perl/macros.perl
 do
   MACROS+=("--load=$macro_file")
 done

--- a/toolkit/scripts/specs/specs_tools.sh
+++ b/toolkit/scripts/specs/specs_tools.sh
@@ -119,7 +119,7 @@ parsed_spec_read_tag() {
     spec_path="$1"
     tag="$2"
 
-    mariner_rpmspec --query --queryformat="%{$tag}\n" --srpm "$spec_path" 2>/dev/null
+    azl_rpmspec --query --queryformat="%{$tag}\n" --srpm "$spec_path" 2>/dev/null
 }
 
 parsed_spec_read_tags() {
@@ -131,7 +131,7 @@ parsed_spec_read_tags() {
     tag="$2"
     results_array="$3"
 
-    for result in $(mariner_rpmspec --query --queryformat="[%{$tag}\n]" --srpm "$spec_path" 2>/dev/null | tac)
+    for result in $(azl_rpmspec --query --queryformat="[%{$tag}\n]" --srpm "$spec_path" 2>/dev/null | tac)
     do
         results_array+=("$result")
     done
@@ -144,7 +144,7 @@ spec_query_srpm() {
     spec_path="$1"
     query_format="$2"
 
-    mariner_rpmspec -q --queryformat="$query_format" --srpm "$spec_path" 2>/dev/null
+    azl_rpmspec -q --queryformat="$query_format" --srpm "$spec_path" 2>/dev/null
 }
 
 spec_read_release_number() {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`rpmops.sh` is a bash script that can be sourced (`source ./toolkit/scripts/rpmops.sh`) and will provide 'mariner' versions of rpmspec (and now rpm). This is done by using the macro files from the git repo instead of the defaults found in the `rpm` tool.

*There is a limitation:* The macros built into `rpm-libs` aren't easily available, so we try to grab a copy from PMC. This means that if the `rpm` package itself is updated in a way that changes the macros the PR checks will use the previously released version. Once the PR is merged they PR checks will revert to the built-in macros until a build publishes the new version of `rpm-libs`.

This is a follow on fix for ~#7493~ / #7560

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use updated macros in `rpmops.sh`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/DefaultCollection/OS/_queries/edit/48574344

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- `DAILY_BUILD_ID=3-0-20240310 source ./toolkit/scripts/rpmops.sh`, record the location of the temp copy of the macros file (~`/tmp/tmp.TAa3kVQHtS/ce8874b8e732f08f0300fa4642afb552fe9250d17588f4b19bff42caf7d6bc4d`)
- `azl_rpm --eval '%{test_macro}'` "%{test_macro}"
- Edit the temp macro file to add `%test_macro its working`
- `azl_rpm --eval '%{test_macro}'` "its working"

- [Also ran the PR gates with an updated `nano.spec`, all gates passed.](https://github.com/microsoft/azurelinux/actions/runs/8331785755/job/22799422146?pr=8425#step:7:10)
