### PR TITLE
Fix Build Break for kernel-signed

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -136,7 +136,6 @@ echo "initrd of kernel %{uname_r} removed" >&2
 /boot/config-%{uname_r}
 /boot/vmlinuz-%{uname_r}
 /boot/.vmlinuz-%{uname_r}.hmac
-%config(noreplace) %{_sysconfdir}/default/grub.d/10_kernel.cfg
 %defattr(0644,root,root)
 /lib/modules/%{uname_r}/*
 /lib/modules/%{uname_r}/.vmlinuz.hmac


### PR DESCRIPTION
This is related to fix build break of kernel (https://github.com/microsoft/azurelinux/pull/8635).  A cherrypick from 3.0-dev did not properly remove references to the 10_kernel.cfg file in kernel-signed.spec as well.