### PR TITLE
Cython: fix package test by using python312 requirements

### DIFF
--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -3,7 +3,7 @@ Cython is an optimising static compiler for both the Python programming language
 Summary:        Language for writing Python extension modules
 Name:           Cython
 Version:        3.0.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -39,7 +39,7 @@ Provides:       %{name}%{?_isa} = %{version}-%{release}
 rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %check
-pip3 install -r test-requirements.txt
+pip3 install -r test-requirements-312.txt
 %python3 runtests.py -vv
 
 %files -n python3-%{name}
@@ -55,6 +55,9 @@ pip3 install -r test-requirements.txt
 %{python3_sitearch}/__pycache__/cython.*
 
 %changelog
+* Thu Mar 21 2024 Andrew Phelps <anphel@microsoft.com> - 3.0.5-2
+- Switch to test-requirements-312.txt
+
 * Fri Nov 10 2023 Andrew Phelps <anphel@microsoft.com> - 3.0.5-1
 - Upgrade to version 3.0.5
 

--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -40,7 +40,7 @@ rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %check
 pip3 install -r test-requirements-312.txt
-%python3 runtests.py -vv
+%python3 runtests.py -vv --no-unit --no-doctest --no-file --no-pyregr --no-examples
 
 %files -n python3-%{name}
 %license LICENSE.txt COPYING.txt

--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -1,5 +1,5 @@
 %global _description \
-Cython is an optimising static compiler for both the Python programming language and the extended Cython programming language (baded on Pyrex). It makes writing C extensions for Python as easy as Python itself.
+Cython is an optimising static compiler for both the Python programming language and the extended Cython programming language (based on Pyrex). It makes writing C extensions for Python as easy as Python itself.
 Summary:        Language for writing Python extension modules
 Name:           Cython
 Version:        3.0.5
@@ -9,6 +9,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://www.cython.org
 Source0:        https://github.com/cython/cython/releases/download/%{version}/%{name}-%{version}.tar.gz
+Patch0:         fix_testcycache.patch
 BuildRequires:  gcc
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -40,7 +41,7 @@ rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %check
 pip3 install -r test-requirements-312.txt
-%python3 runtests.py -vv --no-unit --no-doctest --no-file --no-pyregr --no-examples
+%python3 runtests.py -vv --no-doctest --no-file --no-pyregr --no-examples
 
 %files -n python3-%{name}
 %license LICENSE.txt COPYING.txt
@@ -57,6 +58,8 @@ pip3 install -r test-requirements-312.txt
 %changelog
 * Thu Mar 21 2024 Andrew Phelps <anphel@microsoft.com> - 3.0.5-2
 - Switch to test-requirements-312.txt
+- Only run unit tests
+- Add patch to fix TestPyCache test
 
 * Fri Nov 10 2023 Andrew Phelps <anphel@microsoft.com> - 3.0.5-1
 - Upgrade to version 3.0.5

--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -41,7 +41,8 @@ rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %check
 pip3 install -r test-requirements-312.txt
-%python3 runtests.py -vv --no-doctest --no-file --no-pyregr --no-examples
+# Skip the file based tests, since they typically take over 5 hours to run.
+%python3 runtests.py -vv --no-file
 
 %files -n python3-%{name}
 %license LICENSE.txt COPYING.txt
@@ -58,7 +59,7 @@ pip3 install -r test-requirements-312.txt
 %changelog
 * Thu Mar 21 2024 Andrew Phelps <anphel@microsoft.com> - 3.0.5-2
 - Switch to test-requirements-312.txt
-- Only run unit tests
+- Skip long-running file based tests
 - Add patch to fix TestPyCache test
 
 * Fri Nov 10 2023 Andrew Phelps <anphel@microsoft.com> - 3.0.5-1

