### PR TITLE
Image Customizer: Support disk size suffixes.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -190,15 +190,15 @@ storage:
 
   disks:
   - partitionTableType: gpt
-    maxSize: 4096
+    maxSize: 4096M
     partitions:
     - id: esp
       type: esp
-      start: 1
-      end: 9
+      start: 1M
+      end: 9M
 
     - id: rootfs
-      start: 9
+      start: 9M
       
   fileSystems:
   - deviceId: esp
@@ -241,7 +241,11 @@ Supported options:
 
 ### maxSize [uint64]
 
-The size of the disk, specified in mebibytes (MiB).
+The size of the disk.
+
+Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+
+Must be a multiple of 1 MiB.
 
 ### partitions [[partition](#partition-type)[]]
 
@@ -694,11 +698,15 @@ The label to assign to the partition.
 
 Required.
 
-The start location (inclusive) of the partition, specified in MiBs.
+The start location (inclusive) of the partition.
+
+Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+
+Must be a multiple of 1 MiB.
 
 ### end [uint64]
 
-The end location (exclusive) of the partition, specified in MiBs.
+The end location (exclusive) of the partition.
 
 The End and Size fields cannot be specified at the same time.
 
@@ -707,9 +715,17 @@ partition.
 When both the Size and End fields are omitted, the last partition will fill the
 remainder of the disk (based on the disk's [maxSize](#maxsize-uint64) field).
 
+Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+
+Must be a multiple of 1 MiB.
+
 ### size [uint64]
 
-The size of the partition, specified in MiBs.
+The size of the partition.
+
+Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+
+Must be a multiple of 1 MiB.
 
 <div id="partition-type-string"></div>
 

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -6,6 +6,7 @@ package imagecustomizerapi
 import (
 	"testing"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,11 +15,11 @@ func TestConfigIsValid(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",
-						Start: 1,
+						Start: 1 * diskutils.MiB,
 						Type:  PartitionTypeESP,
 					},
 				},
@@ -49,11 +50,11 @@ func TestConfigIsValidLegacy(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "boot",
-						Start: 1,
+						Start: 1 * diskutils.MiB,
 						Type:  PartitionTypeBiosGrub,
 					},
 				},
@@ -81,11 +82,11 @@ func TestConfigIsValidNoBootType(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "a",
-						Start: 1,
+						Start: 1 * diskutils.MiB,
 					},
 				},
 			}},
@@ -106,11 +107,11 @@ func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",
-						Start: 1,
+						Start: 1 * diskutils.MiB,
 						Type:  PartitionTypeESP,
 					},
 				},
@@ -142,11 +143,11 @@ func TestConfigIsValidMultipleDisks(t *testing.T) {
 			Disks: []Disk{
 				{
 					PartitionTableType: "gpt",
-					MaxSize:            1,
+					MaxSize:            1 * diskutils.MiB,
 				},
 				{
 					PartitionTableType: "gpt",
-					MaxSize:            1,
+					MaxSize:            1 * diskutils.MiB,
 				},
 			},
 			BootType: "legacy",
@@ -214,7 +215,7 @@ func TestConfigIsValidMissingEsp(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions:         []Partition{},
 			}},
 			BootType: "efi",
@@ -236,7 +237,7 @@ func TestConfigIsValidMissingBiosBoot(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions:         []Partition{},
 			}},
 			BootType: "legacy",
@@ -258,11 +259,11 @@ func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",
-						Start: 1,
+						Start: 1 * diskutils.MiB,
 						Type:  PartitionTypeESP,
 					},
 				},
