### PR TITLE
php-pecl-zip: upgrade to version 1.22.3 and fix tests

### DIFF
--- a/SPECS/php-pecl-zip/php-pecl-zip.signatures.json
+++ b/SPECS/php-pecl-zip/php-pecl-zip.signatures.json
@@ -1,5 +1,5 @@
 {
     "Signatures": {
-        "php-pecl-zip-1.21.1.tgz": "1078157bd3a074e78b59da5a6f8f6645a5be168c42d08fa78f5cd9bc93c7dede"
+        "php-pecl-zip-1.22.3.tgz": "b0db54cdea265b4b225c909ed296f7d2c4543c81b45e4dc775e3b782130a8bb3"
     }
 }

--- a/SPECS/php-pecl-zip/php-pecl-zip.spec
+++ b/SPECS/php-pecl-zip/php-pecl-zip.spec
@@ -12,8 +12,8 @@
 %global ini_name  40-%{pecl_name}.ini
 Summary:        A ZIP archive management extension
 Name:           php-pecl-zip
-Version:        1.21.1
-Release:        3%{?dist}
+Version:        1.22.3
+Release:        1%{?dist}
 License:        PHP
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -152,6 +152,9 @@ TEST_PHP_EXECUTABLE=%{_bindir}/zts-php \
 %endif
 
 %changelog
+* Fri Mar 29 2024 Andrew Phelps <anphel@microsoft.com> - 1.22.3-1
+- Upgrade to version 1.22.3
+
 * Fri Oct 28 2022 Osama Esmail <osamaesmail@microsoft.com> - 1.21.1-3
 - Initial CBL-Mariner import from Fedora 36 (license: MIT).
 - License verified.

--- a/SPECS/php-pecl-zip/php-pecl-zip.spec
+++ b/SPECS/php-pecl-zip/php-pecl-zip.spec
@@ -24,10 +24,12 @@ BuildRequires:  make
 BuildRequires:  php-devel
 BuildRequires:  php-pear
 BuildRequires:  pkg-config
+BuildRequires:  tzdata
 BuildRequires:  zlib-devel
 BuildRequires:  pkgconfig(libzip) >= 1.0.0
 Requires:       php(api) = 20210902-%{__isa_bits}
 Requires:       php(zend-abi) = 20210902-%{__isa_bits}
+Requires:       tzdata
 # Supposed to use these macros from SPECS/php/macros.php
 #Requires:     php(zend-abi) = %{php_zend_api}
 #Requires:     php(api) = %{php_core_api}
@@ -154,6 +156,7 @@ TEST_PHP_EXECUTABLE=%{_bindir}/zts-php \
 %changelog
 * Fri Mar 29 2024 Andrew Phelps <anphel@microsoft.com> - 1.22.3-1
 - Upgrade to version 1.22.3
+- Add tzdata BR and requires.
 
 * Fri Oct 28 2022 Osama Esmail <osamaesmail@microsoft.com> - 1.21.1-3
 - Initial CBL-Mariner import from Fedora 36 (license: MIT).

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -20793,7 +20793,7 @@
         "type": "other",
         "other": {
           "name": "php-pecl-zip",
-          "version": "1.22.2",
+          "version": "1.22.3",
           "downloadUrl": "https://pecl.php.net/get/zip-1.22.3.tgz"
         }
       }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -20793,8 +20793,8 @@
         "type": "other",
         "other": {
           "name": "php-pecl-zip",
-          "version": "1.21.1",
-          "downloadUrl": "https://pecl.php.net/get/zip-1.21.1.tgz"
+          "version": "1.22.2",
+          "downloadUrl": "https://pecl.php.net/get/zip-1.22.3.tgz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
upgrade `php-pecl-zip` to version 1.22.3 and fix tests by ensuring `tzdata` is available.

Without `tzdata` available, the tests were failing (even in the previous version) with the following:
```
="Notice: date_default_timezone_set(): Timezone ID 'UTC' is invalid in /usr/src/azl/BUILD/php-pecl-zip-1.21.1/NTS/run-tests.php on line 193"
"/var/tmp/rpm-tmp.W1fncF: line 56: 3135402 Segmentation fault      (core dumped) TEST_PHP_ARGS=\"-n -d extension_dir=$PWD/modules -d extension=zip.so\" TEST_PHP_EXECUTABLE=/usr/bin/php /usr/bin/php -n run-tests.php -q --show-diff"
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change php-pecl-zip: upgrade to version 1.22.3 and fix tests

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=540100&view=results
