### PR TITLE
kexec-tools: remove implicit perl dependency

### DIFF
--- a/SPECS/kexec-tools/kexec-tools.spec
+++ b/SPECS/kexec-tools/kexec-tools.spec
@@ -6,7 +6,7 @@
 Summary:        The kexec/kdump userspace component
 Name:           kexec-tools
 Version:        2.0.27
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -297,7 +297,7 @@ done
 %files
 /usr/sbin/kexec
 /usr/sbin/makedumpfile
-/usr/sbin/makedumpfile-R.pl
+%exclude /usr/sbin/makedumpfile-R.pl
 /usr/sbin/mkdumprd
 /usr/sbin/vmcore-dmesg
 %{_bindir}/*
@@ -331,6 +331,9 @@ done
 /usr/share/makedumpfile/
 
 %changelog
+* Wed Apr 03 2024 Henry Beberman <henry.beberman@microsoft.com> - 2.0.27-5
+- Exclude makedumpfile-R.pl script to avoid an implicit dependency on perl
+
 * Fri Feb 23 2024 Chris Gunn <chrisgun@microsoft.com> - 2.0.27-4
 - Rename initrd.img-<kver> to initramfs-<kver>.img
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change removes `makedumpfile-R.pl` from the kexec-tools package.

Currently kexec-tools in 3.0 has an implicit dependency on perl because `makedumpfile-R.pl` was brought into the files list during a version upgrade. This perl dependency brings in over 60MB of perl binaries into the default marketplace image. This script was present during the build but unpackaged for 2.0, and there are no known consumers of it for 3.0.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove makedumpfile-R.pl from kexec-tools to remove implicit dependency on perl.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=543404&view=results
- Tested the buddy build package and confirmed there's no longer a dependency on perl.
