### PR TITLE
Enabled ccache and artifact suffixes for fast-track PR check

### DIFF
--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -72,6 +72,10 @@ extends:
                   # and make it available to the next stage via an output variable: 'CalculateToolchainPackageRetestList.toolchainPackageRetestList'
                   - template: .pipelines/templates/ToolchainCalculatePackageRetests.yml@self
 
+                  - script: echo "##vso[task.setvariable variable=toolchainArtifactName]$(ob_artifactBaseName)"
+                    name: "ToolchainArtifactName"
+                    displayName: "Set variable for published artifact name"
+
                   # 1. Automatic publishing won't work if 'isCustom: true' is set on the pool. We cannot do 'isCustom: false' because
                   #    then OneBranch attempts to perform additional actions (adding build tags for instance), which require additional permissions
                   #    that the PR check pipeline does not have.
@@ -95,10 +99,11 @@ extends:
                   ob_artifactBaseName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
+                  toolchainArtifactName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainArtifactName'] ]
                 steps:
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
-                      customToolchainArtifactName: $(toolchainArtifactNameBase)_${{ configuration.name }}
+                      customToolchainArtifactName: $(toolchainArtifactName)
                       isCheckBuild: true
                       isQuickRebuildPackages: true
                       isUseCCache: true

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -55,8 +55,7 @@ extends:
                   isCustom: true
                   name: ${{ configuration.agentPool }}
                 variables:
-                  ob_artifactBaseName: $(toolchainArtifactNameBase)_${{ configuration.name }}
-                  ob_artifactSuffix: _$(System.JobAttempt)
+                  ob_artifactBaseName: $(toolchainArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                 steps:
                   - template: .pipelines/templates/RawToolchainDownload.yml@self
@@ -79,7 +78,7 @@ extends:
                   # 2. The value for 'artifact' must equal $(ob_artifactBaseName), as this is the only value OneBranch accepts.
                   - task: PublishPipelineArtifact@1
                     inputs:
-                      artifact: $(ob_artifactBaseName)
+                      artifact: $(toolchainArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                       targetPath: $(ob_outputDirectory)
                     condition: always()
                     displayName: "Publish toolchain artifacts"
@@ -93,8 +92,7 @@ extends:
                   isCustom: true
                   name: ${{ configuration.agentPool }}
                 variables:
-                  ob_artifactBaseName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}
-                  ob_artifactSuffix: _$(System.JobAttempt)
+                  ob_artifactBaseName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
                 steps:
@@ -113,7 +111,7 @@ extends:
 
                   - task: PublishPipelineArtifact@1
                     inputs:
-                      artifact: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}
+                      artifact: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}_$(System.JobAttempt)
                       targetPath: $(ob_outputDirectory)
                     condition: always()
                     displayName: "Publish packages build artifacts"

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -134,7 +134,7 @@ extends:
                   isCustom: true
                   name: ${{ configuration.agentPool }}
                   variables:
-                    rpmsArtifactName: $[ stageDependencies.RPMs_${{ configuration.name }}.Build.outputs['RPMsArtifactName.rpmsArtifactName'] ]
+                    rpmsArtifactName: $[ stageDependencies.RPMs_${{ configuration.name }}.BuildAndTest.outputs['RPMsArtifactName.rpmsArtifactName'] ]
                 steps:
                   - template: .pipelines/templatesWithCheckout/SodiffCheck.yml@self
                     parameters:

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -56,6 +56,7 @@ extends:
                   name: ${{ configuration.agentPool }}
                 variables:
                   ob_artifactBaseName: $(toolchainArtifactNameBase)_${{ configuration.name }}
+                  ob_artifactSuffix: _$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                 steps:
                   - template: .pipelines/templates/RawToolchainDownload.yml@self
@@ -93,6 +94,7 @@ extends:
                   name: ${{ configuration.agentPool }}
                 variables:
                   ob_artifactBaseName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}
+                  ob_artifactSuffix: _$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
                 steps:

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -114,6 +114,10 @@ extends:
                       testSuiteName: "[${{ configuration.name }}] Package test"
                       testRerunList: "$(testListFromToolchain)"
 
+                  - script: echo "##vso[task.setvariable variable=rpmsArtifactName;isOutput=true]$(ob_artifactBaseName)"
+                    name: "RPMsArtifactName"
+                    displayName: "Set variable for published artifact name"
+
                   - task: PublishPipelineArtifact@1
                     inputs:
                       artifact: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}_$(System.JobAttempt)
@@ -129,7 +133,9 @@ extends:
                   type: linux
                   isCustom: true
                   name: ${{ configuration.agentPool }}
+                  variables:
+                    rpmsArtifactName: $[ stageDependencies.RPMs_${{ configuration.name }}.Build.outputs['RPMsArtifactName.rpmsArtifactName'] ]
                 steps:
                   - template: .pipelines/templatesWithCheckout/SodiffCheck.yml@self
                     parameters:
-                      inputArtifactName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}
+                      inputArtifactName: $(rpmsArtifactName)

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -133,8 +133,8 @@ extends:
                   type: linux
                   isCustom: true
                   name: ${{ configuration.agentPool }}
-                  variables:
-                    rpmsArtifactName: $[ stageDependencies.RPMs_${{ configuration.name }}.BuildAndTest.outputs['RPMsArtifactName.rpmsArtifactName'] ]
+                variables:
+                  rpmsArtifactName: $[ stageDependencies.RPMs_${{ configuration.name }}.BuildAndTest.outputs['RPMsArtifactName.rpmsArtifactName'] ]
                 steps:
                   - template: .pipelines/templatesWithCheckout/SodiffCheck.yml@self
                     parameters:

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -79,7 +79,7 @@ extends:
                   # 2. The value for 'artifact' must equal $(ob_artifactBaseName), as this is the only value OneBranch accepts.
                   - task: PublishPipelineArtifact@1
                     inputs:
-                      artifact: $(toolchainArtifactNameBase)_${{ configuration.name }}
+                      artifact: $(ob_artifactBaseName)
                       targetPath: $(ob_outputDirectory)
                     condition: always()
                     displayName: "Publish toolchain artifacts"

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -72,7 +72,7 @@ extends:
                   # and make it available to the next stage via an output variable: 'CalculateToolchainPackageRetestList.toolchainPackageRetestList'
                   - template: .pipelines/templates/ToolchainCalculatePackageRetests.yml@self
 
-                  - script: echo "##vso[task.setvariable variable=toolchainArtifactName]$(ob_artifactBaseName)"
+                  - script: echo "##vso[task.setvariable variable=toolchainArtifactName;isOutput=true]$(ob_artifactBaseName)"
                     name: "ToolchainArtifactName"
                     displayName: "Set variable for published artifact name"
 

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -101,6 +101,7 @@ extends:
                       customToolchainArtifactName: $(toolchainArtifactNameBase)_${{ configuration.name }}
                       isCheckBuild: true
                       isQuickRebuildPackages: true
+                      isUseCCache: true
                       outputArtifactsFolder: $(ob_outputDirectory)
                       maxCPU: "${{ configuration.maxCPUs }}"
                       pipArtifactFeeds: "mariner/Mariner-Pypi-Feed"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The ccache should significantly shorten package build times.

The artifact suffix will prevent artifact upload failures during job re-runs as each run will generate an artifact with a different name.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR check run.