### PR TITLE
Update format idtype function.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -214,7 +214,7 @@ func idToPartitionBlockDevicePath(idType imagecustomizerapi.IdType, id string, n
 func systemdFormatPartitionId(idType imagecustomizerapi.IdType, id string) (string, error) {
 	switch idType {
 	case imagecustomizerapi.IdTypePartLabel, imagecustomizerapi.IdTypeUuid, imagecustomizerapi.IdTypePartUuid:
-		return fmt.Sprintf("%s=%s", strings.ToUpper(string(idType)), id), nil
+		return fmt.Sprintf("%s=%s", strings.ToUpper(strings.ReplaceAll(string(idType), "-", "")), id), nil
 	default:
 		return "", fmt.Errorf("invalid idType provided (%s)", string(idType))
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -213,8 +213,12 @@ func idToPartitionBlockDevicePath(idType imagecustomizerapi.IdType, id string, n
 // systemdFormatPartitionId formats the partition ID based on the ID type following systemd dm-verity style.
 func systemdFormatPartitionId(idType imagecustomizerapi.IdType, id string) (string, error) {
 	switch idType {
-	case imagecustomizerapi.IdTypePartLabel, imagecustomizerapi.IdTypeUuid, imagecustomizerapi.IdTypePartUuid:
-		return fmt.Sprintf("%s=%s", strings.ToUpper(strings.ReplaceAll(string(idType), "-", "")), id), nil
+	case imagecustomizerapi.IdTypePartLabel:
+		return fmt.Sprintf("%s=%s", "PARTLABEL", id), nil
+	case imagecustomizerapi.IdTypeUuid:
+		return fmt.Sprintf("%s=%s", "UUID", id), nil
+	case imagecustomizerapi.IdTypePartUuid:
+		return fmt.Sprintf("%s=%s", "PARTUUID", id), nil
 	default:
 		return "", fmt.Errorf("invalid idType provided (%s)", string(idType))
 	}


### PR DESCRIPTION
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Since the idtype has changed including `-`, update format logic for verity / overlay.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