@@ -295,11 +296,11 @@ func TestConfigIsValidKernelCLI(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2,
+				MaxSize:            2 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",
-						Start: 1,
+						Start: 1 * diskutils.MiB,
 						Type:  PartitionTypeESP,
 					},
 				},

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 )
 
 type Disk struct {
@@ -14,7 +16,7 @@ type Disk struct {
 	PartitionTableType PartitionTableType `yaml:"partitionTableType"`
 
 	// The virtual size of the disk.
-	MaxSize uint64 `yaml:"maxSize"`
+	MaxSize DiskSize `yaml:"maxSize"`
 
 	// The partitions to allocate on the disk.
 	Partitions []Partition `yaml:"partitions"`
@@ -64,7 +66,7 @@ func (d *Disk) IsValid() error {
 			bEnd, bHasEnd := b.GetEnd()
 			bEndStr := ""
 			if bHasEnd {
-				bEndStr = strconv.FormatUint(bEnd, 10)
+				bEndStr = strconv.FormatUint(uint64(bEnd), 10)
 			}
 			return fmt.Errorf("partition's (%s) range [%d, %d) overlaps partition's (%s) range [%d, %s)",
 				a.Id, a.Start, aEnd, b.Id, b.Start, bEndStr)
@@ -74,8 +76,8 @@ func (d *Disk) IsValid() error {
 	if len(sortedPartitions) > 0 {
 		// Make sure the first block isn't used.
 		firstPartition := sortedPartitions[0]
-		if firstPartition.Start == 0 {
-			return fmt.Errorf("block 0 must be reserved for the MBR header (%s)", firstPartition.Id)
+		if firstPartition.Start < diskutils.MiB {
+			return fmt.Errorf("first 1 MiB must be reserved for the MBR header (%s)", firstPartition.Id)
 		}
 
 		// Check that the disk is big enough for the partition layout.
@@ -83,15 +85,15 @@ func (d *Disk) IsValid() error {
 
 		lastPartitionEnd, lastPartitionHasEnd := lastPartition.GetEnd()
 
-		var requiredSize uint64
+		var requiredSize DiskSize
 		if !lastPartitionHasEnd {
-			requiredSize = lastPartition.Start + 1
+			requiredSize = lastPartition.Start + diskutils.MiB
 		} else {
 			requiredSize = lastPartitionEnd
 		}
 
 		if requiredSize > d.MaxSize {
-			return fmt.Errorf("disk's partitions need %d MiB but maxSize is only %d MiB", requiredSize, d.MaxSize)
+			return fmt.Errorf("disk's partitions need %d bytes but maxSize is only %d bytes", requiredSize, d.MaxSize)
 		}
 	}
 

--- a/toolkit/tools/imagecustomizerapi/disk_test.go
+++ b/toolkit/tools/imagecustomizerapi/disk_test.go
@@ -6,6 +6,7 @@ package imagecustomizerapi
 import (
 	"testing"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,11 +14,11 @@ import (
 func TestDiskIsValid(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            2,
+		MaxSize:            2 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
+				Start: 1 * diskutils.MiB,
 			},
 		},
 	}
@@ -29,12 +30,12 @@ func TestDiskIsValid(t *testing.T) {
 func TestDiskIsValidWithEnd(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            2,
+		MaxSize:            2 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
-				End:   ptrutils.PtrTo(uint64(2)),
+				Start: 1 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(2 * diskutils.MiB)),
 			},
 		},
 	}
@@ -46,12 +47,12 @@ func TestDiskIsValidWithEnd(t *testing.T) {
 func TestDiskIsValidWithSize(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            2,
+		MaxSize:            2 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
-				Size:  ptrutils.PtrTo(uint64(1)),
+				Start: 1 * diskutils.MiB,
+				Size:  ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
 			},
 		},
 	}
@@ -63,7 +64,7 @@ func TestDiskIsValidWithSize(t *testing.T) {
 func TestDiskIsValidStartAt0(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            2,
+		MaxSize:            2 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
@@ -74,18 +75,17 @@ func TestDiskIsValidStartAt0(t *testing.T) {
 
 	err := disk.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "block 0")
-	assert.ErrorContains(t, err, "MBR header")
+	assert.ErrorContains(t, err, "first 1 MiB must be reserved for the MBR header")
 }
 
 func TestDiskIsValidInvalidTableType(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: "a",
-		MaxSize:            2,
+		MaxSize:            2 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
+				Start: 1 * diskutils.MiB,
 			},
 		},
 	}
@@ -98,12 +98,12 @@ func TestDiskIsValidInvalidTableType(t *testing.T) {
 func TestDiskIsValidInvalidPartition(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            2,
+		MaxSize:            2 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 2,
-				End:   ptrutils.PtrTo(uint64(0)),
+				Start: 2 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(0)),
 			},
 		},
 	}
@@ -116,15 +116,15 @@ func TestDiskIsValidInvalidPartition(t *testing.T) {
 func TestDiskIsValidTwoExpanding(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            4,
+		MaxSize:            4 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
+				Start: 1 * diskutils.MiB,
 			},
 			{
 				Id:    "b",
-				Start: 2,
+				Start: 2 * diskutils.MiB,
 			},
 		},
 	}
