### PR TITLE
filesystem: remove /srv and /var/srv

### DIFF
--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -1,7 +1,7 @@
 Summary:      Default file system
 Name:         filesystem
 Version:      1.1
-Release:      20%{?dist}
+Release:      21%{?dist}
 License:      GPLv3
 Group:        System Environment/Base
 Vendor:       Microsoft Corporation
@@ -58,9 +58,8 @@ ln -svfn ../lib %{buildroot}/usr/lib/debug/usr/lib
         ln -svfn ../lib %{buildroot}/usr/lib/debug/usr/lib64
         ln -svfn ../.dwz %{buildroot}/usr/lib/debug/usr/.dwz
 
-install -vdm 755 %{buildroot}/var/{log,mail,spool,mnt,srv}
+install -vdm 755 %{buildroot}/var/{log,mail,spool,mnt}
 
-ln -svfn var/srv %{buildroot}/srv
 ln -svfn ../run %{buildroot}/var/run
 ln -svfn ../run/lock %{buildroot}/var/lock
 install -vdm 755 %{buildroot}/var/{opt,cache,lib/{color,misc,locate},local}
@@ -576,7 +575,6 @@ return 0
 %dir /root
 %dir /run
 /sbin
-/srv
 %ghost %attr(555,root,root) /sys
 %dir /tmp
 %dir /usr
@@ -683,7 +681,6 @@ return 0
 %dir /var/log
 %dir /var/mail
 %dir /var/mnt
-%dir /var/srv
 %dir /var/opt
 %dir /var/spool
 %dir /var/tmp
@@ -711,6 +708,9 @@ return 0
 %config(noreplace) /etc/modprobe.d/tipc.conf
 
 %changelog
+* Wed Mar 20 2024 Dan Streetman <ddstreet@microsoft.com> - 1.1-21
+- remove /srv and /var/srv
+
 * Tue Mar 19 2024 Dan Streetman <ddstreet@microsoft.com> - 1.1-20
 - fix nobody uid:gid and nogroup/nobody groups
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-20.azl3.aarch64.rpm
+filesystem-1.1-21.azl3.aarch64.rpm
 kernel-headers-6.6.14.1-5.azl3.noarch.rpm
 glibc-2.38-3.azl3.aarch64.rpm
 glibc-devel-2.38-3.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-20.azl3.x86_64.rpm
+filesystem-1.1-21.azl3.x86_64.rpm
 kernel-headers-6.6.14.1-5.azl3.noarch.rpm
 glibc-2.38-3.azl3.x86_64.rpm
 glibc-devel-2.38-3.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -96,8 +96,8 @@ file-5.45-1.azl3.aarch64.rpm
 file-debuginfo-5.45-1.azl3.aarch64.rpm
 file-devel-5.45-1.azl3.aarch64.rpm
 file-libs-5.45-1.azl3.aarch64.rpm
-filesystem-1.1-20.azl3.aarch64.rpm
-filesystem-asc-1.1-20.azl3.aarch64.rpm
+filesystem-1.1-21.azl3.aarch64.rpm
+filesystem-asc-1.1-21.azl3.aarch64.rpm
 findutils-4.9.0-1.azl3.aarch64.rpm
 findutils-debuginfo-4.9.0-1.azl3.aarch64.rpm
 findutils-lang-4.9.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -99,8 +99,8 @@ file-5.45-1.azl3.x86_64.rpm
 file-debuginfo-5.45-1.azl3.x86_64.rpm
 file-devel-5.45-1.azl3.x86_64.rpm
 file-libs-5.45-1.azl3.x86_64.rpm
-filesystem-1.1-20.azl3.x86_64.rpm
-filesystem-asc-1.1-20.azl3.x86_64.rpm
+filesystem-1.1-21.azl3.x86_64.rpm
+filesystem-asc-1.1-21.azl3.x86_64.rpm
 findutils-4.9.0-1.azl3.x86_64.rpm
 findutils-debuginfo-4.9.0-1.azl3.x86_64.rpm
 findutils-lang-4.9.0-1.azl3.x86_64.rpm


### PR DESCRIPTION
The /srv dir is provided via systemd tmpfiles.d configuration

