### PR TITLE
Image Customizer: Move selinuxMode into its own struct.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/kernelcommandline.go
+++ b/toolkit/tools/imagecustomizerapi/kernelcommandline.go
@@ -4,19 +4,12 @@
 package imagecustomizerapi
 
 type KernelCommandLine struct {
-	// SELinux specifies whether or not to enable SELinux on the image (and what mode SELinux should be in).
-	SELinuxMode SELinuxMode `yaml:"selinuxMode"`
 	// Extra kernel command line args.
 	ExtraCommandLine KernelExtraArguments `yaml:"extraCommandLine"`
 }
 
 func (s *KernelCommandLine) IsValid() error {
-	err := s.SELinuxMode.IsValid()
-	if err != nil {
-		return err
-	}
-
-	err = s.ExtraCommandLine.IsValid()
+	err := s.ExtraCommandLine.IsValid()
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/imagecustomizerapi/os.go
+++ b/toolkit/tools/imagecustomizerapi/os.go
@@ -16,6 +16,7 @@ type OS struct {
 	ResetBootLoaderType  ResetBootLoaderType `yaml:"resetBootLoaderType"`
 	Hostname             string              `yaml:"hostname"`
 	Packages             Packages            `yaml:"packages"`
+	SELinux              SELinux             `yaml:"selinux"`
 	KernelCommandLine    KernelCommandLine   `yaml:"kernelCommandLine"`
 	AdditionalFiles      AdditionalFilesMap  `yaml:"additionalFiles"`
 	PartitionSettings    []PartitionSetting  `yaml:"partitionSettings"`
@@ -47,14 +48,19 @@ func (s *OS) IsValid() error {
 		}
 	}
 
+	err = s.SELinux.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid selinux:\n%w", err)
+	}
+
 	err = s.KernelCommandLine.IsValid()
 	if err != nil {
-		return fmt.Errorf("invalid KernelCommandLine: %w", err)
+		return fmt.Errorf("invalid kernelCommandLine: %w", err)
 	}
 
 	err = s.AdditionalFiles.IsValid()
 	if err != nil {
-		return fmt.Errorf("invalid AdditionalFiles: %w", err)
+		return fmt.Errorf("invalid additionalFiles: %w", err)
 	}
 
 	partitionIDSet := make(map[string]bool)

