### PR TITLE
Remove systemd-bootstrap dependency in libvirt

### DIFF
--- a/SPECS/libvirt/libvirt.spec
+++ b/SPECS/libvirt/libvirt.spec
@@ -397,6 +397,10 @@ Requires: polkit >= 0.112
 # For virConnectGetSysinfo
 Requires: dmidecode
     %endif
+# For service management
+# azl has systemd-bootstrap which also provides /usr/bin/sysctl, explicitly request full systemd.
+Requires(posttrans): systemd
+Requires(preun):  systemd
 # libvirtd depends on 'messagebus' service
 Requires: dbus
 # For uid creation during pre

--- a/SPECS/libvirt/libvirt.spec
+++ b/SPECS/libvirt/libvirt.spec
@@ -185,7 +185,7 @@
 Summary:        Library providing a simple virtualization API
 Name:           libvirt
 Version:        10.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND OFL-1.1
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -397,9 +397,6 @@ Requires: polkit >= 0.112
 # For virConnectGetSysinfo
 Requires: dmidecode
     %endif
-# For service management
-Requires(posttrans): /usr/bin/systemctl
-Requires(preun): /usr/bin/systemctl
 # libvirtd depends on 'messagebus' service
 Requires: dbus
 # For uid creation during pre
@@ -2184,6 +2181,9 @@ exit 0
 %endif
 
 %changelog
+* Wed Apr 03 2024 Betty Lakes <bettylakes@microsoft.com> - 10.0.0-2
+- Remove systemd-bootstrap dependency
+
 * Thu Jan 18 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 10.0.0-1
 - Updating to version 10.0.0.
 - Hard code configuration options to match Mariner 2.0 configurations. Ensure that

--- a/SPECS/libvirt/libvirt.spec
+++ b/SPECS/libvirt/libvirt.spec
@@ -2186,7 +2186,7 @@ exit 0
 
 %changelog
 * Wed Apr 03 2024 Betty Lakes <bettylakes@microsoft.com> - 10.0.0-2
-- Remove systemd-bootstrap dependency
+- Make systemd dependency explicit to avoid confusion with systemd-bootstrap.
 
 * Thu Jan 18 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 10.0.0-1
 - Updating to version 10.0.0.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Remove systemd-bootstrap dependency in libvirt

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
libguesfs wasn't building because of the error:
"package systemd-255-9.azl3.x86_64 obsoletes systemd-bootstrap <= 255-9.azl3 provided by systemd-bootstrap-250.3-17.azl3.x86_64"
To fix the error we decided to remove the systemd-bootstrap dependency from libvirt-daemon-common.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Pipeline build id: [543524](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=543524&view=results)
- Full Build: [543589](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=543589&view=results)
