### PR TITLE
Remove auto provides from systemd-bootstrap

### DIFF
--- a/SPECS/systemd-bootstrap/systemd-bootstrap.spec
+++ b/SPECS/systemd-bootstrap/systemd-bootstrap.spec
@@ -98,6 +98,8 @@ Just the definitions of rpm macros.
 Summary:        Development headers for systemd
 Requires:       %{name} = %{version}-%{release}
 Requires:       glib-devel
+# device-mapper-devel needs this specifically, but we want to minimize the provides where possible.
+Provides:       pkgconfig(libudev)
 AutoReqProv:    no
 
 %description devel

--- a/SPECS/systemd-bootstrap/systemd-bootstrap.spec
+++ b/SPECS/systemd-bootstrap/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,7 +75,7 @@ Requires:       libgcrypt
 Requires:       lz4
 Requires:       pam
 Requires:       xz
-AutoReq:        no
+AutoReqProv:    no
 
 %description
 Systemd is an init replacement with better process control and security
@@ -89,7 +89,7 @@ Systemd libraries
 %package rpm-macros
 Summary:        Macros that define paths and scriptlets related to systemd
 BuildArch:      noarch
-AutoReq:        no
+AutoReqProv:    no
 
 %description rpm-macros
 Just the definitions of rpm macros.
@@ -98,7 +98,7 @@ Just the definitions of rpm macros.
 Summary:        Development headers for systemd
 Requires:       %{name} = %{version}-%{release}
 Requires:       glib-devel
-AutoReq:        no
+AutoReqProv:    no
 
 %description devel
 Development headers for developing applications linking to libsystemd
@@ -285,6 +285,10 @@ fi
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Fri Mar 22 2024 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-18
+- Remove automatic provides so pkgconfig(libsystemd) etc. don't get confused with
+  the real versions
+
 * Mon Mar 11 2024 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-17
 - Split libs into their own subpackage to align with full systemd.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -571,11 +571,11 @@ sqlite-devel-3.44.0-1.azl3.aarch64.rpm
 sqlite-libs-3.44.0-1.azl3.aarch64.rpm
 swig-4.1.1-1.azl3.aarch64.rpm
 swig-debuginfo-4.1.1-1.azl3.aarch64.rpm
-systemd-bootstrap-250.3-17.azl3.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-17.azl3.aarch64.rpm
-systemd-bootstrap-devel-250.3-17.azl3.aarch64.rpm
-systemd-bootstrap-libs-250.3-17.azl3.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-17.azl3.noarch.rpm
+systemd-bootstrap-250.3-18.azl3.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-18.azl3.aarch64.rpm
+systemd-bootstrap-devel-250.3-18.azl3.aarch64.rpm
+systemd-bootstrap-libs-250.3-18.azl3.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-18.azl3.noarch.rpm
 tar-1.35-1.azl3.aarch64.rpm
 tar-debuginfo-1.35-1.azl3.aarch64.rpm
 tdnf-3.5.6-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -577,11 +577,11 @@ sqlite-devel-3.44.0-1.azl3.x86_64.rpm
 sqlite-libs-3.44.0-1.azl3.x86_64.rpm
 swig-4.1.1-1.azl3.x86_64.rpm
 swig-debuginfo-4.1.1-1.azl3.x86_64.rpm
-systemd-bootstrap-250.3-17.azl3.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-17.azl3.x86_64.rpm
-systemd-bootstrap-devel-250.3-17.azl3.x86_64.rpm
-systemd-bootstrap-libs-250.3-17.azl3.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-17.azl3.noarch.rpm
+systemd-bootstrap-250.3-18.azl3.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-18.azl3.x86_64.rpm
+systemd-bootstrap-devel-250.3-18.azl3.x86_64.rpm
+systemd-bootstrap-libs-250.3-18.azl3.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-18.azl3.noarch.rpm
 tar-1.35-1.azl3.x86_64.rpm
 tar-debuginfo-1.35-1.azl3.x86_64.rpm
 tdnf-3.5.6-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The build tools give priority to toolchain packages. While there are cases where we need to use `systemd-bootstrap` they should be minimized where possible. Unfortunately with auto provides turned on, `systemd-bootstrap` was generating `pkgconifg(libsystemd)`. If a package had a build dependency `BuildRequires: systemd-rpm-macros` and `BuildRequires: pkgconfig(libsystemd)` the tools would prioritize picking the toolchain package if possible, but the explicit requires on the full `systemd` would create a conflict.

Use of `systemd-bootstrap` should be intentional and minimized, so turn off the auto provides. This means that a package must explicitly call `BuildRequires: systemd-bootstrap*` to get the bootstrap rpms.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- change `systemd-bootstrap` to  use `AutoReqProv: no` instead of just `AutoReq:no`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build with vte291 package changes included (showed this conflict): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=533809&view=results