### PR TITLE
Split off mkconfig from grub2 package to reduce image footprint

### DIFF
--- a/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
@@ -41,7 +41,7 @@ specifically created for installing on %{buildarch} systems
 %package -n     grub2-efi-binary
 Summary:        GRand Unified Bootloader
 Group:          Applications/System
-Requires:       %{name}-mkconfig
+Requires:       grub2-tools-minimal = %{version}-%{release}
 
 # Some distros split 'grub2' into more subpackages. For now we're bundling it all together
 # inside the default package and adding these 'Provides' to make installation more user-friendly
@@ -57,7 +57,7 @@ specifically created for installing on %{buildarch} systems
 %package -n     grub2-efi-binary-noprefix
 Summary:        GRand Unified Bootloader
 Group:          Applications/System
-Requires:       %{name}-mkconfig
+Requires:       %{name}-tools-minimal = %{version}-%{release}
 
 %description -n grub2-efi-binary-noprefix
 This package contains the GRUB EFI image with no prefix directory set and is signed for secure boot. The package is

--- a/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
@@ -57,7 +57,7 @@ specifically created for installing on %{buildarch} systems
 %package -n     grub2-efi-binary-noprefix
 Summary:        GRand Unified Bootloader
 Group:          Applications/System
-Requires:       %{name}-tools-minimal = %{version}-%{release}
+Requires:       grub2-tools-minimal = %{version}-%{release}
 
 %description -n grub2-efi-binary-noprefix
 This package contains the GRUB EFI image with no prefix directory set and is signed for secure boot. The package is

--- a/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
@@ -12,7 +12,7 @@
 Summary:        Signed GRand Unified Bootloader for %{buildarch} systems
 Name:           grub2-efi-binary-signed-%{buildarch}
 Version:        2.06
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -41,6 +41,7 @@ specifically created for installing on %{buildarch} systems
 %package -n     grub2-efi-binary
 Summary:        GRand Unified Bootloader
 Group:          Applications/System
+Requires:       %{name}-mkconfig
 
 # Some distros split 'grub2' into more subpackages. For now we're bundling it all together
 # inside the default package and adding these 'Provides' to make installation more user-friendly
@@ -56,6 +57,7 @@ specifically created for installing on %{buildarch} systems
 %package -n     grub2-efi-binary-noprefix
 Summary:        GRand Unified Bootloader
 Group:          Applications/System
+Requires:       %{name}-mkconfig
 
 %description -n grub2-efi-binary-noprefix
 This package contains the GRUB EFI image with no prefix directory set and is signed for secure boot. The package is
@@ -77,6 +79,9 @@ cp %{SOURCE3} %{buildroot}/boot/efi/EFI/BOOT/%{grubpxeefiname}
 /boot/efi/EFI/BOOT/%{grubpxeefiname}
 
 %changelog
+* Wed Mar 20 2024 Cameron Baird <cameronbaird@microsoft.com> - 2.06-17
+- Bump release number to match grub release number
+
 * Wed Mar 07 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.06-16
 - Bumping release version to match with `grub2` release version
 

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -6,7 +6,7 @@
 Summary:        GRand Unified Bootloader
 Name:           grub2
 Version:        2.06
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -152,6 +152,7 @@ Unsigned GRUB UEFI image
 %package efi-binary
 Summary:        GRUB UEFI image
 Group:          System Environment/Base
+Requires:       %{name}-mkconfig
 
 # Some distros split 'grub2' into more subpackages. For now we're bundling it all together
 # inside the default package and adding these 'Provides' to make installation more user-friendly
@@ -166,6 +167,7 @@ GRUB UEFI bootloader binaries
 %package efi-binary-noprefix
 Summary:        GRUB UEFI image with no prefix directory set
 Group:          System Environment/Base
+Requires:       %{name}-mkconfig
 
 %description efi-binary-noprefix
 GRUB UEFI bootloader binaries with no prefix directory set
@@ -185,6 +187,13 @@ Group:          System Environment/Base
 %description configuration
 Directory for package-specific boot configurations
 to be persistently stored on AzureLinux
