### PR TITLE
Fix ephemeral-disk-warning.service not running in mariner 3.0

### DIFF
--- a/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
+++ b/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
@@ -3,6 +3,6 @@
   "WALinuxAgent-2.9.0.4.tar.gz": "040969f507f73f3a2c95d5b0568225ad68f7f91bfec99bd92154c3fa9e28034b",
   "ephemeral-disk-warning": "8b18fc001e5dfa43a1f559a074e334330e6fc4fe5b8c586eafc894800cc1c1ad",
   "ephemeral-disk-warning.conf": "128e531c029e04afdab591f44d2b0a69d5a4eb9dec8867282d0acb1ebded76d0",
-  "ephemeral-disk-warning.service": "627b06ab9692aafd20b8c2af4cc779675329426d2ad0c82ddc787d762027d0e9"
+  "ephemeral-disk-warning.service": "f6c5787acd016896e3686b7161b20b95890dfe07d2116b316a5ba29ed0503e71"
  }
 }

--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -1,7 +1,7 @@
 Summary:        The Windows Azure Linux Agent
 Name:           WALinuxAgent
 Version:        2.9.0.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -93,6 +93,9 @@ python3 setup.py check && python3 setup.py test
 
 
 %changelog
+* Tue Apr 02 2024 Sudipta Pandit <sudpandit@microsoft.com> - 2.9.0.4-3
+- Fix ephemeral-disk-warning script path from /usr/bin to /usr/sbin
+
 * Wed Mar 13 2024 Cameron Baird <cameronbaird@microsoft.com> - 2.9.0.4-2
 - Sed service file to refer to actual waagent location, /usr/sbin/waagent
 

--- a/SPECS/WALinuxAgent/ephemeral-disk-warning.service
+++ b/SPECS/WALinuxAgent/ephemeral-disk-warning.service
@@ -7,7 +7,7 @@ ConditionPathExists=/dev/disk/azure/resource-part1
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ephemeral-disk-warning
+ExecStart=/usr/sbin/ephemeral-disk-warning
 RemainAfterExit=yes
 StandardOutput=journal+console
 


### PR DESCRIPTION
Path for ephemeral-disk-waring shell script was changed in mariner 3.0 from `/usr/bin` to `/usr/sbin` directory.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Provide correct script path for the systemd `ephemeral-disk-warning` service.
The path for `ephemeral-disk-warning` script was changed in 3.0 from `/usr/bin` to `/usr/sbin`, it affected the `ephemeral-disk-waring.service` which writes a data loss warning file to the ephemeral disk mounted with azurelinux virtual machines.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- fix script/binary path for `ephemeral-disk-warning.service`
- WALinuxAgent

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Links to CVEs  <!-- optional -->


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [PR-8658](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=541879&view=results)
