### PR TITLE
Add workflow to check for circular deps (3.0 only)

### DIFF
--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -25,6 +25,6 @@ jobs:
           pushd toolkit
           ./scripts/setuplkgtoolchain.sh
           BUILD_ID=$(wget -qO - https://mariner3dailydevrepo.blob.core.windows.net/lkg/lkg-3.0-dev.json | jq -r ".dailybuildid" | tr '\.' '-')
-          make graph REBUILD_TOOLS=y DAILY_BUILD_ID=${BUILD_ID}
+          sudo make -j$(nproc) graph REBUILD_TOOLS=y DAILY_BUILD_ID=${BUILD_ID}
           popd
         if: always()

--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Circular dependency check
+
+on:
+  push:
+    branches: [3.0*]
+  pull_request:
+    branches: [3.0*]
+
+jobs:
+  spec-check:
+    name: Circular dependency check
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the branch of our repo that triggered this action
+      - name: Workflow trigger checkout
+        uses: actions/checkout@v4
+
+      - name: Check for circular dependencies
+        run: |
+          echo "Checking for circular dependency loops..."
+          pushd toolkit
+          ./scripts/setuplkgtoolchain.sh
+          BUILD_ID=$(wget -qO - https://mariner3dailydevrepo.blob.core.windows.net/lkg/lkg-3.0-dev.json | jq -r ".dailybuildid" | tr '\.' '-')
+          make graph REBUILD_TOOLS=y DAILY_BUILD_ID=${BUILD_ID}
+          popd
+        if: always()

--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -22,9 +22,11 @@ jobs:
       - name: Check for circular dependencies
         run: |
           echo "Checking for circular dependency loops..."
-          pushd toolkit
-          ./scripts/setuplkgtoolchain.sh
-          BUILD_ID=$(wget -qO - https://mariner3dailydevrepo.blob.core.windows.net/lkg/lkg-3.0-dev.json | jq -r ".dailybuildid" | tr '\.' '-')
-          sudo make -j$(nproc) graph REBUILD_TOOLS=y DAILY_BUILD_ID=${BUILD_ID}
-          popd
+          # Call this script to sync the toolchain manifests with the LKG daily build.
+          ./toolkit/scripts/setuplkgtoolchain.sh
+          # Determine the LKG daily build ID.
+          LKG_BUILD_ID=$(wget -qO - https://mariner3dailydevrepo.blob.core.windows.net/lkg/lkg-3.0-dev.json | jq -r ".dailybuildid" | tr '\.' '-')
+          # Setup the toolchain using the LKG daily build, and then make the full package graph.
+          # This will fail if any circular dependency loops are detected in the core SPECs.
+          sudo make -C toolkit -j$(nproc) graph REBUILD_TOOLS=y DAILY_BUILD_ID=${LKG_BUILD_ID}
         if: always()

--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -29,4 +29,3 @@ jobs:
           # Setup the toolchain using the LKG daily build, and then make the full package graph.
           # This will fail if any circular dependency loops are detected in the core SPECs.
           sudo make -C toolkit -j$(nproc) graph REBUILD_TOOLS=y DAILY_BUILD_ID=${LKG_BUILD_ID}
-        if: always()

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -274,7 +274,6 @@ Provides:       /sbin/shutdown
 Provides:       syslog
 Provides:       systemd-units = %{version}-%{release}
 Obsoletes:      systemd-bootstrap <= %{version}-%{release}
-Provides:       systemd-bootstrap = %{version}-%{release}
 Obsoletes:      system-setup-keyboard < 0.9
 Provides:       system-setup-keyboard = 0.9
 # systemd-sysv-convert was removed in f20: https://fedorahosted.org/fpc/ticket/308
@@ -348,7 +347,6 @@ Obsoletes:      nss-myhostname < 0.4
 Provides:       nss-myhostname = 0.4
 Provides:       nss-myhostname%{_isa} = 0.4
 Obsoletes:      systemd-bootstrap-libs <= %{version}-%{release}
-Provides:       systemd-bootstrap-libs = %{version}-%{release}
 
 %description libs
 Libraries for systemd and udev.
@@ -364,7 +362,6 @@ Systemd PAM module registers the session with systemd-logind.
 Summary:        Macros that define paths and scriptlets related to systemd
 BuildArch:      noarch
 Obsoletes:      systemd-bootstrap-rpm-macros <= %{version}-%{release}
-Provides:       systemd-bootstrap-rpm-macros = %{version}-%{release}
 
 %description rpm-macros
 Just the definitions of rpm macros.
@@ -384,7 +381,6 @@ Provides:       libudev-devel = %{version}
 Provides:       libudev-devel%{_isa} = %{version}
 Obsoletes:      libudev-devel < 183
 Obsoletes:      systemd-bootstrap-devel <= %{version}-%{release}
-Provides:       systemd-bootstrap-devel = %{version}-%{release}
 
 %description devel
 Development headers and auxiliary files for developing applications linking

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -274,6 +274,7 @@ Provides:       /sbin/shutdown
 Provides:       syslog
 Provides:       systemd-units = %{version}-%{release}
 Obsoletes:      systemd-bootstrap <= %{version}-%{release}
+Provides:       systemd-bootstrap = %{version}-%{release}
 Obsoletes:      system-setup-keyboard < 0.9
 Provides:       system-setup-keyboard = 0.9
 # systemd-sysv-convert was removed in f20: https://fedorahosted.org/fpc/ticket/308
@@ -347,6 +348,7 @@ Obsoletes:      nss-myhostname < 0.4
 Provides:       nss-myhostname = 0.4
 Provides:       nss-myhostname%{_isa} = 0.4
 Obsoletes:      systemd-bootstrap-libs <= %{version}-%{release}
+Provides:       systemd-bootstrap-libs = %{version}-%{release}
 
 %description libs
 Libraries for systemd and udev.
@@ -362,6 +364,7 @@ Systemd PAM module registers the session with systemd-logind.
 Summary:        Macros that define paths and scriptlets related to systemd
 BuildArch:      noarch
 Obsoletes:      systemd-bootstrap-rpm-macros <= %{version}-%{release}
+Provides:       systemd-bootstrap-rpm-macros = %{version}-%{release}
 
 %description rpm-macros
 Just the definitions of rpm macros.
@@ -381,6 +384,7 @@ Provides:       libudev-devel = %{version}
 Provides:       libudev-devel%{_isa} = %{version}
 Obsoletes:      libudev-devel < 183
 Obsoletes:      systemd-bootstrap-devel <= %{version}-%{release}
+Provides:       systemd-bootstrap-devel = %{version}-%{release}
 
 %description devel
 Development headers and auxiliary files for developing applications linking


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add a github workflow to verify changes will not introduce a circular dependency into the full builds. Circular dependencies are difficult to catch during code review, and our buddybuild pipeline does not catch them (since it only builds with a small graph, including the packages specifically requested in that build). We typically catch circular dependency breaks in nightly full builds.
This PR check is currently only enabled for 3.0 branches, as it relies on the DAILY_BUILD_ID repos.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add workflow to check for circular dependency loops

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: This PR has a link to the check: https://github.com/microsoft/azurelinux/actions/runs/8397479624/job/23000849407?pr=8528
- Example of the PR check failing (with intentional circular dependency added to this PR): https://github.com/microsoft/azurelinux/actions/runs/8397600261/job/23001167684?pr=8528