### PR TITLE
Add runtime filter to depsearch

### DIFF
--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -34,7 +34,9 @@ var (
 	specsToSearch = app.Flag("specs", "Space seperated list of specfiles to search from.").String()
 	goalsToSearch = app.Flag("goals", "Space seperated list of goal names to search (Try 'ALL' or 'PackagesToBuild').").String()
 
-	reverseSearch = app.Flag("reverse", "Reverse the search to give a traditional dependency list for the packages instead of dependants.").Bool()
+	reverseSearch        = app.Flag("reverse", "Reverse the search to give a traditional dependency list for the packages instead of dependants.").Bool()
+	runtimeOnly          = app.Flag("runtime-only", "Only consider runtime dependencies").Bool()
+	runtimeOnlyPlusBuild = app.Flag("runtime-only-plus-build", "Only consider runtime dependencies, but include the root build nodes").Bool()
 
 	printTree       = app.Flag("tree", "Print output as a simple tree instead of a list").Bool()
 	verbosity       = app.Flag("verbosity", "Print the full node details (4), limited details (3), RPM (2), or SPEC name (1) for each result").Default("1").Int()
@@ -64,6 +66,17 @@ func main() {
 
 	if !(*maxDepth == -1 || *maxDepth >= 1) {
 		logger.Log.Fatalf("Invalid max depth '%d', valid ranges are -1, >=1", *maxDepth)
+	}
+
+	// Only one of runtimeOnlyPlusBuild or runtimeOnly can be set
+	if *runtimeOnly && *runtimeOnlyPlusBuild {
+		logger.Log.Fatalf("Only one of --runtime-only or --runtime-only-plus-build can be set")
+	}
+	runtimeFilterLevel := -1
+	if *runtimeOnlyPlusBuild {
+		runtimeFilterLevel = 1
+	} else if *runtimeOnly {
+		runtimeFilterLevel = 0
 	}
 
 	// We can color the entries when using --tree, or limit the output in all modes with --rpm-filter
@@ -109,7 +122,7 @@ func main() {
 		logger.Log.Panicf("Failed to generate graph to run depsearch on: %s", err)
 	}
 
-	printSpecs(outputGraph, *printTree, *filter, *filterFile, *printDuplicates, *verbosity, *maxDepth, root)
+	printSpecs(outputGraph, *printTree, *filter, *filterFile, *printDuplicates, *verbosity, *maxDepth, runtimeFilterLevel, root)
 
 	if len(*outputGraphFile) > 0 {
 		pkggraph.WriteDOTGraphFile(outputGraph, *outputGraphFile)
@@ -320,7 +333,7 @@ func (t *treeSearch) printProgress() {
 // Run a DFS and generate a string representation of the tree. Optionally ignore all branches that only container nodes in
 //
 //	the filter list (ie given the toolchain manifest, only print those branches which container non-toolchain packages)
-func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, filter bool, filterFile string, verbosity int, generateStrings, printDuplicates bool) (lines []string, hasNonToolchain bool) {
+func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, filter bool, filterFile string, verbosity int, generateStrings, printDuplicates bool, runtimeFilterLevel int) (lines []string, hasNonToolchain bool) {
 	t.printProgress()
 	// We only care about run nodes for the purposes of detecting toolchain files
 	hasNonToolchain = n.Type == pkggraph.TypeLocalBuild && !isFilteredFile(n.RpmPath, filterFile)
@@ -363,7 +376,12 @@ func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, 
 		)
 		for nodes.Next() {
 			child := nodes.Node().(*pkggraph.PkgNode)
-			childLines, childHasMissingToolchainPkg = t.treeNodeToString(child, depth+1, maxDepth, filter, filterFile, verbosity, generateStrings, printDuplicates)
+
+			// If we are only looking for runtime, skip build nodes (except for the root nodes: goal + each package node we care about)
+			if runtimeFilterLevel != -1 && depth > runtimeFilterLevel && child.Type == pkggraph.TypeLocalBuild {
+				continue
+			}
+			childLines, childHasMissingToolchainPkg = t.treeNodeToString(child, depth+1, maxDepth, filter, filterFile, verbosity, generateStrings, printDuplicates, runtimeFilterLevel)
 			hasNonToolchain = hasNonToolchain || childHasMissingToolchainPkg
 
 			// A child will return an empty string list if it, and all its children, are either duplicates or have been filtered out
@@ -407,14 +425,14 @@ func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, 
 	return lines, hasNonToolchain
 }
 
-func printSpecs(graph *pkggraph.PkgGraph, tree, filter bool, filterFile string, printDuplicates bool, verbosity, maxDepth int, root *pkggraph.PkgNode) {
+func printSpecs(graph *pkggraph.PkgGraph, tree, filter bool, filterFile string, printDuplicates bool, verbosity, maxDepth, runtimeFilterLevel int, root *pkggraph.PkgNode) {
 	t, err := createSearch(graph, root)
 	if err != nil {
 		logger.Log.Fatalf("Failed to start search: %s", err)
 	}
 	// May as well use the tree searh to parse all the filtered packages etc, even if we are
 	//    just printing a list
-	lines, _ := t.treeNodeToString(root, 0, maxDepth, filter, filterFile, verbosity, tree, printDuplicates)
+	lines, _ := t.treeNodeToString(root, 0, maxDepth, filter, filterFile, verbosity, tree, printDuplicates, runtimeFilterLevel)
 	if tree {
 		for _, l := range lines {
 			fmt.Println(l)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
~Add `--runtime-only` and `--runtime-only-plus-build` flags to `depsearch` tool (for examining the build graphs).~
Add `--runtime-filter-level` flag to `depsearch` tool (for examining the build graphs).

This will filter out all build nodes beyond the layer specified.

```bash
sudo make go-depsearch REBUILD_TOOLS=y
./out/tools/depsearch --input ../build/pkg_artifacts/graph.dot  --reverse --verbosity 3 --tree --packages device-mapper-multipath --max-depth=4 --print-duplicates --runtime-filter-level 1
```
Note that is shows both the run and build node for device-mapper-multipath, but if `--runtime-filter-level 0` is used, it will drop the build node.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add runtime filtering to depsearch utility.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test
