### PR TITLE
fix: Make tools install /etc/default/grub with 0644 perms

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -78,6 +78,9 @@ const (
 	// /boot directory should be only accesible by root. The directories need the execute bit as well.
 	bootDirectoryFileMode = 0400
 	bootDirectoryDirMode  = 0700
+
+	// Configuration files related to boot behavior. Users should be able to read these files, and root should have RW access.
+	bootUsrConfigFileMode = 0644
 )
 
 // PackageList represents the list of packages to install into an image
@@ -1166,7 +1169,7 @@ func installGrubTemplateFile(assetFile, targetFile, installRoot, rootDevice, boo
 	installGrubDefFile := filepath.Join(installRoot, targetFile)
 
 	err = file.CopyResourceFile(resources.ResourcesFS, assetFile, installGrubDefFile, bootDirectoryDirMode,
-		bootDirectoryFileMode)
+		bootUsrConfigFileMode)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Make the tools install /etc/default/grub with 0644 perms.

Justification: 0400 forces normal users to escalate privilege simply to read files. Furthermore, 0400 never made much sense for me even for the /boot/grub2/grub.cfg. Not having write permissions for root is a little silly; surely at least root must be able to edit the configuration? 644 makes it so that everyone can read the boot configuration and must escalate to root in order to edit it.

/boot dir is 0700 so the 0400 in /boot/grub2/grub.cfg is redundant as far as groups,others is concerned and only narrows the scope of what root can do in there. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Install /etc/default/grub (and other grub configuration files) with 0644 permissions

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #8429

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build.
