### PR TITLE
Image Customizer: CODEOWNERS for osmodifier tool.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,4 +90,6 @@
 # Image Customizer
 /toolkit/tools/imagecustomizer/ @microsoft/cbl-mariner-imagecustomizer
 /toolkit/tools/imagecustomizerapi/ @microsoft/cbl-mariner-imagecustomizer
+/toolkit/tools/osmodifier @microsoft/cbl-mariner-imagecustomizer
 /toolkit/tools/pkg/imagecustomizerlib/ @microsoft/cbl-mariner-imagecustomizer
+/toolkit/tools/pkg/osmodifierlib @microsoft/cbl-mariner-imagecustomizer


### PR DESCRIPTION
Set cbl-mariner-imagecustomizer team as the owner of the osmodifier tool's directories.