### PR TITLE
Image Customizer: Fix .repo extension detection.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
@@ -112,7 +112,7 @@ func (m *rpmSourcesMounts) mountRpmSourcesHelper(buildDir string, imageChroot *s
 			err = m.createRepoFromRepoConfig(rpmSource, true, allReposConfig, imageChroot)
 
 		default:
-			return fmt.Errorf("unknown RPM source type (%s)", rpmSource)
+			return fmt.Errorf("unknown RPM source type (%s):\nmust be a .repo file or a directory", rpmSource)
 		}
 		if err != nil {
 			return err
@@ -286,7 +286,7 @@ func getRpmSourceFileType(rpmSourcePath string) (string, error) {
 	}
 
 	filename := filepath.Base(rpmSourcePath)
-	dotIndex := strings.Index(filename, ".")
+	dotIndex := strings.LastIndex(filename, ".")
 	fileExt := ""
 	if dotIndex >= 0 {
 		fileExt = filename[dotIndex:]


### PR DESCRIPTION
When detecting the filename extension of `--rpm-source`s, the extension was incorrectly being taken from the first period instead of the last period.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

