### PR TITLE
New toolchain manifest update from tarball script.

### DIFF
--- a/toolkit/resources/manifests/package/update_manifests.py
+++ b/toolkit/resources/manifests/package/update_manifests.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python3
+
+# Script that updates the pkggen_core_*.txt and toolchain_*.txt files from a toolchain archive tarball.
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from typing import List, Dict
+
+# Regex for parsing the package filename.
+# e.g. "ca-certificates-2.0.0-16.cm2.noarch.rpm"
+PACKAGE_NAME_REGEX = re.compile(r'^([\w\+-]+)-([\w\.~]+)-(\d+)(\.(\w+))?\.(\w+)\.rpm$')
+
+# Get the list of package filenames from the toolchain archive tarball.
+def getToolchainArchivePackageFileNames(toolchainArchive: str) -> List[str]:
+    tarProc = subprocess.run(['tar', '-tf', toolchainArchive], check=True, text=True, capture_output=True)
+    lines = tarProc.stdout.split('\n')
+
+    packageFileNames = []
+    for line in lines:
+        if not line.startswith('built_rpms_all/'):
+            continue
+
+        packageFileName = line.removeprefix('built_rpms_all/').strip()
+        if packageFileName == "":
+            continue
+
+        packageFileNames.append(packageFileName)
+
+    return packageFileNames
+
+# Create a map from package names to package file names.
+def createPackagesMap(packageFileNames: List[str]) -> Dict[str, str]:
+    packagesMap = dict()
+    
+    for packageFileName in packageFileNames:
+        match = PACKAGE_NAME_REGEX.match(packageFileName)
+        if not match:
+            print(f"Bad package filename: {packageFileName}", file=sys.stderr)
+            continue
+
+        name, version, release, _, osVersion, arch = match.groups()
+        packagesMap[name] = packageFileName
+
+    return packagesMap
+
+# Read a toolchain manifest file.
+def readManifestFile(filename: str) -> List[str]:
+    with open(filename, 'r') as fd:
+        lines = fd.readlines()
+
+    return lines
+
+# Write a toolchain manifest file.
+def writeManifestFile(lines: List[str], filename: str) -> List[str]:
+    with open(filename, 'w') as fd:
+        for line in lines:
+            print(line, file=fd)
+
+# Update a toolchain manifest file.
+def updateManifestFile(manifestFileName: str, packagesMap: Dict[str, str], checkMissingPackages: bool):
+    lines = readManifestFile(manifestFileName)
+
+    newLines = []
+    manifestPackages = []
+    for i in range(len(lines)):
+        packageFileName = lines[i]
+
+        match = PACKAGE_NAME_REGEX.match(packageFileName)
+        if not match:
+            print(f"Bad manifest filename: {packageFileName}", file=sys.stderr)
+            continue
+
+        name, version, release, _, osVersion, arch = match.groups()
+        manifestPackages.append(name)
+
+        if name not in packagesMap:
+            print(f"Package missing from toolchain tarball: {name}", file=sys.stderr)
+            continue
+
+        newLines.append(packagesMap[name])
+
+    if checkMissingPackages:
+        # Check if there are any packages in the toolchain archive tarball that aren't in the toolchain manifest.
+        newPackages = sorted(set(packagesMap.keys()) - set(manifestPackages))
+        if len(newPackages) > 0:
+            for newPackage in newPackages:
+                print(f"Package missing from manifest: {newPackage}", file=sys.stderr)
+
+    # Write the new manifest file.
+    writeManifestFile(newLines, manifestFileName)
+
+def updateManifests(arch: str, toolchainArchive: str):
+    packageFileNames = getToolchainArchivePackageFileNames(toolchainArchive)
+    packagesMap = createPackagesMap(packageFileNames)
+
+    scriptDirectory = os.path.dirname(os.path.realpath(__file__))
+    pkggenCoreManifestPath = os.path.join(scriptDirectory, f'pkggen_core_{arch}.txt')
+    toolchainManifestPath = os.path.join(scriptDirectory, f'toolchain_{arch}.txt')
+
+    updateManifestFile(pkggenCoreManifestPath, packagesMap, False)
+    updateManifestFile(toolchainManifestPath, packagesMap, True)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('arch', choices=['x86_64', 'aarch64'], help='CPU archiecture (x86_64, aarch64)')
+    parser.add_argument('toolchain_archive', help='Path to toolchain archive tarball')
+    args = parser.parse_args()
+
+    updateManifests(args.arch, args.toolchain_archive)
+
+if __name__ == '__main__':
+    main()

--- a/toolkit/resources/manifests/package/update_manifests.py
+++ b/toolkit/resources/manifests/package/update_manifests.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Script that updates the pkggen_core_*.txt and toolchain_*.txt files from a toolchain archive tarball.
 
 import argparse


### PR DESCRIPTION
Create a new script that updates the contents of the toolchain manifest files using the contents of a toolchain archive tarball. This is intended as a replacement for the existing `update_manifests.sh` script, with  hopefully better handling the package ordering. Specifically, it uses the ordering from the existing manifest files instead of recreating the ordering manually.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran script manually.

