### PR TITLE
toolkit: remove cmdline parameter to disable plymouth

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -148,7 +148,7 @@ echo "initrd of kernel %{uname_r} removed" >&2
 * Tue Mar 19 2024 Dan Streetman <ddstreet@microsoft.com> - 6.6.14.1-5
 - remove unnecessary 10_kernel.cfg grub config file
 
-* Wed Mar 06 2024 Chris Gunn <chrisgun@microsoft.com> - 6.6.7.1-4
+* Wed Mar 06 2024 Chris Gunn <chrisgun@microsoft.com> - 6.6.14.1-4
 - Remove /var/lib/initramfs/kernel files.
 
 * Fri Feb 23 2024 Chris Gunn <chrisgun@microsoft.com> - 6.6.14.1-3

--- a/toolkit/tools/internal/resources/assets/grub2/grub
+++ b/toolkit/tools/internal/resources/assets/grub2/grub
@@ -2,7 +2,7 @@ GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR="AzureLinux"
 GRUB_DISABLE_SUBMENU=y
 GRUB_TERMINAL_OUTPUT="console"
-GRUB_CMDLINE_LINUX="{{.LuksUUID}} {{.LVM}} {{.IMAPolicy}} {{.ReadOnlyVerityRoot}} {{.SELinux}} {{.FIPS}} rd.auto=1 net.ifnames=0 plymouth.enable=0 lockdown=integrity {{.CGroup}}"
+GRUB_CMDLINE_LINUX="{{.LuksUUID}} {{.LVM}} {{.IMAPolicy}} {{.ReadOnlyVerityRoot}} {{.SELinux}} {{.FIPS}} rd.auto=1 net.ifnames=0 lockdown=integrity {{.CGroup}}"
 GRUB_CMDLINE_LINUX_DEFAULT="{{.ExtraCommandLine}} $kernelopts"
     
 # =============================notice===============================


### PR DESCRIPTION
We don't even provide plymouth, we don't need a cmdline parameter to 'disable' it.
