### PR TITLE
abseil-cpp: upgrade to 20240116.0, opentelemetry-cpp: upgrade to 1.14.2, nginx: upgrade to 1.25.4

### DIFF
--- a/SPECS/abseil-cpp/abseil-cpp.signatures.json
+++ b/SPECS/abseil-cpp/abseil-cpp.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "abseil-cpp-20230802.1.tar.gz": "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed"
+  "abseil-cpp-20240116.0.tar.gz": "338420448b140f0dfd1a1ea3c3ce71b3bc172071f24f4d9a57d59b45037da440"
  }
 }

--- a/SPECS/abseil-cpp/abseil-cpp.spec
+++ b/SPECS/abseil-cpp/abseil-cpp.spec
@@ -1,5 +1,6 @@
 # Installed library version
 %global lib_version 2401.0.0
+%define lib_ver_min %(echo %{lib_version} | cut -d. -f1-2)
 
 Summary:        C++ Common Libraries
 Name:           abseil-cpp
@@ -14,19 +15,14 @@ Source0:        https://github.com/abseil/abseil-cpp/archive/refs/tags/%{version
 BuildRequires:  cmake >= 3.20.0
 BuildRequires:  gcc
 BuildRequires:  make
-BuildRequires:  ninja-build
-BuildRequires:  gcc-c++
-
-BuildRequires:  gmock
 BuildRequires:  gmock-devel
 BuildRequires:  gtest
 BuildRequires:  gtest-devel
 
-%ifarch s390x
-# Symbolize.SymbolizeWithMultipleMaps fails in absl_symbolize_test on s390x
-# with LTO
-# https://github.com/abseil/abseil-cpp/issues/1133
-%global _lto_cflags %{nil}
+%if 0%{?with_check}
+BuildRequires:  ninja-build
+BuildRequires:  gcc-c++
+BuildRequires:  gmock
 %endif
 
 %description
@@ -64,7 +60,9 @@ Development headers for %{name}
 
 %build
 %cmake \
+%if 0%{?with_check}
   -GNinja \
+%endif
   -DABSL_USE_EXTERNAL_GOOGLETEST:BOOL=ON \
   -DABSL_FIND_GOOGLETEST:BOOL=ON \
   -DABSL_ENABLE_INSTALL:BOOL=ON \
@@ -83,7 +81,7 @@ Development headers for %{name}
 %files
 %license LICENSE
 %doc FAQ.md README.md UPGRADES.md
-%{_libdir}/libabsl_*.so.2401.*
+%{_libdir}/libabsl_*.so.%{lib_ver_min}.*
 
 %files devel
 %{_includedir}/absl

--- a/SPECS/abseil-cpp/abseil-cpp.spec
+++ b/SPECS/abseil-cpp/abseil-cpp.spec
@@ -1,6 +1,9 @@
+# Installed library version
+%global lib_version 2401.0.0
+
 Summary:        C++ Common Libraries
 Name:           abseil-cpp
-Version:        20230802.1
+Version:        20240116.0
 Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
@@ -11,12 +14,19 @@ Source0:        https://github.com/abseil/abseil-cpp/archive/refs/tags/%{version
 BuildRequires:  cmake >= 3.20.0
 BuildRequires:  gcc
 BuildRequires:  make
+BuildRequires:  ninja-build
+BuildRequires:  gcc-c++
 
-%if 0%{?with_check}
-BuildRequires:  gmock >= 1.12.0
-BuildRequires:  gmock-devel >= 1.12.0
-BuildRequires:  gtest >= 1.12.0
-BuildRequires:  gtest-devel >= 1.12.0
+BuildRequires:  gmock
+BuildRequires:  gmock-devel
+BuildRequires:  gtest
+BuildRequires:  gtest-devel
+
+%ifarch s390x
+# Symbolize.SymbolizeWithMultipleMaps fails in absl_symbolize_test on s390x
+# with LTO
+# https://github.com/abseil/abseil-cpp/issues/1133
+%global _lto_cflags %{nil}
 %endif
 
 %description
@@ -34,45 +44,46 @@ Abseil is not meant to be a competitor to the standard library; we've just
 found that many of these utilities serve a purpose within our code base,
 and we now want to provide those resources to the C++ community as a whole.
 
+%package testing
+Summary:        Libraries needed for running tests on the installed %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description testing
+%{summary}.
+
 %package devel
 Summary:        Development files for %{name}
-Requires:       %{name} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description devel
 Development headers for %{name}
 
 %prep
-%autosetup -p1
+%autosetup -p1 -S gendiff
 
 %build