--- a/SPECS/Cython/fix_testcycache.patch
+++ b/SPECS/Cython/fix_testcycache.patch
@@ -1,0 +1,23 @@
+https://github.com/cython/cython/pull/5945/files
+
+diff -ruN a/Cython/Build/Tests/TestCyCache.py b/Cython/Build/Tests/TestCyCache.py
+--- a/Cython/Build/Tests/TestCyCache.py 2024-03-22 16:33:42.785995661 +0000
++++ b/Cython/Build/Tests/TestCyCache.py 2024-03-22 16:41:00.218527876 +0000
+@@ -3,6 +3,7 @@
+ import gzip
+ import os
+ import tempfile
++from contextlib import closing
+
+ import Cython.Build.Dependencies
+ import Cython.Utils
+@@ -70,7 +71,8 @@
+             f.write('pass')
+         self.fresh_cythonize(a_pyx, cache=self.cache_dir)
+         a_cache = os.path.join(self.cache_dir, os.listdir(self.cache_dir)[0])
+-        gzip.GzipFile(a_cache, 'wb').write('fake stuff'.encode('ascii'))
++        with closing(gzip.GzipFile(a_cache, 'wb')) as gzipfile:
++            gzipfile.write('fake stuff'.encode('ascii'))
+         os.unlink(a_c)
+         self.fresh_cythonize(a_pyx, cache=self.cache_dir)
+         with open(a_c) as f:

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -65,7 +65,7 @@ curl-8.5.0-1.azl3.aarch64.rpm
 curl-debuginfo-8.5.0-1.azl3.aarch64.rpm
 curl-devel-8.5.0-1.azl3.aarch64.rpm
 curl-libs-8.5.0-1.azl3.aarch64.rpm
-Cython-debuginfo-3.0.5-1.azl3.aarch64.rpm
+Cython-debuginfo-3.0.5-2.azl3.aarch64.rpm
 debugedit-5.0-2.azl3.aarch64.rpm
 debugedit-debuginfo-5.0-2.azl3.aarch64.rpm
 diffutils-3.10-1.azl3.aarch64.rpm
@@ -527,7 +527,7 @@ python3-3.12.0-2.azl3.aarch64.rpm
 python3-audit-3.1.2-1.azl3.aarch64.rpm
 python3-cracklib-2.9.11-1.azl3.aarch64.rpm
 python3-curses-3.12.0-2.azl3.aarch64.rpm
-python3-Cython-3.0.5-1.azl3.aarch64.rpm
+python3-Cython-3.0.5-2.azl3.aarch64.rpm
 python3-debuginfo-3.12.0-2.azl3.aarch64.rpm
 python3-devel-3.12.0-2.azl3.aarch64.rpm
 python3-flit-core-3.9.0-1.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -68,7 +68,7 @@ curl-8.5.0-1.azl3.x86_64.rpm
 curl-debuginfo-8.5.0-1.azl3.x86_64.rpm
 curl-devel-8.5.0-1.azl3.x86_64.rpm
 curl-libs-8.5.0-1.azl3.x86_64.rpm
-Cython-debuginfo-3.0.5-1.azl3.x86_64.rpm
+Cython-debuginfo-3.0.5-2.azl3.x86_64.rpm
 debugedit-5.0-2.azl3.x86_64.rpm
 debugedit-debuginfo-5.0-2.azl3.x86_64.rpm
 diffutils-3.10-1.azl3.x86_64.rpm
@@ -533,7 +533,7 @@ python3-3.12.0-2.azl3.x86_64.rpm
 python3-audit-3.1.2-1.azl3.x86_64.rpm
 python3-cracklib-2.9.11-1.azl3.x86_64.rpm
 python3-curses-3.12.0-2.azl3.x86_64.rpm
-python3-Cython-3.0.5-1.azl3.x86_64.rpm
+python3-Cython-3.0.5-2.azl3.x86_64.rpm
 python3-debuginfo-3.12.0-2.azl3.x86_64.rpm
 python3-devel-3.12.0-2.azl3.x86_64.rpm
 python3-flit-core-3.9.0-1.azl3.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix Cython package tests. Use the requirements.txt file specific to python 3.12, this allows the latest version of setuptools to be installed. Previously, the requirements.txt file downgraded setuptools to an old version, which broke the tests.
I've also disabled the file-based tests, since these take over 6 hours to run, and patched one broken test.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change Cython to use python312 requirements
- Disable long running file based tests
- Patch TestPyCache test

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=533428&view=results
