### PR TITLE
Add patch to package qt5-qtbase to address CVE-2022-25643

### DIFF
--- a/SPECS/qt5-qtbase/CVE-2022-25643.patch
+++ b/SPECS/qt5-qtbase/CVE-2022-25643.patch
@@ -1,0 +1,106 @@
+diff --git a/src/corelib/io/qlockfile_win.cpp b/src/corelib/io/qlockfile_win.cpp
+index a20a274870..30ef0625db 100644
+--- a/src/corelib/io/qlockfile_win.cpp
++++ b/src/corelib/io/qlockfile_win.cpp
+@@ -48,6 +48,8 @@
+ #include "QtCore/qdebug.h"
+ #include "QtCore/qthread.h"
+ 
++#include "private/qsystemlibrary_p.h"
++
+ QT_BEGIN_NAMESPACE
+ 
+ static inline bool fileExists(const wchar_t *fileName)
+@@ -150,7 +152,7 @@ QString QLockFilePrivate::processNameByPid(qint64 pid)
+ #if !defined(Q_OS_WINRT)
+     typedef DWORD (WINAPI *GetModuleFileNameExFunc)(HANDLE, HMODULE, LPTSTR, DWORD);
+ 
+-    HMODULE hPsapi = LoadLibraryA("psapi");
++    HMODULE hPsapi = QSystemLibrary::load(L"psapi");
+     if (!hPsapi)
+         return QString();
+     GetModuleFileNameExFunc qGetModuleFileNameEx = reinterpret_cast<GetModuleFileNameExFunc>(
+diff --git a/src/network/kernel/qauthenticator.cpp b/src/network/kernel/qauthenticator.cpp
+index 4e84c0954b..a2f1133bc0 100644
+--- a/src/network/kernel/qauthenticator.cpp
++++ b/src/network/kernel/qauthenticator.cpp
+@@ -50,6 +50,7 @@
+ #include <qstring.h>
+ #include <qdatetime.h>
+ #include <qrandom.h>
++#include "private/qsystemlibrary_p.h"
+ 
+ #ifdef Q_OS_WIN
+ #include <qmutex.h>
+diff --git a/src/plugins/platforms/windows/qwindowsglcontext.cpp b/src/plugins/platforms/windows/qwindowsglcontext.cpp
+index 65b3e7f430..ff04fbbf98 100644
+--- a/src/plugins/platforms/windows/qwindowsglcontext.cpp
++++ b/src/plugins/platforms/windows/qwindowsglcontext.cpp
+@@ -48,6 +48,7 @@
+ #include <qpa/qplatformnativeinterface.h>
+ #include <QtPlatformHeaders/qwglnativecontext.h>
+ 
++#include <private/qsystemlibrary_p.h>
+ #include <algorithm>
+ 
+ #include <wingdi.h>
+@@ -162,19 +163,25 @@ QFunctionPointer QWindowsOpengl32DLL::resolve(const char *name)
+ 
+ bool QWindowsOpengl32DLL::init(bool softwareRendering)
+ {
+-    const QByteArray opengl32 = QByteArrayLiteral("opengl32.dll");
+-    const QByteArray swopengl = QByteArrayLiteral("opengl32sw.dll");
++    const QByteArray opengl32 = QByteArrayLiteral("opengl32");
++    const QByteArray swopengl = QByteArrayLiteral("opengl32sw");
++    bool useSystemLib = false;
+ 
+     QByteArray openglDll = qgetenv("QT_OPENGL_DLL");
+-    if (openglDll.isEmpty())
++    if (openglDll.isEmpty()) {
+         openglDll = softwareRendering ? swopengl : opengl32;
++        useSystemLib = !softwareRendering;
++    }
+ 
+     openglDll = openglDll.toLower();
+     m_nonOpengl32 = openglDll != opengl32;
+ 
+     qCDebug(lcQpaGl) << "Qt: Using WGL and OpenGL from" << openglDll;
+ 
+-    m_lib = ::LoadLibraryA(openglDll.constData());
++    if (useSystemLib)
++        m_lib = QSystemLibrary::load((wchar_t*)(QString::fromLatin1(openglDll).utf16()));
++    else
++        m_lib = LoadLibraryA(openglDll.constData());
+     if (!m_lib) {
+         qErrnoWarning(::GetLastError(), "Failed to load %s", openglDll.constData());
+         return false;
+@@ -184,7 +191,7 @@ bool QWindowsOpengl32DLL::init(bool softwareRendering)
+         // Load opengl32.dll always. GDI functions like ChoosePixelFormat do
+         // GetModuleHandle for opengl32.dll and behave differently (and call back into
+         // opengl32) when the module is present. This is fine for dummy contexts and windows.
+-        ::LoadLibraryA("opengl32.dll");
++        QSystemLibrary::load(L"opengl32");
+     }
+ 
+     wglCreateContext = reinterpret_cast<HGLRC (WINAPI *)(HDC)>(resolve("wglCreateContext"));
+diff --git a/src/plugins/platforms/windows/qwindowsopengltester.cpp b/src/plugins/platforms/windows/qwindowsopengltester.cpp
+index 49da6ee3e3..d78a18b35d 100644
+--- a/src/plugins/platforms/windows/qwindowsopengltester.cpp
++++ b/src/plugins/platforms/windows/qwindowsopengltester.cpp
+@@ -49,6 +49,7 @@
+ #include <QtCore/qstandardpaths.h>
+ #include <QtCore/qlibraryinfo.h>
+ #include <QtCore/qhash.h>
++#include <private/qsystemlibrary_p.h>
+ 
+ #ifndef QT_NO_OPENGL
+ #include <private/qopengl_p.h>
+@@ -396,7 +397,7 @@ bool QWindowsOpenGLTester::testDesktopGL()
+ 
+     // Test #1: Load opengl32.dll and try to resolve an OpenGL 2 function.
+     // This will typically fail on systems that do not have a real OpenGL driver.
+-    lib = LoadLibraryA("opengl32.dll");
++    lib = QSystemLibrary::load(L"opengl32");
+     if (lib) {
+         CreateContext = reinterpret_cast<CreateContextType>(
+             reinterpret_cast<QFunctionPointer>(::GetProcAddress(lib, "wglCreateContext")));

--- a/SPECS/qt5-qtbase/qt5-qtbase.spec
+++ b/SPECS/qt5-qtbase/qt5-qtbase.spec
@@ -33,7 +33,7 @@
 Name:         qt5-qtbase
 Summary:      Qt5 - QtBase components
 Version:      5.12.11
-Release:      11%{?dist}
+Release:      12%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:      GFDL AND LGPLv3 AND GPLv2 AND GPLv3 with exceptions AND QT License Agreement 4.0
 Vendor:       Microsoft Corporation
@@ -156,6 +156,9 @@ Patch88: CVE-2023-51714.patch
 # - https://code.qt.io/cgit/qt/qtbase.git/commit/?id=cca8ed0547405b1c
 Patch89: CVE-2021-38593.patch
 
+# Fix CVE-2022-25643
+Patch90: CVE-2022-25643.patch
+
 # Do not check any files in %%{_qt5_plugindir}/platformthemes/ for requires.
 # Those themes are there for platform integration. If the required libraries are
 # not there, the platform to integrate with isn't either. Then Qt will just
@@ -266,6 +269,7 @@ Qt5 libraries used for drawing widgets and OpenGL items.
 %patch87 -p1
 %patch88 -p1
 %patch89 -p1
+%Patch90 -p1
 
 ## upstream patches
 
@@ -771,6 +775,9 @@ fi
 %{_qt5_libdir}/cmake/Qt5Gui/Qt5Gui_QXdgDesktopPortalThemePlugin.cmake
 
 %changelog
+* Wed Mar 27 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 5.12.11-12
+- Add patch to resolve CVE-2022-25643.
+
 * Thu Feb 15 2024 Sumedh Sharma <sumsharma@microsoft.com> - 5.12.11-11
 - Add patch to resolve CVE-2021-38593, used Ubuntu's patch for guidance.
 

--- a/SPECS/qt5-qtbase/qt5-qtbase.spec
+++ b/SPECS/qt5-qtbase/qt5-qtbase.spec
@@ -269,7 +269,7 @@ Qt5 libraries used for drawing widgets and OpenGL items.
 %patch87 -p1
 %patch88 -p1
 %patch89 -p1
-%Patch90 -p1
+%patch90 -p1
 
 ## upstream patches
 


### PR DESCRIPTION
 Changes to be committed:
	new file:   SPECS/qt5-qtbase/CVE-2022-25643.patch
	modified:   SPECS/qt5-qtbase/qt5-qtbase.spec

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch to package qt5-qtbase to address CVE-2022-25643

###### Change Log  <!-- REQUIRED -->
	new file:   SPECS/qt5-qtbase/CVE-2022-25643.patch
	modified:   SPECS/qt5-qtbase/qt5-qtbase.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
[- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX](https://nvd.nist.gov/vuln/detail/CVE-2020-0569)

###### Test Methodology
- Pipeline build id: xxxx
