### PR TITLE
Revert "[3.0] dhcp/dhclient.conf: add option rfc3442-classless-static…

### DIFF
--- a/SPECS/dhcp/dhcp.spec
+++ b/SPECS/dhcp/dhcp.spec
@@ -1,7 +1,7 @@
 Summary:        Dynamic host configuration protocol
 Name:           dhcp
 Version:        4.4.3.P1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MPLv2.0
 Url:            https://www.isc.org/dhcp/
 Source0:        https://downloads.isc.org/isc/dhcp/4.4.3-P1/dhcp-4.4.3-P1.tar.gz
@@ -70,8 +70,6 @@ cat > %{buildroot}/etc/dhcp/dhclient.conf << "EOF"
 # Begin /etc/dhcp/dhclient.conf
 #
 # Basic dhclient.conf(5)
-
-option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
 
 #prepend domain-name-servers 127.0.0.1;
 request subnet-mask, broadcast-address, time-offset, routers,
@@ -171,6 +169,9 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/dhclient/
 %{_mandir}/man8/dhclient.8.gz
 
 %changelog
+* Thu Apr 04 2024 Sindhu <lakarri@microsoft.com> - 4.4.3.P1-2
+- Revert option for classless static route configuration in dhclient.conf
+
 * Fri Mar 08 2024 Dan Streetman <ddstreet@microsoft.com> - 4.4.3.P1-1
 - update to final isc-dhcp version, which has been EOL since Dec 2022
 


### PR DESCRIPTION
…-route in dhclient.conf (#8375)"

This reverts commit 98e3dcb3f8ceeece9cab8ba0693d9d7eabc35a3d.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The lisa testcase "validate_netvsc_reload" is failing due to dhcp changes in https://github.com/microsoft/azurelinux/pull/8587
The testcase is passing once the above commit is reverted. 

Test fails without fix: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=544973&view=logs&j=528a33a8-464e-565a-7855-df1244039b47
Test passes with fix: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=544809&view=logs&j=528a33a8-464e-565a-7855-df1244039b47

Note that the commit is already reverted in main (2.0) to fix the `validate_netvsc_reload `testcase.
https://github.com/microsoft/azurelinux/pull/8587

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
-  Revert option for classless static route configuration in dhclient.conf

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=543622&view=results
