### PR TITLE
Add CVE-2023-5574 patch to xorg-x11-server ver 1.20.10

### DIFF
--- a/SPECS/xorg-x11-server/CVE-2023-5574.patch
+++ b/SPECS/xorg-x11-server/CVE-2023-5574.patch
@@ -1,0 +1,120 @@
+diff --git a/dix/dispatch.c b/dix/dispatch.c
+index a33bfaa..9aaec28 100644
+--- a/dix/dispatch.c
++++ b/dix/dispatch.c
+@@ -3819,6 +3819,12 @@ static int indexForScanlinePad[65] = {
+     3                           /* 64 bits per scanline pad unit */
+ };
+ 
++static Bool
++DefaultCloseScreen(ScreenPtr screen)
++{
++    return TRUE;
++}
++
+ /*
+ 	grow the array of screenRecs if necessary.
+ 	call the device-supplied initialization procedure
+@@ -3878,6 +3884,9 @@ static int init_screen(ScreenPtr pScreen, int i, Bool gpu)
+             PixmapWidthPaddingInfo[depth].notPower2 = 0;
+         }
+     }
++
++    pScreen->CloseScreen = DefaultCloseScreen;
++
+     return 0;
+ }
+ 
+diff --git a/fb/fb.h b/fb/fb.h
+index 8ab050d..404bca3 100644
+--- a/fb/fb.h
++++ b/fb/fb.h
+@@ -410,6 +410,7 @@ typedef struct {
+ #endif
+     DevPrivateKeyRec    gcPrivateKeyRec;
+     DevPrivateKeyRec    winPrivateKeyRec;
++    CloseScreenProcPtr  CloseScreen;
+ } FbScreenPrivRec, *FbScreenPrivPtr;
+ 
+ #define fbGetScreenPrivate(pScreen) ((FbScreenPrivPtr) \
+diff --git a/fb/fbscreen.c b/fb/fbscreen.c
+index 4ab807a..831d998 100644
+--- a/fb/fbscreen.c
++++ b/fb/fbscreen.c
+@@ -29,6 +29,7 @@
+ Bool
+ fbCloseScreen(ScreenPtr pScreen)
+ {
++    FbScreenPrivPtr screen_priv = fbGetScreenPrivate(pScreen);
+     int d;
+     DepthPtr depths = pScreen->allowedDepths;
+ 
+@@ -37,9 +38,11 @@ fbCloseScreen(ScreenPtr pScreen)
+         free(depths[d].vids);
+     free(depths);
+     free(pScreen->visuals);
+-    if (pScreen->devPrivate)
+-        FreePixmap((PixmapPtr)pScreen->devPrivate);
+-    return TRUE;
++
++
++    pScreen->CloseScreen = screen_priv->CloseScreen;
++
++    return pScreen->CloseScreen(pScreen);
+ }
+ 
+ Bool
+@@ -144,6 +147,7 @@ fbFinishScreenInit(ScreenPtr pScreen, void *pbits, int xsize, int ysize,
+                    int dpix, int dpiy, int width, int bpp)
+ #endif
+ {
++    FbScreenPrivPtr screen_priv;
+     VisualPtr visuals;
+     DepthPtr depths;
+     int nvisuals;
+@@ -178,7 +182,11 @@ fbFinishScreenInit(ScreenPtr pScreen, void *pbits, int xsize, int ysize,
+                       defaultVisual, nvisuals, visuals))
+         return FALSE;
+     /* overwrite miCloseScreen with our own */
++
++    screen_priv = fbGetScreenPrivate(pScreen);
++    screen_priv->CloseScreen = pScreen->CloseScreen;
+     pScreen->CloseScreen = fbCloseScreen;
++
+     return TRUE;
+ }
+ 
+diff --git a/hw/vfb/InitOutput.c b/hw/vfb/InitOutput.c
+index d9f23f3..0a47363 100644
+--- a/hw/vfb/InitOutput.c
++++ b/hw/vfb/InitOutput.c
+@@ -738,13 +738,6 @@ vfbCloseScreen(ScreenPtr pScreen)
+ 
+     pScreen->CloseScreen = pvfb->closeScreen;
+ 
+-    /*
+-     * fb overwrites miCloseScreen, so do this here
+-     */
+-    if (pScreen->devPrivate)
+-        (*pScreen->DestroyPixmap) (pScreen->devPrivate);
+-    pScreen->devPrivate = NULL;
+-
+     return pScreen->CloseScreen(pScreen);
+ }
+ 
+diff --git a/mi/miscrinit.c b/mi/miscrinit.c
+index 264622d..907e46a 100644
+--- a/mi/miscrinit.c
++++ b/mi/miscrinit.c
+@@ -242,10 +242,10 @@ miScreenInit(ScreenPtr pScreen, void *pbits,  /* pointer to screen bits */
+     pScreen->numVisuals = numVisuals;
+     pScreen->visuals = visuals;
+     if (width) {
++        pScreen->CloseScreen = miCloseScreen;
+ #ifdef MITSHM
+         ShmRegisterFbFuncs(pScreen);
+ #endif
+-        pScreen->CloseScreen = miCloseScreen;
+     }
+     /* else CloseScreen */
+     /* QueryBestSize, SaveScreen, GetImage, GetSpans */

--- a/SPECS/xorg-x11-server/xorg-x11-server.spec
+++ b/SPECS/xorg-x11-server/xorg-x11-server.spec
@@ -21,7 +21,7 @@
 Summary:        X.Org X11 X server
 Name:           xorg-x11-server
 Version:        1.20.10
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -58,6 +58,7 @@ Patch8: CVE-2023-6377.patch
 Patch9: CVE-2023-6478.patch
 Patch10: CVE-2024-21885.patch
 Patch11: CVE-2023-6816.patch
+Patch12: CVE-2023-5574.patch
 
 # Backported Xwayland randr resolution change emulation support
 Patch501:       0001-dix-Add-GetCurrentClient-helper.patch
@@ -388,6 +389,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_datadir}/aclocal/xorg-server.m4
 
 %changelog
+* Thu Mar 28 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 1.20.10-8
+- Add patch for CVE-2023-5574
+
 * Mon Mar 12 2024 Aadhar Agarwal <aadagarwal@microsoft.com> - 1.20.10-7
 - Add patch for CVE-2023-6816
 


### PR DESCRIPTION
 Changes to be committed:
	new file:   CVE-2023-5574.patch
	modified:   xorg-x11-server.spec


###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add https://github.com/advisories/GHSA-79x6-r5x5-fvqw patch to xorg-x11-server ver 1.20.10

###### Change Log  <!-- REQUIRED -->
Changes to be committed:
	new file:   https://github.com/advisories/GHSA-79x6-r5x5-fvqw.patch
	modified:   xorg-x11-server.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-5574

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
