### PR TITLE
[fasttrack-2.0] ruby: patch CVE-2024-27280 and CVE-2024-27281 (#8784)

### DIFF
--- a/SPECS/ruby/CVE-2024-27280.patch
+++ b/SPECS/ruby/CVE-2024-27280.patch
@@ -1,0 +1,90 @@
+From 9081496b8ccc19751ba3a1abe6eda3618b1e1ca9 Mon Sep 17 00:00:00 2001
+From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
+Date: Thu, 21 Mar 2024 15:55:48 +0900
+Subject: [PATCH] Merge StringIO 3.0.1.1
+
+---
+ ext/stringio/stringio.c        |  4 ++--
+ test/stringio/test_stringio.rb | 25 +++++++++++++++++++++----
+ 2 files changed, 23 insertions(+), 6 deletions(-)
+
+diff --git a/ext/stringio/stringio.c b/ext/stringio/stringio.c
+index 8df07e80f682c0..12930b35750c7d 100644
+--- a/ext/stringio/stringio.c
++++ b/ext/stringio/stringio.c
+@@ -12,7 +12,7 @@
+ 
+ **********************************************************************/
+ 
+-#define STRINGIO_VERSION "3.0.1"
++#define STRINGIO_VERSION "3.0.1.1"
+ 
+ #include "ruby.h"
+ #include "ruby/io.h"
+@@ -984,7 +984,7 @@ strio_unget_bytes(struct StringIO *ptr, const char *cp, long cl)
+     len = RSTRING_LEN(str);
+     rest = pos - len;
+     if (cl > pos) {
+-	long ex = (rest < 0 ? cl-pos : cl+rest);
++	long ex = cl - (rest < 0 ? pos : len);
+ 	rb_str_modify_expand(str, ex);
+ 	rb_str_set_len(str, len + ex);
+ 	s = RSTRING_PTR(str);
+diff --git a/test/stringio/test_stringio.rb b/test/stringio/test_stringio.rb
+index e0b4504b541b96..144a9f42923030 100644
+--- a/test/stringio/test_stringio.rb
++++ b/test/stringio/test_stringio.rb
+@@ -757,6 +757,15 @@ def test_ungetc_padding
+     assert_equal("b""\0""a", s.string)
+   end
+ 
++  def test_ungetc_fill
++    count = 100
++    s = StringIO.new
++    s.print 'a' * count
++    s.ungetc('b' * (count * 5))
++    assert_equal((count * 5), s.string.size)
++    assert_match(/\Ab+\z/, s.string)
++  end
++
+   def test_ungetbyte_pos
+     b = '\\b00010001 \\B00010001 \\b1 \\B1 \\b000100011'
+     s = StringIO.new( b )
+@@ -782,6 +791,15 @@ def test_ungetbyte_padding
+     assert_equal("b""\0""a", s.string)
+   end
+ 
++  def test_ungetbyte_fill
++    count = 100
++    s = StringIO.new
++    s.print 'a' * count
++    s.ungetbyte('b' * (count * 5))
++    assert_equal((count * 5), s.string.size)
++    assert_match(/\Ab+\z/, s.string)
++  end
++
+   def test_frozen
+     s = StringIO.new
+     s.freeze
+@@ -825,18 +843,17 @@ def test_new_block_warning
+   end
+ 
+   def test_overflow
+-    omit if RbConfig::SIZEOF["void*"] > RbConfig::SIZEOF["long"]
++    return if RbConfig::SIZEOF["void*"] > RbConfig::SIZEOF["long"]
+     limit = RbConfig::LIMITS["INTPTR_MAX"] - 0x10
+     assert_separately(%w[-rstringio], "#{<<-"begin;"}\n#{<<-"end;"}")
+     begin;
+       limit = #{limit}
+       ary = []
+-      while true
++      begin
+         x = "a"*0x100000
+         break if [x].pack("p").unpack("i!")[0] < 0
+         ary << x
+-        omit if ary.size > 100
+-      end
++      end while ary.size <= 100
+       s = StringIO.new(x)
+       s.gets("xxx", limit)
+       assert_equal(0x100000, s.pos)

--- a/SPECS/ruby/CVE-2024-27281.patch
+++ b/SPECS/ruby/CVE-2024-27281.patch
@@ -1,0 +1,104 @@
+From 04db47dbe41d643b50d99615bd5c7b3737afb6e0 Mon Sep 17 00:00:00 2001
+From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
+Date: Thu, 21 Mar 2024 15:44:45 +0900
+Subject: [PATCH] Merge RDoc-6.4.1.1
+
+---
+ lib/rdoc/store.rb   | 45 ++++++++++++++++++++++++++-------------------
+ lib/rdoc/version.rb |  2 +-
+ 2 files changed, 27 insertions(+), 20 deletions(-)
+
+diff --git a/lib/rdoc/store.rb b/lib/rdoc/store.rb
+index 5ba671ca1b6216..c793e49ed845ed 100644
+--- a/lib/rdoc/store.rb
++++ b/lib/rdoc/store.rb
+@@ -556,9 +556,7 @@ def load_all
+   def load_cache
+     #orig_enc = @encoding
+ 
+-    File.open cache_path, 'rb' do |io|
+-      @cache = Marshal.load io.read
+-    end
++    @cache = marshal_load(cache_path)
+ 
+     load_enc = @cache[:encoding]
+ 
+@@ -615,9 +613,7 @@ def load_class klass_name
+   def load_class_data klass_name
+     file = class_file klass_name
+ 
+-    File.open file, 'rb' do |io|
+-      Marshal.load io.read
+-    end
++    marshal_load(file)
+   rescue Errno::ENOENT => e
+     error = MissingFileError.new(self, file, klass_name)
+     error.set_backtrace e.backtrace
+@@ -630,14 +626,10 @@ def load_class_data klass_name
+   def load_method klass_name, method_name
+     file = method_file klass_name, method_name
+ 
+-    File.open file, 'rb' do |io|
+-      obj = Marshal.load io.read
+-      obj.store = self
+-      obj.parent =
+-        find_class_or_module(klass_name) || load_class(klass_name) unless
+-          obj.parent
+-      obj
+-    end
++    obj = marshal_load(file)
++    obj.store = self
++    obj.parent ||= find_class_or_module(klass_name) || load_class(klass_name)
++    obj
+   rescue Errno::ENOENT => e
+     error = MissingFileError.new(self, file, klass_name + method_name)
+     error.set_backtrace e.backtrace
+@@ -650,11 +642,9 @@ def load_method klass_name, method_name
+   def load_page page_name
+     file = page_file page_name
+ 
+-    File.open file, 'rb' do |io|
+-      obj = Marshal.load io.read
+-      obj.store = self
+-      obj
+-    end
++    obj = marshal_load(file)
++    obj.store = self
++    obj
+   rescue Errno::ENOENT => e
+     error = MissingFileError.new(self, file, page_name)
+     error.set_backtrace e.backtrace
+@@ -976,4 +966,21 @@ def unique_modules
+     @unique_modules
+   end
+ 
++  private
++  def marshal_load(file)
++    File.open(file, 'rb') {|io| Marshal.load(io, MarshalFilter)}
++  end
++
++  MarshalFilter = proc do |obj|
++    case obj
++    when true, false, nil, Array, Class, Encoding, Hash, Integer, String, Symbol, RDoc::Text
++    else
++      unless obj.class.name.start_with?("RDoc::")
++        raise TypeError, "not permitted class: #{obj.class.name}"
++      end
++    end
++    obj
++  end
++  private_constant :MarshalFilter
++
+ end
+diff --git a/lib/rdoc/version.rb b/lib/rdoc/version.rb
+index 86c5b360fd6e5a..c3ff6640f572b6 100644
+--- a/lib/rdoc/version.rb
++++ b/lib/rdoc/version.rb
+@@ -3,6 +3,6 @@ module RDoc
+   ##
+   # RDoc version you are using
+ 
+-  VERSION = '6.4.0'
++  VERSION = '6.4.1.1'
+ 
+ end

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -50,7 +50,7 @@
 %global pstore_version          0.1.1
 %global psych_version           4.0.4
 %global racc_version            1.6.0
-%global rdoc_version            6.4.0
+%global rdoc_version            6.4.1.1
 %global readline_version        0.0.3
 %global readline_ext_version    0.1.4
 %global reline_version          0.3.1
@@ -62,7 +62,7 @@
 %global set_version             1.0.2
 %global shellwords_version      0.1.0
 %global singleton_version       0.1.1
-%global stringio_version        3.0.1
+%global stringio_version        3.0.1.1
 %global strscan_version         3.0.1
 %global syslog_version          0.1.0
 %global tempfile_version        0.1.2
@@ -83,7 +83,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        3.1.4
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -99,6 +99,8 @@ Source6:        rubygems.req
 Source7:        macros.rubygems
 # Updates default ruby-uri to 0.12.2 and vendored one to 0.10.3. Remove once ruby gets updated to a version that comes with both lib/uri/version.rb and lib/bundler/vendor/uri/lib/uri/version.rb versions >= 0.12.2 or == 0.10.3
 Patch0:         CVE-2023-36617.patch
+Patch1:         CVE-2024-27280.patch
+Patch2:         CVE-2024-27281.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline
 BuildRequires:  readline-devel
@@ -401,6 +403,9 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
+* Fri Apr 12 2024 Andrew Phelps <anphel@microsoft.com> - 3.1.4-4
+- Add patches for CVE-2024-27280 and CVE-2024-27281
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 3.1.4-3
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Cherry-pick #8784 to `fasttrack/2.0`
Patch CVE-2024-27280 and CVE-2024-27281 in gem files bundled with ruby.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change: ruby: patch CVE-2024-27280 and CVE-2024-27281

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://portal.microsofticm.com/imp/v3/incidents/incident/490845437/summary

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-27280
- https://www.ruby-lang.org/en/news/2024/03/21/buffer-overread-cve-2024-27280/
- https://nvd.nist.gov/vuln/detail/CVE-2024-27281
- https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=549505&view=results
