### PR TITLE
toolkit: remove `%_exclude_path` macro definitions which do not have …

### DIFF
--- a/toolkit/imageconfigs/additionalconfigs/macros.excludedocs
+++ b/toolkit/imageconfigs/additionalconfigs/macros.excludedocs
@@ -1,6 +1,2 @@
 # Exclude documentation files by default
 %_excludedocs 1
-
-# Additional rules to exclude specific documentation files or directories
-%_exclude_path /usr/share/doc/*
-%_exclude_path /usr/share/man/*


### PR DESCRIPTION
…any effect

These macros don't do anything and should not be included in the macro file.