-mkdir build
-pushd build
 %cmake \
-  -DABSL_PROPAGATE_CXX_STD=ON \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-%if 0%{?with_check}
-  -DABSL_BUILD_TESTING=ON \
-  -DABSL_FIND_GOOGLETEST=ON \
-  -DABSL_USE_EXTERNAL_GOOGLETEST=ON \
-  -DBUILD_TESTING=ON \
-%else
-  -DBUILD_TESTING=OFF \
-%endif
-  ..
-%make_build
+  -GNinja \
+  -DABSL_USE_EXTERNAL_GOOGLETEST:BOOL=ON \
+  -DABSL_FIND_GOOGLETEST:BOOL=ON \
+  -DABSL_ENABLE_INSTALL:BOOL=ON \
+  -DABSL_BUILD_TESTING:BOOL=ON \
+  -DABSL_BUILD_TEST_HELPERS:BOOL=ON \
+  -DCMAKE_BUILD_TYPE:STRING=None \
+  -DCMAKE_CXX_STANDARD:STRING=17
+%cmake_build
 
 %install
-pushd build
-%make_install
+%cmake_install
 
 %check
-pushd build
-ctest --output-on-failure
+%ctest --output-on-failure
 
 %files
 %license LICENSE
 %doc FAQ.md README.md UPGRADES.md
-%{_libdir}/libabsl_*.so.2308.*
+%{_libdir}/libabsl_*.so.2401.*
 
 %files devel
 %{_includedir}/absl
@@ -81,6 +92,9 @@ ctest --output-on-failure
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Tue Mar 19 2024 Betty Lakes <bettylakes@microsoft.com> - 20240116.0-1
+- Upgrade version to 20240116.0
+
 * Sun Dec 17 2023 Muhammad Falak <mwani@microsoft.com> - 20230802.1-1
 - Bump version to 20230802.1
 

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -1,7 +1,7 @@
 Summary:        Open source remote procedure call (RPC) framework
 Name:           grpc
 Version:        1.62.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -153,6 +153,9 @@ export GRPC_PYTHON_CFLAGS="%{optflags} -std=c++$CXX_VERSION"
 %{python3_sitearch}/grpcio-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Wed Mar 20 2024 Betty Lakes <bettylakes@microsoft.com> - 1.62.0-2
+- Bump release to rebuild with latest 'abseil-cpp'.
+
 * Thu Mar 07 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 1.62.0-1
 - Upgrade to 1.62.0
 - Import 'grpcio-cython3.patch' from OpenSUSE

--- a/SPECS/nginx/nginx.signatures.json
+++ b/SPECS/nginx/nginx.signatures.json
@@ -1,8 +1,7 @@
 {
   "Signatures": {
-    "nginx-njs-0.7.12.tar.gz": "7a75a39022dfb58dbf461053903a07cc48dd4942f7d82a46601819c1b0077687",
+    "nginx-njs-0.8.3.tar.gz": "5e1341ee8c1dfce420ea6456475dafa7d5f4b9aed310faca32597cf4d221cfe0",
     "nginx.service": "73a1321ae35eafc4e02614cde224fc0bf20ceba97f969b3373dd73c15c22a0e1",
-    "opentelemetry-cpp-contrib-37e4466d882cbddff6f607a20fe327060de76166.tar.gz": "daf07cc694ee12e5e37a1aa5f70619b65ff02c24c3effe628b2e59e84a2e6444",
-    "nginx-1.25.2.tar.gz": "05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711"
+    "nginx-1.25.4.tar.gz": "760729901acbaa517996e681ee6ea259032985e37c2768beef80df3a877deed9"
   }
 }

--- a/SPECS/nginx/nginx.spec
+++ b/SPECS/nginx/nginx.spec
@@ -1,12 +1,11 @@
 %global nginx_user nginx
-%global njs_version 0.7.12
-%global opentelemetry_cpp_contrib_git_commit 37e4466d882cbddff6f607a20fe327060de76166
+%global njs_version 0.8.3
 
 Summary:        High-performance HTTP server and reverse proxy
 Name:           nginx
 # Currently on "stable" version of nginx from https://nginx.org/en/download.html.
 # Note: Stable versions are even (1.20), mainline versions are odd (1.21)
-Version:        1.25.2
+Version:        1.25.4
 Release:        1%{?dist}
 License:        BSD-2-Clause
 Vendor:         Microsoft Corporation
