### PR TITLE
Patch CVE-2024-3817 in terraform's vendored go-getter

### DIFF
--- a/SPECS/terraform/CVE-2024-3817.patch
+++ b/SPECS/terraform/CVE-2024-3817.patch
@@ -1,0 +1,36 @@
+From aa98faf317f26cd461740fd79bf67abb9890fa07 Mon Sep 17 00:00:00 2001
+From: Mark Collao <mark.collao@hashicorp.com>
+Date: Fri, 12 Apr 2024 14:06:23 -0500
+Subject: [PATCH] escape user provide string to git
+
+Modified to apply to vendored code by: Daniel McIlvaney <damcilva@microsoft.com>
+ - Adjusted paths to work for vendored version
+ - Removed test code since it is not included in vendor trace
+---
+ vendor/github.com/hashicorp/go-getter/get_git.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/github.com/hashicorp/go-getter/get_git.go b/vendor/github.com/hashicorp/go-getter/get_git.go
+index db89ede..5227db7 100644
+--- a/vendor/github.com/hashicorp/go-getter/get_git.go
++++ b/vendor/github.com/hashicorp/go-getter/get_git.go
+@@ -200,7 +200,7 @@ func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.UR
+ 		args = append(args, "--depth", strconv.Itoa(depth))
+ 		args = append(args, "--branch", ref)
+ 	}
+-	args = append(args, u.String(), dst)
++	args = append(args, "--", u.String(), dst)
+
+ 	cmd := exec.CommandContext(ctx, "git", args...)
+ 	setupGitEnv(cmd, sshKeyFile)
+@@ -289,7 +289,7 @@ func findDefaultBranch(ctx context.Context, dst string) string {
+ // default branch. "master" is returned if no HEAD symref exists.
+ func findRemoteDefaultBranch(ctx context.Context, u *url.URL) string {
+ 	var stdoutbuf bytes.Buffer
+-	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", u.String(), "HEAD")
++	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", "--", u.String(), "HEAD")
+ 	cmd.Stdout = &stdoutbuf
+ 	err := cmd.Run()
+ 	matches := lsRemoteSymRefRegexp.FindStringSubmatch(stdoutbuf.String())
+--
+2.33.8

--- a/SPECS/terraform/terraform.spec
+++ b/SPECS/terraform/terraform.spec
@@ -1,7 +1,7 @@
 Summary:        Infrastructure as code deployment management tool
 Name:           terraform
 Version:        1.3.2
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -28,10 +28,11 @@ Source0:        https://github.com/hashicorp/terraform/archive/refs/tags/v%{vers
 #       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2023-44487.patch
+Patch1:         CVE-2024-3817.patch
 
 %global debug_package %{nil}
 %define our_gopath %{_topdir}/.gopath
-BuildRequires:  golang <= 1.18.8
+BuildRequires:  golang
 
 %description
 Terraform is an infrastructure as code deployment management tool
@@ -61,6 +62,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./terraform
 %{_bindir}/terraform
 
 %changelog
+* Mon Apr 22 2024 Daniel McIlvaney <damcilva@microsoft.com> - 1.3.2-14
+- Patch CVE-2024-3817 in vendored hashicorp/go-getter
+
 * Thu Feb 01 2024 Daniel McIlvaney <damcilva@microsoft.com> - 1.3.2-13
 - Address CVE-2023-44487 by patching vendored golang.org/x/net
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch the vendored copy of `go-getter` in `terraform` with  [this patch](https://github.com/hashicorp/go-getter/pull/483) to resolve CVE-2024-3817.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2024-3817 in `terraform`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-3817

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=555704&view=results
- Local build
