### PR TITLE
Add runtime require on gawk to dracut

### DIFF
--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        059
-Release:        16%{?dist}
+Release:        17%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -40,6 +40,7 @@ BuildRequires:  asciidoc
 BuildRequires:  systemd-rpm-macros
 
 Requires:       bash >= 4
+Requires:       gawk
 Requires:       kmod
 Requires:       sed
 Requires:       grep
@@ -216,6 +217,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Wed Apr 10 2024 Daniel McIlvaney <damcilva@microsoft.com> - 059-17
+- Add missing runtime requirement on awk
+
 * Wed Mar 27 2024 Cameron Baird <cameronbaird@microsoft.com> - 059-16
 - Remove x86-specific xen-acpi-processor driver from defaults
 
@@ -313,7 +317,7 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 -   Remove toybox from requires.
 
 *   Thu Mar 26 2020 Nicolas Ontiveros <niontive@microsoft.com> 049-1
--   Update version to 49. License verified. 
+-   Update version to 49. License verified.
 
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 048-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We contributed https://github.com/dracutdevs/dracut/commit/67591e8855006eb02aa0ffab7349ab770e471473 / https://github.com/dracutdevs/dracut/issues/2323 to upstream dracut, but since it hasn't made it into ver. 59 yet [we have a patch](https://github.com/microsoft/azurelinux/blob/3.0-dev/SPECS/dracut/fix-functions-Avoid-calling-grep-with-PCRE-P.patch). See https://github.com/microsoft/azurelinux/pull/5424 for details.

This patch adds a requirement on `awk` to prep an initramfs that isn't present in Fedora etc., so likely isn't found in any other `.spec` for `dracut.`

This failure is **non-fatal** since the fallback path of cache-miss still works (as it did for the selinux errors), but the log is very ugly:
```bash
WARN[0022][imager] initramfs 3.0-3.azl3 posttrans               
WARN[0023][imager] dracut: Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE_[AMD|INTEL]!=y 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
WARN[0023][imager] /usr/lib/dracut/dracut-functions.sh: line 247: awk: command not found 
...
```

Adding a `Requires: gawk` fixes this error. Checking the change in runtime requirements (as understood by our build tools via `depsearch`) gives `gawk` and `mpfr` as new (`853K` + `358K` = `1.2M`)

```patch
diff --git a/toolkit/before.txt b/toolkit/after.txt
index 190c75ad4..a3a3fc3da 100644
--- a/toolkit/before.txt
+++ b/toolkit/after.txt
@@ -1,31 +1,33 @@
 audit
 bash
 coreutils
 cpio
 dbus
 dracut
 expat
 filesystem
 findutils
+gawk
 glibc
 gmp
 grep
 gzip
 kbd
 kmod
 libdb
 libkcapi
 libselinux
 libsepol
+mpfr
 ncurses
 nspr
 nss
 openssl
 pcre2
 procps-ng
 readline
 sed
 sqlite
 systemd
 util-linux
 xz
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `Requires: gawk` to `dracut`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

https://microsoft.visualstudio.com/DefaultCollection/OS/_queries/edit/50085799/?triage=true

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