@@ -16,11 +15,9 @@ URL:            https://nginx.org/
 Source0:        https://nginx.org/download/%{name}-%{version}.tar.gz
 Source1:        nginx.service
 Source2:        https://github.com/nginx/njs/archive/refs/tags/%{njs_version}.tar.gz#/%{name}-njs-%{njs_version}.tar.gz
-Source3:        https://github.com/open-telemetry/opentelemetry-cpp-contrib/archive/%{opentelemetry_cpp_contrib_git_commit}.tar.gz#/opentelemetry-cpp-contrib-%{opentelemetry_cpp_contrib_git_commit}.tar.gz
 BuildRequires:  libxml2-devel
 BuildRequires:  libxslt-devel
 BuildRequires:  openssl-devel
-BuildRequires:  pcre-devel
 BuildRequires:  pcre2-devel
 BuildRequires:  readline-devel
 BuildRequires:  which
@@ -57,19 +54,10 @@ The OpenTelemetry module for Nginx
 pushd ../
 mkdir nginx-njs
 tar -C nginx-njs -xf %{SOURCE2}
-mkdir otel-cpp-contrib
-tar -C otel-cpp-contrib -xf %{SOURCE3}
-# The following change is a build break in upstream and a PR has been raised to fix it.
-# PR: https://github.com/open-telemetry/opentelemetry-cpp-contrib/pull/314
-sed -i \
-        '/\#include <opentelemetry\/sdk\/trace\/processor.h>$/a \#include <opentelemetry\/sdk\/trace\/batch_span_processor_options.h>' \
-        otel-cpp-contrib/opentelemetry-cpp-contrib-%{opentelemetry_cpp_contrib_git_commit}/instrumentation/nginx/src/otel_ngx_module.cpp
-popd
 
 %build
 sh configure \
     --add-module=../nginx-njs/njs-%{njs_version}/nginx   \
-    --add-dynamic-module=../otel-cpp-contrib/opentelemetry-cpp-contrib-%{opentelemetry_cpp_contrib_git_commit}/instrumentation/nginx   \
     --conf-path=%{_sysconfdir}/nginx/nginx.conf    \
     --error-log-path=%{_var}/log/nginx/error.log   \
     --group=%{nginx_user} \
@@ -89,7 +77,6 @@ sh configure \
     --with-http_sub_module \
     --with-http_v2_module \
     --with-ipv6 \
-    --with-pcre \
     --with-stream \
     --with-compat
 
@@ -139,11 +126,11 @@ exit 0
 %files filesystem
 %dir %{_sysconfdir}/%{name}
 
-%files otel_ngx_module
-%license ../otel-cpp-contrib/opentelemetry-cpp-contrib-%{opentelemetry_cpp_contrib_git_commit}/LICENSE
-%{_sysconfdir}/%{name}/modules/otel_ngx_module.so
-
 %changelog
+* Wed Mar 20 2024 Betty Lakes <bettylakes@microsoft.com> - 1.25.4-1
+- Upgrade to 1.25.4, upgrade njs to 0.8.3
+- Move from pcre to pcre2
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.25.2-1
 - Auto-upgrade to 1.25.2 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/opentelemetry-cpp/opentelemetry-cpp.signatures.json
+++ b/SPECS/opentelemetry-cpp/opentelemetry-cpp.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "opentelemetry-cpp-1.10.0.tar.gz": "19e8ade04a674c8cf7f0dc6da1f7b0583a27d2cf4dbc03df87894a16a4547834",
-  "opentelemetry-proto-1.0.0.tar.gz": "a13a1a7b76a1f22a0ca2e6c293e176ffef031413ab8ba653a82a1dbc286a3a33"
+  "opentelemetry-cpp-1.14.2.tar.gz": "c7e7801c9f6228751cdb9dd4724d0f04777ed53f524c8828e73bf4c9f894e0bd",
+  "opentelemetry-proto-1.1.0.tar.gz": "df491a05f3fcbf86cc5ba5c9de81f6a624d74d4773d7009d573e37d6e2b6af64"
  }
 }

--- a/SPECS/opentelemetry-cpp/opentelemetry-cpp.spec
+++ b/SPECS/opentelemetry-cpp/opentelemetry-cpp.spec
@@ -1,14 +1,14 @@
 Summary:        The OpenTelemetry C++ Client
 Name:           opentelemetry-cpp
-Version:        1.10.0
-Release:        2%{?dist}
+Version:        1.14.2
+Release:       	1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://github.com/open-telemetry/opentelemetry-cpp
 Source0:        https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Standard proto files source: https://github.com/open-telemetry/opentelemetry-proto
