### PR TITLE
Remove set -ex from the overlay script.

### DIFF
--- a/SPECS/dracut/20overlayfs/overlayfs-mount.sh
+++ b/SPECS/dracut/20overlayfs/overlayfs-mount.sh
@@ -26,8 +26,6 @@
 #   root with the writable overlay, allowing system modifications without
 #   altering the base system.
 
-set -ex
-
 parse_kernel_cmdline_args() {
     # Ensure that the 'dracut-lib' is present and loaded.
     type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh

--- a/SPECS/dracut/dracut.signatures.json
+++ b/SPECS/dracut/dracut.signatures.json
@@ -5,6 +5,6 @@
   "lgpl-2.1.txt": "dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551",
   "megaraid.conf": "914824cdbe0c525b71efa05a75e453335b0068beb8bc28bef2a5866d74bf7dd4",
   "module-setup.sh": "330af5c105793fb37434730ce0ff59467a9cc60a81a5e32193dc53235e9744c1",
-  "overlayfs-mount.sh": "de8591558ee367e483e2b68e8de433043db85bf91c9402b786515fbb351a9c10"
+  "overlayfs-mount.sh": "d6c064e383f00abae1ee621b9657e439e698dba5d49807e38c94fac795f45ea4"
  }
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR removes `set -ex` from the overlay Dracut module script. 

When image with overlays enabled, it always requires `rd.debug` to be enabled, otherwise the overlayfs can not be mounted properly. I compared the output logs between images with / without `rd.debug`:

```
with `rd.debug` enabled
[ 2.011899] dracut-pre-pivot[483]: +++ getarg rd.overlayfs= 
[ 2.014243] dracut-pre-pivot[483]: +++ debug_off 
[ 2.016424] dracut-pre-pivot[483]: +++ set +x 
[ 2.018382] dracut-pre-pivot[483]: +++ return 0 
[ 2.020595] dracut-pre-pivot[479]: ++ overlayfs='/etc,upper1,work1, /var,upper2,work2,'
```

``` 
with `rd.debug disabled
[    2.047313] dracut-pre-pivot[479]: +++ getarg rd.overlayfs=
[    2.049423] dracut-pre-pivot[479]: +++ debug_off
[    2.051088] dracut-pre-pivot[479]: +++ set +x
[    2.052855] dracut-pre-pivot[475]: ++ overlayfs='/etc,upper1,work1, /var,upper2,work2,'
```

You can see we are missing one `return 0` from getarg() if `rd.debug` is disabled. From the [`getarg()` source code](https://github.com/zfsonlinux/dracut/blob/master/modules.d/99base/dracut-lib.sh#L155) line 155 has not be executed. That is due to [the function `debug_on()`](https://github.com/zfsonlinux/dracut/blob/master/modules.d/99base/dracut-lib.sh#L12-L14) requires the image to have debug mode enabled. If the debug mode is off that will cause the function `debug_on()` return status code `1`, and the rest of the logic code will never be able to continue the executing. In order to solve this bug, we can remove the `set -e`. Also, `-x` will be removed too since it can be achieved by enable debugging mode.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/mariner-org/ECF/_sprints/taskboard/Mariner Operator Edge/ECF/2403?workitem=7123
- https://dev.azure.com/mariner-org/ECF/_sprints/taskboard/Mariner Operator Edge/ECF/2403?workitem=7148

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=531956&view=results
