### PR TITLE
perl-Test-File: fix macro issue

### DIFF
--- a/SPECS-EXTENDED/perl-Test-File/perl-Test-File.spec
+++ b/SPECS-EXTENDED/perl-Test-File/perl-Test-File.spec
@@ -1,11 +1,10 @@
 # This module usually ships with version numbers having two digits after the decimal point
 %global cpanversion 1.443
-%global rpmversion 1.44.3
 
 Summary:	Test file attributes through Test::Builder
 Name:		perl-Test-File
-Version:	%{rpmversion}
-Release:	11%{?dist}
+Version:	1.44.3
+Release:	12%{?dist}
 License:	GPL+ or Artistic
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -68,6 +67,9 @@ make test
 %{_mandir}/man3/Test::File.3*
 
 %changelog
+* Thu Mar 28 2024 Andrew Phelps <anphel@microsoft.com> - 1.44.3-12
+- Remove `rpmversion` global definition due to macro conflict with rpm-4.18.2
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.44.3-11
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/perl-Test-File/perl-Test-File.spec
+++ b/SPECS-EXTENDED/perl-Test-File/perl-Test-File.spec
@@ -1,44 +1,44 @@
 # This module usually ships with version numbers having two digits after the decimal point
 %global cpanversion 1.443
 
-Summary:	Test file attributes through Test::Builder
-Name:		perl-Test-File
-Version:	1.44.3
-Release:	12%{?dist}
-License:	GPL+ or Artistic
+Summary:        Test file attributes through Test::Builder
+Name:           perl-Test-File
+Version:        1.44.3
+Release:        12%{?dist}
+License:        Artistic-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
-URL:		https://metacpan.org/release/Test-File
-Source0:	https://cpan.metacpan.org/authors/id/B/BD/BDFOY/Test-File-%{cpanversion}.tar.gz#/perl-Test-File-%{cpanversion}.tar.gz
-BuildArch:	noarch
+URL:            https://metacpan.org/release/Test-File
+Source0:        https://cpan.metacpan.org/authors/id/B/BD/BDFOY/Test-File-%{cpanversion}.tar.gz#/perl-Test-File-%{cpanversion}.tar.gz
+BuildArch:      noarch
 # Module Build
-BuildRequires:	coreutils
-BuildRequires:	make
-BuildRequires:	perl-interpreter
-BuildRequires:	perl-generators
-BuildRequires:	perl(ExtUtils::MakeMaker) >= 6.76
-BuildRequires:	perl(ExtUtils::Manifest) >= 1.21
+BuildRequires:  coreutils
+BuildRequires:  make
+BuildRequires:  perl-interpreter
+BuildRequires:  perl-generators
+BuildRequires:  perl(ExtUtils::MakeMaker) >= 6.76
+BuildRequires:  perl(ExtUtils::Manifest) >= 1.21
 # Module Runtime
-BuildRequires:	perl(base)
-BuildRequires:	perl(Exporter)
-BuildRequires:	perl(File::Spec)
-BuildRequires:	perl(strict)
-BuildRequires:	perl(Test::Builder)
-BuildRequires:	perl(vars)
-BuildRequires:	perl(warnings)
+BuildRequires:  perl(base)
+BuildRequires:  perl(Exporter)
+BuildRequires:  perl(File::Spec)
+BuildRequires:  perl(strict)
+BuildRequires:  perl(Test::Builder)
+BuildRequires:  perl(vars)
+BuildRequires:  perl(warnings)
 # Test Suite
-BuildRequires:	perl(Cwd)
-BuildRequires:	perl(File::Spec::Functions)
-BuildRequires:	perl(Test::Builder) >= 1.001006
-BuildRequires:	perl(Test::Builder::Tester)
-BuildRequires:	perl(Test::More) >= 0.95
-BuildRequires:	perl(Test::utf8)
-BuildRequires:	perl(utf8)
+BuildRequires:  perl(Cwd)
+BuildRequires:  perl(File::Spec::Functions)
+BuildRequires:  perl(Test::Builder) >= 1.001006
+BuildRequires:  perl(Test::Builder::Tester)
+BuildRequires:  perl(Test::More) >= 0.95
+BuildRequires:  perl(Test::utf8)
+BuildRequires:  perl(utf8)
 # Optional Tests
-BuildRequires:	perl(Test::Pod) >= 1.00
-BuildRequires:	perl(Test::Pod::Coverage)
+BuildRequires:  perl(Test::Pod) >= 1.00
+BuildRequires:  perl(Test::Pod::Coverage)
 # Runtime
-Requires:	perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
+Requires:       perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
 
 %description
 This module provides a collection of test utilities for file attributes.
@@ -69,6 +69,8 @@ make test
 %changelog
 * Thu Mar 28 2024 Andrew Phelps <anphel@microsoft.com> - 1.44.3-12
 - Remove `rpmversion` global definition due to macro conflict with rpm-4.18.2
+- Update license to Artistic-2.0
+- License verified.
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.44.3-11
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix for build break in SPECS-EXTENDED: [link](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=537290&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=88a626d5-bd2d-5bcb-0f14-68ce5ab12667)
```
WARN[0010][srpmpacker] error: /specs/perl-Test-File/perl-Test-File.spec: line 3: Macro %rpmversion is a built-in (%global)
error: query of specfile /specs/perl-Test-File/perl-Test-File.spec failed, can't parse 
ERRO[0010][srpmpacker] Failed to check (/specs/perl-Test-File/perl-Test-File.spec). Error: exit status 1
```
Defining `%global rpmversion` in the SPEC became an error after upgrading to rpm 4.18.2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change perl-Test-file version definition

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=538687&view=results