+
+%package mkconfig
+Summary:        Minimal set of utilities to configure a grub-based system
+Group:          System Environment/Base
+
+%description mkconfig
+Minimal set of utilities to configure a grub-based system
 
 %prep
 # Remove module_info.ld script due to error "grub2-install: error: Decompressor is too big"
@@ -339,6 +348,22 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 %{_sysconfdir}/sysconfig/grub
 %attr(0644,root,root) %ghost %config(noreplace) %{_sysconfdir}/default/grub
 %ghost %config(noreplace) /boot/%{name}/grub.cfg
+%exclude %{_datarootdir}/grub/grub-mkconfig_lib
+%exclude /sbin/grub2-probe
+%exclude /sbin/grub2-mkconfig
+%exclude %{_bindir}/grub2-editenv
+%exclude %{_bindir}/grub2-script-check
+%exclude %{_bindir}/grub2-file
+%exclude %{_bindir}/grub2-mkrelpath
+
+%files mkconfig
+%{_datarootdir}/grub/grub-mkconfig_lib
+/sbin/grub2-probe
+/sbin/grub2-mkconfig
+%{_bindir}/grub2-editenv
+%{_bindir}/grub2-script-check
+%{_bindir}/grub2-file
+%{_bindir}/grub2-mkrelpath
 
 %ifarch x86_64
 %files pc
@@ -388,7 +413,10 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 %config(noreplace) %{_sysconfdir}/grub.d/41_custom
 
 %changelog
-* Wed Mar 07 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.06-16
+* Tue Mar 19 2024 Cameron Baird <cameronbaird@microsoft.com> - 2.06-17
+- Introduce grub2-mkconfig subpackage
+
+* Wed Mar 06 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.06-16
 - Updated sbat.csv.in to reflect new distro name.
 
 * Tue Mar 05 2024 Cameron Baird <cameronbaird@microsoft.com> - 2.06-15

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -93,6 +93,7 @@ Requires:       device-mapper
 Requires:       systemd-udev
 Requires:       xz
 Requires:       %{name}-configuration = %{version}-%{release}
+Requires:       %{name}-mkconfig = %{version}-%{release}
 
 # Some distros split 'grub2' into more subpackages. For now we're bundling it all together
 # inside the default package and adding these 'Provides' to make installation more user-friendly

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -190,7 +190,7 @@ to be persistently stored on AzureLinux
 %package tools-minimal
 Summary:        Minimal set of utilities to configure a grub-based system
 Group:          System Environment/Base
-Requires:       %{name}-configuration
+Requires:       %{name}-configuration = %{version}-%{release}
 
 %description tools-minimal
 Minimal set of utilities to configure a grub-based system

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -92,8 +92,7 @@ BuildRequires:  xz-devel
 Requires:       device-mapper
 Requires:       systemd-udev
 Requires:       xz
-Requires:       %{name}-configuration = %{version}-%{release}
-Requires:       %{name}-mkconfig = %{version}-%{release}
+Requires:       %{name}-tools-minimal = %{version}-%{release}
 
 # Some distros split 'grub2' into more subpackages. For now we're bundling it all together
 # inside the default package and adding these 'Provides' to make installation more user-friendly
@@ -102,7 +101,6 @@ Provides:       %{name}-common = %{version}-%{release}
 Provides:       %{name}-tools = %{version}-%{release}
 Provides:       %{name}-tools-efi = %{version}-%{release}
 Provides:       %{name}-tools-extra = %{version}-%{release}
-Provides:       %{name}-tools-minimal = %{version}-%{release}
 
 %description
 The GRUB package contains the GRand Unified Bootloader.
@@ -153,7 +151,7 @@ Unsigned GRUB UEFI image
 %package efi-binary
 Summary:        GRUB UEFI image
 Group:          System Environment/Base
-Requires:       %{name}-mkconfig
+Requires:       %{name}-tools-minimal = %{version}-%{release}
 
 # Some distros split 'grub2' into more subpackages. For now we're bundling it all together
 # inside the default package and adding these 'Provides' to make installation more user-friendly