@@ -137,17 +137,17 @@ func TestDiskIsValidTwoExpanding(t *testing.T) {
 func TestDiskIsValidOverlaps(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            4,
+		MaxSize:            4 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
-				End:   ptrutils.PtrTo(uint64(3)),
+				Start: 1 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
 			},
 			{
 				Id:    "b",
-				Start: 2,
-				End:   ptrutils.PtrTo(uint64(4)),
+				Start: 2 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(4 * diskutils.MiB)),
 			},
 		},
 	}
@@ -160,16 +160,16 @@ func TestDiskIsValidOverlaps(t *testing.T) {
 func TestDiskIsValidOverlapsExpanding(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            4,
+		MaxSize:            4 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
-				End:   ptrutils.PtrTo(uint64(3)),
+				Start: 1 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
 			},
 			{
 				Id:    "b",
-				Start: 2,
+				Start: 2 * diskutils.MiB,
 			},
 		},
 	}
@@ -182,17 +182,17 @@ func TestDiskIsValidOverlapsExpanding(t *testing.T) {
 func TestDiskIsValidTooSmall(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            3,
+		MaxSize:            3 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
-				End:   ptrutils.PtrTo(uint64(2)),
+				Start: 1 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(2 * diskutils.MiB)),
 			},
 			{
 				Id:    "b",
-				Start: 3,
-				End:   ptrutils.PtrTo(uint64(4)),
+				Start: 3 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(4 * diskutils.MiB)),
 			},
 		},
 	}
@@ -205,16 +205,16 @@ func TestDiskIsValidTooSmall(t *testing.T) {
 func TestDiskIsValidTooSmallExpanding(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            3,
+		MaxSize:            3 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
-				End:   ptrutils.PtrTo(uint64(3)),
+				Start: 1 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
 			},
 			{
 				Id:    "b",
-				Start: 3,
+				Start: 3 * diskutils.MiB,
 			},
 		},
 	}
@@ -239,16 +239,16 @@ func TestDiskIsValidZeroSize(t *testing.T) {
 func TestDiskIsValidDuplicatePartitionId(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,
-		MaxSize:            2,
+		MaxSize:            2 * diskutils.MiB,
 		Partitions: []Partition{
 			{
 				Id:    "a",
-				Start: 1,
-				End:   ptrutils.PtrTo(uint64(2)),
+				Start: 1 * diskutils.MiB,
+				End:   ptrutils.PtrTo(DiskSize(2 * diskutils.MiB)),
 			},
 			{
 				Id:    "a",
-				Start: 2,
+				Start: 2 * diskutils.MiB,
 			},
 		},
 	}

--- a/toolkit/tools/imagecustomizerapi/disksize.go
+++ b/toolkit/tools/imagecustomizerapi/disksize.go
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	diskSizeRegex = regexp.MustCompile(`^(\d+)([KMGT])?$`)
+)
+
+type DiskSize uint64
+
+func (s *DiskSize) IsValid() error {
+	return nil
+}
+
+func (s *DiskSize) UnmarshalYAML(value *yaml.Node) error {
+	var err error
+
+	var stringValue string
+	err = value.Decode(&stringValue)
+	if err != nil {
+		return fmt.Errorf("failed to parse disk size:\n%w", err)
+	}
+
+	match := diskSizeRegex.FindStringSubmatch(stringValue)
+	if match == nil {
+		return fmt.Errorf("disk size (%s) has incorrect format: <num>[KMGT] (e.g. 100M, 1G)", stringValue)
+	}
+
+	numString := match[1]
+	num, err := strconv.ParseUint(numString, 0, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse disk size:\n%w", err)
+	}
+
+	if len(match) >= 3 {
+		unit := match[2]
+		multiplier := uint64(1)
+		switch unit {
+		case "K":
+			multiplier = diskutils.KiB
+		case "M":
+			multiplier = diskutils.MiB
+		case "G":
+			multiplier = diskutils.GiB
+		case "T":
+			multiplier = diskutils.TiB
+		case "":
+			return fmt.Errorf("disk size (%s) must have a suffix (i.e. K, M, G, or T)", numString)
+		}
+
+		num *= multiplier
+	}
+
+	// The imager's diskutils works in MiB. So, restrict disk and partition sizes to multiples of 1 MiB.
+	if num%diskutils.MiB != 0 {
+		return fmt.Errorf("disk size (%d) must be a multiple of 1 MiB", num)
+	}
+
+	*s = DiskSize(num)
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/disksize_test.go
+++ b/toolkit/tools/imagecustomizerapi/disksize_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiskSizeNum(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("1048576"), &diskSize)
+	assert.ErrorContains(t, err, "must have a suffix (K, M, G, or T)")
+}
+
+func TestDiskSizeKiB(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("1024K"), &diskSize)
+	assert.NoError(t, err)
+	assert.Equal(t, DiskSize(1024)*diskutils.KiB, diskSize)
+}
+
+func TestDiskSizeMiB(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("1M"), &diskSize)
+	assert.NoError(t, err)
+	assert.Equal(t, DiskSize(1)*diskutils.MiB, diskSize)
+}
+
+func TestDiskSizeGiB(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("2G"), &diskSize)
+	assert.NoError(t, err)
+	assert.Equal(t, DiskSize(2)*diskutils.GiB, diskSize)
+}
+
+func TestDiskSizeTiB(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("3T"), &diskSize)
+	assert.NoError(t, err)
+	assert.Equal(t, DiskSize(3)*diskutils.TiB, diskSize)
+}
+
+func TestDiskSizeAlpha(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("T"), &diskSize)
+	assert.ErrorContains(t, err, "incorrect format")
+}
+
+func TestDiskSizeList(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("- 12"), &diskSize)
+	assert.ErrorContains(t, err, "failed to parse disk size")
+}
+
+func TestDiskSizeNotMultipleOf1Mib(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("512K"), &diskSize)
+	assert.ErrorContains(t, err, "must be a multiple of 1 MiB")
+}
+
+func TestDiskSizeBadFormat(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("2M2"), &diskSize)
+	assert.ErrorContains(t, err, "has incorrect format")
+}

