### PR TITLE
Fixing cascading rebuilds. (CP: #8777)

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -38,7 +38,6 @@ type BuildRequest struct {
 	Node           *pkggraph.PkgNode   // The main node being analyzed for the build.
 	PkgGraph       *pkggraph.PkgGraph  // The graph of all packages.
 	AncillaryNodes []*pkggraph.PkgNode // For SRPM builds: other nodes stemming from the same SRPM. Empty otherwise.
-	ExpectedFiles  []string            // List of RPMs built by this node.
 	UseCache       bool                // Can we use a cached copy of this package instead of building it.
 	IsDelta        bool                // Is this a pre-downloaded RPM (not traditional cache) that we may be able to skip rebuilding.
 	Freshness      uint                // The freshness of the node (used to determine if we can skip building future nodes).
@@ -164,7 +163,7 @@ func buildNode(request *BuildRequest, graphMutex *sync.RWMutex, agent buildagent
 
 	if request.UseCache {
 		logger.Log.Debugf("%s is prebuilt, skipping", baseSrpmName)
-		builtFiles = request.ExpectedFiles
+		builtFiles, _ = pkggraph.FindRPMFiles(node.SrpmPath, request.PkgGraph, graphMutex)
 		return
 	}
 

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -77,21 +77,6 @@ func buildNodesToRequests(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildSta
 
 		defaultNode := buildNodes[0]
 		req := buildRequest(pkgGraph, buildState, packagesToRebuild, defaultNode, buildNodes, isCacheAllowed, hasADeltaNode)
-
-		if req.UseCache {
-			expectedFiles, missingFiles := pkggraph.FindRPMFiles(defaultNode.SrpmPath, pkgGraph, nil)
-			if len(missingFiles) > 0 && len(missingFiles) < len(expectedFiles) {
-				logger.Log.Infof("SRPM '%s' will be rebuilt due to partially missing components: %v", defaultNode.SRPMFileName(), missingFiles)
-			}
-
-			req.ExpectedFiles = expectedFiles
-			if len(missingFiles) != 0 {
-				req.UseCache = false
-				req.Freshness = buildState.GetMaxFreshness()
-				logger.Log.Debugf("Resetting freshness to %d due to missing files.", req.Freshness)
-			}
-		}
-
 		requests = append(requests, req)
 
 		partnerTestNodeRequest := partnerTestNodesToRequest(pkgGraph, buildState, testsToRerun, buildNodes, req.UseCache)
@@ -126,7 +111,7 @@ func buildRequest(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildState, pack
 		Freshness:      buildState.GetMaxFreshness(),
 	}
 
-	requiredRebuild := isRequiredRebuild(request.Node, packagesToRebuild)
+	requiredRebuild := isRequiredRebuild(pkgGraph, request.Node, packagesToRebuild, buildState)
 	if !requiredRebuild && isCacheAllowed {
 		// We might be able to use the cache, set the freshness based on node's dependencies.
 		request.UseCache, request.Freshness = canUseCacheForNode(pkgGraph, request.Node, buildState)
@@ -186,14 +171,11 @@ func testNodesToRequests(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildStat
 	return
 }
 
-// isRequiredRebuild checks if a node is required to be rebuilt based  on the packagesToRebuild list.
-func isRequiredRebuild(node *pkggraph.PkgNode, packagesToRebuild []*pkgjson.PackageVer) (requiredRebuild bool) {
-	packageVer := node.VersionedPkg
-	requiredRebuild = sliceutils.Contains(packagesToRebuild, packageVer, sliceutils.PackageVerMatch)
-	if requiredRebuild {
-		logger.Log.Debugf("Marking (%s) for rebuild per user request", packageVer)
-	}
-	return
+// isRequiredRebuild checks if a node is required to be rebuilt due to:
+// - missing RPMs or
+// - user explicitly requesting the node to be rebuilt.
+func isRequiredRebuild(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, packagesToRebuild []*pkgjson.PackageVer, buildState *GraphBuildState) bool {
+	return nodeHasMissingRPMs(pkgGraph, node, buildState) || nodeRequestedForRebuildByUser(node, packagesToRebuild)
 }
 
 // canUseCacheForNode checks if the cache can be used for a given node by:
@@ -247,4 +229,28 @@ func calculateExpectedFreshness(dependencyNode *pkggraph.PkgNode, buildState *Gr
 	}
 
 	return expectedFreshness, shouldRebuild
+}
+
+// nodeHasMissingRPMs checks if all RPMs expected from the node's SRPM are present.
+// If any of the RPMs produced by the SRPM are missing, we must build the SRPM and reset the freshness of the node.
+func nodeHasMissingRPMs(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, buildState *GraphBuildState) (rpmsMissing bool) {
+	expectedFiles, missingFiles := pkggraph.FindRPMFiles(node.SrpmPath, pkgGraph, nil)
+
+	rpmsMissing = len(missingFiles) != 0
+	if rpmsMissing && len(missingFiles) < len(expectedFiles) {
+		logger.Log.Infof("SRPM (%s) will be rebuilt due to partially missing components: %v", node.SRPMFileName(), missingFiles)
+	}
+
+	return
+}
+
+// nodeRequestedForRebuildByUser checks if the user has explicitly requested the node to be rebuilt.
+func nodeRequestedForRebuildByUser(node *pkggraph.PkgNode, packagesToRebuild []*pkgjson.PackageVer) (rebuildRequested bool) {
+	packageVer := node.VersionedPkg
+	rebuildRequested = sliceutils.Contains(packagesToRebuild, packageVer, sliceutils.PackageVerMatch)
+	if rebuildRequested {
+		logger.Log.Infof("SRPM (%s) will be rebuilt due to user request.", packageVer)
+	}
+
+	return
 }


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Cherry-pick of #8777.

This fixes and occasional issue, where packages depending on an updated version of another package would not get triggered to re-build despite cascading rebuilds being set to 1.

The issue was caused by the order, in which we verify if a rebuild is needed and propagate the "freshness" of a node. Scenario where the issue reproed:
- Packages: `A`, `B`, and `X`.
- Both `A` and `B` were modified in the PR.
- `X` has a build-time dependency on `B`.
- **`B` has a build-time dependency on `A`.**
- Cascading rebuilds are set to 1 meaning "rebuild only the first level of packages depending on the modified packages".

Expected:
In this scenario `A` and `B` should build, because they are updated, there's no delta or cache to grab their versions from. Both should also build with the maximum "freshness". Since cascading rebuilds are set to 1, `X` should also build, because its dependency `B` was built.

Real:
Once `A` built, `B` was unblocked to build. While the scheduler was trying to figure out the "freshness" for `B`, it first checked if one of its dependencies (in this case `A`) was built during this run. It was built during this run, so the code decided `B` needed to be rebuilt but with a "freshness" one lower than `A`. **The logic resetting the "freshness" due to the fact that `B` was an updated package was then skipped**. Once `B` built, `X` didn't rebuild, because its dependency `B` built with "freshness" 0, meaning that was the last package the tooling would try to rebuild in the dependency chain.

Fix:
We now first check, if `B` needs to build because it was updated and reset its "freshness", if that's the case.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR check with changes from #8673. [Pre-fix build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=549057&view=results), [post-fix build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=549091&view=results).
- Local tests.