### PR TITLE
Image Customizer: Functional tests boilerplate.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomizeImagePartitions(t *testing.T) {
+	var err error
+
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	buildDir := filepath.Join(tmpDir, "TestCustomizeImageCopyFiles")
+	configFile := filepath.Join(testDir, "partitions-config.yaml")
+	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
+
+	// Customize image.
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "", true, false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Check output file type.
+	checkFileType(t, outImageFilePath, "raw")
+
+	imageConnection, err := connectToImage(buildDir, outImageFilePath, []mountPoint{
+		{
+			PartitionNum:   3,
+			Path:           "/",
+			FileSystemType: "xfs",
+		},
+		{
+			PartitionNum:   2,
+			Path:           "/boot",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   1,
+			Path:           "/boot/efi",
+			FileSystemType: "vfat",
+		},
+		{
+			PartitionNum:   4,
+			Path:           "/var",
+			FileSystemType: "xfs",
+		},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Check for key files/directories on the partitions.
+	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/etc/fstab"))
+	assert.NoError(t, err, "check for /etc/fstab")
+
+	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/usr/bin/bash"))
+	assert.NoError(t, err, "check for /usr/bin/bash")
+
+	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/boot/grub2/grub.cfg"))
+	assert.NoError(t, err, "check for /boot/grub2/grub2.cfg")
+
+	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi/boot/grub2/grub.cfg"))
+	assert.NoError(t, err, "check for /boot/efi/boot/grub2/grub2.cfg")
+
+	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/var/log"))
+	assert.NoError(t, err, "check for /var/log")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -12,10 +12,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
-	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/installutils"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/buildpipeline"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,29 +24,13 @@ const (
 func TestCustomizeImageEmptyConfig(t *testing.T) {
 	var err error
 
-	if testing.Short() {
-		t.Skip("Short mode enabled")
-	}
-
-	if !buildpipeline.IsRegularBuild() {
-		t.Skip("loopback block device not available")
-	}
-
-	if os.Geteuid() != 0 {
-		t.Skip("Test must be run as root because it uses a chroot")
-	}
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")
 
-	// Create fake disk.
-	diskFilePath, err := createFakeEfiImage(buildDir)
-	if !assert.NoError(t, err) {
-		return
-	}
-
 	// Customize image.
-	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.Config{}, diskFilePath, nil, outImageFilePath,
+	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.Config{}, baseImage, nil, outImageFilePath,
 		"vhd", "", false, false)
 	if !assert.NoError(t, err) {
 		return
@@ -62,30 +43,14 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 func TestCustomizeImageCopyFiles(t *testing.T) {
 	var err error
 
-	if testing.Short() {
-		t.Skip("Short mode enabled")
-	}
-
-	if !buildpipeline.IsRegularBuild() {
-		t.Skip("loopback block device not available")
-	}
-
-	if os.Geteuid() != 0 {
-		t.Skip("Test must be run as root because it uses a chroot")
-	}
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageCopyFiles")
 	configFile := filepath.Join(testDir, "addfiles-config.yaml")
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
-	// Create fake disk.
-	diskFilePath, err := createFakeEfiImage(buildDir)
-	if !assert.NoError(t, err) {
-		return
-	}
-
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, diskFilePath, nil, outImageFilePath, "raw", "", false, false)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "", false, false)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -94,7 +59,7 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	checkFileType(t, outImageFilePath, "raw")
 
 	// Mount the output disk image so that its contents can be checked.
-	imageConnection, err := reconnectToFakeEfiImage(buildDir, outImageFilePath)
+	imageConnection, err := connectToCoreEfiImage(buildDir, outImageFilePath)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -106,7 +71,28 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	assert.Equal(t, "abcdefg\n", string(file_contents))
 }
 
-func reconnectToFakeEfiImage(buildDir string, imageFilePath string) (*ImageConnection, error) {
+func connectToCoreEfiImage(buildDir string, imageFilePath string) (*ImageConnection, error) {
+	return connectToImage(buildDir, imageFilePath, []mountPoint{
+		{
+			PartitionNum:   2,
+			Path:           "/",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   1,
+			Path:           "/boot/efi",
+			FileSystemType: "vfat",
+		},
+	})
+}
+
+type mountPoint struct {
+	PartitionNum   int
+	Path           string
+	FileSystemType string
+}
+
+func connectToImage(buildDir string, imageFilePath string, mounts []mountPoint) (*ImageConnection, error) {
 	imageConnection := NewImageConnection()
 	err := imageConnection.ConnectLoopback(imageFilePath)
 	if err != nil {
@@ -116,12 +102,19 @@ func reconnectToFakeEfiImage(buildDir string, imageFilePath string) (*ImageConne
 
 	rootDir := filepath.Join(buildDir, testImageRootDirName)
 
-	bootPartitionDevPath := fmt.Sprintf("%sp1", imageConnection.Loopback().DevicePath())
-	osPartitionDevPath := fmt.Sprintf("%sp2", imageConnection.Loopback().DevicePath())
+	mountPoints := []*safechroot.MountPoint(nil)
+	for _, mount := range mounts {
+		devPath := fmt.Sprintf("%sp%d", imageConnection.Loopback().DevicePath(), mount.PartitionNum)
 
-	mountPoints := []*safechroot.MountPoint{
-		safechroot.NewPreDefaultsMountPoint(osPartitionDevPath, "/", "ext4", 0, ""),
-		safechroot.NewMountPoint(bootPartitionDevPath, "/boot/efi", "vfat", 0, ""),
+		var mountPoint *safechroot.MountPoint
+		if mount.Path == "/" {
+			mountPoint = safechroot.NewPreDefaultsMountPoint(devPath, mount.Path, mount.FileSystemType, 0,
+				"")
+		} else {
+			mountPoint = safechroot.NewMountPoint(devPath, mount.Path, mount.FileSystemType, 0, "")
+		}
+
+		mountPoints = append(mountPoints, mountPoint)
 	}
 
 	err = imageConnection.ConnectChroot(rootDir, false, []string{}, mountPoints, false)
@@ -207,26 +200,10 @@ func TestValidateConfigScriptNonExecutable(t *testing.T) {
 func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 	var err error
 
-	if testing.Short() {
-		t.Skip("Short mode enabled")
-	}
-
-	if !buildpipeline.IsRegularBuild() {
-		t.Skip("loopback block device not available")
-	}
-
-	if os.Geteuid() != 0 {
-		t.Skip("Test must be run as root because it uses a chroot")
-	}
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageKernelCommandLine")
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")
-
-	// Create fake disk.
-	diskFilePath, err := createFakeEfiImage(buildDir)
-	if !assert.NoError(t, err) {
-		return
-	}
 
 	// Customize image.
 	config := &imagecustomizerapi.Config{
@@ -237,13 +214,13 @@ func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 		},
 	}
 
-	err = CustomizeImage(buildDir, buildDir, config, diskFilePath, nil, outImageFilePath, "raw", "", false, false)
+	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outImageFilePath, "raw", "", false, false)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	// Mount the output disk image so that its contents can be checked.
-	imageConnection, err := reconnectToFakeEfiImage(buildDir, outImageFilePath)
+	imageConnection, err := connectToCoreEfiImage(buildDir, outImageFilePath)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -265,70 +242,6 @@ func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 	}
 
 	assert.True(t, linuxCommandLineRegex.Match(grub2ConfigFile))
-}
-
-func createFakeEfiImage(buildDir string) (string, error) {
-	var err error
-
-	err = os.MkdirAll(buildDir, os.ModePerm)
-	if err != nil {
-		return "", fmt.Errorf("failed to make build directory (%s):\n%w", buildDir, err)
-	}
-
-	// Use a prototypical Azure Linux image partition config.
-	diskConfig := imagecustomizerapi.Disk{
-		PartitionTableType: imagecustomizerapi.PartitionTableTypeGpt,
-		MaxSize:            4 * diskutils.GiB,
-		Partitions: []imagecustomizerapi.Partition{
-			{
-				Id:    "boot",
-				Type:  imagecustomizerapi.PartitionTypeESP,
-				Start: 1 * diskutils.MiB,
-				End:   ptrutils.PtrTo(imagecustomizerapi.DiskSize(9 * diskutils.MiB)),
-			},
-			{
-				Id:    "rootfs",
-				Start: 9 * diskutils.MiB,
-				End:   nil,
-			},
-		},
-	}
-
-	fileSystems := []imagecustomizerapi.FileSystem{
-		{
-			DeviceId: "boot",
-			Type:     "fat32",
-			MountPoint: &imagecustomizerapi.MountPoint{
-				Path:    "/boot/efi",
-				Options: "umask=0077",
-			},
-		},
-		{
-			DeviceId: "rootfs",
-			Type:     "ext4",
-			MountPoint: &imagecustomizerapi.MountPoint{
-				Path: "/",
-			},
-		},
-	}
-
-	rawDisk := filepath.Join(buildDir, "disk.raw")
-
-	installOS := func(imageChroot *safechroot.Chroot) error {
-		// Don't write anything for the OS.
-		// The createNewImage function will still write the bootloader and fstab file, which will allow the partition
-		// discovery logic to work. This allows for a limited set of tests to run without needing any of the RPM files.
-		return nil
-	}
-
-	err = createNewImageWithBootLoader(rawDisk, diskConfig, fileSystems, "efi", imagecustomizerapi.SELinux{},
-		imagecustomizerapi.KernelCommandLine{}, buildDir, testImageRootDirName, imagecustomizerapi.SELinuxModeDisabled,
-		installOS)
-	if err != nil {
-		return "", err
-	}
-
-	return rawDisk, nil
 }
 
 func checkFileType(t *testing.T, filePath string, expectedFileType string) {

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -79,35 +79,6 @@ func createNewImage(filename string, diskConfig imagecustomizerapi.Disk,
 	return nil
 }
 
-func createNewImageWithBootLoader(filename string, diskConfig imagecustomizerapi.Disk,
-	fileSystems []imagecustomizerapi.FileSystem, bootType imagecustomizerapi.BootType,
-	selinuxConfig imagecustomizerapi.SELinux, kernelCommandLine imagecustomizerapi.KernelCommandLine, buildDir string,
-	chrootDirName string, currentSELinuxMode imagecustomizerapi.SELinuxMode, installOS installOSFunc,
-) error {
-	imageConnection := NewImageConnection()
-	defer imageConnection.Close()
-
-	err := createNewImageHelper(imageConnection, filename, diskConfig, fileSystems, buildDir, chrootDirName,
-		installOS)
-	if err != nil {
-		return fmt.Errorf("failed to create new image:\n%w", err)
-	}
-
-	err = configureDiskBootLoader(imageConnection, fileSystems, bootType, selinuxConfig, kernelCommandLine,
-		currentSELinuxMode)
-	if err != nil {
-		return fmt.Errorf("failed to add bootloader to new image:\n%w", err)
-	}
-
-	// Close image.
-	err = imageConnection.CleanClose()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func createNewImageHelper(imageConnection *ImageConnection, filename string, diskConfig imagecustomizerapi.Disk,
 	fileSystems []imagecustomizerapi.FileSystem, buildDir string, chrootDirName string,
 	installOS installOSFunc,


### PR DESCRIPTION
A lot of code within the image customizer requires a base image to work correctly. So, this change adds the option to pass in a core-efi image file to the tests that can be used as a base image. If the image isn't provided then the tests that need it will be skipped.

The tests that previously used a fake image have been changed to use the real base image. And a new test has been added to test partition customization.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran the tests that were added.
