### PR TITLE
fix: move stopGPGAgent into safechroot to stop /dev from being left b…

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -434,8 +434,6 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 		filesystemPkg = "filesystem"
 	)
 
-	defer stopGPGAgent(installChroot)
-
 	ReportAction("Initializing RPM Database")
 
 	installRoot := filepath.Join(rootMountPoint, installChroot.RootDir())
@@ -2713,27 +2711,4 @@ func KernelPackages(config configuration.Config) []*pkgjson.PackageVer {
 		}
 	}
 	return packageList
-}
-
-// stopGPGAgent stops gpg-agent and keyboxd if they are running inside the installChroot.
-//
-// It is possible that one of the packages or post-install scripts started a GPG agent.
-// e.g. when installing the azurelinux-repos SPEC, a GPG import occurs. This starts the gpg-agent process inside the chroot.
-// To be able to cleanly exit the setup chroot, we must stop it.
-func stopGPGAgent(installChroot *safechroot.Chroot) {
-	installChroot.UnsafeRun(func() error {
-		err := shell.ExecuteLiveWithCallback(logger.Log.Debug, logger.Log.Warn, false, "gpgconf", "--kill", "gpg-agent")
-		if err != nil {
-			// This is non-fatal, as there is no guarantee the image has gpg agent started.
-			logger.Log.Warnf("Failed to stop gpg-agent. This is expected if it is not installed: %s", err)
-		}
-
-		err = shell.ExecuteLiveWithCallback(logger.Log.Debug, logger.Log.Warn, false, "gpgconf", "--kill", "keyboxd")
-		if err != nil {
-			// This is non-fatal, as there is no guarantee the image has gpg agent started.
-			logger.Log.Warnf("Failed to stop keyboxd. This is expected if it is not installed: %s", err)
-		}
-
-		return nil
-	})
 }

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -695,12 +695,12 @@ func (c *Chroot) GetMountPoints() []*MountPoint {
 	return mountPoints
 }
 
-// stopGPGAgent stops gpg-agent and keyboxd if they are running inside the chroot.
+// stopGPGComponents stops gpg-agent and keyboxd if they are running inside the chroot.
 //
-// A GPG agent may have been started while the chroot was in use.
+// A GPG agent may have been started while the chroot was in use. Newer versions of "gnupg2" will also start keyboxd.
 // E.g. when installing the azurelinux-repos-shared package, a GPG import occurs. This starts the gpg-agent process inside the chroot.
 // To be able to cleanly exit the setup chroot, we must stop it.
