### PR TITLE
Expose verity hash corruption options besides panic.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -350,9 +350,7 @@ please refer to the [overlay type](#overlay-type) section.
 
 - `corruptionOption`: Optional. Specifies the behavior in case of detected
   corruption. This is configurable with the following options:
-  - `io-error`: Default setting. Without specifying argument of corruption
-    behaviors, or giving an string `io-error`, by default kernel fails the IO
-    operation with I/O error.
+  - `io-error`: Default setting. Fails the I/O operation with an I/O error.
   - `ignore`: ignores the corruption and continues operation.
   - `panic`: causes the system to panic (print errors) and then try restarting
     if corruption is detected.

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -348,6 +348,18 @@ please refer to the [overlay type](#overlay-type) section.
 - `hashPartition`: A partition used exclusively for storing a calculated hash
   tree.
 
+- `corruptionOption`: Optional. Specifies the behavior in case of detected
+  corruption. This is configurable with the following options:
+  - `CorruptionOptionDefault`: Without specifying corruption behaviors, or
+    giving empty string `""`, by default kernel fails the IO operation with I/O
+    error.
+  - `CorruptionOptionIgnore`: `ignore`, ignores the corruption and continues
+    operation.
+  - `CorruptionOptionPanic`: `panic`, causes the system to panic if corruption
+    is detected.
+  - `CorruptionOptionRestart`: `restart`, attempts to restart the system upon
+    detecting corruption.
+
 Example:
 
 ```yaml
@@ -359,6 +371,7 @@ os:
     hashPartition:
       idType: part-label
       Id: hash_partition
+    corruptionOption: panic
 ```
 
 ## fileConfig type

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -350,15 +350,13 @@ please refer to the [overlay type](#overlay-type) section.
 
 - `corruptionOption`: Optional. Specifies the behavior in case of detected
   corruption. This is configurable with the following options:
-  - `CorruptionOptionDefault`: Without specifying corruption behaviors, or
-    giving empty string `""`, by default kernel fails the IO operation with I/O
-    error.
-  - `CorruptionOptionIgnore`: `ignore`, ignores the corruption and continues
-    operation.
-  - `CorruptionOptionPanic`: `panic`, causes the system to panic if corruption
-    is detected.
-  - `CorruptionOptionRestart`: `restart`, attempts to restart the system upon
-    detecting corruption.
+  - `"fail"`: Default setting. Without specifying argument of corruption
+    behaviors, or giving an string `fail`, by default kernel fails the IO
+    operation with I/O error.
+  - `ignore`: ignores the corruption and continues operation.
+  - `panic`: causes the system to panic (print errors) and then try restarting
+    if corruption is detected.
+  - `restart`: attempts to restart the system upon detecting corruption.
 
 Example:
 

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -350,8 +350,8 @@ please refer to the [overlay type](#overlay-type) section.
 
 - `corruptionOption`: Optional. Specifies the behavior in case of detected
   corruption. This is configurable with the following options:
-  - `"fail"`: Default setting. Without specifying argument of corruption
-    behaviors, or giving an string `fail`, by default kernel fails the IO
+  - `io-error`: Default setting. Without specifying argument of corruption
+    behaviors, or giving an string `io-error`, by default kernel fails the IO
     operation with I/O error.
   - `ignore`: ignores the corruption and continues operation.
   - `panic`: causes the system to panic (print errors) and then try restarting

--- a/toolkit/tools/imagecustomizerapi/corruptionoption.go
+++ b/toolkit/tools/imagecustomizerapi/corruptionoption.go
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type CorruptionOption string
+
+const (
+	CorruptionOptionDefault CorruptionOption = ""
+	CorruptionOptionIgnore  CorruptionOption = "ignore"
+	CorruptionOptionPanic   CorruptionOption = "panic"
+	CorruptionOptionRestart CorruptionOption = "restart"
+)
+
+func (c CorruptionOption) IsValid() error {
+	switch c {
+	case CorruptionOptionDefault, CorruptionOptionIgnore, CorruptionOptionPanic, CorruptionOptionRestart:
+		// All good.
+		return nil
+
+	default:
+		return fmt.Errorf("invalid CorruptionOption value (%v)", c)
+	}
+}

--- a/toolkit/tools/imagecustomizerapi/corruptionoption.go
+++ b/toolkit/tools/imagecustomizerapi/corruptionoption.go
@@ -10,6 +10,7 @@ import (
 type CorruptionOption string
 
 const (
+	CorruptionOptionDefault CorruptionOption = ""
 	CorruptionOptionIoError CorruptionOption = "io-error"
 	CorruptionOptionIgnore  CorruptionOption = "ignore"
 	CorruptionOptionPanic   CorruptionOption = "panic"
@@ -18,7 +19,11 @@ const (
 
 func (c CorruptionOption) IsValid() error {
 	switch c {
-	case CorruptionOptionIoError, CorruptionOptionIgnore, CorruptionOptionPanic, CorruptionOptionRestart:
+	case CorruptionOptionDefault,
+		CorruptionOptionIoError,
+		CorruptionOptionIgnore,
+		CorruptionOptionPanic,
+		CorruptionOptionRestart:
 		// All good.
 		return nil
 

--- a/toolkit/tools/imagecustomizerapi/corruptionoption.go
+++ b/toolkit/tools/imagecustomizerapi/corruptionoption.go
@@ -10,7 +10,7 @@ import (
 type CorruptionOption string
 
 const (
-	CorruptionOptionDefault CorruptionOption = ""
+	CorruptionOptionIoError CorruptionOption = "io-error"
 	CorruptionOptionIgnore  CorruptionOption = "ignore"
 	CorruptionOptionPanic   CorruptionOption = "panic"
 	CorruptionOptionRestart CorruptionOption = "restart"
@@ -18,7 +18,7 @@ const (
 
 func (c CorruptionOption) IsValid() error {
 	switch c {
-	case CorruptionOptionDefault, CorruptionOptionIgnore, CorruptionOptionPanic, CorruptionOptionRestart:
+	case CorruptionOptionIoError, CorruptionOptionIgnore, CorruptionOptionPanic, CorruptionOptionRestart:
 		// All good.
 		return nil
 

--- a/toolkit/tools/imagecustomizerapi/corruptionoption_test.go
+++ b/toolkit/tools/imagecustomizerapi/corruptionoption_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCorruptionOptionDefaultIsValid(t *testing.T) {
+	err := CorruptionOptionDefault.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestCorruptionOptionPanicIsValid(t *testing.T) {
+	err := CorruptionOptionPanic.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestCorruptionOptionIsValidBadValue(t *testing.T) {
+	err := CorruptionOption("bad").IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid CorruptionOption value")
+}

--- a/toolkit/tools/imagecustomizerapi/corruptionoption_test.go
+++ b/toolkit/tools/imagecustomizerapi/corruptionoption_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCorruptionOptionDefaultIsValid(t *testing.T) {
-	err := CorruptionOptionDefault.IsValid()
+func TestCorruptionOptionIoErrorIsValid(t *testing.T) {
+	err := CorruptionOptionIoError.IsValid()
 	assert.NoError(t, err)
 }
 

--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Verity struct {
-	DataPartition IdentifiedPartition `yaml:"dataPartition"`
-	HashPartition IdentifiedPartition `yaml:"hashPartition"`
+	DataPartition    IdentifiedPartition `yaml:"dataPartition"`
+	HashPartition    IdentifiedPartition `yaml:"hashPartition"`
+	CorruptionOption *CorruptionOption   `yaml:"corruptionOption"`
 }
 
 func (v *Verity) IsValid() error {
@@ -19,6 +20,12 @@ func (v *Verity) IsValid() error {
 
 	if err := v.HashPartition.IsValid(); err != nil {
 		return fmt.Errorf("invalid hashPartition: %v", err)
+	}
+
+	if v.CorruptionOption != nil {
+		if err := v.CorruptionOption.IsValid(); err != nil {
+			return fmt.Errorf("invalid corruptionOption: %v", err)
+		}
 	}
 
 	return nil

--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -10,7 +10,7 @@ import (
 type Verity struct {
 	DataPartition    IdentifiedPartition `yaml:"dataPartition"`
 	HashPartition    IdentifiedPartition `yaml:"hashPartition"`
-	CorruptionOption *CorruptionOption   `yaml:"corruptionOption"`
+	CorruptionOption CorruptionOption    `yaml:"corruptionOption"`
 }
 
 func (v *Verity) IsValid() error {
@@ -22,10 +22,8 @@ func (v *Verity) IsValid() error {
 		return fmt.Errorf("invalid hashPartition: %v", err)
 	}
 
-	if v.CorruptionOption != nil {
-		if err := v.CorruptionOption.IsValid(); err != nil {
-			return fmt.Errorf("invalid corruptionOption: %v", err)
-		}
+	if err := v.CorruptionOption.IsValid(); err != nil {
+		return fmt.Errorf("invalid corruptionOption: %v", err)
 	}
 
 	return nil

--- a/toolkit/tools/imagecustomizerapi/verity_test.go
+++ b/toolkit/tools/imagecustomizerapi/verity_test.go
@@ -53,7 +53,7 @@ func TestVerityIsValid(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		corruptionOption: "panic",
+		CorruptionOption: "panic",
 	}
 
 	err := validVerity.IsValid()
@@ -70,7 +70,7 @@ func TestVerityIsValidInvalidCorruptionOption(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		corruptionOption: "bad",
+		CorruptionOption: "bad",
 	}
 
 	err := invalidVerity.IsValid()

--- a/toolkit/tools/imagecustomizerapi/verity_test.go
+++ b/toolkit/tools/imagecustomizerapi/verity_test.go
@@ -44,6 +44,8 @@ func TestVerityIsValidInvalidHashPartition(t *testing.T) {
 }
 
 func TestVerityIsValid(t *testing.T) {
+	panicOption := CorruptionOption("panic")
+
 	validVerity := Verity{
 		DataPartition: IdentifiedPartition{
 			IdType: "part-uuid",
@@ -53,7 +55,7 @@ func TestVerityIsValid(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		CorruptionOption: CorruptionOption("panic"),
+		CorruptionOption: &panicOption,
 	}
 
 	err := validVerity.IsValid()
@@ -61,6 +63,8 @@ func TestVerityIsValid(t *testing.T) {
 }
 
 func TestVerityIsValidInvalidCorruptionOption(t *testing.T) {
+	badOption := CorruptionOption("bad")
+
 	invalidVerity := Verity{
 		DataPartition: IdentifiedPartition{
 			IdType: "part-uuid",
@@ -70,7 +74,7 @@ func TestVerityIsValidInvalidCorruptionOption(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		CorruptionOption: CorruptionOption("bad"),
+		CorruptionOption: &badOption,
 	}
 
 	err := invalidVerity.IsValid()

--- a/toolkit/tools/imagecustomizerapi/verity_test.go
+++ b/toolkit/tools/imagecustomizerapi/verity_test.go
@@ -53,7 +53,7 @@ func TestVerityIsValid(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		CorruptionOption: "panic",
+		CorruptionOption: CorruptionOption("panic"),
 	}
 
 	err := validVerity.IsValid()
@@ -70,7 +70,7 @@ func TestVerityIsValidInvalidCorruptionOption(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		CorruptionOption: "bad",
+		CorruptionOption: CorruptionOption("bad"),
 	}
 
 	err := invalidVerity.IsValid()

--- a/toolkit/tools/imagecustomizerapi/verity_test.go
+++ b/toolkit/tools/imagecustomizerapi/verity_test.go
@@ -44,8 +44,6 @@ func TestVerityIsValidInvalidHashPartition(t *testing.T) {
 }
 
 func TestVerityIsValid(t *testing.T) {
-	panicOption := CorruptionOption("panic")
-
 	validVerity := Verity{
 		DataPartition: IdentifiedPartition{
 			IdType: "part-uuid",
@@ -55,7 +53,7 @@ func TestVerityIsValid(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		CorruptionOption: &panicOption,
+		CorruptionOption: CorruptionOption("panic"),
 	}
 
 	err := validVerity.IsValid()
@@ -63,8 +61,6 @@ func TestVerityIsValid(t *testing.T) {
 }
 
 func TestVerityIsValidInvalidCorruptionOption(t *testing.T) {
-	badOption := CorruptionOption("bad")
-
 	invalidVerity := Verity{
 		DataPartition: IdentifiedPartition{
 			IdType: "part-uuid",
@@ -74,7 +70,7 @@ func TestVerityIsValidInvalidCorruptionOption(t *testing.T) {
 			IdType: "part-label",
 			Id:     "hash_partition",
 		},
-		CorruptionOption: &badOption,
+		CorruptionOption: CorruptionOption("bad"),
 	}
 
 	err := invalidVerity.IsValid()

--- a/toolkit/tools/imagecustomizerapi/verity_test.go
+++ b/toolkit/tools/imagecustomizerapi/verity_test.go
@@ -42,3 +42,38 @@ func TestVerityIsValidInvalidHashPartition(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "invalid hashPartition")
 }
+
+func TestVerityIsValid(t *testing.T) {
+	validVerity := Verity{
+		DataPartition: IdentifiedPartition{
+			IdType: "part-uuid",
+			Id:     "123e4567-e89b-4d3a-a456-426614174000",
+		},
+		HashPartition: IdentifiedPartition{
+			IdType: "part-label",
+			Id:     "hash_partition",
+		},
+		corruptionOption: "panic",
+	}
+
+	err := validVerity.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestVerityIsValidInvalidCorruptionOption(t *testing.T) {
+	invalidVerity := Verity{
+		DataPartition: IdentifiedPartition{
+			IdType: "part-uuid",
+			Id:     "123e4567-e89b-4d3a-a456-426614174000",
+		},
+		HashPartition: IdentifiedPartition{
+			IdType: "part-label",
+			Id:     "hash_partition",
+		},
+		corruptionOption: "bad",
+	}
+
+	err := invalidVerity.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid CorruptionOption value")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -199,7 +199,7 @@ func systemdFormatCorruptionOption(corruptionOption *imagecustomizerapi.Corrupti
 	}
 
 	switch *corruptionOption {
-	case imagecustomizerapi.CorruptionOptionDefault:
+	case imagecustomizerapi.CorruptionOptionIoError:
 		return "", nil
 	case imagecustomizerapi.CorruptionOptionIgnore:
 		return "ignore-corruption", nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -195,9 +195,7 @@ func systemdFormatPartitionId(idType imagecustomizerapi.IdType, id string) (stri
 
 func systemdFormatCorruptionOption(corruptionOption imagecustomizerapi.CorruptionOption) (string, error) {
 	switch corruptionOption {
-	case imagecustomizerapi.CorruptionOptionDefault:
-		return "", nil
-	case imagecustomizerapi.CorruptionOptionIoError:
+	case imagecustomizerapi.CorruptionOptionDefault, imagecustomizerapi.CorruptionOptionIoError:
 		return "", nil
 	case imagecustomizerapi.CorruptionOptionIgnore:
 		return "ignore-corruption", nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -89,7 +89,7 @@ func updateFstabForVerity(buildDir string, imageChroot *safechroot.Chroot) error
 
 func updateGrubConfig(dataPartitionIdType imagecustomizerapi.IdType, dataPartitionId string,
 	hashPartitionIdType imagecustomizerapi.IdType, hashPartitionId string,
-	corruptionOption *imagecustomizerapi.CorruptionOption, rootHash string, grubCfgFullPath string,
+	corruptionOption imagecustomizerapi.CorruptionOption, rootHash string, grubCfgFullPath string,
 ) error {
 	var err error
 
@@ -193,12 +193,10 @@ func systemdFormatPartitionId(idType imagecustomizerapi.IdType, id string) (stri
 	}
 }
 
-func systemdFormatCorruptionOption(corruptionOption *imagecustomizerapi.CorruptionOption) (string, error) {
-	if corruptionOption == nil {
+func systemdFormatCorruptionOption(corruptionOption imagecustomizerapi.CorruptionOption) (string, error) {
+	switch corruptionOption {
+	case imagecustomizerapi.CorruptionOptionDefault:
 		return "", nil
-	}
-
-	switch *corruptionOption {
 	case imagecustomizerapi.CorruptionOptionIoError:
 		return "", nil
 	case imagecustomizerapi.CorruptionOptionIgnore:
@@ -208,7 +206,7 @@ func systemdFormatCorruptionOption(corruptionOption *imagecustomizerapi.Corrupti
 	case imagecustomizerapi.CorruptionOptionRestart:
 		return "restart-on-corruption", nil
 	default:
-		return "", fmt.Errorf("invalid corruptionOption provided (%s)", string(*corruptionOption))
+		return "", fmt.Errorf("invalid corruptionOption provided (%s)", string(corruptionOption))
 	}
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -512,7 +512,8 @@ func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *
 	}
 
 	err = updateGrubConfig(config.OS.Verity.DataPartition.IdType, config.OS.Verity.DataPartition.Id,
-		config.OS.Verity.HashPartition.IdType, config.OS.Verity.HashPartition.Id, rootHash, grubCfgFullPath)
+		config.OS.Verity.HashPartition.IdType, config.OS.Verity.HashPartition.Id, config.OS.Verity.CorruptionOption,
+		rootHash, grubCfgFullPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Mariner should not go into an endless reboot loop when one of files protected by verity becomes corrupted.
We could expose separate verity action, that does not cause kernel panic.
The options added are all that systemd supports today.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local MIC build

Related internal task tracking: https://dev.azure.com/mariner-org/ECF/_workitems/edit/7151/
