### PR TITLE
Fix build break for atinject

### DIFF
--- a/SPECS/atinject/atinject.spec
+++ b/SPECS/atinject/atinject.spec
@@ -18,8 +18,8 @@
 %global git_version 20100611git1f74ea7
 Summary:        Dependency injection specification for Java (JSR-330)
 Name:           atinject
-Version:        %{base_version}+%{git_version}
-Release:        5%{?dist}
+Version:        %{base_version}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,8 +75,8 @@ sed -i -e 's/pom\.groupId/project.groupId/' tck-pom.xml
 set -e
 alias rm=:
 alias xargs=:
-alias javadoc='javadoc -source 6 -notimestamp -Xdoclint:none'
-alias javac='javac -source 6 -target 6'
+alias javadoc='javadoc -source 7 -notimestamp -Xdoclint:none'
+alias javac='javac -source 7 -target 7'
 . ./build.sh
 
 # Inject OSGi manifests required by Eclipse.
@@ -114,6 +114,9 @@ cp -pr  build/javadoc/* %{buildroot}%{_javadocdir}/%{name}/
 %{_javadocdir}/%{name}
 
 %changelog
+* Thu Feb 22 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 1-6
+- Updated to build with Java 7.  Modified version
+
 * Thu Feb 22 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 1+20100611git1f74ea7-5
 - Updating naming for 3.0 version of Azure Linux.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Summary <!-- REQUIRED -->
This change is primarily to fix a build break with atinject.  