### PR TITLE
containerized-rpmbuild: fix typo in installing packages string

### DIFF
--- a/toolkit/scripts/containerized-build/resources/azl.Dockerfile
+++ b/toolkit/scripts/containerized-build/resources/azl.Dockerfile
@@ -25,5 +25,5 @@ RUN if [[ "${mode}" == "build" ]]; then echo "cd /usr/src/azl || { echo \"ERROR:
 RUN if [[ "${mode}" == "test" ]]; then echo "cd /mnt || { echo \"ERROR: Could not change directory to /mnt \"; exit 1; }"  >> /root/.bashrc; fi
 
 # Install packages from bashrc so we can use the previously setup tdnf defaults.
-RUN echo "echo installing packages vim git ${coextra_packages}" >> /root/.bashrc && \
+RUN echo "echo installing packages vim git ${extra_packages}" >> /root/.bashrc && \
     echo "tdnf install -qy vim git ${extra_packages}" >> /root/.bashrc


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Change #7982 introduced a typo in the variable name we use to print which extra packages `containerized-rpmbuild` will install. The correct packages are installed, but the string informing the user what's being installed doesn't print the extra packages.

This change fixes that.

###### Change Log  <!-- REQUIRED -->
- Fix typo mentioned above.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Tested locally in `containerized-rpmbuild`
