### PR TITLE
[WIP] Remove commit b448de2 in kernel

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.15.153.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Thu Apr 04 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.153.1-2
+- Bump release to match kernel
+
 * Wed Mar 27 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.153.1-1
 - Auto-upgrade to 5.15.153.1
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -12,7 +12,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.15.153.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -73,6 +73,9 @@ done
 %endif
 
 %changelog
+* Thu Apr 04 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.153.1-2
+- Bump release to match kernel
+
 * Wed Mar 27 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.153.1-1
 - Auto-upgrade to 5.15.153.1
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -28,7 +28,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.15.153.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -40,6 +40,7 @@ Source2:        config_aarch64
 Source3:        sha512hmac-openssl.sh
 Source4:        cbl-mariner-ca-20211013.pem
 Patch0:         nvme_multipath_default_false.patch
+Patch1:         revert-mm-sparsemem-fix-race-in-accessing-memory_sec.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -163,6 +164,7 @@ manipulation of eBPF programs and maps.
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-2-%{version}
 %patch0 -p1
+%patch1 -p1
 
 make mrproper
 
@@ -426,6 +428,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Thu Apr 04 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.153.1-2
+- Patch out b448de2 "mm/sparsemem: fix race in accessing memory_section->usage"
+
 * Wed Mar 27 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.153.1-1
 - Auto-upgrade to 5.15.153.1
 