--- a/toolkit/tools/imagecustomizerapi/disksize_test.go
+++ b/toolkit/tools/imagecustomizerapi/disksize_test.go
@@ -13,7 +13,7 @@ import (
 func TestDiskSizeNum(t *testing.T) {
 	var diskSize DiskSize
 	err := UnmarshalYaml([]byte("1048576"), &diskSize)
-	assert.ErrorContains(t, err, "must have a suffix (K, M, G, or T)")
+	assert.ErrorContains(t, err, "must have a suffix (i.e. K, M, G, or T)")
 }
 
 func TestDiskSizeKiB(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -6,6 +6,8 @@ package imagecustomizerapi
 import (
 	"fmt"
 	"unicode"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 )
 
 type Partition struct {
@@ -14,11 +16,11 @@ type Partition struct {
 	// Name is the label to assign to the partition.
 	Label string `yaml:"label"`
 	// Start is the offset where the partition begins (inclusive), in MiBs.
-	Start uint64 `yaml:"start"`
+	Start DiskSize `yaml:"start"`
 	// End is the offset where the partition ends (exclusive), in MiBs.
-	End *uint64 `yaml:"end"`
+	End *DiskSize `yaml:"end"`
 	// Size is the size of the partition in MiBs.
-	Size *uint64 `yaml:"size"`
+	Size *DiskSize `yaml:"size"`
 	// Type specifies the type of partition the partition is.
 	Type PartitionType `yaml:"type"`
 }
@@ -43,15 +45,15 @@ func (p *Partition) IsValid() error {
 	}
 
 	if p.IsBiosBoot() {
-		if p.Start != 1 {
-			return fmt.Errorf("BIOS boot partition must start at block 1")
+		if p.Start != diskutils.MiB {
+			return fmt.Errorf("BIOS boot partition must start at 1 MiB")
 		}
 	}
 
 	return nil
 }
 
-func (p *Partition) GetEnd() (uint64, bool) {
+func (p *Partition) GetEnd() (DiskSize, bool) {
 	if p.End != nil {
 		return *p.End, true
 	}

--- a/toolkit/tools/imagecustomizerapi/partition_test.go
+++ b/toolkit/tools/imagecustomizerapi/partition_test.go
@@ -6,6 +6,7 @@ package imagecustomizerapi
 import (
 	"testing"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,7 +25,7 @@ func TestPartitionIsValidFixedSize(t *testing.T) {
 	partition := Partition{
 		Id:    "a",
 		Start: 0,
-		End:   ptrutils.PtrTo(uint64(1)),
+		End:   ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
 	}
 
 	err := partition.IsValid()
@@ -35,7 +36,7 @@ func TestPartitionIsValidZeroSize(t *testing.T) {
 	partition := Partition{
 		Id:    "a",
 		Start: 0,
-		End:   ptrutils.PtrTo(uint64(0)),
+		End:   ptrutils.PtrTo(DiskSize(0)),
 	}
 
 	err := partition.IsValid()
@@ -48,7 +49,7 @@ func TestPartitionIsValidZeroSizeV2(t *testing.T) {
 	partition := Partition{
 		Id:    "a",
 		Start: 0,
-		Size:  ptrutils.PtrTo(uint64(0)),
+		Size:  ptrutils.PtrTo(DiskSize(0)),
 	}
 
 	err := partition.IsValid()
@@ -60,8 +61,8 @@ func TestPartitionIsValidZeroSizeV2(t *testing.T) {
 func TestPartitionIsValidNegativeSize(t *testing.T) {
 	partition := Partition{
 		Id:    "a",
-		Start: 2,
-		End:   ptrutils.PtrTo(uint64(1)),
+		Start: 2 * diskutils.MiB,
+		End:   ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
 	}
 
 	err := partition.IsValid()
@@ -73,9 +74,9 @@ func TestPartitionIsValidNegativeSize(t *testing.T) {
 func TestPartitionIsValidBothEndAndSize(t *testing.T) {
 	partition := Partition{
 		Id:    "a",
-		Start: 2,
-		End:   ptrutils.PtrTo(uint64(3)),
-		Size:  ptrutils.PtrTo(uint64(1)),
+		Start: 2 * diskutils.MiB,
+		End:   ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
+		Size:  ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
 	}
 
 	err := partition.IsValid()

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -6,6 +6,7 @@ package imagecustomizerapi
 import (
 	"testing"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,11 +14,11 @@ func TestStorageIsValidDuplicatePartitionID(t *testing.T) {
 	value := Storage{
 		Disks: []Disk{{
 			PartitionTableType: "gpt",
-			MaxSize:            2048,
+			MaxSize:            2 * diskutils.GiB,
 			Partitions: []Partition{
 				{
 					Id:    "esp",
-					Start: 1,
+					Start: 1 * diskutils.MiB,
 					Type:  PartitionTypeESP,
 				},
 			},
@@ -50,11 +51,11 @@ func TestStorageIsValidUnsupportedFileSystem(t *testing.T) {
 	storage := Storage{
 		Disks: []Disk{{
 			PartitionTableType: PartitionTableTypeGpt,
-			MaxSize:            2048,
+			MaxSize:            2 * diskutils.GiB,
 			Partitions: []Partition{
 				{
 					Id:    "a",
-					Start: 1,
+					Start: 1 * diskutils.MiB,
 					End:   nil,
 				},
 			},
@@ -77,11 +78,11 @@ func TestStorageIsValidBadEspFsType(t *testing.T) {
 	storage := Storage{
 		Disks: []Disk{{
 			PartitionTableType: PartitionTableTypeGpt,
-			MaxSize:            2048,
+			MaxSize:            2 * diskutils.GiB,
 			Partitions: []Partition{
 				{
 					Id:    "esp",
-					Start: 1,
+					Start: 1 * diskutils.MiB,
 					End:   nil,
 					Type:  PartitionTypeESP,
 				},
@@ -105,11 +106,11 @@ func TestStorageIsValidBadBiosBootFsType(t *testing.T) {
 	storage := Storage{
 		Disks: []Disk{{
 			PartitionTableType: PartitionTableTypeGpt,
-			MaxSize:            2048,
+			MaxSize:            2 * diskutils.GiB,
 			Partitions: []Partition{
 				{
 					Id:    "bios",
-					Start: 1,
+					Start: 1 * diskutils.MiB,
 					End:   nil,
 					Type:  PartitionTypeBiosGrub,
 				},
@@ -133,11 +134,11 @@ func TestStorageIsValidBadBiosBootStart(t *testing.T) {
 	storage := Storage{
 		Disks: []Disk{{
 			PartitionTableType: PartitionTableTypeGpt,
-			MaxSize:            2048,
+			MaxSize:            2 * diskutils.GiB,
 			Partitions: []Partition{
 				{
 					Id:    "bios",
-					Start: 2,
+					Start: 2 * diskutils.MiB,
 					End:   nil,
 					Type:  PartitionTypeBiosGrub,
 				},
@@ -154,18 +155,18 @@ func TestStorageIsValidBadBiosBootStart(t *testing.T) {
 
 	err := storage.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "BIOS boot partition must start at block 1")
+	assert.ErrorContains(t, err, "BIOS boot partition must start at 1 MiB")
 }
 
 func TestStorageIsValidBadDeviceId(t *testing.T) {
 	value := Storage{
 		Disks: []Disk{{
 			PartitionTableType: "gpt",
-			MaxSize:            2048,
+			MaxSize:            2 * diskutils.GiB,
 			Partitions: []Partition{
 				{
 					Id:    "esp",
-					Start: 1,
+					Start: 1 * diskutils.MiB,
 					Type:  PartitionTypeESP,
 				},
 			},

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/buildpipeline"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
@@ -277,17 +278,17 @@ func createFakeEfiImage(buildDir string) (string, error) {
 	// Use a prototypical Azure Linux image partition config.
 	diskConfig := imagecustomizerapi.Disk{
 		PartitionTableType: imagecustomizerapi.PartitionTableTypeGpt,
-		MaxSize:            4096,
+		MaxSize:            4 * diskutils.GiB,
 		Partitions: []imagecustomizerapi.Partition{
 			{
 				Id:    "boot",
 				Type:  imagecustomizerapi.PartitionTypeESP,
-				Start: 1,
-				End:   ptrutils.PtrTo(uint64(9)),
+				Start: 1 * diskutils.MiB,
+				End:   ptrutils.PtrTo(imagecustomizerapi.DiskSize(9 * diskutils.MiB)),
 			},
 			{
 				Id:    "rootfs",
-				Start: 9,
+				Start: 9 * diskutils.MiB,
 				End:   nil,
 			},
 		},

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
@@ -1,12 +1,12 @@
 storage:
   disks:
   - partitionTableType: gpt
-    maxSize: 4096
+    maxSize: 4G
     partitions:
     - id: boot
       type: bios-grub
-      start: 1
-      size: 8
+      start: 1M
+      size: 8M
 
     - id: rootfs
       start: 9

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/mshvkernel-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/mshvkernel-config.yaml
@@ -1,15 +1,15 @@
 storage:
   disks:
   - partitionTableType: gpt
-    maxSize: 4096
+    maxSize: 4G
     partitions:
     - id: efi
       type: esp
-      start: 1
-      end: 65
+      start: 1M
+      end: 65M
 
     - id: rootfs
-      start: 65
+      start: 65M
 
   bootType: efi
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
@@ -1,23 +1,23 @@
 storage:
   disks:
   - partitionTableType: gpt
-    maxSize: 4096
+    maxSize: 4G
     partitions:
     - id: esp
       type: esp
-      start: 1
-      end: 9
+      start: 1M
+      end: 9M
 
     - id: boot
-      start: 9
-      end: 108
+      start: 9M
+      end: 108M
 
     - id: rootfs
-      start: 108
-      end: 2048
+      start: 108M
+      end: 2G
 
     - id: var
-      start: 2048
+      start: 2G
       
   bootType: efi
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -2,29 +2,29 @@ storage:
   bootType: efi
   disks:
   - partitionTableType: gpt
-    maxSize: 5120
+    maxSize: 5120M
     partitions:
     - id: esp
       type: esp
-      start: 1
-      end: 9
+      start: 1M
+      end: 9M
 
     - id: boot
-      start: 9
-      end: 1024
+      start: 9M
+      end: 1024M
 
     - id: root
       label: root
-      start: 1024
-      end: 3072
+      start: 1024M
+      end: 3072M
 
     - id: verityhash
       label: root-hash
-      start: 3072
-      end: 3200
+      start: 3072M
+      end: 3200M
 
     - id: var
-      start: 3200
+      start: 3200M
 
   fileSystems:
   - deviceId: esp


### PR DESCRIPTION
When specifying the disk and partition sizes, allow the suffixes K, M, G, and T which mean KiB, MiB, GiB, and TiB respectively.

This change also forces the user to provide a suffix. Previously, the unsuffixed number meant MiBs. But it should probably be bytes instead. To help with this transition, unsuffixed numbers have been blocked for now. But we may support them in the future.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer.

