### PR TITLE
Revert "systemd: add Provides: for the "bootstrap" package names"

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        10%{?dist}
+Release:        9%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -274,7 +274,6 @@ Provides:       /sbin/shutdown
 Provides:       syslog
 Provides:       systemd-units = %{version}-%{release}
 Obsoletes:      systemd-bootstrap <= %{version}-%{release}
-Provides:       systemd-bootstrap = %{version}-%{release}
 Obsoletes:      system-setup-keyboard < 0.9
 Provides:       system-setup-keyboard = 0.9
 # systemd-sysv-convert was removed in f20: https://fedorahosted.org/fpc/ticket/308
@@ -348,7 +347,6 @@ Obsoletes:      nss-myhostname < 0.4
 Provides:       nss-myhostname = 0.4
 Provides:       nss-myhostname%{_isa} = 0.4
 Obsoletes:      systemd-bootstrap-libs <= %{version}-%{release}
-Provides:       systemd-bootstrap-libs = %{version}-%{release}
 
 %description libs
 Libraries for systemd and udev.
@@ -364,7 +362,6 @@ Systemd PAM module registers the session with systemd-logind.
 Summary:        Macros that define paths and scriptlets related to systemd
 BuildArch:      noarch
 Obsoletes:      systemd-bootstrap-rpm-macros <= %{version}-%{release}
-Provides:       systemd-bootstrap-rpm-macros = %{version}-%{release}
 
 %description rpm-macros
 Just the definitions of rpm macros.
@@ -384,7 +381,6 @@ Provides:       libudev-devel = %{version}
 Provides:       libudev-devel%{_isa} = %{version}
 Obsoletes:      libudev-devel < 183
 Obsoletes:      systemd-bootstrap-devel <= %{version}-%{release}
-Provides:       systemd-bootstrap-devel = %{version}-%{release}
 
 %description devel
 Development headers and auxiliary files for developing applications linking
@@ -1193,9 +1189,6 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
-* Wed Mar 20 2024 Dan Streetman <ddstreet@microsoft.com> - 255-10
-- provide the "bootstrap" package names
-
 * Wed Mar 20 2024 Dan Streetman <ddstreet@microsoft.com> - 255-9
 - build dep the "bootstrap" macros because our maint scripts are broken without
   our rpm macros available during the build


### PR DESCRIPTION
This reverts commit e2f7ca6f2f705b2447aa3e98f6ef8bf76ec6f08f.

This commit exposes a limitation in our build-cycle resolution code. Will need to fix it, but revert in the meantime.
We should not have been able to publish this package as-is, so I believe the revert of the release number is ok.

Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/49601294

Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=533021&view=results
