### PR TITLE
Use azurelinux instead of mariner pacakges in base-image-packages.json

### DIFF
--- a/toolkit/imageconfigs/packagelists/base-image-packages.json
+++ b/toolkit/imageconfigs/packagelists/base-image-packages.json
@@ -1,6 +1,9 @@
 {
     "packages": [
         "azurelinux-release",
+        "azurelinux-repos",
+        "azurelinux-repos-ms-non-oss",
+        "azurelinux-repos-ms-oss",
         "bash",
         "ca-certificates",
         "cronie-anacron",
@@ -11,9 +14,6 @@
         "filesystem",
         "grub2-efi-binary",
         "logrotate",
-        "mariner-repos",
-        "mariner-repos-extras",
-        "mariner-repos-microsoft",
         "procps-ng",
         "shim",
         "sudo",

--- a/toolkit/imageconfigs/packagelists/base-image-packages.json
+++ b/toolkit/imageconfigs/packagelists/base-image-packages.json
@@ -1,5 +1,6 @@
 {
     "packages": [
+        "azurelinux-release",
         "bash",
         "ca-certificates",
         "cronie-anacron",
@@ -10,7 +11,6 @@
         "filesystem",
         "grub2-efi-binary",
         "logrotate",
-        "mariner-release",
         "mariner-repos",
         "mariner-repos-extras",
         "mariner-repos-microsoft",


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The `baremetal_vhdx` and `qemu_guest_vhdx` images have been broken in the past few days in our 3.0-dev branch. See [link](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=538431&view=logs&j=2ccbf1db-6c73-5af8-5ba2-cf05469dcf51&t=62118ca4-5f53-54b3-7ec9-8ef4ab0e9237&l=1989). The break appears related to some of the references to renamed packages in base-image-packages.json from PR #8389 
Rename these to reference the new package names.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change base-image-packages.json references to azurelinux packages

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: I modified the image build pipeline to fix these package names inline with sed commands. Link to test run is [here](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=538713&view=logs&j=2ccbf1db-6c73-5af8-5ba2-cf05469dcf51&t=62118ca4-5f53-54b3-7ec9-8ef4ab0e9237&l=511)