### PR TITLE
coreutils: fix serial-console.sh

### DIFF
--- a/SPECS/coreutils/coreutils.signatures.json
+++ b/SPECS/coreutils/coreutils.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "coreutils-9.4.tar.xz": "ea613a4cf44612326e917201bbbcdfbd301de21ffc3b59b6e5c07e040b275e52",
-  "serial-console.sh": "db2621379157587cd5ed83be09be7f3a19d2bcbc5509088ed49cc4579f0cebdf"
+  "serial-console.sh": "3941d395d29068e63b066128403825b607ec4e771be7f65e37af374a5e783a54"
  }
 }

--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:        Basic system utilities
 Name:           coreutils
 Version:        9.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -91,6 +91,9 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
+* Wed Mar 20 2024 Dan Streetman <ddstreet@microsoft.com> - 9.4-2
+- fix serial-console.sh
+
 * Fri Jan 26 2024 Andrew Phelps <anphel@microsoft.com> - 9.4-1
 - Upgrade to version 9.4
 

--- a/SPECS/coreutils/serial-console.sh
+++ b/SPECS/coreutils/serial-console.sh
@@ -2,32 +2,40 @@
 # Copyright (C) 2018 VMware Inc.
 # Author: Alexey Makhalov <amakhalov@vmware.com>
 #
-# Expand screen terminal to the full screen mode.
-# Known side effect: screen might be "garbaged" by reply string.
-
-full_screen () {
-	if [[ -t 0 ]] && [[ -t 1 ]]; then
-		# s - save cursor position
-		# [r;cH - set cursor position to r;c
-		# [6n - get cursor position
-		# u - restore cursor position
-		#
-		# reply from terminal: [r;cR
-		echo -ne '\es\e[999;999H\e[6n\eu'
-		read -sd '['
-		read -sd ';' rows
-		read -sd 'R' cols
-		if [[ "$( stty size )" != "${rows} ${cols}" ]] ; then
-			stty rows ${rows} cols ${cols}
-		fi
-	fi
-}
-
+# Copyright (C) 2024 Microsoft Corporation
+# Author: Dan Streetman <ddstreet@microsoft.com>
+#
+# Correctly set tty rows/cols for serial ports where the kernel does
+# not support NAWS. This is a simpler version of what the xterm-based
+# 'resize' program does. If the serial port client terminal window is
+# resized, this (or the 'resize' command) will need to be re-run.
+#
 
 case $( tty ) in
-	/dev/ttyS*|/dev/ttyUSB*|/dev/ttyAMA*|/dev/ttyXRUSB*)
-		export TERM=screen
-		full_screen
-		;;
+    /dev/ttyS*|/dev/ttyUSB*|/dev/ttyAMA*|/dev/ttyXRUSB*)
+        # This will only work if both stdin and stdout are opened on a terminal
+        [[ -t 0 && -t 1 ]] || break
+
+        # terminfo 'save cursor'
+        tput sc
+
+        # set cursor pos to (0-based) row,col
+        tput cup 998 998
+
+        # Cursor Position Request (CPR)
+        echo -ne '\e[6n'
+
+        # read CPR (format is: '\e[' rows ';' cols 'R')
+        read -sd '['
+        read -sd ';' rows
+        read -sd 'R' cols
+
+        # terminfo 'restore cursor'
+        tput rc
+
+        if [[ "$( stty size )" != "${rows} ${cols}" ]]; then
+            stty rows ${rows} cols ${cols}
+        fi
+        ;;
 esac
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.4-2.azl3.aarch64.rpm
 ncurses-term-6.4-2.azl3.aarch64.rpm
 readline-8.2-1.azl3.aarch64.rpm
 readline-devel-8.2-1.azl3.aarch64.rpm
-coreutils-9.4-1.azl3.aarch64.rpm
-coreutils-lang-9.4-1.azl3.aarch64.rpm
+coreutils-9.4-2.azl3.aarch64.rpm
+coreutils-lang-9.4-2.azl3.aarch64.rpm
 bash-5.2.15-1.azl3.aarch64.rpm
 bash-devel-5.2.15-1.azl3.aarch64.rpm
 bash-lang-5.2.15-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.4-2.azl3.x86_64.rpm
 ncurses-term-6.4-2.azl3.x86_64.rpm
 readline-8.2-1.azl3.x86_64.rpm
 readline-devel-8.2-1.azl3.x86_64.rpm
-coreutils-9.4-1.azl3.x86_64.rpm
-coreutils-lang-9.4-1.azl3.x86_64.rpm
+coreutils-9.4-2.azl3.x86_64.rpm
+coreutils-lang-9.4-2.azl3.x86_64.rpm
 bash-5.2.15-1.azl3.x86_64.rpm
 bash-devel-5.2.15-1.azl3.x86_64.rpm
 bash-lang-5.2.15-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -47,9 +47,9 @@ chkconfig-debuginfo-1.25-1.azl3.aarch64.rpm
 chkconfig-lang-1.25-1.azl3.aarch64.rpm
 cmake-3.28.2-1.azl3.aarch64.rpm
 cmake-debuginfo-3.28.2-1.azl3.aarch64.rpm
-coreutils-9.4-1.azl3.aarch64.rpm
-coreutils-debuginfo-9.4-1.azl3.aarch64.rpm
-coreutils-lang-9.4-1.azl3.aarch64.rpm
+coreutils-9.4-2.azl3.aarch64.rpm
+coreutils-debuginfo-9.4-2.azl3.aarch64.rpm
+coreutils-lang-9.4-2.azl3.aarch64.rpm
 cpio-2.14-1.azl3.aarch64.rpm
 cpio-debuginfo-2.14-1.azl3.aarch64.rpm
 cpio-lang-2.14-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -48,9 +48,9 @@ chkconfig-debuginfo-1.25-1.azl3.x86_64.rpm
 chkconfig-lang-1.25-1.azl3.x86_64.rpm
 cmake-3.28.2-1.azl3.x86_64.rpm
 cmake-debuginfo-3.28.2-1.azl3.x86_64.rpm
-coreutils-9.4-1.azl3.x86_64.rpm
-coreutils-debuginfo-9.4-1.azl3.x86_64.rpm
-coreutils-lang-9.4-1.azl3.x86_64.rpm
+coreutils-9.4-2.azl3.x86_64.rpm
+coreutils-debuginfo-9.4-2.azl3.x86_64.rpm
+coreutils-lang-9.4-2.azl3.x86_64.rpm
 cpio-2.14-1.azl3.x86_64.rpm
 cpio-debuginfo-2.14-1.azl3.x86_64.rpm
 cpio-lang-2.14-1.azl3.x86_64.rpm


### PR DESCRIPTION
This script was not correctly saving/restoring the cursor position, resulting in the first letter of the login prompt starting at the screen bottom right position immediately on login (only to a serial console).

Also, this should not be setting TERM to 'screen'.
