### PR TITLE
add image-id file in etc dir

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -168,7 +168,8 @@ $(STATUS_FLAGS_DIR)/imager_disk_output.flag: $(go-imager) $(image_package_cache_
 		$(if $(filter y,$(ENABLE_CPU_PROFILE)),--enable-cpu-prof) \
 		$(if $(filter y,$(ENABLE_MEM_PROFILE)),--enable-mem-prof) \
 		$(if $(filter y,$(ENABLE_TRACE)),--enable-trace) \
-		--timestamp-file=$(TIMESTAMP_DIR)/imager.jsonl && \
+		--timestamp-file=$(TIMESTAMP_DIR)/imager.jsonl \
+		--build-number=$(BUILD_ID) && \
 	touch $@
 
 # Sometimes files will have been deleted, that is fine so long as we were able to detect the change

--- a/toolkit/tools/go.mod
+++ b/toolkit/tools/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
 	github.com/fatih/color v1.16.0
 	github.com/gdamore/tcell v1.4.0
+	github.com/google/uuid v1.3.0
 	github.com/jinzhu/copier v0.3.2
 	github.com/juliangruber/go-intersect v1.1.0
 	github.com/klauspost/pgzip v1.2.5
@@ -35,7 +36,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/klauspost/compress v1.10.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -760,9 +760,9 @@ func addMachineID(installChroot *safechroot.Chroot) (err error) {
 // BUILD_NUMBER: The build number of the image
 // IMAGE_BUILD_DATE: The date when the image is built in format YYYYMMDDHHMMSS
 // IMAGE_UUID: The UUID of the image
-func AddImageIDFile(installChroot *safechroot.Chroot, buildNumber string) (err error) {
+func AddImageIDFile(installChrootRootDir string, buildNumber string) (err error) {
 	// Check if /etc directory exists and it does not, throw an error
-	_, err = os.Stat(filepath.Join(installChroot.RootDir(), "/etc"))
+	_, err = os.Stat(filepath.Join(installChrootRootDir, "/etc"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = fmt.Errorf("directory /etc does not exist in the install root")
@@ -786,7 +786,7 @@ func AddImageIDFile(installChroot *safechroot.Chroot, buildNumber string) (err e
 	imageBuildDate := time.Now().UTC().Format("20060102150405")
 
 	imageIDContent := fmt.Sprintf("BUILD_NUMBER=%s\nIMAGE_BUILD_DATE=%s\nIMAGE_UUID=%s\n", buildNumber, imageBuildDate, uuid.New().String())
-	imageIDFilePath := filepath.Join(installChroot.RootDir(), imageIDFile)
+	imageIDFilePath := filepath.Join(installChrootRootDir, imageIDFile)
 
 	fileCreateErr := file.Create(imageIDFilePath, imageIDFilePerms)
 	if fileCreateErr != nil {

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -755,7 +755,7 @@ func addMachineID(installChroot *safechroot.Chroot) (err error) {
 	return
 }
 
-// Adds image-id file in the /etc directory of the install root.
+// AddImageIDFile adds image-id file in the /etc directory of the install root.
 // The file contains the following fields:
 // BUILD_NUMBER: The build number of the image
 // IMAGE_BUILD_DATE: The date when the image is built in format YYYYMMDDHHMMSS

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -794,6 +794,8 @@ func AddImageIDFile(installChroot *safechroot.Chroot, buildNumber string) (err e
 		return
 	}
 
+	ReportAction(fmt.Sprintf("Writing following content to image-id file: %s", imageIDContent))
+
 	fileWriteErr := file.Write(imageIDContent, imageIDFilePath)
 	if fileWriteErr != nil {
 		err = fmt.Errorf("failed to write to image-id file: %v", fileWriteErr)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -760,7 +760,7 @@ func addMachineID(installChroot *safechroot.Chroot) (err error) {
 // BUILD_NUMBER: The build number of the image
 // IMAGE_BUILD_DATE: The date when the image is built in format YYYYMMDDHHMMSS
 // IMAGE_UUID: The UUID of the image
-func AddImageID(installChroot *safechroot.Chroot, buildNumber string) (err error) {
+func AddImageIDFile(installChroot *safechroot.Chroot, buildNumber string) (err error) {
 	const (
 		imageIDFile      = "/etc/image-id"
 		imageIDFilePerms = 0444

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -140,7 +140,7 @@ func TestAddImageIDFile(t *testing.T) {
 
 	etcPath := filepath.Join(chroot.RootDir(), "etc")
 	os.Mkdir(etcPath, os.ModePerm)
-	err = AddImageIDFile(chroot, buildNumber)
+	err = AddImageIDFile(chroot.RootDir(), buildNumber)
 	assert.NoError(t, err)
 
 	imageIDFileContents, err := os.ReadFile(filepath.Join(chroot.RootDir(), imageIDFilePath))
@@ -173,7 +173,7 @@ func TestAddImageIDFileEmptyBuildNumber(t *testing.T) {
 
 	etcPath := filepath.Join(chroot.RootDir(), "etc")
 	os.Mkdir(etcPath, os.ModePerm)
-	err = AddImageIDFile(chroot, buildNumber)
+	err = AddImageIDFile(chroot.RootDir(), buildNumber)
 	assert.NoError(t, err)
 
 	imageIDFileContents, err := os.ReadFile(filepath.Join(chroot.RootDir(), imageIDFilePath))
@@ -194,6 +194,6 @@ func TestAddImageIDFileGuardClause(t *testing.T) {
 
 	defer chroot.Close(false)
 
-	err = AddImageIDFile(chroot, "")
+	err = AddImageIDFile(chroot.RootDir(), "")
 	assert.Error(t, err)
 }

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -120,32 +120,3 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	assert.Equal(t, orig_contents, copy_1_contents)
 	assert.Equal(t, orig_contents, copy_2_contents)
 }
-
-// Test AddImageIDFile function in installutils.go
-func TestAddImageIDFile(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("Test must be run as root because it uses a chroot")
-	}
-
-	proposedDir := filepath.Join(tmpDir, "TestAddImageIDFile")
-	chroot := safechroot.NewChroot(proposedDir, false)
-
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, true)
-	assert.NoError(t, err)
-
-	defer chroot.Close(false)
-
-	buildNumber := "build-1234"
-	imageIDFilePath := "/etc/image-id"
-
-	err = AddImageIDFile(chroot, buildNumber)
-	assert.NoError(t, err)
-
-	imageIDFileContents, err := os.ReadFile(filepath.Join(chroot.RootDir(), imageIDFilePath))
-	assert.NoError(t, err)
-
-	assert.Contains(t, string(imageIDFileContents), "BUILD_NUMBER")
-	assert.Contains(t, string(imageIDFileContents), buildNumber)
-	assert.Contains(t, string(imageIDFileContents), "IMAGE_BUILD_DATE")
-	assert.Contains(t, string(imageIDFileContents), "IMAGE_UUID")
-}

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -120,3 +120,80 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	assert.Equal(t, orig_contents, copy_1_contents)
 	assert.Equal(t, orig_contents, copy_2_contents)
 }
+
+// Test AddImageIDFile function in installutils.go
+func TestAddImageIDFile(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
+	proposedDir := filepath.Join(tmpDir, "TestAddImageIDFile")
+	chroot := safechroot.NewChroot(proposedDir, false)
+
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, true)
+	assert.NoError(t, err)
+
+	defer chroot.Close(false)
+
+	buildNumber := "build-1234"
+	imageIDFilePath := "/etc/image-id"
+
+	etcPath := filepath.Join(chroot.RootDir(), "etc")
+	os.Mkdir(etcPath, os.ModePerm)
+	err = AddImageIDFile(chroot, buildNumber)
+	assert.NoError(t, err)
+
+	imageIDFileContents, err := os.ReadFile(filepath.Join(chroot.RootDir(), imageIDFilePath))
+	assert.NoError(t, err)
+
+	// assert that file has BUILD_NUMBER and the build number
+	assert.Contains(t, string(imageIDFileContents), "BUILD_NUMBER="+buildNumber)
+	// assert that file has IMAGE_BUILD_DATE and a timestamp in the format of YYYYMMDDHHMMSS
+	assert.Regexp(t, "IMAGE_BUILD_DATE=[0-9]{14}", string(imageIDFileContents))
+	// assert that file has IMAGE_UUID and a UUID
+	assert.Regexp(t, "IMAGE_UUID=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", string(imageIDFileContents))
+}
+
+func TestAddImageIDFileEmptyBuildNumber(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
+	proposedDir := filepath.Join(tmpDir, "TestAddImageIDFile")
+	chroot := safechroot.NewChroot(proposedDir, false)
+
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, true)
+	assert.NoError(t, err)
+
+	defer chroot.Close(false)
+
+	buildNumber := ""
+	expectedBuildNumber := "local"
+	imageIDFilePath := "/etc/image-id"
+
+	etcPath := filepath.Join(chroot.RootDir(), "etc")
+	os.Mkdir(etcPath, os.ModePerm)
+	err = AddImageIDFile(chroot, buildNumber)
+	assert.NoError(t, err)
+
+	imageIDFileContents, err := os.ReadFile(filepath.Join(chroot.RootDir(), imageIDFilePath))
+	assert.NoError(t, err)
+	assert.Contains(t, string(imageIDFileContents), expectedBuildNumber)
+}
+
+func TestAddImageIDFileGuardClause(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
+	proposedDir := filepath.Join(tmpDir, "TestAddImageIDFileGuardClause")
+	chroot := safechroot.NewChroot(proposedDir, false)
+
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, true)
+	assert.NoError(t, err)
+
+	defer chroot.Close(false)
+
+	err = AddImageIDFile(chroot, "")
+	assert.Error(t, err)
+}

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -600,7 +600,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 		return
 	}
 
-	err = installutils.AddImageIDFile(installChroot, *buildNumber)
+	err = installutils.AddImageIDFile(installChroot.RootDir(), *buildNumber)
 
 	// Only configure the bootloader or read only partitions for actual disks, a rootfs does not need these
 	if !isRootFS {

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -37,6 +37,7 @@ var (
 	liveInstallFlag = app.Flag("live-install", "Enable to perform a live install to the disk specified in config file.").Bool()
 	emitProgress    = app.Flag("emit-progress", "Write progress updates to stdout, such as percent complete and current action.").Bool()
 	timestampFile   = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
+	buildNumber     = app.Flag("build-number", "Build number to be used in the image.").String()
 	logFlags        = exe.SetupLogFlags(app)
 	profFlags       = exe.SetupProfileFlags(app)
 )
@@ -598,6 +599,8 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 		err = fmt.Errorf("failed to populate image contents: %s", err)
 		return
 	}
+
+	err = installutils.AddImageIDFile(installChroot, *buildNumber)
 
 	// Only configure the bootloader or read only partitions for actual disks, a rootfs does not need these
 	if !isRootFS {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR introduces a new functionality to Azure Linux tooling which generates a file `/etc/image-id` to contain the metadata for the images as they are built in the pipelines. 

Background:
We are adding a new file called image-id inside the /etc directory which includes the metadata for the image.
There are 3 fields in this file. Below is an example of this file's content:
```
BUILD_NUMBER=""       # ["3.0.20240320-3.0-531186", "2.0.20240225-fasttrack-513397", "local"]
IMAGE_BUILD_DATE=""   # ["YYYYMMDDHHMMSS"]
IMAGE_UUID=""         # ["6746853c-e6e6-11ee-9319-0242ac110002"]
```

BUILD_NUMBER is the build number of the ado pipeline run (when building in the pipeline). This field defaults to "local" for local image builds.
IMAGE_BUILD_DATE stores the date information of when the image is created in the YYYYMMDDHHMMSS format.
IMAGE_UUID is the uuid generated during make image.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
No change to packages.
The following files are updated:
- toolkit/tools/imager/imager.go
- toolkit/tools/imagegen/installutils/installutils.go
- toolkit/tools/imagegen/installutils/installutils_test.go
- toolkit/tools/go.mod
- toolkit/scripts/imggen.mk

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Stage 0 Pipeline build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=543228&view=results
- Corresponding PR in ADO pipelines: https://dev.azure.com/mariner-org/mariner/_git/CBL-Mariner-Pipelines/pullrequest/18616.