### PR TITLE
add libgcc back in distroless base image

### DIFF
--- a/SPECS/distroless-packages/distroless-packages.spec
+++ b/SPECS/distroless-packages/distroless-packages.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage with core sets of packages for distroless containers.
 Name:           distroless-packages
 Version:        %{azl}.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -28,6 +28,7 @@ Requires:       %{name}-minimal = %{version}-%{release}
 Requires:       filesystem
 Requires:       glibc-iconv
 Requires:       iana-etc
+Requires:       libgcc
 Requires:       azurelinux-release
 Requires:       openssl
 Requires:       openssl-libs
@@ -55,6 +56,9 @@ Requires:       busybox
 %files debug
 
 %changelog
+* Fri Mar 22 2024 Mandeep Plaha <mandeepplaha@microsoft.com> - 3.0-3
+- Explicitly add libgcc as a runtime dependency for distroless-base
+
 * Wed Feb 07 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 3.0-2
 - Update the runtime dependency from mariner-release to azurelinux-release
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR adds `libgcc` package as an explicit runtime dependency to distroless base container image. `libgcc` package is present in the image in Azure Linux 2.0, however, it was coming in as a dependency from some other package. Changes in Azure Linux 3.0 have resulted in `libgcc` being removed from the distroless base container image. To maintain the composition, we need to add this package back to the distroless base image.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Package: `distroless-packages-base`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Manual comparison of packages in the distroless/debug containers from Azure Linux 2.0 and 3.0.

| Azure Linux 2.0 distroless/debug | Azure Linux 3.0 distroless/debug |
|-|-|
| busybox | busybox |
| distroless-packages-base | distroless-packages-base |
| distroless-packages-debug | distroless-packages-debug |
| distroless-packages-minimal | distroless-packages-minimal |
| filesystem | filesystem |
| glibc | glibc |
| glibc-iconv | glibc-iconv |
| iana-etc | iana-etc |
| libgcc | |
| mariner-release | azurelinux-release |
| openssl | openssl |
| openssl-libs | openssl-libs |
| prebuilt-ca-certificates | prebuilt-ca-certificates |
| tzdata | tzdata |
