### PR TITLE
Update cri-o to version 1.21.7 to address CVE-2022-0811 & CVE-2022-1708

### DIFF
--- a/SPECS/cri-o/CVE-2022-1708.patch
+++ b/SPECS/cri-o/CVE-2022-1708.patch
@@ -1,0 +1,477 @@
+Modified patch to apply to version 1.21.7.
+Modified-by: sumsharma@microsoft.com
+
+commit f032cf649ecc7e0c46718bd9e7814bfb317cb544 (from afab4b78d1d66fb5144ef003b20eba5e53833336)
+Merge: afab4b78d 79e404fa5
+Author: Peter Hunt <pehunt@redhat.com>
+Date:   Mon Jun 6 13:54:06 2022 -0400
+
+    Merge pull request from GHSA-fcm2-6c3h-pg6j
+    
+    oci: add support for capping memory and disk usage from exec sync output
+---
+ internal/config/conmonmgr/conmonmgr.go        |  32 +++++-
+ internal/config/conmonmgr/conmonmgr_test.go   | 106 +++++++++++++++++-
+ internal/oci/oci.go                           |   5 +
+ internal/oci/runtime_oci.go                   |  19 +++-
+ internal/oci/runtime_oci_test.go              |  39 +++++++
+ internal/oci/runtime_vm.go                    |   5 +-
+ pkg/config/config.go                          |   4 +
+ test/ctr.bats                                 |   8 ++
+ .../pkg/kubelet/util/ioutils/ioutils.go       |  70 ++++++++++++
+ vendor/modules.txt                            |   1 +
+ 10 files changed, 282 insertions(+), 7 deletions(-)
+ create mode 100644 vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/ioutils.go
+
+diff --git a/internal/config/conmonmgr/conmonmgr.go b/internal/config/conmonmgr/conmonmgr.go
+index 9aef7ef..5276039 100644
+--- a/internal/config/conmonmgr/conmonmgr.go
++++ b/internal/config/conmonmgr/conmonmgr.go
+@@ -1,6 +1,7 @@
+ package conmonmgr
+ 
+ import (
++	"bytes"
+ 	"path"
+ 	"strings"
+ 
+@@ -10,11 +11,15 @@ import (
+ 	"github.com/sirupsen/logrus"
+ )
+ 
+-var versionSupportsSync = semver.MustParse("2.0.19")
++var (
++	versionSupportsSync             = semver.MustParse("2.0.19")
++	versionSupportsLogGlobalSizeMax = semver.MustParse("2.1.2")
++)
+ 
+ type ConmonManager struct {
+-	conmonVersion *semver.Version
+-	supportsSync  bool
++	conmonVersion            *semver.Version
++	supportsSync             bool
++	supportsLogGlobalSizeMax bool
+ }
+ 
+ // this function is heavily based on github.com/containers/common#probeConmon
+@@ -37,6 +42,7 @@ func New(conmonPath string) (*ConmonManager, error) {
+ 	}
+ 
+ 	c.initializeSupportsSync()
++	c.initializeSupportsLogGlobalSizeMax(conmonPath)
+ 	return c, nil
+ }
+ 
+@@ -49,6 +55,26 @@ func (c *ConmonManager) parseConmonVersion(versionString string) error {
+ 	return nil
+ }
+ 
++func (c *ConmonManager) initializeSupportsLogGlobalSizeMax(conmonPath string) {
++	c.supportsLogGlobalSizeMax = c.conmonVersion.GTE(versionSupportsLogGlobalSizeMax)
++	if !c.supportsLogGlobalSizeMax {
++		// Read help output as a fallback in case the feature was backported to conmon,
++		// but the version wasn't bumped.
++		helpOutput, err := cmdrunner.CombinedOutput(conmonPath, "--help")
++		c.supportsLogGlobalSizeMax = err == nil && bytes.Contains(helpOutput, []byte("--log-global-size-max"))
++	}
++	verb := "does not"
++	if c.supportsLogGlobalSizeMax {
++		verb = "does"
++	}
++
++	logrus.Infof("Conmon %s support the --log-global-size-max option", verb)
++}
++
++func (c *ConmonManager) SupportsLogGlobalSizeMax() bool {
++	return c.supportsLogGlobalSizeMax
++}
++
+ func (c *ConmonManager) initializeSupportsSync() {
+ 	c.supportsSync = c.conmonVersion.GTE(versionSupportsSync)
+ 	verb := "does not"
+diff --git a/internal/config/conmonmgr/conmonmgr_test.go b/internal/config/conmonmgr/conmonmgr_test.go
+index a097312..e804c62 100644
+--- a/internal/config/conmonmgr/conmonmgr_test.go
++++ b/internal/config/conmonmgr/conmonmgr_test.go
+@@ -74,7 +74,7 @@ var _ = t.Describe("ConmonManager", func() {
+ 		It("should succeed when output expected", func() {
+ 			// Given
+ 			gomock.InOrder(
+-				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte("conmon version 2.0.0"), nil),
++				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte("conmon version 2.2.2"), nil),
+ 			)
+ 
+ 			// When
+@@ -174,4 +174,108 @@ var _ = t.Describe("ConmonManager", func() {
+ 			Expect(mgr.SupportsSync()).To(Equal(true))
+ 		})
+ 	})
++	t.Describe("initializeSupportsLogGlobalSizeMax", func() {
++		var mgr *ConmonManager
++		BeforeEach(func() {
++			runner = runnerMock.NewMockCommandRunner(mockCtrl)
++			cmdrunner.SetMocked(runner)
++			mgr = new(ConmonManager)
++		})
++		It("should be false when major version less", func() {
++			// Given
++			gomock.InOrder(
++				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte{}, errors.New("cmd failed")),
++			)
++			err := mgr.parseConmonVersion("1.1.2")
++			Expect(err).To(BeNil())
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(false))
++		})
++		It("should be true when major version greater", func() {
++			// Given
++			err := mgr.parseConmonVersion("3.1.1")
++			Expect(err).To(BeNil())
++
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
++		})
++		It("should be false when minor version less", func() {
++			// Given
++			gomock.InOrder(
++				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte{}, errors.New("cmd failed")),
++			)
++			err := mgr.parseConmonVersion("2.0.2")
++			Expect(err).To(BeNil())
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(false))
++		})
++		It("should be true when minor version greater", func() {
++			// Given
++			err := mgr.parseConmonVersion("2.2.2")
++			Expect(err).To(BeNil())
++
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
++		})
++		It("should be false when patch version less", func() {
++			// Given
++			gomock.InOrder(
++				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte{}, errors.New("cmd failed")),
++			)
++			err := mgr.parseConmonVersion("2.1.1")
++			Expect(err).To(BeNil())
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(false))
++		})
++		It("should be true when patch version greater", func() {
++			// Given
++			err := mgr.parseConmonVersion("2.1.3")
++			Expect(err).To(BeNil())
++
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
++		})
++		It("should be true when version equal", func() {
++			// Given
++			err := mgr.parseConmonVersion("2.1.2")
++			Expect(err).To(BeNil())
++
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
++		})
++		It("should be true if feature backported", func() {
++			// Given
++			gomock.InOrder(
++				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte("--log-global-size-max"), nil),
++			)
++			err := mgr.parseConmonVersion("0.0.0")
++			Expect(err).To(BeNil())
++
++			// When
++			mgr.initializeSupportsLogGlobalSizeMax("")
++
++			// Then
++			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
++		})
++	})
+ })
+diff --git a/internal/oci/oci.go b/internal/oci/oci.go
+index 478726d..d992e90 100644
+--- a/internal/oci/oci.go
++++ b/internal/oci/oci.go
+@@ -35,6 +35,11 @@ const (
+ 	// killContainerTimeout is the timeout that we wait for the container to
+ 	// be SIGKILLed.
+ 	killContainerTimeout = 2 * time.Minute
++
++	// maxExecSyncSize is the maximum size of exec sync output CRI-O will process.
++	// It is set to the amount of logs allowed in the dockershim implementation:
++	// https://github.com/kubernetes/kubernetes/pull/82514
++	maxExecSyncSize = 16 * 1024 * 1024
+ )
+ 
+ // Runtime is the generic structure holding both global and specific
+diff --git a/internal/oci/runtime_oci.go b/internal/oci/runtime_oci.go
+index 4bf66ee..37f62c6 100644
+--- a/internal/oci/runtime_oci.go
++++ b/internal/oci/runtime_oci.go
+@@ -458,6 +458,9 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
+ 	if r.config.ConmonSupportsSync() {
+ 		args = append(args, "--sync")
+ 	}
++	if r.config.ConmonSupportsLogGlobalSizeMax() {
++		args = append(args, "--log-global-size-max", strconv.Itoa(maxExecSyncSize))
++	}
+ 	if c.terminal {
+ 		args = append(args, "-t")
+ 	}
+@@ -564,7 +567,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
+ 	// ExecSyncResponse we have to read the logfile.
+ 	// XXX: Currently runC dups the same console over both stdout and stderr,
+ 	//      so we can't differentiate between the two.
+-	logBytes, err := ioutil.ReadFile(logPath)
++	logBytes, err := TruncateAndReadFile(ctx, logPath, maxExecSyncSize)
+ 	if err != nil {
+ 		return nil, &ExecSyncError{
+ 			Stdout:   stdoutBuf,
+@@ -583,6 +586,20 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
+ 	}, nil
+ }
+ 
++func TruncateAndReadFile(ctx context.Context, path string, size int64) ([]byte, error) {
++	info, err := os.Stat(path)
++	if err != nil {
++		return nil, err
++	}
++	if info.Size() > size {
++		log.Errorf(ctx, "Exec sync output in file %s has size %d which is longer than expected size of %d", path, info.Size(), size)
++		if err := os.Truncate(path, size); err != nil {
++			return nil, err
++		}
++	}
++	return os.ReadFile(path)
++}
++
+ // UpdateContainer updates container resources
+ func (r *runtimeOCI) UpdateContainer(ctx context.Context, c *Container, res *rspec.LinuxResources) error {
+ 	if c.Spoofed() {
+diff --git a/internal/oci/runtime_oci_test.go b/internal/oci/runtime_oci_test.go
+index 3385e30..90901e8 100644
+--- a/internal/oci/runtime_oci_test.go
++++ b/internal/oci/runtime_oci_test.go
+@@ -3,6 +3,7 @@ package oci_test
+ import (
+ 	"context"
+ 	"math/rand"
++	"os"
+ 	"os/exec"
+ 	"time"
+ 
+@@ -142,6 +143,44 @@ var _ = t.Describe("Oci", func() {
+ 			})
+ 		}
+ 	})
++	Context("TruncateAndReadFile", func() {
++		tests := []struct {
++			title    string
++			contents []byte
++			expected []byte
++			fail     bool
++			size     int64
++		}{
++			{
++				title:    "should read file if size is smaller than limit",
++				contents: []byte("abcd"),
++				expected: []byte("abcd"),
++				size:     5,
++			},
++			{
++				title:    "should read only size if size is same as limit",
++				contents: []byte("abcd"),
++				expected: []byte("abcd"),
++				size:     4,
++			},
++			{
++				title:    "should read only size if size is larger than limit",
++				contents: []byte("abcd"),
++				expected: []byte("abc"),
++				size:     3,
++			},
++		}
++		for _, test := range tests {
++			test := test
++			It(test.title, func() {
++				fileName := t.MustTempFile("to-read")
++				Expect(os.WriteFile(fileName, test.contents, 0o644)).To(BeNil())
++				found, err := oci.TruncateAndReadFile(context.Background(), fileName, test.size)
++				Expect(err).To(BeNil())
++				Expect(found).To(Equal(test.expected))
++			})
++		}
++	})
+ })
+ 
+ func waitContainerStopAndFailAfterTimeout(ctx context.Context,
+diff --git a/internal/oci/runtime_vm.go b/internal/oci/runtime_vm.go
+index 6f10cfc..be8a0fa 100644
+--- a/internal/oci/runtime_vm.go
++++ b/internal/oci/runtime_vm.go
+@@ -33,6 +33,7 @@ import (
+ 	"golang.org/x/sys/unix"
+ 	"k8s.io/client-go/tools/remotecommand"
+ 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
++	kioutil "k8s.io/kubernetes/pkg/kubelet/util/ioutils"
+ 	utilexec "k8s.io/utils/exec"
+ )
+ 
+@@ -309,8 +310,8 @@ func (r *runtimeVM) ExecSyncContainer(ctx context.Context, c *Container, command
+ 	defer log.Debugf(ctx, "runtimeVM.ExecSyncContainer() end")
+ 
+ 	var stdoutBuf, stderrBuf bytes.Buffer
+-	stdout := cioutil.NewNopWriteCloser(&stdoutBuf)
+-	stderr := cioutil.NewNopWriteCloser(&stderrBuf)
++	stdout := kioutil.WriteCloserWrapper(kioutil.LimitWriter(&stdoutBuf, maxExecSyncSize))
++	stderr := kioutil.WriteCloserWrapper(kioutil.LimitWriter(&stderrBuf, maxExecSyncSize))
+ 
+ 	exitCode, err := r.execContainerCommon(ctx, c, command, timeout, nil, stdout, stderr, c.terminal, nil)
+ 	if err != nil {
+diff --git a/pkg/config/config.go b/pkg/config/config.go
+index 25c51e2..606c7a9 100644
+--- a/pkg/config/config.go
++++ b/pkg/config/config.go
+@@ -1011,6 +1011,10 @@ func (c *RuntimeConfig) ConmonSupportsSync() bool {
+ 	return c.conmonManager.SupportsSync()
+ }
+ 
++func (c *RuntimeConfig) ConmonSupportsLogGlobalSizeMax() bool {
++	return c.conmonManager.SupportsLogGlobalSizeMax()
++}
++
+ func (c *RuntimeConfig) ValidatePinnsPath(executable string) error {
+ 	var err error
+ 	c.PinnsPath, err = validateExecutablePath(executable, c.PinnsPath)
+diff --git a/test/ctr.bats b/test/ctr.bats
+index 31cf6c7..a9f9393 100644
+--- a/test/ctr.bats
++++ b/test/ctr.bats
+@@ -487,6 +487,14 @@ function check_oci_annotation() {
+ 	crictl exec --sync "$ctr_id" /bin/sh -c "[[ -t 1 ]]"
+ }
+ 
++@test "ctr execsync should cap output" {
++	start_crio
++
++	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
++
++	[[ $(crictl exec --sync "$ctr_id" /bin/sh -c "for i in $(seq 1 50000000); do echo -n 'a'; done" | wc -c) -le 16777216 ]]
++}
++
+ @test "ctr device add" {
+ 	# In an user namespace we can only bind mount devices from the host, not mknod
+ 	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481
+diff --git a/vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/ioutils.go b/vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/ioutils.go
+new file mode 100644
+index 0000000..1b2b5a6
+--- /dev/null
++++ b/vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/ioutils.go
+@@ -0,0 +1,70 @@
++/*
++Copyright 2016 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package ioutils
++
++import "io"
++
++// writeCloserWrapper represents a WriteCloser whose closer operation is noop.
++type writeCloserWrapper struct {
++	Writer io.Writer
++}
++
++func (w *writeCloserWrapper) Write(buf []byte) (int, error) {
++	return w.Writer.Write(buf)
++}
++
++func (w *writeCloserWrapper) Close() error {
++	return nil
++}
++
++// WriteCloserWrapper returns a writeCloserWrapper.
++func WriteCloserWrapper(w io.Writer) io.WriteCloser {
++	return &writeCloserWrapper{w}
++}
++
++// LimitWriter is a copy of the standard library ioutils.LimitReader,
++// applied to the writer interface.
++// LimitWriter returns a Writer that writes to w
++// but stops with EOF after n bytes.
++// The underlying implementation is a *LimitedWriter.
++func LimitWriter(w io.Writer, n int64) io.Writer { return &LimitedWriter{w, n} }
++
++// A LimitedWriter writes to W but limits the amount of
++// data returned to just N bytes. Each call to Write
++// updates N to reflect the new amount remaining.
++// Write returns EOF when N <= 0 or when the underlying W returns EOF.
++type LimitedWriter struct {
++	W io.Writer // underlying writer
++	N int64     // max bytes remaining
++}
++
++func (l *LimitedWriter) Write(p []byte) (n int, err error) {
++	if l.N <= 0 {
++		return 0, io.ErrShortWrite
++	}
++	truncated := false
++	if int64(len(p)) > l.N {
++		p = p[0:l.N]
++		truncated = true
++	}
++	n, err = l.W.Write(p)
++	l.N -= int64(n)
++	if err == nil && truncated {
++		err = io.ErrShortWrite
++	}
++	return
++}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 030e1d1..d911968 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -1373,6 +1373,7 @@ k8s.io/kubernetes/pkg/kubelet/cri/streaming
+ k8s.io/kubernetes/pkg/kubelet/cri/streaming/portforward
+ k8s.io/kubernetes/pkg/kubelet/cri/streaming/remotecommand
+ k8s.io/kubernetes/pkg/kubelet/types
++k8s.io/kubernetes/pkg/kubelet/util/ioutils
+ k8s.io/kubernetes/pkg/proxy
+ k8s.io/kubernetes/pkg/proxy/config
+ k8s.io/kubernetes/pkg/proxy/healthcheck
+-- 
+2.25.1

--- a/SPECS/cri-o/cri-o.signatures.json
+++ b/SPECS/cri-o/cri-o.signatures.json
@@ -1,7 +1,7 @@
 {
  "Signatures": {
-  "cri-o-1.21.2-vendor.tar.gz": "a189bb12672719142a509813daf5203ae08b105c704e25816e37a32535030dc0",
-  "cri-o-1.21.2.tar.gz": "a8e745822b50d1581cb3d12edeede05eca316f1f57a3a865f7f7d600fe627828",
+  "cri-o-1.21.7-vendor.tar.gz": "64edd6277f2e4d0540151e38d8e637904130726ef68cf82826e2624686e758b4",
+  "cri-o-1.21.7.tar.gz": "171342a882cfb8d8600f0c5e928924aa86cf2ae124277aa1b18ff1cf3da76cfa",
   "cri-o-rpmlintrc": "851a8f7e0b91e011d19a123c2ec703590f3261bfc3fedc41f058dc7556de86cc",
   "crio.conf": "0b4d11a34542656ad1077fefefdbd0782c15ea521da914bfed0fc7bf84215f0e",
   "crio.service": "aa19713bbb91d0871de67a4a36a75e9558a31b5b4952b8cf81a667c41f0a7c0c",

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -25,14 +25,13 @@
 Summary:        OCI-based implementation of Kubernetes Container Runtime Interface
 # Define macros for further referenced sources
 Name:           cri-o
-Version:        1.21.2
-Release:        19%{?dist}
+Version:        1.21.7
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/cri-o/cri-o
-#Source0:       https://github.com/%{name}/%{name}/archive/refs/tags/v%{version}.tar.gz
-Source0:        %{name}-%{version}.tar.gz
+Source0:        https://github.com/%{name}/%{name}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated Go modules from this tarball, since network is disabled during build time.
 # How to re-build this file:
@@ -52,6 +51,7 @@ Source3:        sysconfig.crio
 Source4:        crio.conf
 Source5:        cri-o-rpmlintrc
 Source6:        kubelet.env
+Patch0:         CVE-2022-1708.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  fdupes
@@ -99,10 +99,10 @@ This package provides the CRI-O container runtime configuration for kubeadm
 
 %prep
 %setup -q
+tar -xf %{SOURCE1} --no-same-owner
+%patch0 -p1 -b .files
 
 %build
-tar -xf %{SOURCE1} --no-same-owner
-
 # We can't use symlinks here because go-list gets confused by symlinks, so we
 # have to copy the source to $HOME/go and then use that as the GOPATH.
 export GOPATH=$HOME/go
@@ -203,6 +203,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Fri Apr 05 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.21.7-1
+- Bump version to fix CVE-2022-0811 & CVE-2022-1708
+
 * Fri Feb 02 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.21.2-19
 - Bump release to rebuild with go 1.21.6
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2247,8 +2247,8 @@
         "type": "other",
         "other": {
           "name": "cri-o",
-          "version": "1.21.2",
-          "downloadUrl": "https://github.com/cri-o/cri-o/archive/refs/tags/v1.21.2.tar.gz"
+          "version": "1.21.7",
+          "downloadUrl": "https://github.com/cri-o/cri-o/archive/refs/tags/v1.21.7.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Bump version to address CVE-2022-0811. v1.26.7 is the last release in the minor version series.
[v1.26.1 Release Notes](https://github.com/cri-o/cri-o/releases/tag/v1.21.6)

Backported patch for CVE-2022-1708. [Reference Patch](https://github.com/cri-o/cri-o/commit/f032cf649ecc7e0c46718bd9e7814bfb317cb544)

[PR ](https://github.com/microsoft/azurelinux/pull/8714)raised for bumping conmon version to address CVE-2022-1708

###### Change Log  <!-- REQUIRED -->
- Bump version to 1.21.7
- Backport patch for CVE-2022-1708

###### Does this affect the toolchain?  <!-- REQUIRED -->
No

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-0811
- https://nvd.nist.gov/vuln/detail/CVE-2022-1708

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=544981)
