### PR TITLE
pytorch: fix cve-2024-31580, cve-2024-31583, cve-2024-27319

### DIFF
--- a/SPECS/pytorch/CVE-2024-27319.patch
+++ b/SPECS/pytorch/CVE-2024-27319.patch
@@ -1,0 +1,72 @@
+diff -urpN pytorch-v2.0.0/third_party/onnx/onnx/common/assertions.cc b/third_party/onnx/onnx/common/assertions.cc
+--- pytorch-v2.0.0/third_party/onnx/onnx/common/assertions.cc	2023-04-03 15:46:03.000000000 -0400
++++ b/third_party/onnx/onnx/common/assertions.cc	2024-04-22 13:15:05.240131051 -0400
+@@ -6,6 +6,7 @@
+ // Adventurous users should note that the APIs will probably change.
+ 
+ #include "onnx/common/assertions.h"
++#include <array>
+ #include <cstdarg>
+ #include <cstdio>
+ #include "onnx/common/common.h"
+@@ -13,16 +14,20 @@
+ namespace ONNX_NAMESPACE {
+ 
+ std::string barf(const char* fmt, ...) {
+-  char msg[2048];
++  constexpr size_t buffer_size = 2048;
++  std::array<char, buffer_size> msg{};
+   va_list args;
+ 
+   va_start(args, fmt);
+-  // Although vsnprintf might have vulnerability issue while using format string with overflowed length,
+-  // it should be safe here to use fixed length for buffer "msg". No further checking is needed.
+-  vsnprintf(msg, 2048, fmt, args);
++
++  // use fixed length for buffer "msg" to avoid buffer overflow
++  vsnprintf(static_cast<char*>(msg.data()), msg.size() - 1, fmt, args);
++
++  // ensure null-terminated string to avoid out of bounds read
++  msg.back() = '\0';
+   va_end(args);
+ 
+-  return std::string(msg);
++  return std::string(msg.data());
+ }
+ 
+ void throw_assert_error(std::string& msg) {
+diff -urpN pytorch-v2.0.0/third_party/onnx-tensorrt/third_party/onnx/onnx/common/assertions.cc b/third_party/onnx-tensorrt/third_party/onnx/onnx/common/assertions.cc
+--- pytorch-v2.0.0/third_party/onnx-tensorrt/third_party/onnx/onnx/common/assertions.cc	2023-04-03 15:46:03.000000000 -0400
++++ b/third_party/onnx-tensorrt/third_party/onnx/onnx/common/assertions.cc	2024-04-22 13:14:01.512210959 -0400
+@@ -1,6 +1,7 @@
+ // ATTENTION: The code in this file is highly EXPERIMENTAL.
+ // Adventurous users should note that the APIs will probably change.
+ 
++#include <array>
+ #include <cstdarg>
+ #include <cstdio>
+ 
+@@ -9,14 +10,20 @@
+ namespace ONNX_NAMESPACE {
+ 
+ std::string barf(const char* fmt, ...) {
+-  char msg[2048];
++  constexpr size_t buffer_size = 2048;
++  std::array<char, buffer_size> msg{};
+   va_list args;
+ 
+   va_start(args, fmt);
+-  vsnprintf(msg, 2048, fmt, args);
++
++  // use fixed length for buffer "msg" to avoid buffer overflow
++  vsnprintf(static_cast<char*>(msg.data()), msg.size() - 1, fmt, args);
++
++  // ensure null-terminated string to avoid out of bounds read
++  msg.back() = '\0';
+   va_end(args);
+ 
+-  return std::string(msg);
++  return std::string(msg.data());
+ }
+ 
+ void throw_assert_error(std::string& msg) {

--- a/SPECS/pytorch/CVE-2024-31580.patch
+++ b/SPECS/pytorch/CVE-2024-31580.patch
@@ -1,0 +1,38 @@
+From b5c3a17c2c207ebefcb85043f0cf94be9b2fef81 Mon Sep 17 00:00:00 2001
+From: Octavian Guzu <octavguzu@fb.com>
+Date: Tue, 3 Oct 2023 18:48:08 +0000
+Subject: [PATCH] [fuzzing result][fuzz_torch_jit_lite_interpreter]
+ read-heap-buffer-overflow-far-from-bounds (size 4) in c10::IValue::IValue()
+ (#110441)
+
+Summary: This diff fixes a heap underflow found by fuzzing in torch/csrc/jit/runtime/vararg_functions.cpp
+
+Test Plan:
+CI and
+```
+arc lionhead crash reproduce 1753074381791061
+```
+doesn't crash anymore.
+
+Differential Revision: D49537535
+
+Pull Request resolved: https://github.com/pytorch/pytorch/pull/110441
+Approved by: https://github.com/Skylion007
+---
+ torch/csrc/jit/runtime/vararg_functions.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/torch/csrc/jit/runtime/vararg_functions.cpp b/torch/csrc/jit/runtime/vararg_functions.cpp
+index 69e2c0fc1790603..bb28b61fe7e2c89 100644
+--- a/torch/csrc/jit/runtime/vararg_functions.cpp
++++ b/torch/csrc/jit/runtime/vararg_functions.cpp
+@@ -267,6 +267,9 @@ void listUnpack(Stack& stack, size_t num_outputs) {
+ }
+ 
+ void tupleConstruct(Stack& stack, size_t num_inputs) {
++  if (num_inputs > stack.size()) {
++    TORCH_CHECK(false, "Invalid number of inputs: ", num_inputs);
++  }
+   switch (num_inputs) {
+     case 0:
+       stack.emplace_back(c10::ivalue::Tuple::create());

--- a/SPECS/pytorch/CVE-2024-31583.patch
+++ b/SPECS/pytorch/CVE-2024-31583.patch
@@ -1,0 +1,42 @@
+From 9c7071b0e324f9fb68ab881283d6b8d388a4bcd2 Mon Sep 17 00:00:00 2001
+From: Octavian Guzu <octavian.guzu@gmail.com>
+Date: Fri, 29 Sep 2023 22:32:34 +0000
+Subject: [PATCH] [fuzzing result][fuzz_torch_jit_lite_interpreter]
+ read-heap-use-after-free (size 8) in std::_Function_base::_M_empty()
+ (#110289)
+
+Summary: This diff fixes a heap UAF found by fuzzing in torch/csrc/jit/mobile/interpreter.cpp
+
+Test Plan:
+CI and
+```
+arc lionhead crash reproduce 1009060456885023
+```
+doesn't crash anymore.
+
+Reviewed By: malfet
+
+Differential Revision: D49538326
+
+Pull Request resolved: https://github.com/pytorch/pytorch/pull/110289
+Approved by: https://github.com/malfet
+---
+ torch/csrc/jit/mobile/interpreter.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/torch/csrc/jit/mobile/interpreter.cpp b/torch/csrc/jit/mobile/interpreter.cpp
+index 9183c067f6599e8..6324ea9e3f03a18 100644
+--- a/torch/csrc/jit/mobile/interpreter.cpp
++++ b/torch/csrc/jit/mobile/interpreter.cpp
+@@ -128,7 +128,10 @@ bool InterpreterState::run(Stack& stack) {
+               mobile_debug_info->setOpIdx(pc);
+             }
+           }
+-
++          if (inst.X < 0 ||
++              static_cast<size_t>(inst.X) >= code.operators_.size()) {
++            throw JITException("Invalid OP Instruction");
++          }
+           RECORD_EDGE_SCOPE_WITH_DEBUG_HANDLE_AND_INPUTS(
+               code.op_names_[inst.X].name, debug_handle, stack);
+           code.operators_[inst.X](stack);

--- a/SPECS/pytorch/pytorch.spec
+++ b/SPECS/pytorch/pytorch.spec
@@ -12,6 +12,7 @@ Source0:        https://github.com/pytorch/pytorch/releases/download/v%{version}
 # Use the generate_source_tarball.sh script to create a tarball of submodules during version updates.
 Source1:        %{name}-%{version}-submodules.tar.gz
 Patch0:         CVE-2024-31580.patch
+Patch1:         CVE-2024-31583.patch
 BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
@@ -84,7 +85,7 @@ cp -arf docs %{buildroot}/%{_pkgdocdir}
 
 %changelog
 * Mon Apr 22 2024 Dan Streetman <ddstreet@microsoft.com> - 2.0.0-4
-- patch CVE-2024-31580
+- patch CVE-2024-31580, CVE-2024-31583
 
 * Mon Dec 18 2023 Mandeep Plaha <mandeepplaha@microsoft.com> - 2.0.0-3
 - Set MAX_JOBS=8 to prevent build failure in ADO pipelines

--- a/SPECS/pytorch/pytorch.spec
+++ b/SPECS/pytorch/pytorch.spec
@@ -13,6 +13,8 @@ Source0:        https://github.com/pytorch/pytorch/releases/download/v%{version}
 Source1:        %{name}-%{version}-submodules.tar.gz
 Patch0:         CVE-2024-31580.patch
 Patch1:         CVE-2024-31583.patch
+Patch2:         CVE-2024-27319.patch
+
 BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  gcc-c++

--- a/SPECS/pytorch/pytorch.spec
+++ b/SPECS/pytorch/pytorch.spec
@@ -2,7 +2,7 @@
 Summary:        Tensors and Dynamic neural networks in Python with strong GPU acceleration.
 Name:           pytorch
 Version:        2.0.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ URL:            https://pytorch.org/
 Source0:        https://github.com/pytorch/pytorch/releases/download/v%{version}/%{name}-v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Use the generate_source_tarball.sh script to create a tarball of submodules during version updates.
 Source1:        %{name}-%{version}-submodules.tar.gz
+Patch0:         CVE-2024-31580.patch
 BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
@@ -55,7 +56,7 @@ PyTorch is a Python package that provides two high-level features:
 You can reuse your favorite Python packages such as NumPy, SciPy and Cython to extend PyTorch when needed.
 
 %prep
-%autosetup -a 1 -n %{name}-v%{version}
+%autosetup -a 1 -p 1 -n %{name}-v%{version}
 
 %build
 # Use MAX_JOBS=8 to prevent build failure in ADO pipelines
@@ -82,6 +83,9 @@ cp -arf docs %{buildroot}/%{_pkgdocdir}
 %{_docdir}/*
 
 %changelog
+* Mon Apr 22 2024 Dan Streetman <ddstreet@microsoft.com> - 2.0.0-4
+- patch CVE-2024-31580
+
 * Mon Dec 18 2023 Mandeep Plaha <mandeepplaha@microsoft.com> - 2.0.0-3
 - Set MAX_JOBS=8 to prevent build failure in ADO pipelines
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
PAtches 'pytorch' package for cve-2024-31580, cve-2024-31583, cve-2024-27319


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
PAtches 'pytorch' package for cve-2024-31580, cve-2024-31580, cve-2024-27319
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/cve-2024-31580
- https://nvd.nist.gov/vuln/detail/cve-2024-31583
- https://nvd.nist.gov/vuln/detail/cve-2024-27319

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=555643&view=results