### PR TITLE
systemd: move libidn2 recommends dep from core systemd to systemd-net…

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        11%{?dist}
+Release:        12%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -303,8 +303,6 @@ Conflicts:      %{name}-standalone-shutdown < %{version}-%{release}^
 Provides:       %{name}-shutdown = %{version}-%{release}
 
 # Recommends to replace normal Requires deps for stuff that is dlopen()ed
-Recommends:     libidn2.so.0%{?elf_suffix}
-Recommends:     libidn2.so.0(IDN2_0.0.0)%{?elf_bits}
 Recommends:     libpcre2-8.so.0%{?elf_suffix}
 Recommends:     libpwquality.so.1%{?elf_suffix}
 Recommends:     libpwquality.so.1(LIBPWQUALITY_1.0)%{?elf_bits}
@@ -535,6 +533,8 @@ Requires:       %{name}%{_isa} = %{version}-%{release}
 License:        LGPL-2.1-or-later
 # https://src.fedoraproject.org/rpms/systemd/pull-request/34
 Obsoletes:      systemd < 246.6-2
+Recommends:     libidn2.so.0%{?elf_suffix}
+Recommends:     libidn2.so.0(IDN2_0.0.0)%{?elf_bits}
 
 %description networkd
 systemd-networkd is a system service that manages networks. It detects and
@@ -1192,6 +1192,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Thu Apr 18 2024 Dan Streetman <ddstreet@microsoft.com> - 255-12
+- move libidn2 recommends from core package to systemd-networkd
+
 * Wed Apr 24 2024 Dan Streetman <ddstreet@microsoft.com> - 255-11
 - adjust pam.d/systemd-user file to include correct pam files
 


### PR DESCRIPTION
…workd

Only systemd-resolved and systemd-networkd use libidn2, so the core systemd package doesn't need to recommend it.

Related work item: https://microsoft.visualstudio.com/OS/_workitems/edit/49774049/
