### PR TITLE
Upgraded `gnupg2` to version 2.4.4.

### DIFF
--- a/SPECS/gnupg2/gnupg2.signatures.json
+++ b/SPECS/gnupg2/gnupg2.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "gnupg-2.4.3.tar.bz2": "a271ae6d732f6f4d80c258ad9ee88dd9c94c8fdc33c3e45328c4d7c126bd219d"
+    "gnupg-2.4.4.tar.bz2": "67ebe016ca90fa7688ce67a387ebd82c6261e95897db7b23df24ff335be85bc6"
   }
 }

--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -1,7 +1,7 @@
 Summary:        OpenPGP standard implementation used for encrypted communication and data storage.
 Name:           gnupg2
-Version:        2.4.3
-Release:        2%{?dist}
+Version:        2.4.4
+Release:        1%{?dist}
 License:        BSD and CC0 and GPLv2+ and LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -67,18 +67,6 @@ popd
 # Some GnuPG commands expect it to exist.
 install -Dm 644 /dev/null %{buildroot}%{_sysconfdir}/gnupg/gpgconf.conf
 
-# By default prevent GnuPG from using keyboxd for storage.
-# It tends to cause unexpected hangs of GnuPG commands and tools depending on GnuPG.
-# For more details, see:
-# - https://discussion.fedoraproject.org/t/gpg-blocking-forever-cant-git-commit-as-a-result/96605/6
-# - https://bugzilla.redhat.com/show_bug.cgi?id=2249218
-# - https://dev.gnupg.org/T6838
-install -vdm 755 %{buildroot}%{_sysconfdir}/skel/.gnupg
-cat > %{buildroot}%{_sysconfdir}/skel/.gnupg/common.conf << EOF
-# Uncomment to enabled keyboxd.
-# use_keyboxd
-EOF
-
 %find_lang %{name}
 
 %check
