### PR TITLE
Image Customizer: Move fileSystemType to fileSystem type.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -93,7 +93,6 @@ os:
         - [partitions](#partitions-partition)
           - [partition type](#partition-type)
             - [id](#id-string)
-            - [fileSystemType](#filesystemtype-string)
             - [label](#label-string)
             - [start](#start-uint64)
             - [end](#end-uint64)
@@ -102,6 +101,7 @@ os:
     - [fileSystems](#filesystems-filesystem)
       - [fileSystem type](#filesystem-type)
         - [deviceId](#deviceid-string)
+        - [type](#type-string)
         - [mountPoint](#mountpoint-mountpoint)
           - [mountPoint type](#mountpoint-type)
             - [idType](#idtype-string)
@@ -195,19 +195,19 @@ storage:
       - boot
       start: 1
       end: 9
-      fileSystemType: fat32
 
     - id: rootfs
       start: 9
-      fileSystemType: ext4
       
   fileSystems:
   - deviceId: esp
+    type: fat32
     mountPoint:
       path: /boot/efi
       options: umask=0077
 
   - deviceId: rootfs
+    type: ext4
     mountPoint:
       path: /
 
@@ -337,6 +337,18 @@ Required.
 
 The ID of the partition.
 This is used correlate [partition](#partition-type) objects with fileSystem objects.
+
+### type [string]
+
+Required.
+
+The filesystem type of the partition.
+
+Supported options:
+
+- `ext4`
+- `fat32`
+- `xfs`
 
 ### mountPoint [[mountPoint](#mountpoint-type)]
 
@@ -601,18 +613,6 @@ Required.
 The ID of the partition.
 This is used to correlate Partition objects with [fileSystem](#filesystem-type)
 objects.
-
-### fileSystemType [string]
-
-Required.
-
-The filesystem type of the partition.
-
-Supported options:
-
-- `ext4`
-- `fat32`
-- `xfs`
 
 ### label [string]
 

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -17,9 +17,8 @@ func TestConfigIsValid(t *testing.T) {
 				MaxSize:            2,
 				Partitions: []Partition{
 					{
-						Id:             "esp",
-						FileSystemType: "fat32",
-						Start:          1,
+						Id:    "esp",
+						Start: 1,
 						Flags: []PartitionFlag{
 							"esp",
 							"boot",
@@ -31,6 +30,7 @@ func TestConfigIsValid(t *testing.T) {
 			FileSystems: []FileSystem{
 				{
 					DeviceId: "esp",
+					Type:     "fat32",
 					MountPoint: &MountPoint{
 						Path: "/boot/efi",
 					},
@@ -55,9 +55,8 @@ func TestConfigIsValidLegacy(t *testing.T) {
 				MaxSize:            2,
 				Partitions: []Partition{
 					{
-						Id:             "boot",
-						FileSystemType: "fat32",
-						Start:          1,
+						Id:    "boot",
+						Start: 1,
 						Flags: []PartitionFlag{
 							"bios-grub",
 						},
@@ -65,6 +64,12 @@ func TestConfigIsValidLegacy(t *testing.T) {
 				},
 			}},
 			BootType: "legacy",
+			FileSystems: []FileSystem{
+				{
+					DeviceId: "boot",
+					Type:     "fat32",
+				},
+			},
 		},
 		OS: OS{
 			ResetBootLoaderType: "hard-reset",
@@ -84,9 +89,8 @@ func TestConfigIsValidNoBootType(t *testing.T) {
 				MaxSize:            2,
 				Partitions: []Partition{
 					{
-						Id:             "a",
-						FileSystemType: "ext4",
-						Start:          1,
+						Id:    "a",
+						Start: 1,
 					},
 				},
 			}},
@@ -110,9 +114,8 @@ func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 				MaxSize:            2,
 				Partitions: []Partition{
 					{
-						Id:             "esp",
-						FileSystemType: "fat32",
-						Start:          1,
+						Id:    "esp",
+						Start: 1,
 						Flags: []PartitionFlag{
 							"esp",
 							"boot",
@@ -121,6 +124,15 @@ func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 				},
 			}},
 			BootType: "efi",
+			FileSystems: []FileSystem{
+				{
+					DeviceId: "esp",
+					Type:     "fat32",
+					MountPoint: &MountPoint{
+						Path: "/boot/efi",
+					},
+				},
+			},
 		},
 		OS: OS{
 			Hostname: "test",
@@ -257,9 +269,8 @@ func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 				MaxSize:            2,
 				Partitions: []Partition{
 					{
-						Id:             "esp",
-						FileSystemType: "fat32",
-						Start:          1,
+						Id:    "esp",
+						Start: 1,
 						Flags: []PartitionFlag{
 							"esp",
 							"boot",
@@ -271,6 +282,7 @@ func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 			FileSystems: []FileSystem{
 				{
 					DeviceId: "esp",
+					Type:     "fat32",
 					MountPoint: &MountPoint{
 						Path: "boot/efi",
 					},
@@ -289,46 +301,6 @@ func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 	assert.ErrorContains(t, err, "absolute path")
 }
 
-func TestConfigIsValidInvalidPartitionId(t *testing.T) {
-	config := &Config{
-		Storage: &Storage{
-			Disks: []Disk{{
-				PartitionTableType: "gpt",
-				MaxSize:            2,
-				Partitions: []Partition{
-					{
-						Id:             "esp",
-						FileSystemType: "fat32",
-						Start:          1,
-						Flags: []PartitionFlag{
-							"esp",
-							"boot",
-						},
-					},
-				},
-			}},
-			BootType: "efi",
-			FileSystems: []FileSystem{
-				{
-					DeviceId: "boot",
-					MountPoint: &MountPoint{
-						Path: "/boot/efi",
-					},
-				},
-			},
-		},
-		OS: OS{
-			ResetBootLoaderType: "hard-reset",
-			Hostname:            "test",
-		},
-	}
-
-	err := config.IsValid()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "partition")
-	assert.ErrorContains(t, err, "id")
-}
-
 func TestConfigIsValidKernelCLI(t *testing.T) {
 	config := &Config{
 		Storage: &Storage{
@@ -337,9 +309,8 @@ func TestConfigIsValidKernelCLI(t *testing.T) {
 				MaxSize:            2,
 				Partitions: []Partition{
 					{
-						Id:             "esp",
-						FileSystemType: "fat32",
-						Start:          1,
+						Id:    "esp",
+						Start: 1,
 						Flags: []PartitionFlag{
 							"esp",
 							"boot",
@@ -351,6 +322,7 @@ func TestConfigIsValidKernelCLI(t *testing.T) {
 			FileSystems: []FileSystem{
 				{
 					DeviceId: "esp",
+					Type:     "fat32",
 					MountPoint: &MountPoint{
 						Path: "/boot/efi",
 					},

--- a/toolkit/tools/imagecustomizerapi/disk_test.go
+++ b/toolkit/tools/imagecustomizerapi/disk_test.go
@@ -16,9 +16,8 @@ func TestDiskIsValid(t *testing.T) {
 		MaxSize:            2,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
+				Id:    "a",
+				Start: 1,
 			},
 		},
 	}
@@ -33,10 +32,9 @@ func TestDiskIsValidWithEnd(t *testing.T) {
 		MaxSize:            2,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
-				End:            ptrutils.PtrTo(uint64(2)),
+				Id:    "a",
+				Start: 1,
+				End:   ptrutils.PtrTo(uint64(2)),
 			},
 		},
 	}
@@ -51,10 +49,9 @@ func TestDiskIsValidWithSize(t *testing.T) {
 		MaxSize:            2,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
-				Size:           ptrutils.PtrTo(uint64(1)),
+				Id:    "a",
+				Start: 1,
+				Size:  ptrutils.PtrTo(uint64(1)),
 			},
 		},
 	}
@@ -69,9 +66,8 @@ func TestDiskIsValidStartAt0(t *testing.T) {
 		MaxSize:            2,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          0,
+				Id:    "a",
+				Start: 0,
 			},
 		},
 	}
@@ -88,9 +84,8 @@ func TestDiskIsValidInvalidTableType(t *testing.T) {
 		MaxSize:            2,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
+				Id:    "a",
+				Start: 1,
 			},
 		},
 	}
@@ -106,10 +101,9 @@ func TestDiskIsValidInvalidPartition(t *testing.T) {
 		MaxSize:            2,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          2,
-				End:            ptrutils.PtrTo(uint64(0)),
+				Id:    "a",
+				Start: 2,
+				End:   ptrutils.PtrTo(uint64(0)),
 			},
 		},
 	}
@@ -125,14 +119,12 @@ func TestDiskIsValidTwoExpanding(t *testing.T) {
 		MaxSize:            4,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
+				Id:    "a",
+				Start: 1,
 			},
 			{
-				Id:             "b",
-				FileSystemType: "ext4",
-				Start:          2,
+				Id:    "b",
+				Start: 2,
 			},
 		},
 	}
@@ -148,16 +140,14 @@ func TestDiskIsValidOverlaps(t *testing.T) {
 		MaxSize:            4,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
-				End:            ptrutils.PtrTo(uint64(3)),
+				Id:    "a",
+				Start: 1,
+				End:   ptrutils.PtrTo(uint64(3)),
 			},
 			{
-				Id:             "b",
-				FileSystemType: "ext4",
-				Start:          2,
-				End:            ptrutils.PtrTo(uint64(4)),
+				Id:    "b",
+				Start: 2,
+				End:   ptrutils.PtrTo(uint64(4)),
 			},
 		},
 	}
@@ -173,15 +163,13 @@ func TestDiskIsValidOverlapsExpanding(t *testing.T) {
 		MaxSize:            4,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
-				End:            ptrutils.PtrTo(uint64(3)),
+				Id:    "a",
+				Start: 1,
+				End:   ptrutils.PtrTo(uint64(3)),
 			},
 			{
-				Id:             "b",
-				FileSystemType: "ext4",
-				Start:          2,
+				Id:    "b",
+				Start: 2,
 			},
 		},
 	}
@@ -197,16 +185,14 @@ func TestDiskIsValidTooSmall(t *testing.T) {
 		MaxSize:            3,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
-				End:            ptrutils.PtrTo(uint64(2)),
+				Id:    "a",
+				Start: 1,
+				End:   ptrutils.PtrTo(uint64(2)),
 			},
 			{
-				Id:             "b",
-				FileSystemType: "ext4",
-				Start:          3,
-				End:            ptrutils.PtrTo(uint64(4)),
+				Id:    "b",
+				Start: 3,
+				End:   ptrutils.PtrTo(uint64(4)),
 			},
 		},
 	}
@@ -222,15 +208,13 @@ func TestDiskIsValidTooSmallExpanding(t *testing.T) {
 		MaxSize:            3,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
-				End:            ptrutils.PtrTo(uint64(3)),
+				Id:    "a",
+				Start: 1,
+				End:   ptrutils.PtrTo(uint64(3)),
 			},
 			{
-				Id:             "b",
-				FileSystemType: "ext4",
-				Start:          3,
+				Id:    "b",
+				Start: 3,
 			},
 		},
 	}
@@ -258,9 +242,8 @@ func TestDiskIsValidMissingEspFlag(t *testing.T) {
 		MaxSize:            3,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "fat32",
-				Start:          1,
+				Id:    "a",
+				Start: 1,
 				Flags: []PartitionFlag{
 					"boot",
 				},
@@ -281,9 +264,8 @@ func TestDiskIsValidMissingBootFlag(t *testing.T) {
 		MaxSize:            3,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "fat32",
-				Start:          1,
+				Id:    "a",
+				Start: 1,
 				Flags: []PartitionFlag{
 					"esp",
 				},
@@ -304,15 +286,13 @@ func TestDiskIsValidDuplicatePartitionId(t *testing.T) {
 		MaxSize:            2,
 		Partitions: []Partition{
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          1,
-				End:            ptrutils.PtrTo(uint64(2)),
+				Id:    "a",
+				Start: 1,
+				End:   ptrutils.PtrTo(uint64(2)),
 			},
 			{
-				Id:             "a",
-				FileSystemType: "ext4",
-				Start:          2,
+				Id:    "a",
+				Start: 2,
 			},
 		},
 	}

--- a/toolkit/tools/imagecustomizerapi/filesystem.go
+++ b/toolkit/tools/imagecustomizerapi/filesystem.go
@@ -9,7 +9,11 @@ import (
 
 // FileSystem holds the file system information for a partition.
 type FileSystem struct {
-	DeviceId   string      `yaml:"deviceId"`
+	// DeviceId is the ID of the source partition.
+	DeviceId string `yaml:"deviceId"`
+	// FileSystemType is the type of file system to use on the partition.
+	Type FileSystemType `yaml:"type"`
+	// MountPoint contains the mount settings.
 	MountPoint *MountPoint `yaml:"mountPoint"`
 }
 
@@ -17,6 +21,11 @@ type FileSystem struct {
 func (f *FileSystem) IsValid() error {
 	if f.DeviceId == "" {
 		return fmt.Errorf("invalid deviceId value: must not be empty")
+	}
+
+	err := f.Type.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid fileSystem (%s) type value:\n%w", f.DeviceId, err)
 	}
 
 	if f.MountPoint != nil {

--- a/toolkit/tools/imagecustomizerapi/filesystem_test.go
+++ b/toolkit/tools/imagecustomizerapi/filesystem_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileSystemIsValidBadDeviceId(t *testing.T) {
+	fileSystem := FileSystem{
+		DeviceId: "",
+		Type:     FileSystemTypeExt4,
+	}
+
+	err := fileSystem.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid deviceId value: must not be empty")
+}

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -13,8 +13,6 @@ import (
 type Partition struct {
 	// ID is used to correlate `Partition` objects with `PartitionSetting` objects.
 	Id string `yaml:"id"`
-	// FileSystemType is the type of file system to use on the partition.
-	FileSystemType FileSystemType `yaml:"fileSystemType"`
 	// Name is the label to assign to the partition.
 	Label string `yaml:"label"`
 	// Start is the offset where the partition begins (inclusive), in MiBs.
@@ -28,12 +26,7 @@ type Partition struct {
 }
 
 func (p *Partition) IsValid() error {
-	err := p.FileSystemType.IsValid()
-	if err != nil {
-		return fmt.Errorf("invalid partition (%s) fileSystemType value:\n%w", p.Id, err)
-	}
-
-	err = isGPTNameValid(p.Label)
+	err := isGPTNameValid(p.Label)
 	if err != nil {
 		return err
 	}
@@ -53,21 +46,9 @@ func (p *Partition) IsValid() error {
 		}
 	}
 
-	isESP := sliceutils.ContainsValue(p.Flags, PartitionFlagESP)
-	if isESP {
-		if p.FileSystemType != FileSystemTypeFat32 {
-			return fmt.Errorf("ESP partition must have 'fat32' filesystem type")
-		}
-	}
-
-	isBiosBoot := sliceutils.ContainsValue(p.Flags, PartitionFlagBiosGrub)
-	if isBiosBoot {
+	if p.IsBiosBoot() {
 		if p.Start != 1 {
 			return fmt.Errorf("BIOS boot partition must start at block 1")
-		}
-
-		if p.FileSystemType != FileSystemTypeFat32 {
-			return fmt.Errorf("BIOS boot partition must have 'fat32' filesystem type")
 		}
 	}
 
@@ -84,6 +65,14 @@ func (p *Partition) GetEnd() (uint64, bool) {
 	}
 
 	return 0, false
+}
+
+func (p *Partition) IsESP() bool {
+	return sliceutils.ContainsValue(p.Flags, PartitionFlagESP)
+}
+
+func (p *Partition) IsBiosBoot() bool {
+	return sliceutils.ContainsValue(p.Flags, PartitionFlagBiosGrub)
 }
 
 // isGPTNameValid checks if a GPT partition name is valid.

--- a/toolkit/tools/imagecustomizerapi/partition_test.go
+++ b/toolkit/tools/imagecustomizerapi/partition_test.go
@@ -12,9 +12,8 @@ import (
 
 func TestPartitionIsValidExpanding(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
+		Id:    "a",
+		Start: 0,
 	}
 
 	err := partition.IsValid()
@@ -23,10 +22,9 @@ func TestPartitionIsValidExpanding(t *testing.T) {
 
 func TestPartitionIsValidFixedSize(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		End:            ptrutils.PtrTo(uint64(1)),
+		Id:    "a",
+		Start: 0,
+		End:   ptrutils.PtrTo(uint64(1)),
 	}
 
 	err := partition.IsValid()
@@ -35,10 +33,9 @@ func TestPartitionIsValidFixedSize(t *testing.T) {
 
 func TestPartitionIsValidZeroSize(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		End:            ptrutils.PtrTo(uint64(0)),
+		Id:    "a",
+		Start: 0,
+		End:   ptrutils.PtrTo(uint64(0)),
 	}
 
 	err := partition.IsValid()
@@ -49,10 +46,9 @@ func TestPartitionIsValidZeroSize(t *testing.T) {
 
 func TestPartitionIsValidZeroSizeV2(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		Size:           ptrutils.PtrTo(uint64(0)),
+		Id:    "a",
+		Start: 0,
+		Size:  ptrutils.PtrTo(uint64(0)),
 	}
 
 	err := partition.IsValid()
@@ -63,10 +59,9 @@ func TestPartitionIsValidZeroSizeV2(t *testing.T) {
 
 func TestPartitionIsValidNegativeSize(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          2,
-		End:            ptrutils.PtrTo(uint64(1)),
+		Id:    "a",
+		Start: 2,
+		End:   ptrutils.PtrTo(uint64(1)),
 	}
 
 	err := partition.IsValid()
@@ -77,11 +72,10 @@ func TestPartitionIsValidNegativeSize(t *testing.T) {
 
 func TestPartitionIsValidBothEndAndSize(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          2,
-		End:            ptrutils.PtrTo(uint64(3)),
-		Size:           ptrutils.PtrTo(uint64(1)),
+		Id:    "a",
+		Start: 2,
+		End:   ptrutils.PtrTo(uint64(3)),
+		Size:  ptrutils.PtrTo(uint64(1)),
 	}
 
 	err := partition.IsValid()
@@ -92,11 +86,10 @@ func TestPartitionIsValidBothEndAndSize(t *testing.T) {
 
 func TestPartitionIsValidGoodName(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		End:            nil,
-		Label:          "a",
+		Id:    "a",
+		Start: 0,
+		End:   nil,
+		Label: "a",
 	}
 
 	err := partition.IsValid()
@@ -105,11 +98,10 @@ func TestPartitionIsValidGoodName(t *testing.T) {
 
 func TestPartitionIsValidNameTooLong(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		End:            nil,
-		Label:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Id:    "a",
+		Start: 0,
+		End:   nil,
+		Label: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}
 
 	err := partition.IsValid()
@@ -120,11 +112,10 @@ func TestPartitionIsValidNameTooLong(t *testing.T) {
 
 func TestPartitionIsValidNameNonASCII(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		End:            nil,
-		Label:          "❤️",
+		Id:    "a",
+		Start: 0,
+		End:   nil,
+		Label: "❤️",
 	}
 
 	err := partition.IsValid()
@@ -135,11 +126,10 @@ func TestPartitionIsValidNameNonASCII(t *testing.T) {
 
 func TestPartitionIsValidGoodFlag(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "fat32",
-		Start:          0,
-		End:            nil,
-		Flags:          []PartitionFlag{"esp"},
+		Id:    "a",
+		Start: 0,
+		End:   nil,
+		Flags: []PartitionFlag{"esp"},
 	}
 
 	err := partition.IsValid()
@@ -148,73 +138,13 @@ func TestPartitionIsValidGoodFlag(t *testing.T) {
 
 func TestPartitionIsValidBadFlag(t *testing.T) {
 	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		End:            nil,
-		Flags:          []PartitionFlag{"a"},
+		Id:    "a",
+		Start: 0,
+		End:   nil,
+		Flags: []PartitionFlag{"a"},
 	}
 
 	err := partition.IsValid()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "partitionFlag")
-}
-
-func TestPartitionIsValidUnsupportedFileSystem(t *testing.T) {
-	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ntfs",
-		Start:          0,
-		End:            nil,
-		Flags:          []PartitionFlag{"a"},
-	}
-
-	err := partition.IsValid()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "fileSystemType")
-}
-
-func TestPartitionIsValidBadEspFsType(t *testing.T) {
-	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          0,
-		End:            nil,
-		Flags:          []PartitionFlag{"esp"},
-	}
-
-	err := partition.IsValid()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "ESP")
-	assert.ErrorContains(t, err, "fat32")
-}
-
-func TestPartitionIsValidBadBiosBootFsType(t *testing.T) {
-	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          1,
-		End:            nil,
-		Flags:          []PartitionFlag{"bios-grub"},
-	}
-
-	err := partition.IsValid()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "BIOS boot")
-	assert.ErrorContains(t, err, "fat32")
-}
-
-func TestPartitionIsValidBadBiosBootStart(t *testing.T) {
-	partition := Partition{
-		Id:             "a",
-		FileSystemType: "ext4",
-		Start:          2,
-		End:            nil,
-		Flags:          []PartitionFlag{"bios-grub"},
-	}
-
-	err := partition.IsValid()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "BIOS boot")
-	assert.ErrorContains(t, err, "start")
 }

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -13,12 +13,11 @@ func TestStorageIsValidDuplicatePartitionID(t *testing.T) {
 	value := Storage{
 		Disks: []Disk{{
 			PartitionTableType: "gpt",
-			MaxSize:            2,
+			MaxSize:            2048,
 			Partitions: []Partition{
 				{
-					Id:             "esp",
-					FileSystemType: "fat32",
-					Start:          1,
+					Id:    "esp",
+					Start: 1,
 					Flags: []PartitionFlag{
 						"esp",
 						"boot",
@@ -30,12 +29,14 @@ func TestStorageIsValidDuplicatePartitionID(t *testing.T) {
 		FileSystems: []FileSystem{
 			{
 				DeviceId: "esp",
+				Type:     "fat32",
 				MountPoint: &MountPoint{
 					Path: "/boot/efi",
 				},
 			},
 			{
 				DeviceId: "esp",
+				Type:     "fat32",
 				MountPoint: &MountPoint{
 					Path: "/",
 				},
@@ -46,4 +47,153 @@ func TestStorageIsValidDuplicatePartitionID(t *testing.T) {
 	err := value.IsValid()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "duplicate fileSystem deviceId used")
+}
+
+func TestStorageIsValidUnsupportedFileSystem(t *testing.T) {
+	storage := Storage{
+		Disks: []Disk{{
+			PartitionTableType: PartitionTableTypeGpt,
+			MaxSize:            2048,
+			Partitions: []Partition{
+				{
+					Id:    "a",
+					Start: 1,
+					End:   nil,
+					Flags: nil,
+				},
+			},
+		}},
+		BootType: BootTypeEfi,
+		FileSystems: []FileSystem{
+			{
+				DeviceId: "a",
+				Type:     "ntfs",
+			},
+		},
+	}
+
+	err := storage.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid fileSystemType value (ntfs)")
+}
+
+func TestStorageIsValidBadEspFsType(t *testing.T) {
+	storage := Storage{
+		Disks: []Disk{{
+			PartitionTableType: PartitionTableTypeGpt,
+			MaxSize:            2048,
+			Partitions: []Partition{
+				{
+					Id:    "esp",
+					Start: 1,
+					End:   nil,
+					Flags: []PartitionFlag{PartitionFlagESP, PartitionFlagBoot},
+				},
+			},
+		}},
+		BootType: BootTypeEfi,
+		FileSystems: []FileSystem{
+			{
+				DeviceId: "esp",
+				Type:     "ext4",
+			},
+		},
+	}
+
+	err := storage.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ESP partition must have 'fat32' filesystem type")
+}
+
+func TestStorageIsValidBadBiosBootFsType(t *testing.T) {
+	storage := Storage{
+		Disks: []Disk{{
+			PartitionTableType: PartitionTableTypeGpt,
+			MaxSize:            2048,
+			Partitions: []Partition{
+				{
+					Id:    "bios",
+					Start: 1,
+					End:   nil,
+					Flags: []PartitionFlag{PartitionFlagBiosGrub},
+				},
+			},
+		}},
+		BootType: BootTypeEfi,
+		FileSystems: []FileSystem{
+			{
+				DeviceId: "bios",
+				Type:     "ext4",
+			},
+		},
+	}
+
+	err := storage.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "BIOS boot partition must have 'fat32' filesystem type")
+}
+
+func TestStorageIsValidBadBiosBootStart(t *testing.T) {
+	storage := Storage{
+		Disks: []Disk{{
+			PartitionTableType: PartitionTableTypeGpt,
+			MaxSize:            2048,
+			Partitions: []Partition{
+				{
+					Id:    "bios",
+					Start: 2,
+					End:   nil,
+					Flags: []PartitionFlag{PartitionFlagBiosGrub},
+				},
+			},
+		}},
+		BootType: BootTypeLegacy,
+		FileSystems: []FileSystem{
+			{
+				DeviceId: "bios",
+				Type:     "fat32",
+			},
+		},
+	}
+
+	err := storage.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "BIOS boot partition must start at block 1")
+}
+
+func TestStorageIsValidBadDeviceId(t *testing.T) {
+	value := Storage{
+		Disks: []Disk{{
+			PartitionTableType: "gpt",
+			MaxSize:            2048,
+			Partitions: []Partition{
+				{
+					Id:    "esp",
+					Start: 1,
+					Flags: []PartitionFlag{
+						"esp",
+						"boot",
+					},
+				},
+			},
+		}},
+		BootType: "efi",
+		FileSystems: []FileSystem{
+			{
+				DeviceId: "esp",
+				Type:     "fat32",
+				MountPoint: &MountPoint{
+					Path: "/boot/efi",
+				},
+			},
+			{
+				DeviceId: "a",
+				Type:     "fat32",
+			},
+		},
+	}
+
+	err := value.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "no partition with matching ID (a)")
 }

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -120,6 +120,7 @@ func ContainsFunc[K any](inputSlice []K, fn func(K) bool) bool {
 	return false
 }
 
+FindValueFunc returns the first value in the slice that matches fn(item) == true along with true, otherwise it returns the default value for an instance of value's type, and false.
 func FindValueFunc[K any](inputSlice []K, fn func(K) bool) (K, bool) {
 	for _, item := range inputSlice {
 		if fn(item) {

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -119,3 +119,14 @@ func ContainsFunc[K any](inputSlice []K, fn func(K) bool) bool {
 	}
 	return false
 }
+
+func FindValueFunc[K any](inputSlice []K, fn func(K) bool) (K, bool) {
+	for _, item := range inputSlice {
+		if fn(item) {
+			return item, true
+		}
+	}
+
+	var value K
+	return value, false
+}

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -120,7 +120,8 @@ func ContainsFunc[K any](inputSlice []K, fn func(K) bool) bool {
 	return false
 }
 
-FindValueFunc returns the first value in the slice that matches fn(item) == true along with true, otherwise it returns the default value for an instance of value's type, and false.
+// FindValueFunc returns the first value in the slice that matches fn(item) == true along with true, otherwise it
+// returns the default value for an instance of value's type, and false.
 func FindValueFunc[K any](inputSlice []K, fn func(K) bool) (K, bool) {
 	for _, item := range inputSlice {
 		if fn(item) {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -280,17 +280,15 @@ func createFakeEfiImage(buildDir string) (string, error) {
 		MaxSize:            4096,
 		Partitions: []imagecustomizerapi.Partition{
 			{
-				Id:             "boot",
-				Flags:          []imagecustomizerapi.PartitionFlag{"esp", "boot"},
-				Start:          1,
-				End:            ptrutils.PtrTo(uint64(9)),
-				FileSystemType: "fat32",
+				Id:    "boot",
+				Flags: []imagecustomizerapi.PartitionFlag{"esp", "boot"},
+				Start: 1,
+				End:   ptrutils.PtrTo(uint64(9)),
 			},
 			{
-				Id:             "rootfs",
-				Start:          9,
-				End:            nil,
-				FileSystemType: "ext4",
+				Id:    "rootfs",
+				Start: 9,
+				End:   nil,
 			},
 		},
 	}
@@ -298,6 +296,7 @@ func createFakeEfiImage(buildDir string) (string, error) {
 	fileSystems := []imagecustomizerapi.FileSystem{
 		{
 			DeviceId: "boot",
+			Type:     "fat32",
 			MountPoint: &imagecustomizerapi.MountPoint{
 				Path:    "/boot/efi",
 				Options: "umask=0077",
@@ -305,6 +304,7 @@ func createFakeEfiImage(buildDir string) (string, error) {
 		},
 		{
 			DeviceId: "rootfs",
+			Type:     "ext4",
 			MountPoint: &imagecustomizerapi.MountPoint{
 				Path: "/",
 			},

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -114,7 +114,7 @@ func createNewImageHelper(imageConnection *ImageConnection, filename string, dis
 ) error {
 
 	// Convert config to image config types, so that the imager's utils can be used.
-	imagerDiskConfig, err := diskConfigToImager(diskConfig)
+	imagerDiskConfig, err := diskConfigToImager(diskConfig, fileSystems)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
@@ -8,18 +8,18 @@ storage:
       - bios-grub
       start: 1
       size: 8
-      fileSystemType: fat32
 
     - id: rootfs
       start: 9
-      fileSystemType: ext4
 
   bootType: legacy
 
   fileSystems:
   - deviceId: boot
+    type: fat32
 
   - deviceId: rootfs
+    type: ext4
     mountPoint:
       path: /
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/mshvkernel-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/mshvkernel-config.yaml
@@ -9,21 +9,21 @@ storage:
       - boot
       start: 1
       end: 65
-      fileSystemType: fat32
 
     - id: rootfs
       start: 65
-      fileSystemType: ext4
 
   bootType: efi
 
   fileSystems:
   - deviceId: efi
+    type: fat32
     mountPoint:
       path: /boot/efi
       options: umask=0077
 
   - deviceId: rootfs
+    type: ext4
     mountPoint:
       path: /
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
@@ -9,39 +9,39 @@ storage:
       - boot
       start: 1
       end: 9
-      fileSystemType: fat32
 
     - id: boot
       start: 9
       end: 108
-      fileSystemType: ext4
 
     - id: rootfs
       start: 108
       end: 2048
-      fileSystemType: xfs
 
     - id: var
       start: 2048
-      fileSystemType: xfs
-
+      
   bootType: efi
 
   fileSystems:
   - deviceId: esp
+    type: fat32
     mountPoint:
       path: /boot/efi
       options: umask=0077
 
   - deviceId: boot
+    type: ext4
     mountPoint:
       path: /boot
 
   - deviceId: rootfs
+    type: xfs
     mountPoint:
       path: /
 
   - deviceId: var
+    type: xfs
     mountPoint:
       path: /var
 


### PR DESCRIPTION
Move the `fileSystemType` property from the `partition` type to the `fileSystem` type and rename it to just `type`.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

