### PR TITLE
Image Customizer: Fix modify existing user.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1619,12 +1619,12 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 	if includeExistingKeys {
 		authorizedKeysFileFullPath := filepath.Join(installChroot.RootDir(), authorizedKeysFile)
 
-		exists, err := file.PathExists(authorizedKeysFileFullPath)
+		fileExists, err := file.PathExists(authorizedKeysFileFullPath)
 		if err != nil {
 			return fmt.Errorf("failed to check if authorized_keys file exists:\n%w", err)
 		}
 
-		if exists {
+		if fileExists {
 			pubKeyData, err = file.ReadLines(authorizedKeysFileFullPath)
 			if err != nil {
 				return fmt.Errorf("failed to read existing authorized_keys file:\n%w", err)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1340,7 +1340,8 @@ func addUsers(installChroot *safechroot.Chroot, users []configuration.User) (err
 			return
 		}
 
-		err = ProvisionUserSSHCerts(installChroot, user.Name, user.SSHPubKeyPaths, user.SSHPubKeys, false)
+		err = ProvisionUserSSHCerts(installChroot, user.Name, user.SSHPubKeyPaths, user.SSHPubKeys,
+			false /*includeExistingKeys*/)
 		if err != nil {
 			return
 		}
@@ -1590,8 +1591,8 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 		return
 	}
 
-	userSSHKeyDir := userutils.UserSshDirectory(username)
-	authorizedKeysFile := filepath.Join(userSSHKeyDir, userutils.SshAuthorizedKeysFileName)
+	userSSHKeyDir := userutils.UserSSHDirectory(username)
+	authorizedKeysFile := filepath.Join(userSSHKeyDir, userutils.SSHAuthorizedKeysFileName)
 
 	exists, err = file.PathExists(authorizedKeysTempFile)
 	if err != nil {
@@ -1621,13 +1622,13 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 
 		fileExists, err := file.PathExists(authorizedKeysFileFullPath)
 		if err != nil {
-			return fmt.Errorf("failed to check if authorized_keys file exists:\n%w", err)
+			return fmt.Errorf("failed to check if authorized_keys file (%s) exists:\n%w", authorizedKeysFileFullPath, err)
 		}
 
 		if fileExists {
 			pubKeyData, err = file.ReadLines(authorizedKeysFileFullPath)
 			if err != nil {
-				return fmt.Errorf("failed to read existing authorized_keys file:\n%w", err)
+				return fmt.Errorf("failed to read existing authorized_keys (%s) file:\n%w", authorizedKeysFileFullPath, err)
 			}
 
 			allSSHKeys = append(allSSHKeys, pubKeyData...)

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -21,7 +21,9 @@ const (
 	RootHomeDir       = "/root"
 	UserHomeDirPrefix = "/home"
 
-	ShadowFile = "/etc/shadow"
+	ShadowFile                = "/etc/shadow"
+	SshDirectoryName          = ".ssh"
+	SshAuthorizedKeysFileName = "authorized_keys"
 )
 
 func HashPassword(password string) (string, error) {
@@ -134,12 +136,20 @@ func UpdateUserPassword(installRoot, username, hashedPassword string) error {
 	return nil
 }
 
+// UserHomeDirectory returns the home directory for a user.
 func UserHomeDirectory(username string) string {
 	if username == RootUser {
 		return RootHomeDir
 	} else {
 		return filepath.Join(UserHomeDirPrefix, username)
 	}
+}
+
+// UserSshDirectory returns the path of the .ssh directory for a user.
+func UserSshDirectory(username string) string {
+	homeDir := UserHomeDirectory(username)
+	userSSHKeyDir := filepath.Join(homeDir, SshDirectoryName)
+	return userSSHKeyDir
 }
 
 // NameIsValid returns an error if the User name is empty

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -22,8 +22,8 @@ const (
 	UserHomeDirPrefix = "/home"
 
 	ShadowFile                = "/etc/shadow"
-	SshDirectoryName          = ".ssh"
-	SshAuthorizedKeysFileName = "authorized_keys"
+	SSHDirectoryName          = ".ssh"
+	SSHAuthorizedKeysFileName = "authorized_keys"
 )
 
 func HashPassword(password string) (string, error) {
@@ -145,10 +145,10 @@ func UserHomeDirectory(username string) string {
 	}
 }
 
-// UserSshDirectory returns the path of the .ssh directory for a user.
-func UserSshDirectory(username string) string {
+// UserSSHDirectory returns the path of the .ssh directory for a user.
+func UserSSHDirectory(username string) string {
 	homeDir := UserHomeDirectory(username)
-	userSSHKeyDir := filepath.Join(homeDir, SshDirectoryName)
+	userSSHKeyDir := filepath.Join(homeDir, SSHDirectoryName)
 	return userSSHKeyDir
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -278,6 +278,10 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	}
 
 	if userExists {
+		if user.UID != nil {
+			return fmt.Errorf("cannot set UID (%d) on a user (%s) that already exists", *user.UID, user.Name)
+		}
+
 		// Update the user's password.
 		err = userutils.UpdateUserPassword(imageChroot.RootDir(), user.Name, hashedPassword)
 		if err != nil {
@@ -315,7 +319,8 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 		user.SSHPublicKeyPaths[i] = file.GetAbsPathWithBase(baseConfigPath, user.SSHPublicKeyPaths[i])
 	}
 
-	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPublicKeyPaths, user.SSHPublicKeys)
+	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPublicKeyPaths, user.SSHPublicKeys,
+		userExists)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/users-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/users-config.yaml
@@ -1,0 +1,5 @@
+os:
+  users:
+  - name: test
+    secondaryGroups:
+    - sudo


### PR DESCRIPTION
1. When user exists, append to `authorized_keys` file instead of overwriting it.

2. Return error if UID is provided but the user already exists.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer.

