### PR TITLE
Image Customizer: Improve error message for missing EFI files.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -402,6 +402,18 @@ func (b *LiveOSIsoBuilder) extractBootDirFiles(writeableRootfsDir string) error 
 		}
 	}
 
+	if b.artifacts.bootx64EfiPath == "" {
+		return fmt.Errorf("failed to find the boot efi file (%s):\n"+
+			"this file is provided by the (shim) package",
+			bootx64Binary)
+	}
+
+	if b.artifacts.grubx64EfiPath == "" {
+		return fmt.Errorf("failed to find the grub efi file (%s or %s):\n"+
+			"this file is provided by either the (grub2-efi-binary) or the (grub2-efi-binary-noprefix) package",
+			grubx64Binary, grubx64NoPrefixBinary)
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomizeImageLiveCdIsoNoShimEfi(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	buildDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCdIso")
+	outImageFilePath := filepath.Join(buildDir, "image.iso")
+
+	config := &imagecustomizerapi.Config{
+		OS: imagecustomizerapi.OS{
+			Packages: imagecustomizerapi.Packages{
+				Remove: []string{
+					"shim",
+				},
+			},
+		},
+	}
+
+	// Customize image.
+	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso", "", true, false)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to find the boot efi file")
+}
+
+func TestCustomizeImageLiveCdIsoNoGrubEfi(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	buildDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCdIso")
+	outImageFilePath := filepath.Join(buildDir, "image.iso")
+
+	config := &imagecustomizerapi.Config{
+		OS: imagecustomizerapi.OS{
+			Packages: imagecustomizerapi.Packages{
+				Remove: []string{
+					"grub2-efi-binary",
+				},
+			},
+		},
+	}
+
+	// Customize image.
+	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso", "", true, false)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to find the grub efi file")
+}


### PR DESCRIPTION
When building a Live-CD using the image customizer, if the user accidentally removes the grub2-efi-binary or shim packages, then the error for what is wrong isn't particularly helpful. This change improves the error message.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer.
- Added UTs.