@@ -168,7 +166,7 @@ GRUB UEFI bootloader binaries
 %package efi-binary-noprefix
 Summary:        GRUB UEFI image with no prefix directory set
 Group:          System Environment/Base
-Requires:       %{name}-mkconfig
+Requires:       %{name}-tools-minimal = %{version}-%{release}
 
 %description efi-binary-noprefix
 GRUB UEFI bootloader binaries with no prefix directory set
@@ -189,11 +187,12 @@ Group:          System Environment/Base
 Directory for package-specific boot configurations
 to be persistently stored on AzureLinux
 
-%package mkconfig
+%package tools-minimal
 Summary:        Minimal set of utilities to configure a grub-based system
 Group:          System Environment/Base
+Requires:       %{name}-configuration
 
-%description mkconfig
+%description tools-minimal
 Minimal set of utilities to configure a grub-based system
 
 %prep
@@ -343,21 +342,28 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 %license COPYING
 %dir /boot/%{name}
 %config() %{_sysconfdir}/bash_completion.d/grub
-/sbin/*
-%{_bindir}/*
-%{_datarootdir}/grub/*
 %{_sysconfdir}/sysconfig/grub
-%attr(0644,root,root) %ghost %config(noreplace) %{_sysconfdir}/default/grub
-%ghost %config(noreplace) /boot/%{name}/grub.cfg
-%exclude %{_datarootdir}/grub/grub-mkconfig_lib
-%exclude /sbin/grub2-probe
-%exclude /sbin/grub2-mkconfig
-%exclude %{_bindir}/grub2-editenv
-%exclude %{_bindir}/grub2-script-check
-%exclude %{_bindir}/grub2-file
-%exclude %{_bindir}/grub2-mkrelpath
+/sbin/grub2-bios-setup
+/sbin/grub2-install
+/sbin/grub2-macbless
+/sbin/grub2-ofpathname
+/sbin/grub2-reboot
+/sbin/grub2-set-default
+/sbin/grub2-sparc64-setup
+%{_bindir}/grub2-fstest
+%{_bindir}/grub2-glue-efi
+%{_bindir}/grub2-kbdcomp
+%{_bindir}/grub2-menulst2cfg
+%{_bindir}/grub2-mkimage
+%{_bindir}/grub2-mklayout
+%{_bindir}/grub2-mknetdir
+%{_bindir}/grub2-mkpasswd-pbkdf2
+%{_bindir}/grub2-mkrescue
+%{_bindir}/grub2-mkstandalone
+%{_bindir}/grub2-render-label
+%{_bindir}/grub2-syslinux2cfg
 
-%files mkconfig
+%files tools-minimal
 %{_datarootdir}/grub/grub-mkconfig_lib
 /sbin/grub2-probe
 /sbin/grub2-mkconfig
@@ -405,6 +411,8 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 %dir %{_sysconfdir}/grub.d
 %dir %{_sysconfdir}/default/grub.d
 %{_sysconfdir}/grub.d/README
+%attr(0644,root,root) %ghost %config(noreplace) %{_sysconfdir}/default/grub
+%ghost %config(noreplace) /boot/%{name}/grub.cfg
 %config() %{_sysconfdir}/grub.d/00_header
 %config() %{_sysconfdir}/grub.d/10_linux
 %config() %{_sysconfdir}/grub.d/20_linux_xen
@@ -415,7 +423,7 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 
 %changelog
 * Tue Mar 19 2024 Cameron Baird <cameronbaird@microsoft.com> - 2.06-17
-- Introduce grub2-mkconfig subpackage
+- Introduce grub2-tools-minimal subpackage
 
 * Wed Mar 06 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.06-16
 - Updated sbat.csv.in to reflect new distro name.

--- a/toolkit/imageconfigs/packagelists/core-packages-image-aarch64.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image-aarch64.json
@@ -2,7 +2,7 @@
     "packages": [
         "shim-unsigned",
         "grub2-efi-binary",
-        "grub2",
+        "grub2-mkconfig",
         "ca-certificates",
         "cronie-anacron",
         "logrotate",

--- a/toolkit/imageconfigs/packagelists/core-packages-image-aarch64.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image-aarch64.json
@@ -2,7 +2,6 @@
     "packages": [
         "shim-unsigned",
         "grub2-efi-binary",
-        "grub2-mkconfig",
         "ca-certificates",
         "cronie-anacron",
         "logrotate",

--- a/toolkit/imageconfigs/packagelists/core-packages-image.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image.json
@@ -2,7 +2,6 @@
     "packages": [
         "shim",
         "grub2-efi-binary",
-        "grub2-mkconfig",
         "ca-certificates",
         "cronie-anacron",
         "logrotate",

--- a/toolkit/imageconfigs/packagelists/core-packages-image.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image.json
@@ -2,7 +2,7 @@
     "packages": [
         "shim",
         "grub2-efi-binary",
-        "grub2",
+        "grub2-mkconfig",
         "ca-certificates",
         "cronie-anacron",
         "logrotate",

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -118,7 +118,6 @@ func validatePackages(config configuration.Config) (err error) {
 		verityDebugPkgName = "verity-read-only-root-debug-tools"
 		dracutFipsPkgName  = "dracut-fips"
 		fipsKernelCmdLine  = "fips=1"
-		grub2PkgName       = "grub2-mkconfig"
 	)
 
 	for _, systemConfig := range config.SystemConfigs {
@@ -130,7 +129,6 @@ func validatePackages(config configuration.Config) (err error) {
 		foundVerityInitramfsPackage := false
 		foundVerityInitramfsDebugPackage := false
 		foundDracutFipsPackage := false
-		foundGrub2Package := false
 		kernelCmdLineString := systemConfig.KernelCommandLine.ExtraCommandLine
 		selinuxPkgName := systemConfig.KernelCommandLine.SELinuxPolicy
 		if selinuxPkgName == "" {
@@ -153,9 +151,6 @@ func validatePackages(config configuration.Config) (err error) {
 			if pkg == selinuxPkgName {
 				foundSELinuxPackage = true
 			}
-			if pkg == grub2PkgName {
-				foundGrub2Package = true
-			}
 		}
 		if systemConfig.ReadOnlyVerityRoot.Enable {
 			if !foundVerityInitramfsPackage {
@@ -173,11 +168,6 @@ func validatePackages(config configuration.Config) (err error) {
 		if systemConfig.KernelCommandLine.SELinux != configuration.SELinuxOff {
 			if !foundSELinuxPackage {
 				return fmt.Errorf("%s: [SELinux] selected, but '%s' package is not included in the package lists", validateError, selinuxPkgName)
-			}
-		}
-		if !systemConfig.IsRootFS() && systemConfig.EnableGrubMkconfig {
-			if !foundGrub2Package {
-				return fmt.Errorf("%s: [EnableGrubMkconfig] selected, but '%s' package is not included in the package lists", validateError, grub2PkgName)
 			}
 		}
 	}

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -118,7 +118,7 @@ func validatePackages(config configuration.Config) (err error) {
 		verityDebugPkgName = "verity-read-only-root-debug-tools"
 		dracutFipsPkgName  = "dracut-fips"
 		fipsKernelCmdLine  = "fips=1"
-		grub2PkgName       = "grub2"
+		grub2PkgName       = "grub2-mkconfig"
 	)
 
 	for _, systemConfig := range config.SystemConfigs {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Originally, grub2-mkconfig (which is needed to generate the boot configuration for a grub-based image) was packaged in grub2.rpm. This rpm has a 35MB footprint which is undesirable for a slimmed down core image. 

Introduce grub2-mkconfig.rpm which contains only the necessary utilities for mkconfig. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Introduce grub2-mkconfig subpackage

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local build
- Inspected subpackage RPM for size: a mere 7.5MB needed for the core image as opposed to 35MB.
- 
![image](https://github.com/microsoft/azurelinux/assets/37827103/471561f4-771b-4230-8138-b1edd8fa8371)

