### PR TITLE
Upgrade expat to 2.6.2 CVE-2023-52425 and CVE-2024-28757

### DIFF
--- a/SPECS/expat/expat.signatures.json
+++ b/SPECS/expat/expat.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "expat-2.5.0.tar.bz2": "6f0e6e01f7b30025fa05c85fdad1e5d0ec7fd35d9f61b22f34998de11969ff67"
+    "expat-2.6.2.tar.bz2": "9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0"
   }
 }

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -42,7 +42,8 @@ This package contains minimal set of shared expat libraries.
 %make_install
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}/%{_docdir}/%{name}
-rm %{buildroot}%{_mandir}/man1/xmlwf.1.gz
+echo "Listing files in the install directory:"
+ls -l %{buildroot}/
 %{_fixperms} %{buildroot}/*
 
 %check

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -53,6 +53,7 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 %defattr(-,root,root)
 %doc AUTHORS Changes
 %{_bindir}/*
+%exclude %{_mandir}/man1/xmlwf.1.gz
 
 %files devel
 %{_includedir}/*

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -42,8 +42,8 @@ This package contains minimal set of shared expat libraries.
 %make_install
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}/%{_docdir}/%{name}
+rm %{buildroot}/%{_mandir}/man1/xmlwf.1.gz
 %{_fixperms} %{buildroot}/*
-rm %{_mandir}/man1/xmlwf.1.gz
 
 %check
 %make_build check

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -42,8 +42,8 @@ This package contains minimal set of shared expat libraries.
 %make_install
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}/%{_docdir}/%{name}
-rm %{_mandir}/man1/xmlwf.1.gz
 %{_fixperms} %{buildroot}/*
+rm %{_mandir}/man1/xmlwf.1.gz
 
 %check
 %make_build check

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -1,7 +1,7 @@
 %define         underscore_version %(echo %{version} | cut -d. -f1-3 --output-delimiter="_")
 Summary:        An XML parser library
 Name:           expat
-Version:        2.5.0
+Version:        2.6.2
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -65,6 +65,9 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 %{_libdir}/libexpat.so.1*
 
 %changelog
+* Thu Mar 21 2024 Aditya Dubey <adityadubey@microsoft.com> - 2.6.2-1
+- Upgrading to 2.6.2 to fix CVE-2023-52425
+
 * Wed Oct 26 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.5.0-1
 - Upgrade to 2.5.0
 

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -42,8 +42,6 @@ This package contains minimal set of shared expat libraries.
 %make_install
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}/%{_docdir}/%{name}
-echo "Listing files in the install directory:"
-ls -l %{buildroot}/
 %{_fixperms} %{buildroot}/*
 
 %check

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -42,6 +42,7 @@ This package contains minimal set of shared expat libraries.
 %make_install
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}/%{_docdir}/%{name}
+rm %{_mandir}/man1/xmlwf.1.gz
 %{_fixperms} %{buildroot}/*
 
 %check
@@ -53,7 +54,6 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 %defattr(-,root,root)
 %doc AUTHORS Changes
 %{_bindir}/*
-%exclude %{_mandir}/man1/xmlwf.1.gz
 
 %files devel
 %{_includedir}/*

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -54,6 +54,7 @@ ls -l %{buildroot}/
 %files
 %defattr(-,root,root)
 %doc AUTHORS Changes
+%{_mandir}/man1/xmlwf.1.gz
 %{_bindir}/*
 
 %files devel

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -67,7 +67,7 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 
 %changelog
 * Thu Mar 21 2024 Aditya Dubey <adityadubey@microsoft.com> - 2.6.2-1
-- Upgrading to 2.6.2 to fix CVE-2023-52425
+- Upgrading to 2.6.2 to fix CVE-2023-52425 and CVE-2023-28757
 
 * Wed Oct 26 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.5.0-1
 - Upgrade to 2.5.0

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -42,7 +42,7 @@ This package contains minimal set of shared expat libraries.
 %make_install
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}/%{_docdir}/%{name}
-rm %{buildroot}/%{_mandir}/man1/xmlwf.1.gz
+rm %{buildroot}%{_mandir}/man1/xmlwf.1.gz
 %{_fixperms} %{buildroot}/*
 
 %check

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3398,8 +3398,8 @@
         "type": "other",
         "other": {
           "name": "expat",
-          "version": "2.5.0",
-          "downloadUrl": "https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.bz2"
+          "version": "2.6.2",
+          "downloadUrl": "https://github.com/libexpat/libexpat/releases/download/R_2_6_2/expat-2.6.2.tar.bz2"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -95,7 +95,7 @@ elfutils-libelf-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-devel-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-lang-0.186-2.cm2.aarch64.rpm
-expat-2.5.0-1.cm2.aarch64.rpm
+expat-2.6.2-1.cm2.aarch64.rpm
 expat-devel-2.5.0-1.cm2.aarch64.rpm
 expat-libs-2.5.0-1.cm2.aarch64.rpm
 libpipeline-1.5.5-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -96,8 +96,8 @@ elfutils-libelf-devel-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-lang-0.186-2.cm2.aarch64.rpm
 expat-2.6.2-1.cm2.aarch64.rpm
-expat-devel-2.5.0-1.cm2.aarch64.rpm
-expat-libs-2.5.0-1.cm2.aarch64.rpm
+expat-devel-2.6.2-1.cm2.aarch64.rpm
+expat-libs-2.6.2-1.cm2.aarch64.rpm
 libpipeline-1.5.5-3.cm2.aarch64.rpm
 libpipeline-devel-1.5.5-3.cm2.aarch64.rpm
 gdbm-1.21-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -95,7 +95,7 @@ elfutils-libelf-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-devel-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-lang-0.186-2.cm2.x86_64.rpm
-expat-2.5.0-1.cm2.x86_64.rpm
+expat-2.6.2-1.cm2.x86_64.rpm
 expat-devel-2.5.0-1.cm2.x86_64.rpm
 expat-libs-2.5.0-1.cm2.x86_64.rpm
 libpipeline-1.5.5-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -96,8 +96,8 @@ elfutils-libelf-devel-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-lang-0.186-2.cm2.x86_64.rpm
 expat-2.6.2-1.cm2.x86_64.rpm
-expat-devel-2.5.0-1.cm2.x86_64.rpm
-expat-libs-2.5.0-1.cm2.x86_64.rpm
+expat-devel-2.6.2-1.cm2.x86_64.rpm
+expat-libs-2.6.2-1.cm2.x86_64.rpm
 libpipeline-1.5.5-3.cm2.x86_64.rpm
 libpipeline-devel-1.5.5-3.cm2.x86_64.rpm
 gdbm-1.21-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -73,7 +73,7 @@ elfutils-libelf-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-devel-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-lang-0.186-2.cm2.aarch64.rpm
-expat-2.5.0-1.cm2.aarch64.rpm
+expat-2.6.2-1.cm2.aarch64.rpm
 expat-debuginfo-2.5.0-1.cm2.aarch64.rpm
 expat-devel-2.5.0-1.cm2.aarch64.rpm
 expat-libs-2.5.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -74,9 +74,9 @@ elfutils-libelf-devel-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.aarch64.rpm
 elfutils-libelf-lang-0.186-2.cm2.aarch64.rpm
 expat-2.6.2-1.cm2.aarch64.rpm
-expat-debuginfo-2.5.0-1.cm2.aarch64.rpm
-expat-devel-2.5.0-1.cm2.aarch64.rpm
-expat-libs-2.5.0-1.cm2.aarch64.rpm
+expat-debuginfo-2.6.2-1.cm2.aarch64.rpm
+expat-devel-2.6.2-1.cm2.aarch64.rpm
+expat-libs-2.6.2-1.cm2.aarch64.rpm
 file-5.40-2.cm2.aarch64.rpm
 file-debuginfo-5.40-2.cm2.aarch64.rpm
 file-devel-5.40-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -76,7 +76,7 @@ elfutils-libelf-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-devel-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-lang-0.186-2.cm2.x86_64.rpm
-expat-2.5.0-1.cm2.x86_64.rpm
+expat-2.6.2-1.cm2.x86_64.rpm
 expat-debuginfo-2.5.0-1.cm2.x86_64.rpm
 expat-devel-2.5.0-1.cm2.x86_64.rpm
 expat-libs-2.5.0-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -77,9 +77,9 @@ elfutils-libelf-devel-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-devel-static-0.186-2.cm2.x86_64.rpm
 elfutils-libelf-lang-0.186-2.cm2.x86_64.rpm
 expat-2.6.2-1.cm2.x86_64.rpm
-expat-debuginfo-2.5.0-1.cm2.x86_64.rpm
-expat-devel-2.5.0-1.cm2.x86_64.rpm
-expat-libs-2.5.0-1.cm2.x86_64.rpm
+expat-debuginfo-2.6.2-1.cm2.x86_64.rpm
+expat-devel-2.6.2-1.cm2.x86_64.rpm
+expat-libs-2.6.2-1.cm2.x86_64.rpm
 file-5.40-2.cm2.x86_64.rpm
 file-debuginfo-5.40-2.cm2.x86_64.rpm
 file-devel-5.40-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrading to 2.6.2 to fix CVE-2023-52425. This also fixes CVE-2024-28757. 

libexpat through 2.6.1 allows an XML Entity Expansion attack when there is isolated use of external parsers (created via 
XML_ExternalEntityParserCreate). Affected packages: cmake, python3, and expat. 

Upgrading expat solves the issue for the 3 packages


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgraded package to version 2.6.2 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-52425
- https://nvd.nist.gov/vuln/detail/CVE-2024-28757
###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build id: [link](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=532877&view=results)
- Passed PR pipeline build check