### PR TITLE
Update sos to copy kernel config and vmcore

### DIFF
--- a/SPECS/sos/copy-kernel-config.patch
+++ b/SPECS/sos/copy-kernel-config.patch
@@ -1,0 +1,33 @@
+From f4df6e9abad6601ad1d67821306be0117dbfab24 Mon Sep 17 00:00:00 2001
+From: Aadhar Agarwal <aadagarwal@microsoft.com>
+Date: Thu, 21 Mar 2024 14:25:09 -0700
+Subject: [PATCH] [kernel] Copy the kernel config
+
+Signed-off-by: Aadhar Agarwal <aadagarwal@microsoft.com>
+---
+ sos/report/plugins/kernel.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/sos/report/plugins/kernel.py b/sos/report/plugins/kernel.py
+index d09d1176e1..1503af2bc9 100644
+--- a/sos/report/plugins/kernel.py
++++ b/sos/report/plugins/kernel.py
+@@ -111,7 +111,7 @@ def setup(self):
+             "/proc/buddyinfo",
+             "/proc/slabinfo",
+             "/proc/zoneinfo",
+-            "/lib/modules/%s/modules.dep" % self.policy.kernel_version(),
++            f"/lib/modules/{self.policy.kernel_version()}/modules.dep",
+             "/etc/conf.modules",
+             "/etc/modules.conf",
+             "/etc/modprobe.conf",
+@@ -136,7 +136,8 @@ def setup(self):
+             "/sys/kernel/debug/extfrag/extfrag_index",
+             clocksource_path + "available_clocksource",
+             clocksource_path + "current_clocksource",
+-            "/proc/pressure/"
++            "/proc/pressure/",
++            f"/boot/config-{self.policy.kernel_version()}"
+         ])
+ 
+         if self.get_option("with-timer"):

--- a/SPECS/sos/create-azure-kdump-class.patch
+++ b/SPECS/sos/create-azure-kdump-class.patch
@@ -1,0 +1,81 @@
+From ab520a3ad3eb891802366616b000288f647b2163 Mon Sep 17 00:00:00 2001
+From: Aadhar Agarwal <aadagarwal@microsoft.com>
+Date: Mon, 15 Apr 2024 16:32:43 -0700
+Subject: [PATCH] [kdump] Create AzureKDump class
+
+This change collects kdump information for Azure Linux.
+
+With this change, we will check the 'path' variable in /etc/kdump.conf
+to check where information is being dumped.
+
+If get_vm_core is set to true, collect the latest vm core created
+in the last 24 hours that is <= 2GB
+
+Signed-off-by: Aadhar Agarwal <aadagarwal@microsoft.com>
+---
+ sos/report/plugins/kdump.py | 47 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/sos/report/plugins/kdump.py b/sos/report/plugins/kdump.py
+index e31e9408f0..9440125642 100644
+--- a/sos/report/plugins/kdump.py
++++ b/sos/report/plugins/kdump.py
+@@ -8,7 +8,7 @@
+ 
+ import platform
+ from sos.report.plugins import Plugin, PluginOpt, RedHatPlugin, DebianPlugin, \
+-    UbuntuPlugin, CosPlugin
++    UbuntuPlugin, CosPlugin, AzurePlugin
+ 
+ 
+ class KDump(Plugin):
+@@ -124,4 +124,49 @@ def setup(self):
+         if self.get_option("collect-kdumps"):
+             self.add_copy_spec(["/var/kdump-*"])
+ 
++
++class AzureKDump(KDump, AzurePlugin):
++
++    files = ('/etc/kdump.conf',)
++    packages = ('kexec-tools',)
++
++    option_list = [
++        PluginOpt("get_vm_core", default=False, val_type=bool,
++                  desc="collect vm core")
++    ]
++
++    def read_kdump_conffile(self):
++        """ Parse /etc/kdump file """
++        path = "/var/crash"
++
++        kdump = '/etc/kdump.conf'
++        with open(kdump, 'r', encoding='UTF-8') as file:
++            for line in file:
++                if line.startswith("path"):
++                    path = line.split()[1]
++
++        return path
++
++    def setup(self):
++        super().setup()
++
++        self.add_copy_spec([
++            "/etc/kdump.conf",
++            "/usr/lib/udev/rules.d/*kexec.rules"
++        ])
++
++        try:
++            path = self.read_kdump_conffile()
++        except Exception:  # pylint: disable=broad-except
++            # set no filesystem and default path
++            path = "/var/crash"
++
++        self.add_cmd_output(f"ls -alhR {path}")
++        self.add_copy_spec(f"{path}/*/vmcore-dmesg.txt")
++        self.add_copy_spec(f"{path}/*/kexec-dmesg.log")
++
++        # collect the latest vmcore created in the last 24hrs <= 2GB
++        if self.get_option("get_vm_core"):
++            self.add_copy_spec(f"{path}/*/vmcore", sizelimit=2048, maxage=24)
++
+ # vim: set et ts=4 sw=4 :

