### PR TITLE
[kata-cc] kata-packages-uvm: add cifs-utils as dependency 

### DIFF
--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -96,7 +96,7 @@ Requires:       golang
 %files coco-sign
 
 %changelog
-* Thu Apr 11 2024 Archana Choudhary <archana1@microsoft.com> - 1.0.0-3.cm2
+* Thu Apr 11 2024 Archana Choudhary <archana1@microsoft.com> - 1.0.0-3
 - Add cifs-utils to the list of dependencies
 
 * Tue Feb 06 2024 Archana Choudhary <archana1@microsoft.com> - 1.0.0-2

--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage for Kata UVM components
 Name:           kata-packages-uvm
 Version:        1.0.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -41,6 +41,7 @@ Metapackage to install the set of packages inside a Kata containers UVM
 %package        coco
 Summary:        Metapackage to install the set of packages inside a Kata confidential containers UVM.
 Requires:       %{name} = %{version}-%{release}
+Requires:       cifs-utils
 Requires:       device-mapper
 Requires:       opa
 
@@ -95,6 +96,9 @@ Requires:       golang
 %files coco-sign
 
 %changelog
+* Thu Apr 11 2024 Archana Choudhary <archana1@microsoft.com> - 1.0.0-3.cm2
+- Add cifs-utils to the list of dependencies
+
 * Tue Feb 06 2024 Archana Choudhary <archana1@microsoft.com> - 1.0.0-2
 - Remove dependency on kernel-uvm-cvm
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Adds cifs-utils package. The package is needed to support cifs mount in kernel-uvm.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- kata-packages-uvm: add cifs-utils to the list of dependencies

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=548501&view=results
