### PR TITLE
add named args to check-manifest.sh

### DIFF
--- a/.github/workflows/check-manifests.yml
+++ b/.github/workflows/check-manifests.yml
@@ -25,12 +25,20 @@ jobs:
 
     - name: Check x86_64 manifests
       run: |
+        echo ##########
+        echo "Ensure toolchain and pkggen manifests (./toolkit/resources/manifests/package/*) match the versions in the .spec files"
+        echo "Run './scripts/toolchain/check_manifests.sh -a "x86_64"' to validate locally"
+        echo ##########
         pushd toolkit
         ./scripts/toolchain/check_manifests.sh -a "x86_64"
         popd
 
     - name: Check aarch64 manifests
       run: |
+        echo ##########
+        echo "Ensure toolchain and pkggen manifests (./toolkit/resources/manifests/package/*) match the versions in the .spec files"
+        echo "Run './scripts/toolchain/check_manifests.sh -a "aarch64"' to validate locally"
+        echo ##########
         pushd toolkit
         ./scripts/toolchain/check_manifests.sh -a "aarch64"
         popd

--- a/.github/workflows/check-manifests.yml
+++ b/.github/workflows/check-manifests.yml
@@ -26,12 +26,12 @@ jobs:
     - name: Check x86_64 manifests
       run: |
         pushd toolkit
-        make check-x86_64-manifests
+        ./scripts/toolchain/check_manifests.sh -a "x86_64"
         popd
 
     - name: Check aarch64 manifests
       run: |
         pushd toolkit
-        make check-aarch64-manifests
+        ./scripts/toolchain/check_manifests.sh -a "aarch64"
         popd
       if: always()

--- a/SPECS/sed/sed.spec
+++ b/SPECS/sed/sed.spec
@@ -1,7 +1,7 @@
 Summary:        Stream editor
 Name:           sed
 Version:        4.9
-Release:        2%{?dist}
+Release:        1%{?dist}
 License:        GPLv3
 URL:            https://www.gnu.org/software/sed
 Group:          Applications/Editors

--- a/SPECS/sed/sed.spec
+++ b/SPECS/sed/sed.spec
@@ -1,7 +1,7 @@
 Summary:        Stream editor
 Name:           sed
 Version:        4.9
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 URL:            https://www.gnu.org/software/sed
 Group:          Applications/Editors

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -97,23 +97,9 @@ copy-toolchain-rpms:
 # check that the manifest files only contain RPMs that could have been generated from toolchain specs.
 check-manifests: check-x86_64-manifests check-aarch64-manifests
 check-aarch64-manifests: $(toolchain_files)
-	cd $(SCRIPTS_DIR)/toolchain && \
-		./check_manifests.sh \
-			"$(toolchain_spec_list)" \
-			"$(SPECS_DIR)" \
-			"$(TOOLCHAIN_MANIFESTS_DIR)" \
-			"$(DIST_TAG)" \
-			"$(DIST_VERSION_MACRO)" \
-			"aarch64"
+	$(SCRIPTS_DIR)/toolchain/check_manifests.sh -a "aarch64"
 check-x86_64-manifests: $(toolchain_files)
-	cd $(SCRIPTS_DIR)/toolchain && \
-		./check_manifests.sh \
-			"$(toolchain_spec_list)" \
-			"$(SPECS_DIR)" \
-			"$(TOOLCHAIN_MANIFESTS_DIR)" \
-			"$(DIST_TAG)" \
-			"$(DIST_VERSION_MACRO)" \
-			"x86_64"
+	$(SCRIPTS_DIR)/toolchain/check_manifests.sh -a "x86_64"
 
 # To save toolchain artifacts use compress-toolchain and cache the tarballs
 # To restore toolchain artifacts use hydrate-toolchain and give the location of the tarballs on the command-line

--- a/toolkit/scripts/toolchain/check_manifests.sh
+++ b/toolkit/scripts/toolchain/check_manifests.sh
@@ -31,7 +31,6 @@ then
 fi
 
 while (( "$#")); do
-  echo "$1 is $1"
   case "$1" in
     -a ) ARCH="$2"; shift 2;;
     -t ) TOOLCHAIN_SPEC_LIST="$2"; shift 2 ;;

--- a/toolkit/scripts/toolchain/check_manifests.sh
+++ b/toolkit/scripts/toolchain/check_manifests.sh
@@ -30,16 +30,26 @@ then
     exit 1
 fi
 
-while (( "$#")); do
-  case "$1" in
-    -a ) ARCH="$2"; shift 2;;
-    -t ) TOOLCHAIN_SPEC_LIST="$2"; shift 2 ;;
-    -s ) SPECS_DIR="$2"; shift 2 ;;
-    -m ) MANIFESTS_DIR="$2"; shift 2 ;;
-    -d ) DIST_TAG="$2"; shift 2;;
-    -i ) DISTRO_MACRO="$2"; shift 2;;
-    -h ) help; exit 0 ;;
-    ?* ) echo -e "ERROR: Invalid option\n\n"; help; exit 1 ;;
+while getopts "a:t:s:m:d:i:h:" OPTIONS
+do
+  case "${OPTIONS}" in
+    a ) ARCH=$OPTARG ;;
+    t ) TOOLCHAIN_SPEC_LIST=$OPTARG ;;
+    s ) SPECS_DIR=$OPTARG ;;
+    m ) MANIFESTS_DIR=$OPTARG ;;
+    d ) DIST_TAG=$OPTARG ;;
+    i ) DISTRO_MACRO=$OPTARG ;;
+    h ) help; exit 0 ;;
+    \? )
+        echo "ERROR: Invalid Option: -$OPTARG" 1>&2
+        help
+        exit 1
+        ;;
+    : )
+        echo "ERROR: Invalid Option: -$OPTIONS requires an argument" 1>&2
+        help
+        exit 1
+        ;;
   esac
 done
 
@@ -49,7 +59,6 @@ if [ ! "$ARCH" ]; then
     help >&2
     exit 1
 fi
-
 
 write_rpms_from_spec () {
     # $1 = spec file


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
check-manifests.sh: replace positional args with named, populate values by default

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- check-manifests.sh: replace positional args with named
- check-manifests.sh: populate values by default
- this will make it easier for user to call check-manifests.sh script directly, instead of relying on the make target
- call the script directly in check-manifests.yml
- we can remove the now defunct make target, making our makefile leaner

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Locally: successfully invoked check-manifests.sh directly
- Locally: successfully invoked modified check-manifests make target
- Pipeline: pipeline successfully passed when no toolchain specs were modified, and successfully caught error when toolchain spec was modified, without supporting change in manifest file