### PR TITLE
filesystem: fix nobody GID

### DIFF
--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -1,7 +1,7 @@
 Summary:      Default file system
 Name:         filesystem
 Version:      1.1
-Release:      19%{?dist}
+Release:      20%{?dist}
 License:      GPLv3
 Group:        System Environment/Base
 Vendor:       Microsoft Corporation
@@ -91,7 +91,7 @@ systemd-resolve:x:77:77:systemd Resolver:/:/bin/false
 systemd-timesync:x:78:78:systemd Time Synchronization:/:/bin/false
 systemd-coredump:x:79:79:systemd Core Dumper:/:/usr/bin/false
 systemd-oom:x:80:80:systemd Userspace OOM Killer:/:/usr/bin/false
-nobody:x:65534:65533:Unprivileged User:/dev/null:/bin/false
+nobody:x:65534:65534:Unprivileged User:/dev/null:/bin/false
 EOF
 cat > %{buildroot}/etc/group <<- "EOF"
 root:x:0:
@@ -129,6 +129,7 @@ systemd-timesync:x:78:
 systemd-coredump:x:79:
 systemd-oom:x:80:
 nogroup:x:65533:
+nobody:x:65534:
 users:x:100:
 sudo:x:27:
 wheel:x:28:
@@ -710,6 +711,9 @@ return 0
 %config(noreplace) /etc/modprobe.d/tipc.conf
 
 %changelog
+* Tue Mar 19 2024 Dan Streetman <ddstreet@microsoft.com> - 1.1-20
+- fix nobody uid:gid and nogroup/nobody groups
+
 * Wed Feb 28 2024 Dan Streetman <ddstreet@microsoft.com> - 1.1-19
 - fix /etc/hosts
 - add /etc/host.conf to enable multi

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-19.azl3.aarch64.rpm
+filesystem-1.1-20.azl3.aarch64.rpm
 kernel-headers-6.6.14.1-4.azl3.noarch.rpm
 glibc-2.38-3.azl3.aarch64.rpm
 glibc-devel-2.38-3.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-19.azl3.x86_64.rpm
+filesystem-1.1-20.azl3.x86_64.rpm
 kernel-headers-6.6.14.1-4.azl3.noarch.rpm
 glibc-2.38-3.azl3.x86_64.rpm
 glibc-devel-2.38-3.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -96,8 +96,8 @@ file-5.45-1.azl3.aarch64.rpm
 file-debuginfo-5.45-1.azl3.aarch64.rpm
 file-devel-5.45-1.azl3.aarch64.rpm
 file-libs-5.45-1.azl3.aarch64.rpm
-filesystem-1.1-19.azl3.aarch64.rpm
-filesystem-asc-1.1-19.azl3.aarch64.rpm
+filesystem-1.1-20.azl3.aarch64.rpm
+filesystem-asc-1.1-20.azl3.aarch64.rpm
 findutils-4.9.0-1.azl3.aarch64.rpm
 findutils-debuginfo-4.9.0-1.azl3.aarch64.rpm
 findutils-lang-4.9.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -99,8 +99,8 @@ file-5.45-1.azl3.x86_64.rpm
 file-debuginfo-5.45-1.azl3.x86_64.rpm
 file-devel-5.45-1.azl3.x86_64.rpm
 file-libs-5.45-1.azl3.x86_64.rpm
-filesystem-1.1-19.azl3.x86_64.rpm
-filesystem-asc-1.1-19.azl3.x86_64.rpm
+filesystem-1.1-20.azl3.x86_64.rpm
+filesystem-asc-1.1-20.azl3.x86_64.rpm
 findutils-4.9.0-1.azl3.x86_64.rpm
 findutils-debuginfo-4.9.0-1.azl3.x86_64.rpm
 findutils-lang-4.9.0-1.azl3.x86_64.rpm


### PR DESCRIPTION
The 'nogroup' group has differing implementations across major distros:

Ubuntu:        'nogroup' GID 65534
Fedora/RHEL:   'nobody'  GID 65534
OpenSUSE/SLES: 'nobody'  GID 65534 *and* 'nogroup' GID 65533

However, *all* distros provide the 'nobody' user with *both* UID and GID 65534.

This brings our group settings in line with OpenSUSE/SLES (providing *both* 'nogroup' and 'nobody' groups), and brings our 'nobody' user settings in line with *all* other distros (uid:gid of 65534:65534).