--- a/SPECS/sos/create-azure-plugin.patch
+++ b/SPECS/sos/create-azure-plugin.patch
@@ -1,0 +1,66 @@
+From 8a7fdf7f3e1194fa4674eea1d5442ca1660c0a67 Mon Sep 17 00:00:00 2001
+From: Aadhar Agarwal <aadagarwal@microsoft.com>
+Date: Tue, 19 Mar 2024 11:19:38 -0700
+Subject: [PATCH] [Plugin,Policy] Make an AzurePlugin class, Update the vendor
+ url, Update the check function
+
+Signed-off-by: Aadhar Agarwal <aadagarwal@microsoft.com>
+---
+ sos/policies/distros/azure.py  | 6 +++++-
+ sos/report/plugins/__init__.py | 5 +++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/sos/policies/distros/azure.py b/sos/policies/distros/azure.py
+index 950799fa83..b521d1e1be 100644
+--- a/sos/policies/distros/azure.py
++++ b/sos/policies/distros/azure.py
+@@ -8,6 +8,7 @@
+ #
+ # See the LICENSE file in the source distribution for further information.
+ 
++from sos.report.plugins import AzurePlugin
+ from sos.policies.distros.redhat import RedHatPolicy, OS_RELEASE
+ import os
+ 
+@@ -17,7 +18,7 @@ class AzurePolicy(RedHatPolicy):
+     distro = "Azure Linux"
+     vendor = "Microsoft"
+     vendor_urls = [
+-        ('Distribution Website', 'https://github.com/microsoft/CBL-Mariner')
++        ('Distribution Website', 'https://github.com/microsoft/azurelinux')
+     ]
+ 
+     def __init__(self, sysroot=None, init=None, probe_runtime=True,
+@@ -25,6 +26,7 @@ def __init__(self, sysroot=None, init=None, probe_runtime=True,
+         super(AzurePolicy, self).__init__(sysroot=sysroot, init=init,
+                                           probe_runtime=probe_runtime,
+                                           remote_exec=remote_exec)
++        self.valid_subclasses += [AzurePlugin]
+ 
+     @classmethod
+     def check(cls, remote=''):
+@@ -40,6 +42,8 @@ def check(cls, remote=''):
+                 if line.startswith('NAME'):
+                     if 'Common Base Linux Mariner' in line:
+                         return True
++                    if 'Microsoft Azure Linux' in line:
++                        return True
+         return False
+ 
+ # vim: set et ts=4 sw=4 :
+diff --git a/sos/report/plugins/__init__.py b/sos/report/plugins/__init__.py
+index 94ee50d7fd..fc674be086 100644
+--- a/sos/report/plugins/__init__.py
++++ b/sos/report/plugins/__init__.py
+@@ -3621,6 +3621,11 @@ class SCLPlugin(RedHatPlugin):
+         self.add_copy_spec(scl_copyspecs)
+ 
+ 
++class AzurePlugin(PluginDistroTag):
++    """Tagging class for Azure Linux"""
++    pass
++
++
+ def import_plugin(name, superclasses=None):
+     """Import name as a module and return a list of all classes defined in that
+     module. superclasses should be a tuple of valid superclasses to import,

--- a/SPECS/sos/sos.spec
+++ b/SPECS/sos/sos.spec
@@ -2,7 +2,7 @@
 Summary:        A set of tools to gather troubleshooting information from a system
 Name:           sos
 Version:        4.6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,9 @@ Source0:        https://github.com/sosreport/sos/archive/%{version}.tar.gz#/%{na
 # The sos-4.6.1.tar.gz is missing a commit to bump the version to 4.6.1
 # https://github.com/orgs/sosreport/discussions/3492
 Patch0:         bump-version-4-6-1.patch
+Patch1:         create-azure-plugin.patch
+Patch2:         copy-kernel-config.patch
+Patch3:         create-azure-kdump-class.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 Requires:       bzip2
@@ -73,6 +76,11 @@ rm -rf %{buildroot}%{_prefix}/config/
 %config(noreplace) %{_sysconfdir}/sos/sos.conf
 
 %changelog
+* Thu Apr 18 2024 Aadhar Agarwal <aadagarwal@microsoft.com> - 4.6.1-2
+- Backport a patch that adds an AzurePlugin class
+- Backport a patch to copy the kernel config
+- Backport a patch that adds an AzureKDump class
+
 * Tue Jan 30 2024 Aadhar Agarwal <aadagarwal@microsoft.com> - 4.6.1-1
 - Upgrade to 4.6.1
 - Migrated to SPDX license


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- This PR backports changes from upstream sos to gather more information in the sosreport

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- 3 patches have been introduced
- `create-azure-plugin.patch` - upstream [change](https://github.com/sosreport/sos/pull/3576)
    - Created an AzurePlugin class - This will help us create custom Azure classes for plugins
    - Changed the distribution website to point to `https://github.com/microsoft/azurelinux` instead of `https://github.com/microsoft/CBL-Mariner`
    - Modified the `check` function to also check for `Microsoft Azure Linux` in `/etc/os-release`

- `copy-kernel-config.patch`  - upstream [change](https://github.com/sosreport/sos/pull/3580)
    - Copy the Azure Linux kernel config - `/boot/config-{kernel-version}`

- `create-azure-kdump-class.patch` - upstream [change](https://github.com/sosreport/sos/pull/3599)
    - Created an Azure KDump class
         - In this class, we are checking the `path` variable from `/etc/kdump.conf` file, and getting information from there
         - We introduce a new sos plugin opt called `get_vm_core`. Its value is false by default. If we would like to collect vm cores, then we need to set its value to true.
         - When its value is set to true, it will collect the vmcores produced in the last 24 hours that are <= 2GB
         - Here are a couple of ways to set the plugin opt to true:
             - `sudo sos report -o kdump -k kdump.get_vm_core=true` - This only runs the kdump plugin
             - `sudo sos report -a -k kdump.get_vm_core=true` - This runs all the plugins

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/49177429

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=555641&view=results
- Installed the sos report rpm into a 2.0 Azure VM and ensured the changes are present and sos report is functional

- Verified the latest sos rpm can be installed: 
![image](https://github.com/microsoft/azurelinux/assets/108542189/19e1cb91-e557-47b6-aeb8-8b6dee0a363e)

- Verified the new sos plugin opt `kdump.get_vm_core` exists:
![image](https://github.com/microsoft/azurelinux/assets/108542189/9c3bd128-e253-4674-ab06-70e94008b081)

- Verified the Distribution Website is correct: 
![image](https://github.com/microsoft/azurelinux/assets/108542189/a215a542-5a29-450c-b9cd-49993935bbc6)

- Verified that the kernel config is present:
![image](https://github.com/microsoft/azurelinux/assets/108542189/e488c3c6-f7fd-4e4c-a731-6d935389b492)

- Verified that sos tried collecting the vmcore but it was greater than 2GB so it was skipped:
![image](https://github.com/microsoft/azurelinux/assets/108542189/d60bf14f-116d-4cc2-b2da-3b5f7b832425)