-func (c *Chroot) stopGPGAgent() (err error) {
+func (c *Chroot) stopGPGComponents() (err error) {
 	_, err = exec.LookPath("gpgconf")
 	if err != nil {
 		// gpgconf is not installed, so gpg-agent is not running.

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -4,6 +4,7 @@
 package safechroot
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -437,7 +438,7 @@ func (c *Chroot) Close(leaveOnDisk bool) (err error) {
 		err = c.stopGPGComponents()
 		if err != nil {
 			// Don't want to leave a stale root if gpg components fail to exit. Logging a Warn and letting close continue...
-			logger.Log.Warnf("Failed to stop GPG components: %s", err)
+			logger.Log.Warnf("Failed to stop GPG components while tearing down the (%s) chroot: %s", c.rootDir, err)
 		}
 
 		// mount is only supported in regular pipeline
@@ -714,33 +715,51 @@ func (c *Chroot) stopGPGComponents() (err error) {
 	}
 
 	err = c.UnsafeRun(func() (err error) {
-		stdout, stderr, err := shell.Execute("gpgconf", "--list-components")
-
-		logger.Log.Debugf("gpgconf --list-components output:\n%s", stdout)
-
-		if err != nil || stderr != "" {
-			err = fmt.Errorf("failed to list gpg components.\nerr: %s\nstderr: %s\nUnable to check and stop GPG components", err, stderr)
-			return
-		}
-
+		// Split --list-components stdout into a list of name tags, one for each component
+		components, err := c.listGPGComponents()
+		// List of components to kill. The names must be verbatim identical to the name tag that is used by `gpgconf`
 		componentsToKill := []string{"gpg-agent", "keyboxd"}
-		// Split --list-components stdout on newline and iterate over each line
-		for _, line := range strings.Split(stdout, "\n") {
-			for _, component := range componentsToKill {
-				// Check if the line contains a component to kill
-				if strings.Contains(line, component) {
-					logger.Log.Debugf("Found %s running inside chroot. Stopping it.", component)
-					_, _, err = shell.Execute("gpgconf", "--kill", component)
-					if err != nil {
-						err = fmt.Errorf("failed to stop gpg component \"%s\": \n%s", component, err)
-						return
-					}
+		for _, component := range componentsToKill {
+			// Check if the line contains a component to kill
+			if components[component] {
+				logger.Log.Debugf("Found %s running inside chroot. Stopping it.", component)
+				_, stderr, err := shell.Execute("gpgconf", "--kill", component)
+				if err != nil {
+					err = fmt.Errorf("failed to stop GPG component (%s):\nerr: %w\nstderr: %s", component, err, stderr)
+					return err
 				}
 			}
 		}
 
 		return
 	})
+
+	return
+}
+
+func (c *Chroot) listGPGComponents() (components map[string]bool, err error) {
+	stdout, stderr, err := shell.Execute("gpgconf", "--list-components")
+
+	if err != nil {
+		err = fmt.Errorf("failed to list GPG components.\nerr: %w\nstderr: %s", err, stderr)
+		return
+	}
+
+	logger.Log.Debugf("gpgconf --list-components output:\n%s", stdout)
+
+	reader := strings.NewReader(stdout)
+	scanner := bufio.NewScanner(reader)
+
+	components = make(map[string]bool)
+	for scanner.Scan() {
+		line := scanner.Text()
+		components[strings.Split(line, ":")[0]] = true
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		err = fmt.Errorf("error parsing gpgconf --list-components output: %w", err)
+	}
 
 	return
 }

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -4,7 +4,6 @@
 package safechroot
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -437,7 +436,7 @@ func (c *Chroot) Close(leaveOnDisk bool) (err error) {
 		// This is to avoid leaving folders like /dev mounted when the chroot folder is forcefully deleted in cleanup.
 		err = c.stopGPGComponents()
 		if err != nil {
-			// Don't want to leave a stale root if gpg components fail to exit. Logging a Warn and letting close continue...
+			// Don't want to leave a stale root if GPG components fail to exit. Logging a Warn and letting close continue...
 			logger.Log.Warnf("Failed to stop GPG components while tearing down the (%s) chroot: %s", c.rootDir, err)
 		}
 
@@ -709,56 +708,55 @@ func (c *Chroot) GetMountPoints() []*MountPoint {
 func (c *Chroot) stopGPGComponents() (err error) {
 	_, err = exec.LookPath("gpgconf")
 	if err != nil {
-		// gpgconf is not installed, so gpg-agent is not running.
 		logger.Log.Debugf("gpgconf is not installed, so gpg-agent is not running: %s", err)
-		return
+		return nil
 	}
 
 	err = c.UnsafeRun(func() (err error) {
-		// Split --list-components stdout into a list of name tags, one for each component
-		components, err := c.listGPGComponents()
+		components, err := listGPGComponents()
+		if err != nil {
+			return err
+		}
 		// List of components to kill. The names must be verbatim identical to the name tag that is used by `gpgconf`
 		componentsToKill := []string{"gpg-agent", "keyboxd"}
-		for _, component := range componentsToKill {
-			// Check if the line contains a component to kill
-			if components[component] {
-				logger.Log.Debugf("Found %s running inside chroot. Stopping it.", component)
-				_, stderr, err := shell.Execute("gpgconf", "--kill", component)
-				if err != nil {
-					err = fmt.Errorf("failed to stop GPG component (%s):\nerr: %w\nstderr: %s", component, err, stderr)
-					return err
-				}
-			}
-		}
-
-		return
+		return killGPGComponents(componentsToKill, components)
 	})
 
 	return
 }
 
-func (c *Chroot) listGPGComponents() (components map[string]bool, err error) {
+// killGPGComponents will kill the GPG components from the 'componentsToKill' list
+// if they are inside the 'availableComponents' set.
+func killGPGComponents(componentsToKill []string, availableComponents map[string]bool) (err error) {
+	for _, component := range componentsToKill {
+		if availableComponents[component] {
+			logger.Log.Debugf("Found %s running inside chroot. Stopping it.", component)
+			_, stderr, err := shell.Execute("gpgconf", "--kill", component)
+			if err != nil {
+				return fmt.Errorf("failed to stop GPG component (%s):\nerr: %w\nstderr: %s", component, err, stderr)
+			}
+		}
+	}
+	return
+}
+
+// listGPGComponents will return a set of all GPG component.
+func listGPGComponents() (components map[string]bool, err error) {
 	stdout, stderr, err := shell.Execute("gpgconf", "--list-components")
 
 	if err != nil {
-		err = fmt.Errorf("failed to list GPG components.\nerr: %w\nstderr: %s", err, stderr)
+		err = fmt.Errorf("failed to list GPG components.\nerr:%w\nstderr: %s", err, stderr)
 		return
 	}
 
 	logger.Log.Debugf("gpgconf --list-components output:\n%s", stdout)
 
-	reader := strings.NewReader(stdout)
-	scanner := bufio.NewScanner(reader)
-
 	components = make(map[string]bool)
-	for scanner.Scan() {
-		line := scanner.Text()
-		components[strings.Split(line, ":")[0]] = true
-	}
 
-	err = scanner.Err()
-	if err != nil {
-		err = fmt.Errorf("error parsing gpgconf --list-components output: %w", err)
+	// Split --list-components stdout into a list of name tags, one for each component
+	// Stdout has the following format: <component>:<description>:<pgmname>:
+	for _, line := range strings.Split(stdout, "\n") {
+		components[strings.Split(line, ":")[0]] = true
 	}
 
 	return


### PR DESCRIPTION
…ehind in chroot cleanup

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
**What does the PR accomplish, why was it needed?**
This broadens the stopping of the gpgAgent to all safechroots. Previously, Image Customizer was using a safechroot to create customized Azure Linux images and was failing to do a final close-out of the chroot because keyboxd was holding the /dev mount open and the loopback device would fail to be detached.

Demo of before the fix and after the fix:
<img width="551" alt="image" src="https://github.com/microsoft/azurelinux/assets/22079170/5bed631f-5c97-4cca-825a-8de2b9e6d00b">


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove defer stopGPGAgent from installutils' PopulateInstallChroot() because it is now handled when the chroot is closed
- Move stopGPGAgent from installutils into safechroot
- Add stopGPGAgent to safechroot's close() before unmounting


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [full build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=551400&view=results) 
