### PR TITLE
Image Customizer: Support explicit grow partition size.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -164,7 +164,7 @@ os:
     - [modules](#modules-module)
       - [module type](#module-type)
         - [name](#module-name)
-        - [loadMode](#loadMode-string)
+        - [loadMode](#loadmode-string)
         - [options](#options-mapstring-string)
     - [overlay type](#overlay-type)
     - [verity type](#verity-type)
@@ -243,7 +243,8 @@ Supported options:
 
 The size of the disk.
 
-Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+Supported format: `<NUM>(K|M|G|T)`: A size in KiB (`K`), MiB (`M`), GiB (`G`), or TiB
+(`T`).
 
 Must be a multiple of 1 MiB.
 
@@ -700,7 +701,8 @@ Required.
 
 The start location (inclusive) of the partition.
 
-Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+Supported format: `<NUM>(K|M|G|T)`: A size in KiB (`K`), MiB (`M`), GiB (`G`), or TiB
+(`T`).
 
 Must be a multiple of 1 MiB.
 
@@ -708,14 +710,16 @@ Must be a multiple of 1 MiB.
 
 The end location (exclusive) of the partition.
 
-The End and Size fields cannot be specified at the same time.
+The `end` and `size` fields cannot be specified at the same time.
 
-Either the Size or End field is required for all partitions except for the last
+Either the `size` or `end` field is required for all partitions except for the last
 partition.
-When both the Size and End fields are omitted, the last partition will fill the
-remainder of the disk (based on the disk's [maxSize](#maxsize-uint64) field).
+When both the `size` and `end` fields are omitted or when the `size` field is set to the
+value `grow`, the last partition will fill the remainder of the disk based on the disk's
+[maxSize](#maxsize-uint64) field.
 
-Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+Supported format: `<NUM>(K|M|G|T)`: A size in KiB (`K`), MiB (`M`), GiB (`G`), or TiB
+(`T`).
 
 Must be a multiple of 1 MiB.
 
@@ -723,7 +727,11 @@ Must be a multiple of 1 MiB.
 
 The size of the partition.
 
-Supported suffixes: `K` (KiB), `M` (MiB), `G` (GiB), and `T` (TiB).
+Supported formats:
+
+- `<NUM>(K|M|G|T)`: An explicit size in KiB (`K`), MiB (`M`), GiB (`G`), or TiB (`T`).
+
+- `grow`: Fill up the remainder of the disk. Must be the last partition.
 
 Must be a multiple of 1 MiB.
 

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -60,7 +60,7 @@ func (d *Disk) IsValid() error {
 
 		aEnd, aHasEnd := a.GetEnd()
 		if !aHasEnd {
-			return fmt.Errorf("partition (%s) is not last partition but ommitted end value", a.Id)
+			return fmt.Errorf("partition (%s) is not last partition but size is set to \"grow\"", a.Id)
 		}
 		if aEnd > b.Start {
 			bEnd, bHasEnd := b.GetEnd()

--- a/toolkit/tools/imagecustomizerapi/disk_test.go
+++ b/toolkit/tools/imagecustomizerapi/disk_test.go
@@ -52,7 +52,10 @@ func TestDiskIsValidWithSize(t *testing.T) {
 			{
 				Id:    "a",
 				Start: 1 * diskutils.MiB,
-				Size:  ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
+				Size: PartitionSize{
+					Type: PartitionSizeTypeExplicit,
+					Size: 1 * diskutils.MiB,
+				},
 			},
 		},
 	}
@@ -131,7 +134,31 @@ func TestDiskIsValidTwoExpanding(t *testing.T) {
 
 	err := disk.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "is not last partition")
+	assert.ErrorContains(t, err, "is not last partition but size is set to \"grow\"")
+}
+
+func TestDiskIsValidTwoExpandingGrow(t *testing.T) {
+	disk := &Disk{
+		PartitionTableType: PartitionTableTypeGpt,
+		MaxSize:            4 * diskutils.MiB,
+		Partitions: []Partition{
+			{
+				Id:    "a",
+				Start: 1 * diskutils.MiB,
+			},
+			{
+				Id:    "b",
+				Start: 2 * diskutils.MiB,
+				Size: PartitionSize{
+					Type: PartitionSizeTypeGrow,
+				},
+			},
+		},
+	}
+
+	err := disk.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "is not last partition but size is set to \"grow\"")
 }
 
 func TestDiskIsValidOverlaps(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/disksize_test.go
+++ b/toolkit/tools/imagecustomizerapi/disksize_test.go
@@ -13,7 +13,7 @@ import (
 func TestDiskSizeNum(t *testing.T) {
 	var diskSize DiskSize
 	err := UnmarshalYaml([]byte("1048576"), &diskSize)
-	assert.ErrorContains(t, err, "must have a suffix (i.e. K, M, G, or T)")
+	assert.ErrorContains(t, err, "must have a unit suffix (K, M, G, or T)")
 }
 
 func TestDiskSizeKiB(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/partition_test.go
+++ b/toolkit/tools/imagecustomizerapi/partition_test.go
@@ -49,13 +49,15 @@ func TestPartitionIsValidZeroSizeV2(t *testing.T) {
 	partition := Partition{
 		Id:    "a",
 		Start: 0,
-		Size:  ptrutils.PtrTo(DiskSize(0)),
+		Size: PartitionSize{
+			Type: PartitionSizeTypeExplicit,
+			Size: 0,
+		},
 	}
 
 	err := partition.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "partition")
-	assert.ErrorContains(t, err, "size")
+	assert.ErrorContains(t, err, "size can't be 0 or negative")
 }
 
 func TestPartitionIsValidNegativeSize(t *testing.T) {
@@ -67,8 +69,7 @@ func TestPartitionIsValidNegativeSize(t *testing.T) {
 
 	err := partition.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "partition")
-	assert.ErrorContains(t, err, "size")
+	assert.ErrorContains(t, err, "size can't be 0 or negative")
 }
 
 func TestPartitionIsValidBothEndAndSize(t *testing.T) {
@@ -76,13 +77,30 @@ func TestPartitionIsValidBothEndAndSize(t *testing.T) {
 		Id:    "a",
 		Start: 2 * diskutils.MiB,
 		End:   ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
-		Size:  ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
+		Size: PartitionSize{
+			Type: PartitionSizeTypeExplicit,
+			Size: 1 * diskutils.MiB,
+		},
 	}
 
 	err := partition.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "end")
-	assert.ErrorContains(t, err, "size")
+	assert.ErrorContains(t, err, "cannot specify both end and size on partition")
+}
+
+func TestPartitionIsValidEndAndGrow(t *testing.T) {
+	partition := Partition{
+		Id:    "a",
+		Start: 2 * diskutils.MiB,
+		End:   ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
+		Size: PartitionSize{
+			Type: PartitionSizeTypeGrow,
+		},
+	}
+
+	err := partition.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "cannot specify both end and size on partition")
 }
 
 func TestPartitionIsValidGoodName(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/partitionsize.go
+++ b/toolkit/tools/imagecustomizerapi/partitionsize.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	PartitionSizeGrow = "grow"
+)
+
+type PartitionSizeType int
+
+const (
+	PartitionSizeTypeUnset PartitionSizeType = iota
+	PartitionSizeTypeGrow
+	PartitionSizeTypeExplicit
+)
+
+type PartitionSize struct {
+	Type PartitionSizeType
+	Size DiskSize
+}
+
+func (s *PartitionSize) IsValid() error {
+	return nil
+}
+
+func (s *PartitionSize) UnmarshalYAML(value *yaml.Node) error {
+	var err error
+
+	var stringValue string
+	err = value.Decode(&stringValue)
+	if err != nil {
+		return fmt.Errorf("failed to parse partition size:\n%w", err)
+	}
+
+	switch stringValue {
+	case PartitionSizeGrow:
+		*s = PartitionSize{
+			Type: PartitionSizeTypeGrow,
+		}
+		return nil
+	}
+
+	diskSize, err := parseDiskSize(stringValue)
+	if err != nil {
+		return fmt.Errorf("%w:\nexpected format: grow | <NUM>(K|M|G|T) (e.g. grow, 100M, 1G)", err)
+	}
+
+	*s = PartitionSize{
+		Type: PartitionSizeTypeExplicit,
+		Size: diskSize,
+	}
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/partitionsize_test.go
+++ b/toolkit/tools/imagecustomizerapi/partitionsize_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParitionSizeGrow(t *testing.T) {
+	var size PartitionSize
+	err := UnmarshalYaml([]byte("grow"), &size)
+	assert.NoError(t, err)
+}
+
+func TestParitionSizeMiB(t *testing.T) {
+	var size PartitionSize
+	err := UnmarshalYaml([]byte("1M"), &size)
+	assert.NoError(t, err)
+	assert.Equal(t, PartitionSize{PartitionSizeTypeExplicit, 1 * diskutils.MiB}, size)
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
@@ -9,7 +9,8 @@ storage:
       size: 8M
 
     - id: rootfs
-      start: 9
+      start: 9M
+      size: grow
 
   bootType: legacy
 


### PR DESCRIPTION
Currently, to specify that a partition fills up the remainer of the disk, the user must omit both the `end` and `size` field. This change allows the user to set the `size` field to `grow`.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge


###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

