### PR TITLE
systemd: require our "bootstrap" macros when building

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        8%{?dist}
+Release:        9%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -143,6 +143,8 @@ BuildRequires:  p11-kit-devel
 BuildRequires:  polkit-devel
 # This is required for /etc/os-release, as the systemd uses this during src/boot/efi build
 BuildRequires:  azurelinux-release
+# This is required because...toolkit
+BuildRequires:  systemd-bootstrap-rpm-macros
 
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
@@ -1187,6 +1189,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Wed Mar 20 2024 Dan Streetman <ddstreet@microsoft.com> - 255-9
+- build dep the "bootstrap" macros because our maint scripts are broken without
+  our rpm macros available during the build
+
 * Mon Mar 11 2024 Daniel McIlvaney <damcilva@microsoft.com> - 255-8
 - Obsolete the new systemd-bootstrap-libs subpacakge.
 


### PR DESCRIPTION
Currently, our systemd maintainer scripts are all broken, because the systemd rpm macros aren't available during the systemd build.

This results in all the systemd packages having the actual macros in the maint scripts, e.g.:

```
$ rpm -q --scripts systemd-udev | grep '%systemd'
%systemd_post systemd-udev{d,-settle,-trigger}.service systemd-udevd-{control,kernel}.socket systemd-homed.service systemd-boot-update.service systemd-oomd.service systemd-portabled.service systemd-pstore.service systemd-timesyncd.service remote-cryptsetup.target
%systemd_preun systemd-udev{d,-settle,-trigger}.service systemd-udevd-{control,kernel}.socket systemd-homed.service systemd-boot-update.service systemd-oomd.service systemd-portabled.service systemd-pstore.service systemd-timesyncd.service remote-cryptsetup.target
%systemd_postun_with_restart systemd-udevd.service systemd-timesyncd.service

```

That of course results in errors when installing/removing/upgrading any of the systemd packages that contain maint scripts that reference any of the missing macros.