-Source1:        opentelemetry-proto-1.0.0.tar.gz
+Source1:        opentelemetry-proto-1.1.0.tar.gz
 BuildRequires:  c-ares-devel
 BuildRequires:  cmake
 BuildRequires:  curl-devel
@@ -16,9 +16,14 @@ BuildRequires:  gmock-devel
 BuildRequires:  grpc-devel
 BuildRequires:  grpc-plugins
 BuildRequires:  gtest-devel
+BuildRequires:  abseil-cpp-devel
 BuildRequires:  nlohmann-json-devel
 BuildRequires:  protobuf-devel
+BuildRequires:  protobuf-static
+BuildRequires:  protobuf-c-devel
 BuildRequires:  re2-devel
+BuildRequires:	systemd-devel
+Requires:       abseil-cpp
 
 %description
 The official OpenTelemetry CPP client
@@ -45,6 +50,7 @@ mkdir build && cd build
 	-DWITH_NO_DEPRECATED_CODE=ON \
 	-DWITH_OTLP_GRPC=ON \
 	-DWITH_OTLP_HTTP=ON \
+	-DWITH_ABSEIL=ON \
 	-DWITH_STL=ON \
 	-DWITH_ZPAGES=ON \
 	-DOTELCPP_PROTO_PATH=../third_party/opentelemetry-proto \
@@ -60,32 +66,18 @@ mkdir build && cd build
 
 %files
 %license LICENSE