--- a/toolkit/tools/imagecustomizerapi/selinux.go
+++ b/toolkit/tools/imagecustomizerapi/selinux.go
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type SELinux struct {
+	// SELinux specifies whether or not to enable SELinux on the image (and what mode SELinux should be in).
+	Mode SELinuxMode `yaml:"mode"`
+}
+
+func (s *SELinux) IsValid() error {
+	err := s.Mode.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid mode:\n%w", err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -91,7 +91,7 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = handleSELinux(config.OS.KernelCommandLine.SELinuxMode, config.OS.ResetBootLoaderType,
+	err = handleSELinux(config.OS.SELinux.Mode, config.OS.ResetBootLoaderType,
 		imageChroot)
 	if err != nil {
 		return err
@@ -417,7 +417,7 @@ func handleBootLoader(baseConfigPath string, config *imagecustomizerapi.Config, 
 	case imagecustomizerapi.ResetBootLoaderTypeHard:
 		// Hard-reset the grub config.
 		err := configureDiskBootLoader(imageConnection, config.OS.PartitionSettings,
-			config.OS.BootType, config.OS.KernelCommandLine, currentSelinuxMode)
+			config.OS.BootType, config.OS.SELinux, config.OS.KernelCommandLine, currentSelinuxMode)
 		if err != nil {
 			return fmt.Errorf("failed to configure bootloader:\n%w", err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -250,23 +250,11 @@ func validateIsoConfig(baseConfigPath string, config *imagecustomizerapi.Iso) er
 		return nil
 	}
 
-	err := validateIsoKernelCommandline(config.KernelCommandLine)
+	err := validateAdditionalFiles(baseConfigPath, config.AdditionalFiles)
 	if err != nil {
 		return err
 	}
 
-	err = validateAdditionalFiles(baseConfigPath, config.AdditionalFiles)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateIsoKernelCommandline(kernelCommandLine imagecustomizerapi.KernelCommandLine) error {
-	if kernelCommandLine.SELinuxMode != imagecustomizerapi.SELinuxModeDefault {
-		return fmt.Errorf("unsupported SELinux configuration for the output ISO image.")
-	}
 	return nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -318,7 +318,7 @@ func createFakeEfiImage(buildDir string) (string, error) {
 		return nil
 	}
 
-	err = createNewImageWithBootLoader(rawDisk, diskConfig, partitionSettings, "efi",
+	err = createNewImageWithBootLoader(rawDisk, diskConfig, partitionSettings, "efi", imagecustomizerapi.SELinux{},
 		imagecustomizerapi.KernelCommandLine{}, buildDir, testImageRootDirName, imagecustomizerapi.SELinuxModeDisabled,
 		installOS)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -81,8 +81,8 @@ func createNewImage(filename string, diskConfig imagecustomizerapi.Disk,
 
 func createNewImageWithBootLoader(filename string, diskConfig imagecustomizerapi.Disk,
 	partitionSettings []imagecustomizerapi.PartitionSetting, bootType imagecustomizerapi.BootType,
-	kernelCommandLine imagecustomizerapi.KernelCommandLine, buildDir string, chrootDirName string,
-	currentSELinuxMode imagecustomizerapi.SELinuxMode, installOS installOSFunc,
+	selinuxConfig imagecustomizerapi.SELinux, kernelCommandLine imagecustomizerapi.KernelCommandLine, buildDir string,
+	chrootDirName string, currentSELinuxMode imagecustomizerapi.SELinuxMode, installOS installOSFunc,
 ) error {
 	imageConnection := NewImageConnection()
 	defer imageConnection.Close()
@@ -93,7 +93,8 @@ func createNewImageWithBootLoader(filename string, diskConfig imagecustomizerapi
 		return fmt.Errorf("failed to create new image:\n%w", err)
 	}
 
-	err = configureDiskBootLoader(imageConnection, partitionSettings, bootType, kernelCommandLine, currentSELinuxMode)
+	err = configureDiskBootLoader(imageConnection, partitionSettings, bootType, selinuxConfig, kernelCommandLine,
+		currentSELinuxMode)
 	if err != nil {
 		return fmt.Errorf("failed to add bootloader to new image:\n%w", err)
 	}
@@ -148,15 +149,15 @@ func createNewImageHelper(imageConnection *ImageConnection, filename string, dis
 }
 
 func configureDiskBootLoader(imageConnection *ImageConnection, partitionSettings []imagecustomizerapi.PartitionSetting,
-	bootType imagecustomizerapi.BootType, kernelCommandLine imagecustomizerapi.KernelCommandLine,
-	currentSELinuxMode imagecustomizerapi.SELinuxMode,
+	bootType imagecustomizerapi.BootType, selinuxConfig imagecustomizerapi.SELinux,
+	kernelCommandLine imagecustomizerapi.KernelCommandLine, currentSELinuxMode imagecustomizerapi.SELinuxMode,
 ) error {
 	imagerBootType, err := bootTypeToImager(bootType)
 	if err != nil {
 		return err
 	}
 
-	imagerKernelCommandLine, err := kernelCommandLineToImager(kernelCommandLine, currentSELinuxMode)
+	imagerKernelCommandLine, err := kernelCommandLineToImager(kernelCommandLine, selinuxConfig, currentSELinuxMode)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
@@ -43,4 +43,3 @@ os:
 
   kernelCommandLine:
     extraCommandLine: console=tty0 console=ttyS0
-    selinux: disabled

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-disabled.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-disabled.yaml
@@ -1,3 +1,3 @@
 os:
-  kernelCommandLine:
-    selinuxMode: disabled
+  selinux:
+    mode: disabled

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-enforcing.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-enforcing.yaml
@@ -1,6 +1,6 @@
 os:
-  kernelCommandLine:
-    selinuxMode: enforcing
+  selinux:
+    mode: enforcing
 
   packages:
     install:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-force-enforcing.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-force-enforcing.yaml
@@ -1,6 +1,6 @@
 os:
-  kernelCommandLine:
-    selinuxMode: force-enforcing
+  selinux:
+    mode: force-enforcing
 
   packages:
     install:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-permissive.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-permissive.yaml
@@ -1,6 +1,6 @@
 os:
-  kernelCommandLine:
-    selinuxMode: permissive
+  selinux:
+    mode: permissive
 
   packages:
     install:

--- a/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
@@ -163,9 +163,10 @@ func mountIdentifierTypeToImager(mountIdentifierType imagecustomizerapi.MountIde
 }
 
 func kernelCommandLineToImager(kernelCommandLine imagecustomizerapi.KernelCommandLine,
+	selinuxConfig imagecustomizerapi.SELinux,
 	currentSELinuxMode imagecustomizerapi.SELinuxMode,
 ) (configuration.KernelCommandLine, error) {
-	imagerSELinuxMode, err := selinuxModeMaybeDefaultToImager(kernelCommandLine.SELinuxMode, currentSELinuxMode)
+	imagerSELinuxMode, err := selinuxModeMaybeDefaultToImager(selinuxConfig.Mode, currentSELinuxMode)
 	if err != nil {
 		return configuration.KernelCommandLine{}, err
 	}


### PR DESCRIPTION
Move the `selinuxMode` property from the `kernelCommandLine` property into a dedicated `selinux` property. While SELinux can impact the kernel command-line, it is its own feature and therefore should be separate.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

