### PR TITLE
fix: add repoutils.FindCreateRepoCommand to flexibly use either creat…

### DIFF
--- a/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager/rpmrepomanager.go
+++ b/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager/rpmrepomanager.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/packagerepo/repoutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 )
 
@@ -36,8 +37,13 @@ func CreateRepo(repoDir string) (err error) {
 		return
 	}
 
+	createRepoCmd, err := repoutils.FindCreateRepoCommand()
+	if err != nil {
+		return fmt.Errorf("unable to create repo:\n%w", err)
+	}
+
 	// Create a new repodata
-	_, stderr, err := shell.Execute("createrepo", "--compatibility", repoDir)
+	_, stderr, err := shell.Execute(createRepoCmd, "--compatibility", repoDir)
 	if err != nil {
 		logger.Log.Warn(stderr)
 	}
@@ -48,8 +54,14 @@ func CreateRepo(repoDir string) (err error) {
 // CreateOrUpdateRepo will create an RPM repository at repoDir or update
 // it if the metadata files already exist.
 func CreateOrUpdateRepo(repoDir string) (err error) {
+	// Check if createrepo command is available
+	createRepoCmd, err := repoutils.FindCreateRepoCommand()
+	if err != nil {
+		return fmt.Errorf("unable to create repo:\n%w", err)
+	}
+
 	// Create or update repodata
-	_, stderr, err := shell.Execute("createrepo", "--compatibility", "--update", repoDir)
+	_, stderr, err := shell.Execute(createRepoCmd, "--compatibility", "--update", repoDir)
 	if err != nil {
 		logger.Log.Warn(stderr)
 	}

--- a/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
@@ -5,6 +5,7 @@ package repoutils
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
@@ -156,4 +157,25 @@ func verifyClonedRepoContents(clonedRepoContents, expectedPackages []*repocloner
 	logger.Log.Infof("Cloned repo contents verified successfully.")
 
 	return
+}
+
+// FindCreateRepoCommand searches for createrepo or createrepo_c in $PATH and returns the first one found
+func FindCreateRepoCommand() (cmd string, err error) {
+	creatrepo_cmds := []string{"createrepo", "createrepo_c"}
+
+	selectedCmd := ""
+	// Check if a command exists in the $PATH
+	for _, cmd := range creatrepo_cmds {
+		_, err = exec.LookPath(cmd)
+		if err == nil {
+			selectedCmd = cmd
+			break
+		}
+	}
+
+	if selectedCmd == "" {
+		return "", fmt.Errorf("failed to find a working createrepo command.\nattempted commands: %v", creatrepo_cmds)
+	}
+
+	return selectedCmd, nil
 }

--- a/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
@@ -161,7 +161,7 @@ func verifyClonedRepoContents(clonedRepoContents, expectedPackages []*repocloner
 
 // FindCreateRepoCommand searches for createrepo or createrepo_c in $PATH and returns the first one found
 func FindCreateRepoCommand() (cmd string, err error) {
-	creatrepo_cmds := []string{"createrepo", "createrepo_c"}
+	creatrepo_cmds := []string{"createrepo_c", "createrepo"}
 
 	selectedCmd := ""
 	// Check if a command exists in the $PATH


### PR DESCRIPTION
…erepo or createrepo_c

Copy of PR to main: https://github.com/microsoft/azurelinux/pull/8771

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Improves our retrieval of the createrepo command used by the rpmrepomanager. 

Previously, running image customizer on an Ubuntu devbox resulted in a `executable file not found in $PATH error` even with createrepo-c (Debian's createrepo package) installed.

Screenshot below shows:
* repro of the error
* building the tool with this fix
* a successful run with the tool now fixed
<img width="700" alt="image" src="https://github.com/microsoft/azurelinux/assets/22079170/518cd5fa-ba49-4926-a51c-7fd847db09b9">


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Links to CVEs  <!-- optional -->


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local
