### PR TITLE
Remove kernel-mshv-tools

### DIFF
--- a/SPECS/kernel-mshv/kernel-mshv.spec
+++ b/SPECS/kernel-mshv/kernel-mshv.spec
@@ -11,7 +11,7 @@
 Summary:        Mariner kernel that has MSHV Host support
 Name:           kernel-mshv
 Version:        5.15.126.mshv3
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv2
 Group:          Development/Tools
 Vendor:         Microsoft Corporation
@@ -68,15 +68,6 @@ Requires:       python3
 %description docs
 This package contains the MSHV kernel doc files
 
-%package tools
-Summary:        This package contains the 'perf' performance analysis tools for MSHV kernel
-Group:          System/Tools
-Requires:       %{name} = %{version}-%{release}
-Requires:       audit
-
-%description tools
-This package contains the 'perf' performance analysis tools for MSHV kernel.
-
 %prep
 %autosetup -p1
 
@@ -120,7 +111,7 @@ make INSTALL_MOD_PATH=%{buildroot} modules_install
 
 # Add kernel-mshv-specific boot configurations to /etc/default/grub.d
 # This configuration contains additional boot parameters required in our
-# Linux-Dom0-based images. 
+# Linux-Dom0-based images.
 install -Dm 755 %{SOURCE3} %{buildroot}%{_sysconfdir}/default/grub.d/50_mariner_mshv.cfg
 install -Dm 755 %{SOURCE4} %{buildroot}%{_sysconfdir}/grub.d/50_mariner_mshv_menuentry
 
@@ -159,14 +150,6 @@ install -vsm 755 tools/objtool/fixdep %{buildroot}%{_prefix}/src/linux-headers-%
 cp .config %{buildroot}%{_prefix}/src/linux-headers-%{uname_r} # copy .config manually to be where it's expected to be
 ln -sf "%{_prefix}/src/linux-headers-%{uname_r}" "%{buildroot}/lib/modules/%{uname_r}/build"
 find %{buildroot}/lib/modules -name '*.ko' -print0 | xargs -0 chmod u+x
-
-# disable (JOBS=1) parallel build to fix this issue:
-# fixdep: error opening depfile: ./.plugin_cfg80211.o.d: No such file or directory
-# Linux version that was affected is 4.4.26
-make -C tools JOBS=1 DESTDIR=%{buildroot} prefix=%{_prefix} perf_install
-
-# Remove trace (symlink to perf). This file causes duplicate identical debug symbols
-rm -vf %{buildroot}%{_bindir}/trace
 
 %triggerin -- initramfs
 mkdir -p %{_localstatedir}/lib/rpm-state/initramfs/pending
@@ -208,22 +191,10 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %defattr(-,root,root)
 %{_defaultdocdir}/linux-%{uname_r}/*
 
-%files tools
-%defattr(-,root,root)
-%{_libexecdir}
-%exclude %dir %{_libdir}/debug
-%{_lib64dir}/traceevent
-%{_lib64dir}/libperf-jvmti.so
-%{_bindir}
-%{_sysconfdir}/bash_completion.d/*
-%{_datadir}/perf-core/strace/groups/file
-%{_datadir}/perf-core/strace/groups/string
-%{_docdir}/*
-%{_libdir}/perf/examples/bpf/*
-%{_libdir}/perf/include/bpf/*
-%{_includedir}/perf/perf_dlfilter.h
-
 %changelog
+* Mon Mar 25 2024 Manuel Huber <mahuber@microsoft.com> - 5.15.126.mshv3-8
+- Remove the tools subpackage.
+
 * Wed Mar 06 2024 Chris Gunn <chrisgun@microsoft.com> - 5.15.126.mshv3-7
 - Remove /var/lib/initramfs/kernel files.
 
@@ -240,7 +211,7 @@ echo "initrd of kernel %{uname_r} removed" >&2
 - Introduce 50_mariner_mshv_menuentry, which implements
     the custom boot path when running over MSHV.
 - Check for required mshv components in 50_mariner_mshv.cfg before
-    defaulting to kernel-mshv boot. 
+    defaulting to kernel-mshv boot.
 
 * Tue Dec 12 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.126.mshv3-2
 - Add patch for perf_bpf_test_add_nonnull_argument
@@ -250,21 +221,21 @@ echo "initrd of kernel %{uname_r} removed" >&2
 - Update to v5.15.126.mshv3
 
 * Tue Sep 19 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.110.mshv2-5
-- Enable grub2-mkconfig-based boot path by installing 
-    50_mariner_mshv.cfg 
-- Call grub2-mkconfig to regenerate configs only if the user has 
-    previously used grub2-mkconfig for boot configuration. 
+- Enable grub2-mkconfig-based boot path by installing
+    50_mariner_mshv.cfg
+- Call grub2-mkconfig to regenerate configs only if the user has
+    previously used grub2-mkconfig for boot configuration.
 
 * Thu Jun 22 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.110.mshv2-4
 - Don't include duplicate systemd parameters in mariner-mshv.cfg; should be read from
     systemd.cfg which is packaged in systemd
 
 * Tue May 30 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.110.mshv2-3
-- Align mariner_cmdline_mshv with the working configuration from 
+- Align mariner_cmdline_mshv with the working configuration from
     old loader's linuxloader.conf
 
 * Wed May 24 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.110.mshv2-2
-- Add temporary 0001-Support-new-HV-loader... patch to support lxhvloader. 
+- Add temporary 0001-Support-new-HV-loader... patch to support lxhvloader.
 - Can be reverted once the kernel patch is upstreamed.
 - Introduce mariner-mshv.cfg symlink to improve grub menuentry
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR removes the kernel-mshv-tools subpackage to unblock Azure Linux 3.0 builds. We will address at a later point whether and how to re-include the subpackage.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove the tools subpackage to unblock Azure Linux 3.0 builds

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 535264