@@ -99,7 +87,6 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %{_libexecdir}/*
 %{_datadir}/gnupg/*
 %{_sysconfdir}/gnupg
-%{_sysconfdir}/skel/.gnupg
 %exclude %{_infodir}/dir
 %exclude /usr/share/doc/*
 
@@ -107,8 +94,8 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %defattr(-,root,root)
 
 %changelog
-* Fri Mar 29 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.4.3-2
-- Disabled keyboxd by default.
+* Fri Mar 29 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.4.4-1
+- Upgrade to 2.4.4.
 
 * Tue Nov 21 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.3-1
 - Auto-upgrade to 2.4.3 - Azure Linux 3.0 - package upgrades

--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -1,7 +1,7 @@
 Summary:        OpenPGP standard implementation used for encrypted communication and data storage.
 Name:           gnupg2
 Version:        2.4.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD and CC0 and GPLv2+ and LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -63,6 +63,13 @@ ln -s gpg2 gpg
 ln -s gpgv2 gpgv
 popd
 
+# Disable GnuPG from using keyboxd for storage.
+install -vdm 755 %{buildroot}%{_sysconfdir}/skel/.gnupg
+cat > %{buildroot}%{_sysconfdir}/skel/.gnupg/common.conf << EOF
+# Uncomment to enabled keyboxd.
+# use_keyboxd
+EOF
+
 %find_lang %{name}
 
 %check
@@ -82,6 +89,7 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %{_infodir}/gnupg*
 %{_libexecdir}/*
 %{_datadir}/gnupg/*
+%{_sysconfdir}/skel/.gnupg/common.conf << EOF
 %exclude %{_infodir}/dir
 %exclude /usr/share/doc/*
 
@@ -89,6 +97,9 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %defattr(-,root,root)
 
 %changelog
+* Fri Mar 29 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.4.3-2
+- Disabled keyboxd by default.
+
 * Tue Nov 21 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.3-1
 - Auto-upgrade to 2.4.3 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -63,7 +63,16 @@ ln -s gpg2 gpg
 ln -s gpgv2 gpgv
 popd
 
-# Disable GnuPG from using keyboxd for storage.
+# Empty legacy global configuration file.
+# Some GnuPG commands expect it to exist.
+install -Dm 644 /dev/null %{buildroot}%{_sysconfdir}/gnupg/gpgconf.conf
+
+# By default prevent GnuPG from using keyboxd for storage.
+# It tends to cause unexpected hangs of GnuPG commands and tools depending on GnuPG.
+# For more details, see:
+# - https://discussion.fedoraproject.org/t/gpg-blocking-forever-cant-git-commit-as-a-result/96605/6
+# - https://bugzilla.redhat.com/show_bug.cgi?id=2249218
+# - https://dev.gnupg.org/T6838
 install -vdm 755 %{buildroot}%{_sysconfdir}/skel/.gnupg
 cat > %{buildroot}%{_sysconfdir}/skel/.gnupg/common.conf << EOF
 # Uncomment to enabled keyboxd.
@@ -89,7 +98,8 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %{_infodir}/gnupg*
 %{_libexecdir}/*
 %{_datadir}/gnupg/*
-%{_sysconfdir}/skel/.gnupg/common.conf << EOF
+%{_sysconfdir}/gnupg
+%{_sysconfdir}/skel/.gnupg
 %exclude %{_infodir}/dir
 %exclude /usr/share/doc/*
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4550,8 +4550,8 @@
         "type": "other",
         "other": {
           "name": "gnupg2",
-          "version": "2.4.3",
-          "downloadUrl": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.3.tar.bz2"
+          "version": "2.4.4",
+          "downloadUrl": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.4.tar.bz2"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -221,8 +221,8 @@ libksba-devel-1.6.4-1.azl3.aarch64.rpm
 libxslt-1.1.39-1.azl3.aarch64.rpm
 npth-1.6-4.azl3.aarch64.rpm
 pinentry-1.2.1-1.azl3.aarch64.rpm
-gnupg2-2.4.3-2.azl3.aarch64.rpm
-gnupg2-lang-2.4.3-2.azl3.aarch64.rpm
+gnupg2-2.4.4-1.azl3.aarch64.rpm
+gnupg2-lang-2.4.4-1.azl3.aarch64.rpm
 gpgme-1.23.2-2.azl3.aarch64.rpm
 azurelinux-repos-shared-3.0-2.azl3.noarch.rpm
 azurelinux-repos-3.0-2.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -221,8 +221,8 @@ libksba-devel-1.6.4-1.azl3.aarch64.rpm
 libxslt-1.1.39-1.azl3.aarch64.rpm
 npth-1.6-4.azl3.aarch64.rpm
 pinentry-1.2.1-1.azl3.aarch64.rpm
-gnupg2-2.4.3-1.azl3.aarch64.rpm
-gnupg2-lang-2.4.3-1.azl3.aarch64.rpm
+gnupg2-2.4.3-2.azl3.aarch64.rpm
+gnupg2-lang-2.4.3-2.azl3.aarch64.rpm
 gpgme-1.23.2-2.azl3.aarch64.rpm
 azurelinux-repos-shared-3.0-2.azl3.noarch.rpm
 azurelinux-repos-3.0-2.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -221,8 +221,8 @@ libksba-devel-1.6.4-1.azl3.x86_64.rpm
 libxslt-1.1.39-1.azl3.x86_64.rpm
 npth-1.6-4.azl3.x86_64.rpm
 pinentry-1.2.1-1.azl3.x86_64.rpm
-gnupg2-2.4.3-1.azl3.x86_64.rpm
-gnupg2-lang-2.4.3-1.azl3.x86_64.rpm
+gnupg2-2.4.3-2.azl3.x86_64.rpm
+gnupg2-lang-2.4.3-2.azl3.x86_64.rpm
 gpgme-1.23.2-2.azl3.x86_64.rpm
 azurelinux-repos-shared-3.0-2.azl3.noarch.rpm
 azurelinux-repos-3.0-2.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -221,8 +221,8 @@ libksba-devel-1.6.4-1.azl3.x86_64.rpm
 libxslt-1.1.39-1.azl3.x86_64.rpm
 npth-1.6-4.azl3.x86_64.rpm
 pinentry-1.2.1-1.azl3.x86_64.rpm
-gnupg2-2.4.3-2.azl3.x86_64.rpm
-gnupg2-lang-2.4.3-2.azl3.x86_64.rpm
+gnupg2-2.4.4-1.azl3.x86_64.rpm
+gnupg2-lang-2.4.4-1.azl3.x86_64.rpm
 gpgme-1.23.2-2.azl3.x86_64.rpm
 azurelinux-repos-shared-3.0-2.azl3.noarch.rpm
 azurelinux-repos-3.0-2.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -133,9 +133,9 @@ glibc-tools-2.38-3.azl3.aarch64.rpm
 gmp-6.3.0-1.azl3.aarch64.rpm
 gmp-debuginfo-6.3.0-1.azl3.aarch64.rpm
 gmp-devel-6.3.0-1.azl3.aarch64.rpm
-gnupg2-2.4.3-2.azl3.aarch64.rpm
-gnupg2-debuginfo-2.4.3-2.azl3.aarch64.rpm
-gnupg2-lang-2.4.3-2.azl3.aarch64.rpm
+gnupg2-2.4.4-1.azl3.aarch64.rpm
+gnupg2-debuginfo-2.4.4-1.azl3.aarch64.rpm
+gnupg2-lang-2.4.4-1.azl3.aarch64.rpm
 gperf-3.1-5.azl3.aarch64.rpm
 gperf-debuginfo-3.1-5.azl3.aarch64.rpm
 gpgme-1.23.2-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -133,9 +133,9 @@ glibc-tools-2.38-3.azl3.aarch64.rpm
 gmp-6.3.0-1.azl3.aarch64.rpm
 gmp-debuginfo-6.3.0-1.azl3.aarch64.rpm
 gmp-devel-6.3.0-1.azl3.aarch64.rpm
-gnupg2-2.4.3-1.azl3.aarch64.rpm
-gnupg2-debuginfo-2.4.3-1.azl3.aarch64.rpm
-gnupg2-lang-2.4.3-1.azl3.aarch64.rpm
+gnupg2-2.4.3-2.azl3.aarch64.rpm
+gnupg2-debuginfo-2.4.3-2.azl3.aarch64.rpm
+gnupg2-lang-2.4.3-2.azl3.aarch64.rpm
 gperf-3.1-5.azl3.aarch64.rpm
 gperf-debuginfo-3.1-5.azl3.aarch64.rpm
 gpgme-1.23.2-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -138,9 +138,9 @@ glibc-tools-2.38-3.azl3.x86_64.rpm
 gmp-6.3.0-1.azl3.x86_64.rpm
 gmp-debuginfo-6.3.0-1.azl3.x86_64.rpm
 gmp-devel-6.3.0-1.azl3.x86_64.rpm
-gnupg2-2.4.3-2.azl3.x86_64.rpm
-gnupg2-debuginfo-2.4.3-2.azl3.x86_64.rpm
-gnupg2-lang-2.4.3-2.azl3.x86_64.rpm
+gnupg2-2.4.4-1.azl3.x86_64.rpm
+gnupg2-debuginfo-2.4.4-1.azl3.x86_64.rpm
+gnupg2-lang-2.4.4-1.azl3.x86_64.rpm
 gperf-3.1-5.azl3.x86_64.rpm
 gperf-debuginfo-3.1-5.azl3.x86_64.rpm
 gpgme-1.23.2-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -138,9 +138,9 @@ glibc-tools-2.38-3.azl3.x86_64.rpm
 gmp-6.3.0-1.azl3.x86_64.rpm
 gmp-debuginfo-6.3.0-1.azl3.x86_64.rpm
 gmp-devel-6.3.0-1.azl3.x86_64.rpm
-gnupg2-2.4.3-1.azl3.x86_64.rpm
-gnupg2-debuginfo-2.4.3-1.azl3.x86_64.rpm
-gnupg2-lang-2.4.3-1.azl3.x86_64.rpm
+gnupg2-2.4.3-2.azl3.x86_64.rpm
+gnupg2-debuginfo-2.4.3-2.azl3.x86_64.rpm
+gnupg2-lang-2.4.3-2.azl3.x86_64.rpm
 gperf-3.1-5.azl3.x86_64.rpm
 gperf-debuginfo-3.1-5.azl3.x86_64.rpm
 gpgme-1.23.2-2.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The latest version for `gpg` has an update fixing an issue with `gpg` hanging due to a stale store lock. The new version moves the time the lock is acquired and resolve the issue. See also:
- https://discussion.fedoraproject.org/t/gpg-blocking-forever-cant-git-commit-as-a-result/96605/6
- https://bugzilla.redhat.com/show_bug.cgi?id=2249218
- https://dev.gnupg.org/T6838

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated `gnupg2` to 2.4.4.
- Added an empty `gpgconf.conf` file to prevent some of the package's tools from crashing (they expect it to be present).

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build.](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=539443&view=results)
- Local builds with tests.