### PR TITLE
Image Customizer: Apply missing camelCase to ISO struct.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/iso.go
+++ b/toolkit/tools/imagecustomizerapi/iso.go
@@ -9,8 +9,8 @@ import (
 
 // Iso defines how the generated iso media should be configured.
 type Iso struct {
-	KernelCommandLine KernelCommandLine  `yaml:"KernelCommandLine"`
-	AdditionalFiles   AdditionalFilesMap `yaml:"AdditionalFiles"`
+	KernelCommandLine KernelCommandLine  `yaml:"kernelCommandLine"`
+	AdditionalFiles   AdditionalFilesMap `yaml:"additionalFiles"`
 }
 
 func (i *Iso) IsValid() error {
@@ -18,13 +18,13 @@ func (i *Iso) IsValid() error {
 
 	err = i.KernelCommandLine.IsValid()
 	if err != nil {
-		return fmt.Errorf("invalid KernelCommandLine: %w", err)
+		return fmt.Errorf("invalid kernelCommandLine: %w", err)
 	}
 
 	if i.AdditionalFiles != nil {
 		err := i.AdditionalFiles.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid AdditionalFiles: %w", err)
+			return fmt.Errorf("invalid additionalFiles: %w", err)
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -241,11 +241,11 @@ func validateAdditionalFiles(baseConfigPath string, additionalFiles imagecustomi
 		sourceFileFullPath := file.GetAbsPathWithBase(baseConfigPath, sourceFile)
 		isFile, err := file.IsFile(sourceFileFullPath)
 		if err != nil {
-			aggregateErr = errors.Join(aggregateErr, fmt.Errorf("invalid AdditionalFiles source file (%s):\n%w", sourceFile, err))
+			aggregateErr = errors.Join(aggregateErr, fmt.Errorf("invalid additionalFiles source file (%s):\n%w", sourceFile, err))
 		}
 
 		if !isFile {
-			aggregateErr = errors.Join(aggregateErr, fmt.Errorf("invalid AdditionalFiles source file (%s): not a file", sourceFile))
+			aggregateErr = errors.Join(aggregateErr, fmt.Errorf("invalid additionalFiles source file (%s): not a file", sourceFile))
 		}
 	}
 	return aggregateErr


### PR DESCRIPTION
The ISO struct was missed in the change to convert the YAML API to use camelCase.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

