### PR TITLE
Downgrade cloud-init to 23.3 via epoch 

### DIFF
--- a/SPECS/cloud-init/cloud-init.signatures.json
+++ b/SPECS/cloud-init/cloud-init.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "10-azure-kvp.cfg": "79e0370c010be5cd4717960e4b414570c9ec6e6d29aede77ccecc43d2b03bb9a",
-  "cloud-init-23.4.1.tar.gz": "f12d207cf147ab981787487d38cda09ee71975505df224c96a6cf1d59f53ca2f"
+  "cloud-init-23.3.tar.gz": "1a5a54369f78891b79f43061c1ff0fb31e2bd74ff9527d7150ddd6517c3e2b07"
  }
 }

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,17 +1,20 @@
+%define upstream_version_group 23.3.3
+%define package_version %(echo %{upstream_version_group} | cut -d. -f1-2)
+
 Summary:        Cloud instance init scripts
 Name:           cloud-init
-Version:        23.4.1
-Release:        4%{?dist}
+Epoch:          1
+Version:        %{package_version}
+Release:        1%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
-Source0:        https://launchpad.net/cloud-init/trunk/%{version}/+download/%{name}-%{version}.tar.gz
+Source0:        https://launchpad.net/cloud-init/trunk/%{upstream_version_group}/+download/%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
-Patch0:         Retain-exit-code-in-cloud-init-status-for-recoverabl.patch
-Patch1:         ci-Pin-pytest-8.0.0.patch
-Patch2:         exec_cmd_error_handling.patch
+Patch0:         overrideDatasourceDetection.patch
+Patch1:         exec_cmd_error_handling.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus
@@ -70,7 +73,7 @@ ssh keys and to let the user run various scripts.
 
 %package azure-kvp
 Summary:        Cloud-init configuration for Hyper-V telemetry
-Requires:       %{name} = %{version}-%{release}
+Requires:       %{name} = %{epoch}:%{version}-%{release}
 
 %description    azure-kvp
 Cloud-init configuration for Hyper-V telemetry
@@ -84,7 +87,7 @@ python3 setup.py build
 %install
 %{py3_install "--init-system=systemd"}
 
-python3 tools/render-template --variant mariner > %{buildroot}/%{_sysconfdir}/cloud/cloud.cfg
+python3 tools/render-cloudcfg --variant mariner > %{buildroot}/%{_sysconfdir}/cloud/cloud.cfg
 sed -i "s,@@PACKAGED_VERSION@@,%{version}-%{release}," %{buildroot}/%{python3_sitelib}/cloudinit/version.py
 
 %if "%{_arch}" == "aarch64"
@@ -147,6 +150,12 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Wed Apr 03 2024 Rachel Menge <rachelmenge@microsoft.com> - 1:23.3-1
+- Downgrade to 23.3
+- Add back overrideDatasourceDetection.patch
+- Remove ci-Pin-pytest-8.0.0.patch as pytest is pinned to pytest<=7.3.1
+- Remove Retain-exit-code-in-cloud-init-status-for-recoverabl.patch
+
 * Wed Mar 13 2024 Minghe Ren <mingheren@microsoft.com> - 23.4.1-4
 - Add patch to resolve error handling approach when executing command
 

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -5,7 +5,7 @@ Summary:        Cloud instance init scripts
 Name:           cloud-init
 Epoch:          1
 Version:        %{package_version}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -150,8 +150,8 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
-* Wed Apr 03 2024 Rachel Menge <rachelmenge@microsoft.com> - 1:23.3-1
-- Downgrade to 23.3
+* Wed Apr 03 2024 Rachel Menge <rachelmenge@microsoft.com> - 1:23.3-2
+- Downgrade to 23.3 with release 2 to avoid collision with 23.3 in PMC
 - Add back overrideDatasourceDetection.patch
 - Remove ci-Pin-pytest-8.0.0.patch as pytest is pinned to pytest<=7.3.1
 - Remove Retain-exit-code-in-cloud-init-status-for-recoverabl.patch

--- a/SPECS/cloud-init/overrideDatasourceDetection.patch
+++ b/SPECS/cloud-init/overrideDatasourceDetection.patch
@@ -1,0 +1,35 @@
+From 35988cc4452f7df42e3c1b462731489bd33dade6 Mon Sep 17 00:00:00 2001
+From: Chris Patterson <cpatterson@microsoft.com>
+Date: Mon, 11 Sep 2023 16:56:06 -0400
+Subject: [PATCH] sources: do not override datasource detection if None is in
+ list
+
+Users with datasource_list = [Azure, None] started failing to boot
+properly outside of Azure with the changes to override datasource detection.
+
+If the fallback "None" is included in the datasource_list, do not treat
+the system as configured with a single datasource.
+
+If users want to force a single datasource regardless of detection,
+they can do so by removing None from the list.
+
+Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
+---
+ cloudinit/sources/__init__.py | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff -ruN a/cloudinit/sources/__init__.py b/cloudinit/sources/__init__.py
+--- a/cloudinit/sources/__init__.py	2023-08-28 09:20:24.000000000 -0700
++++ b/cloudinit/sources/__init__.py	2023-09-13 15:00:23.287549869 -0700
+@@ -352,10 +352,7 @@
+                 self,
+             )
+             return True
+-        elif self.sys_cfg.get("datasource_list", []) in (
+-            [self.dsname],
+-            [self.dsname, "None"],
+-        ):
++        elif self.sys_cfg.get("datasource_list", []) == [self.dsname]:
+             LOG.debug(
+                 "Machine is configured to run on single datasource %s.", self
+             )

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1807,8 +1807,8 @@
         "type": "other",
         "other": {
           "name": "cloud-init",
-          "version": "23.4.1",
-          "downloadUrl": "https://launchpad.net/cloud-init/trunk/23.4.1/+download/cloud-init-23.4.1.tar.gz"
+          "version": "23.3",
+          "downloadUrl": "https://launchpad.net/cloud-init/trunk/23.3.3/+download/cloud-init-23.3.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Up epoch to downgrade cloud-init to 23.3. cloud-init 23.4 introduced a change which requires rfc3442 support. Currently, Mariner's dhclient does not fully support rfc3442. This leads to failure in establishing global routing. Downgrade cloud-init to remove rfc3442 requirement.

Note that the diff in version of `23.3` and not `23.3.3` as mentioned in source url is intentional 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Downgrade to 23.3 using epoch 1
- Add back overrideDatasourceDetection.patch
- Remove ci-Pin-pytest-8.0.0.patch as pytest is pinned to pytest<=7.3.1
- Remove Retain-exit-code-in-cloud-init-status-for-recoverabl.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/49661506

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id w/ tests (100% pass): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=545390&view=results
- Built locally within toolkit
- Built locally within container w/ tests (100% pass:)
`=========== 4861 passed, 8 skipped, 1 xfailed, 3 warnings in 55.74s ============"`
- Full build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=545392&view=results
- Penguinator build with no fails: [Pipelines - Run 20240404.5 (azure.com)](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=544339&view=ms.vss-test-web.build-test-results-tab)
- Fasttrack run of tests: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=545397&view=results