--- a/SPECS/kernel/revert-mm-sparsemem-fix-race-in-accessing-memory_sec.patch
+++ b/SPECS/kernel/revert-mm-sparsemem-fix-race-in-accessing-memory_sec.patch
@@ -1,0 +1,104 @@
+From 45db22e7eaa7a68c57e15114670017a07e71106f Mon Sep 17 00:00:00 2001
+From: Rachel Menge <rachelmenge@microsoft.com>
+Date: Thu, 4 Apr 2024 17:32:11 -0400
+Subject: [PATCH] Revert "mm/sparsemem: fix race in accessing
+ memory_section->usage"
+
+This reverts commit b448de2459b6d62a53892487ab18b7d823ff0529.
+due to NVIDIA driver incompatibility
+https://github.com/NVIDIA/open-gpu-kernel-modules/issues/594
+---
+ include/linux/mmzone.h | 14 +++-----------
+ mm/sparse.c            | 17 ++++++++---------
+ 2 files changed, 11 insertions(+), 20 deletions(-)
+
+diff --git a/include/linux/mmzone.h b/include/linux/mmzone.h
+index 8b8349ffa1cd..9e1485083398 100644
+--- a/include/linux/mmzone.h
++++ b/include/linux/mmzone.h
+@@ -1287,7 +1287,6 @@ static inline unsigned long section_nr_to_pfn(unsigned long sec)
+ #define SUBSECTION_ALIGN_DOWN(pfn) ((pfn) & PAGE_SUBSECTION_MASK)
+ 
+ struct mem_section_usage {
+-	struct rcu_head rcu;
+ #ifdef CONFIG_SPARSEMEM_VMEMMAP
+ 	DECLARE_BITMAP(subsection_map, SUBSECTIONS_PER_SECTION);
+ #endif
+@@ -1458,7 +1457,7 @@ static inline int pfn_section_valid(struct mem_section *ms, unsigned long pfn)
+ {
+ 	int idx = subsection_map_index(pfn);
+ 
+-	return test_bit(idx, READ_ONCE(ms->usage)->subsection_map);
++	return test_bit(idx, ms->usage->subsection_map);
+ }
+ #else
+ static inline int pfn_section_valid(struct mem_section *ms, unsigned long pfn)
+@@ -1482,7 +1481,6 @@ static inline int pfn_section_valid(struct mem_section *ms, unsigned long pfn)
+ static inline int pfn_valid(unsigned long pfn)
+ {
+ 	struct mem_section *ms;
+-	int ret;
+ 
+ 	/*
+ 	 * Ensure the upper PAGE_SHIFT bits are clear in the
+@@ -1496,19 +1494,13 @@ static inline int pfn_valid(unsigned long pfn)
+ 	if (pfn_to_section_nr(pfn) >= NR_MEM_SECTIONS)
+ 		return 0;
+ 	ms = __pfn_to_section(pfn);
+-	rcu_read_lock();
+-	if (!valid_section(ms)) {
+-		rcu_read_unlock();
++	if (!valid_section(ms))
+ 		return 0;
+-	}
+ 	/*
+ 	 * Traditionally early sections always returned pfn_valid() for
+ 	 * the entire section-sized span.
+ 	 */
+-	ret = early_section(ms) || pfn_section_valid(ms, pfn);
+-	rcu_read_unlock();
+-
+-	return ret;
++	return early_section(ms) || pfn_section_valid(ms, pfn);
+ }
+ #endif
+ 
+diff --git a/mm/sparse.c b/mm/sparse.c
+index 27092badd15b..120bc8ea5293 100644
+--- a/mm/sparse.c
++++ b/mm/sparse.c
+@@ -789,13 +789,6 @@ static void section_deactivate(unsigned long pfn, unsigned long nr_pages,
+ 	if (empty) {
+ 		unsigned long section_nr = pfn_to_section_nr(pfn);
+ 
+-		/*
+-		 * Mark the section invalid so that valid_section()
+-		 * return false. This prevents code from dereferencing
+-		 * ms->usage array.
+-		 */
+-		ms->section_mem_map &= ~SECTION_HAS_MEM_MAP;
+-
+ 		/*
+ 		 * When removing an early section, the usage map is kept (as the
+ 		 * usage maps of other sections fall into the same page). It
+@@ -804,10 +797,16 @@ static void section_deactivate(unsigned long pfn, unsigned long nr_pages,
+ 		 * was allocated during boot.
+ 		 */
+ 		if (!PageReserved(virt_to_page(ms->usage))) {
+-			kfree_rcu(ms->usage, rcu);
+-			WRITE_ONCE(ms->usage, NULL);
++			kfree(ms->usage);
++			ms->usage = NULL;
+ 		}
+ 		memmap = sparse_decode_mem_map(ms->section_mem_map, section_nr);
++		/*
++		 * Mark the section invalid so that valid_section()
++		 * return false. This prevents code from dereferencing
++		 * ms->usage array.
++		 */
++		ms->section_mem_map &= ~SECTION_HAS_MEM_MAP;
+ 	}
+ 
+ 	/*
+-- 
+2.34.1

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-20.cm2.aarch64.rpm
-kernel-headers-5.15.153.1-1.cm2.noarch.rpm
+kernel-headers-5.15.153.1-2.cm2.noarch.rpm
 glibc-2.35-6.cm2.aarch64.rpm
 glibc-devel-2.35-6.cm2.aarch64.rpm
 glibc-i18n-2.35-6.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-20.cm2.x86_64.rpm
-kernel-headers-5.15.153.1-1.cm2.noarch.rpm
+kernel-headers-5.15.153.1-2.cm2.noarch.rpm
 glibc-2.35-6.cm2.x86_64.rpm
 glibc-devel-2.35-6.cm2.x86_64.rpm
 glibc-i18n-2.35-6.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -136,7 +136,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.153.1-1.cm2.noarch.rpm
+kernel-headers-5.15.153.1-2.cm2.noarch.rpm
 kmod-29-2.cm2.aarch64.rpm
 kmod-debuginfo-29-2.cm2.aarch64.rpm
 kmod-devel-29-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -141,8 +141,8 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-cross-headers-5.15.153.1-1.cm2.noarch.rpm
-kernel-headers-5.15.153.1-1.cm2.noarch.rpm
+kernel-cross-headers-5.15.153.1-2.cm2.noarch.rpm
+kernel-headers-5.15.153.1-2.cm2.noarch.rpm
 kmod-29-2.cm2.x86_64.rpm
 kmod-debuginfo-29-2.cm2.x86_64.rpm
 kmod-devel-29-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch out b448de2 "mm/sparsemem: fix race in accessing memory_section->usage" This commit causes build failures for NVIDIA drivers. These errors manifest as
`ERROR: modpost: GPL-incompatible module nvidia.ko uses GPL-only symbol 'rcu_read_unlock_strict'`

Note that this behavior is behind CONFIG_SPARSEMEM_VMEMMAP which is enabled in CBL-Mariner 2.0

Tracking github issue:
https://github.com/NVIDIA/open-gpu-kernel-modules/issues/594

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove commit b448de2 in kernel

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddybuild : https://dev.azure.com/mariner-org/mariner/_build/results?buildId=544443&view=results
<img width="416" alt="image" src="https://github.com/microsoft/azurelinux/assets/10325590/74e570c9-24dd-49ba-bfa7-a6ecdf4a817a">