-%{_libdir}/libopentelemetry_common.so
-%{_libdir}/libopentelemetry_exporter_in_memory.so
-%{_libdir}/libopentelemetry_exporter_ostream_metrics.so
-%{_libdir}/libopentelemetry_exporter_ostream_span.so
-%{_libdir}/libopentelemetry_exporter_otlp_grpc_client.so
-%{_libdir}/libopentelemetry_exporter_otlp_grpc_log.so
-%{_libdir}/libopentelemetry_exporter_otlp_grpc_metrics.so
-%{_libdir}/libopentelemetry_exporter_otlp_grpc.so
-%{_libdir}/libopentelemetry_exporter_otlp_http_client.so
-%{_libdir}/libopentelemetry_exporter_otlp_http_metric.so
-%{_libdir}/libopentelemetry_exporter_otlp_http.so
-%{_libdir}/libopentelemetry_http_client_curl.so
-%{_libdir}/libopentelemetry_metrics.so
-%{_libdir}/libopentelemetry_otlp_recordable.so
-%{_libdir}/libopentelemetry_proto_grpc.so
-%{_libdir}/libopentelemetry_proto.so
-%{_libdir}/libopentelemetry_resources.so
-%{_libdir}/libopentelemetry_trace.so
-%{_libdir}/libopentelemetry_version.so
-%{_libdir}/libopentelemetry_zpages.so
+%{_libdir}/libopentelemetry_*.so
+%{_libdir}/pkgconfig/opentelemetry_*.pc
 
 %files devel
 %{_includedir}/opentelemetry/*
 %{_libdir}/cmake/opentelemetry-cpp/*
 
 %changelog
+* Mon Mar 18 2024 Betty Lakes <bettylakes@microsoft.com> - 1.14.2-1
+- Upgrade to 1.14.2
+- Upgrade opentelemetry-proto to 1.1.0
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 1.10.0-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/SPECS/opentelemetry-cpp/opentelemetry-cpp.spec
+++ b/SPECS/opentelemetry-cpp/opentelemetry-cpp.spec
@@ -67,9 +67,9 @@ mkdir build && cd build
 %files
 %license LICENSE
 %{_libdir}/libopentelemetry_*.so
-%{_libdir}/pkgconfig/opentelemetry_*.pc
 
 %files devel
+%{_libdir}/pkgconfig/opentelemetry_*.pc
 %{_includedir}/opentelemetry/*
 %{_libdir}/cmake/opentelemetry-cpp/*
 

--- a/SPECS/protobuf-c/protobuf-c.spec
+++ b/SPECS/protobuf-c/protobuf-c.spec
@@ -1,7 +1,7 @@
 Summary:        Google's data interchange format - C implementation
 Name:           protobuf-c
 Version:        1.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -62,6 +62,9 @@ find %{buildroot} -type f -name "libprotobuf-c.a" -delete -print
 %{_libdir}/libprotobuf-c.so
 
 %changelog
+* Wed Mar 20 2024 Betty Lakes <bettylakes@microsoft.com> - 1.5.0-4
+- Bumping release to rebuild with latest 'abseil-cpp'.
+
 * Wed Mar 06 2024 Lanze Liu <lanzeliu@microsoft.com> - 1.5.0-3
 - Remove protobuf-c static sub-package
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -1,7 +1,7 @@
 Summary:        Google's data interchange format
 Name:           protobuf
 Version:        25.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -64,6 +64,7 @@ This contains protobuf python3 libraries.
 %{cmake} \
     -Dprotobuf_BUILD_TESTS=OFF \
     -Dprotobuf_ABSL_PROVIDER=package \
+    -Dprotobuf_ABSL_MIN=20240116.0 \
     -Dprotobuf_BUILD_SHARED_LIBS=ON \
     -DCMAKE_INSTALL_LIBDIR=%{_libdir}
 
@@ -108,6 +109,9 @@ popd
 %{python3_sitelib}/*
 
 %changelog
+* Wed Mar 20 2024 Betty Lakes <bettylakes@microsoft.com> - 25.3-2
+- Set new abseil-cpp version
+
 * Thu Feb 29 2024 Sindhu Karri <lakarri@microsoft.com> - 25.3-1
 - Upgrade to 25.3
 - Added BR on abseil-cpp

--- a/SPECS/re2/re2.spec
+++ b/SPECS/re2/re2.spec
@@ -4,7 +4,7 @@
 Summary:        C++ fast alternative to backtracking RE engines
 Name:           re2
 Version:        %{shortver}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -83,6 +83,9 @@ rm -fv %{buildroot}%{_libdir}/libre2.a
 %{_libdir}/cmake/re2/*.cmake
 
 %changelog
+* Wed Mar 20 2024 Betty Lakes <bettylakes@microsoft.com> - 20240201-2
+- Bumping release to rebuild with latest 'abseil-cpp'.
+
 * Wed Jan 31 2024 Jon Slobodzian <joslobo@microsoft.com> - 20240201-1
 - Upgrading for Mariner 3.0
 - Removed unnecessary patch file

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -15,8 +15,8 @@
         "type": "other",
         "other": {
           "name": "abseil-cpp",
-          "version": "20230802.1",
-          "downloadUrl": "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"
+          "version": "20240116.0",
+          "downloadUrl": "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.0.tar.gz"
         }
       }
     },
@@ -15213,8 +15213,8 @@
         "type": "other",
         "other": {
           "name": "opentelemetry-cpp",
-          "version": "1.10.0",
-          "downloadUrl": "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.10.0.tar.gz"
+          "version": "1.14.2",
+          "downloadUrl": "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13972,8 +13972,8 @@
         "type": "other",
         "other": {
           "name": "nginx",
-          "version": "1.25.2",
-          "downloadUrl": "https://nginx.org/download/nginx-1.25.2.tar.gz"
+          "version": "1.25.4",
+          "downloadUrl": "https://nginx.org/download/nginx-1.25.4.tar.gz"
         }
       }
     },
@@ -15215,16 +15215,6 @@
           "name": "opentelemetry-cpp",
           "version": "1.14.2",
           "downloadUrl": "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "other",
-        "other": {
-          "name": "opentelemetry-cpp-contrib",
-          "version": "37e4466d882cbddff6f607a20fe327060de76166",
-          "downloadUrl": "https://github.com/open-telemetry/opentelemetry-cpp-contrib/archive/37e4466d882cbddff6f607a20fe327060de76166.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
[What does the PR accomplish, why was it needed?
abseil-cpp: upgrade to 20240116.0, opentelemetry-cpp: upgrade to 1.14.2, nginx: upgrade to 1.25.4

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade abseil-cpp to 20240116.0 (for opentelemetry + it was failing tests on previous version)
- Add testing libraries for abseil-cpp, so it will pass the new version tests
- Bump releases for grpc, re2, protobuf and protobuf-c because of new abseil-cpp version
- Upgrade opentelemetry-cpp to 1.14.2 (added abseil-cpp dependency)
- Upgrade nginx to 1.25.4 and njs_version to 0.8.3
- Move nginx to pcre2
- Remove opentelemetry-cpp-contrib as we don't need it anymore with the new versions

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Package build buddy build [535434](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=535434&view=results)

- Buddy builds for install package are not reliable, testing using containerized build:
- x86_64 installing packages:
![image](https://github.com/microsoft/azurelinux/assets/38226164/d571a888-21e8-47f0-a4af-ef52363fba24)

- x86_64 installed packages: 
![image](https://github.com/microsoft/azurelinux/assets/38226164/bea9a67e-60f2-404a-910e-75e580d9270f)
![image](https://github.com/microsoft/azurelinux/assets/38226164/81e7f242-f8f5-4c60-b257-1a082050538a)