### PR TITLE
explicitly add libgcc as a Requires to distroless base

### DIFF
--- a/SPECS/distroless-packages/distroless-packages.spec
+++ b/SPECS/distroless-packages/distroless-packages.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage with core sets of packages for distroless containers.
 Name:           distroless-packages
 Version:        0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -28,6 +28,7 @@ Requires:       %{name}-minimal = %{version}-%{release}
 Requires:       filesystem
 Requires:       glibc-iconv
 Requires:       iana-etc
+Requires:       libgcc
 Requires:       mariner-release
 Requires:       openssl
 Requires:       openssl-libs
@@ -55,6 +56,9 @@ Requires:       busybox
 %files debug
 
 %changelog
+* Mon Mar 25 2024 Mandeep Plaha <mandeepplaha@microsoft.com> - 0.1-4
+- Explicitly add libgcc as a runtime dependency for distroless-base
+
 * Wed Nov 16 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 0.1-3
 - Replace prebuilt-ca-certificates-base with prebuilt-ca-certificates in minimal
 - Add tzdata to minimal


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR adds `libgcc` package explictly as a runtime dependency for distroless/base subpackage to ensure that the distroless/base container image continues to have it. Currently, `libgcc` is brought it by some other package as its dependency. It was observed that the changes in Azure Linux 3.0 had resulted in the removal of `libgcc` package from distroless base, so it was explictly added to not cause a breaking change. For reference, this is the merged PR in Azure Linux 3.0: https://github.com/microsoft/azurelinux/pull/8520.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Package: `distroless-packages-base`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
This is considered a non-breaking change as we are just explicitly including `libgcc` as a runtime dependency; it is already present due to some other package.

| Azure Linux 2.0 distroless/debug |
|-|
| busybox |
| distroless-packages-base |
| distroless-packages-debug |
| distroless-packages-minimal |
| filesystem |
| glibc |
| glibc-iconv |
| iana-etc |
| libgcc |
| mariner-release |
| openssl |
| openssl-libs |
| prebuilt-ca-certificates |
| tzdata |