### PR TITLE
fix rubygem-fluentd and rubygem-addressable requirements 

### DIFF
--- a/SPECS/rubygem-addressable/rubygem-addressable.spec
+++ b/SPECS/rubygem-addressable/rubygem-addressable.spec
@@ -3,7 +3,7 @@
 Summary:        an alternative implementation to the URI implementation that is part of Ruby's standard library
 Name:           rubygem-%{gem_name}
 Version:        2.8.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Apache 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,7 +11,7 @@ Group:          Development/Languages
 URL:            https://github.com/sporkmonger/addressable
 Source0:        https://github.com/sporkmonger/addressable/archive/refs/tags/addressable-%{version}.tar.gz#/%{gem_name}-%{gem_name}-%{version}.tar.gz
 BuildRequires:  ruby
-Requires:       rubygem-public_suffix < 5.0
+Requires:       rubygem-public_suffix < 6.0
 Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 %description
@@ -34,6 +34,9 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
+* Wed Apr 17 2024 Andrew Phelps <anphel@microsoft.com> - 2.8.5-2
+- Update runtime rubygem required version
+
 * Thu Nov 02 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.8.5-1
 - Auto-upgrade to 2.8.5 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/rubygem-fluentd/rubygem-fluentd.spec
+++ b/SPECS/rubygem-fluentd/rubygem-fluentd.spec
@@ -3,7 +3,7 @@
 Summary:        Fluentd event collector
 Name:           rubygem-%{gem_name}
 Version:        1.16.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -15,15 +15,16 @@ BuildRequires:  git
 BuildRequires:  ruby
 Requires:       rubygem-async-http
 Requires:       rubygem-cool.io < 2.0.0
-Requires:       rubygem-http_parser.rb < 0.7.0
+Requires:       rubygem-http_parser.rb < 0.9.0
 Requires:       rubygem-msgpack < 2.0.0
 Requires:       rubygem-rake < 14
 Requires:       rubygem-serverengine < 3.0.0
-Requires:       rubygem-sigdump < 0.3
+Requires:       rubygem-sigdump > 0.2.5
 Requires:       rubygem-strptime < 1.0.0
 Requires:       rubygem-tzinfo < 3.0
-Requires:       rubygem-tzinfo-data < 2
-Requires:       rubygem-yajl-ruby < 2
+Requires:       rubygem-tzinfo-data > 1.0
+Requires:       rubygem-yajl-ruby > 1.0
+Requires:       rubygem-webrick > 1.4
 Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 %description
@@ -58,6 +59,9 @@ gem install -V --local --force --install-dir %{buildroot}%{gemdir} --bindir %{bu
 %{gemdir}/specifications/fluentd-%{version}.gemspec
 
 %changelog
+* Wed Apr 17 2024 Andrew Phelps <anphel@microsoft.com> - 1.16.2-2
+- Update runtime rubygem required versions
+
 * Thu Nov 02 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.16.2-1
 - Auto-upgrade to 1.16.2 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Update `rubygem-fluentd` requirements based on https://github.com/fluent/fluentd/blob/v1.16/fluentd.gemspec
This resolves the following:
```
"Unresolved dependencies:"
"--> rubygem-http_parser.rb:C:'<'V:'0.7.0',C2:''V2:''"
```

Update `rubygem-addressable` requirements based on # https://github.com/sporkmonger/addressable/blob/addressable-2.8.5/addressable.gemspec
This resolves the following:
```
"Unresolved dependencies:"
"--> rubygem-public_suffix:C:'<'V:'5.0',C2:''V2:''"
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update `rubygem-fluentd` requirements
- Update `rubygem-addressable` requirements

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=552743&view=results
