### PR TITLE
fix log format in go-tools

### DIFF
--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -122,11 +122,11 @@ func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls
 			// Check if the error contains the string "invalid response: 404", we should print a warning in that case so the
 			// sees it even if we are running with --no-verbose. 404's are unlikely to fix themselves on retry, give up.
 			if netErr.Error() == "invalid response: 404" {
-				logger.Log.Warnf("Attempt (%d/%d): Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Warnf("Attempt %d/%d: Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
 				logger.Log.Warnf("404 errors are likely unrecoverable, will not retry")
 				close(cancel)
 			} else {
-				logger.Log.Infof("Attempt (%d/%d): Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Infof("Attempt %d/%d: Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
 			}
 		}
 		retryNum++

--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -94,7 +94,7 @@ func main() {
 			logger.Log.Fatalf("Failed to check if file (%s) exists. Error:\n%s", *dstFile, err)
 		}
 		if exists {
-			logger.Log.Infof("File (%s) already exists, skipping download.", *dstFile)
+			logger.Log.Infof("File (%s) already exists, skipping download", *dstFile)
 			return
 		}
 	}
@@ -122,11 +122,11 @@ func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls
 			// Check if the error contains the string "invalid response: 404", we should print a warning in that case so the
 			// sees it even if we are running with --no-verbose. 404's are unlikely to fix themselves on retry, give up.
 			if netErr.Error() == "invalid response: 404" {
-				logger.Log.Warnf("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Warnf("Attempt (%d/%d): Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
 				logger.Log.Warnf("404 errors are likely unrecoverable, will not retry")
 				close(cancel)
 			} else {
-				logger.Log.Infof("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Infof("Attempt (%d/%d): Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
 			}
 		}
 		retryNum++

--- a/toolkit/tools/graphPreprocessor/graphPreprocessor.go
+++ b/toolkit/tools/graphPreprocessor/graphPreprocessor.go
@@ -32,7 +32,7 @@ func replaceRunNodesWithPrebuiltNodes(pkgGraph *pkggraph.PkgGraph) (err error) {
 		_, missing := pkggraph.FindRPMFiles(node.SrpmPath, pkgGraph, nil)
 
 		if len(missing) > 0 {
-			logger.Log.Tracef("Can't mark %s as prebuilt, missing: %v", node.SrpmPath, missing)
+			logger.Log.Tracef("Can't mark (%s) as prebuilt, missing: (%v)", node.SrpmPath, missing)
 			continue
 		}
 
@@ -47,7 +47,7 @@ func replaceRunNodesWithPrebuiltNodes(pkgGraph *pkggraph.PkgGraph) (err error) {
 			if parentNode.Type != pkggraph.TypeGoal {
 				pkgGraph.RemoveEdge(parentNode.ID(), node.ID())
 
-				logger.Log.Debugf("Adding a 'PreBuilt' node '%s' with id %d. For '%s'", preBuiltNode.FriendlyName(), preBuiltNode.ID(), parentNode.FriendlyName())
+				logger.Log.Debugf("Adding a 'PreBuilt' node (%s) with id (%d). For (%s)", preBuiltNode.FriendlyName(), preBuiltNode.ID(), parentNode.FriendlyName())
 				err = pkgGraph.AddEdge(parentNode, preBuiltNode)
 
 				if err != nil {
@@ -72,9 +72,9 @@ func main() {
 	}
 
 	if *hydratedBuild {
-		logger.Log.Debugf("Nodes before replacing prebuilt nodes: %d", len(scrubbedGraph.AllNodes()))
+		logger.Log.Debugf("Nodes before replacing prebuilt nodes: (%d)", len(scrubbedGraph.AllNodes()))
 		err = replaceRunNodesWithPrebuiltNodes(scrubbedGraph)
-		logger.Log.Debugf("Nodes after replacing prebuilt nodes: %d", len(scrubbedGraph.AllNodes()))
+		logger.Log.Debugf("Nodes after replacing prebuilt nodes: (%d)", len(scrubbedGraph.AllNodes()))
 		if err != nil {
 			logger.Log.Panicf("Failed to replace run nodes with preBuilt nodes. Error: %s", err)
 		}

--- a/toolkit/tools/graphPreprocessor/graphPreprocessor.go
+++ b/toolkit/tools/graphPreprocessor/graphPreprocessor.go
@@ -32,7 +32,7 @@ func replaceRunNodesWithPrebuiltNodes(pkgGraph *pkggraph.PkgGraph) (err error) {
 		_, missing := pkggraph.FindRPMFiles(node.SrpmPath, pkgGraph, nil)
 
 		if len(missing) > 0 {
-			logger.Log.Tracef("Can't mark (%s) as prebuilt, missing: (%v)", node.SrpmPath, missing)
+			logger.Log.Tracef("Can't mark (%s) as prebuilt, missing: %v", node.SrpmPath, missing)
 			continue
 		}
 
@@ -47,7 +47,7 @@ func replaceRunNodesWithPrebuiltNodes(pkgGraph *pkggraph.PkgGraph) (err error) {
 			if parentNode.Type != pkggraph.TypeGoal {
 				pkgGraph.RemoveEdge(parentNode.ID(), node.ID())
 
-				logger.Log.Debugf("Adding a 'PreBuilt' node (%s) with id (%d). For (%s)", preBuiltNode.FriendlyName(), preBuiltNode.ID(), parentNode.FriendlyName())
+				logger.Log.Debugf("Adding a 'PreBuilt' node (%s) with id %d. For (%s)", preBuiltNode.FriendlyName(), preBuiltNode.ID(), parentNode.FriendlyName())
 				err = pkgGraph.AddEdge(parentNode, preBuiltNode)
 
 				if err != nil {
@@ -72,9 +72,9 @@ func main() {
 	}
 
 	if *hydratedBuild {
-		logger.Log.Debugf("Nodes before replacing prebuilt nodes: (%d)", len(scrubbedGraph.AllNodes()))
+		logger.Log.Debugf("Nodes before replacing prebuilt nodes: %d", len(scrubbedGraph.AllNodes()))
 		err = replaceRunNodesWithPrebuiltNodes(scrubbedGraph)
-		logger.Log.Debugf("Nodes after replacing prebuilt nodes: (%d)", len(scrubbedGraph.AllNodes()))
+		logger.Log.Debugf("Nodes after replacing prebuilt nodes: %d", len(scrubbedGraph.AllNodes()))
 		if err != nil {
 			logger.Log.Panicf("Failed to replace run nodes with preBuilt nodes. Error: %s", err)
 		}

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -325,7 +325,7 @@ func printSlice(pairList []mapPair, valueDescription string, maxResults int) {
 			break
 		}
 
-		logger.Log.Infof("(%d): (%s) - (%d) %s", i+1, pair.key, len(pair.value), valueDescription)
+		logger.Log.Infof("%d: (%s) - %d (%s)", i+1, pair.key, len(pair.value), valueDescription)
 		for _, value := range pair.value {
 			logger.Log.Debugf("--> (%s)", value)
 		}

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -325,9 +325,9 @@ func printSlice(pairList []mapPair, valueDescription string, maxResults int) {
 			break
 		}
 
-		logger.Log.Infof("%d: %s - %d %s", i+1, pair.key, len(pair.value), valueDescription)
+		logger.Log.Infof("(%d): (%s) - (%d) %s", i+1, pair.key, len(pair.value), valueDescription)
 		for _, value := range pair.value {
-			logger.Log.Debugf("--> %s", value)
+			logger.Log.Debugf("--> (%s)", value)
 		}
 	}
 }

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -126,7 +126,7 @@ func addUnresolvedPackage(g *pkggraph.PkgGraph, pkgVer *pkgjson.PackageVer) (new
 		return
 	}
 	if nodes != nil {
-		err = fmt.Errorf("attempted to mark a local package (%+v) as unresolved", pkgVer)
+		err = fmt.Errorf("attempted to mark a local package %+v as unresolved", pkgVer)
 		return
 	}
 
@@ -157,7 +157,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	}
 
 	if nodes != nil {
-		logger.Log.Warnf("Skipping duplicate package name for package (%+v) read from SRPM (%s). Original: (%+v)", pkg.Provides, pkg.SrpmPath, nodes.RunNode)
+		logger.Log.Warnf("Skipping duplicate package name for package %+v read from SRPM (%s). Original: %+v", pkg.Provides, pkg.SrpmPath, nodes.RunNode)
 		foundDuplicate = true
 		return
 	}
@@ -166,23 +166,23 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding run node (%s) with id (%d)", newRunNode.FriendlyName(), newRunNode.ID())
+	logger.Log.Debugf("Adding run node (%s) with id %d", newRunNode.FriendlyName(), newRunNode.ID())
 
 	newBuildNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateBuild, pkggraph.TypeLocalBuild, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding build node (%s) with id (%d)", newBuildNode.FriendlyName(), newBuildNode.ID())
+	logger.Log.Debugf("Adding build node (%s) with id %d", newBuildNode.FriendlyName(), newBuildNode.ID())
 
 	// A "run" node has an implicit dependency on its corresponding "build" node, encode that here.
 	err = g.AddEdge(newRunNode, newBuildNode)
 	if err != nil {
-		err = fmt.Errorf("failed to add run -> build edge failed for (%+v):\n%w", pkg.Provides, err)
+		err = fmt.Errorf("failed to add run -> build edge failed for %+v:\n%w", pkg.Provides, err)
 		return
 	}
 
 	if !pkg.RunTests {
-		logger.Log.Debugf("Skipping adding a test node for package (%+v)", pkg)
+		logger.Log.Debugf("Skipping adding a test node for package %+v", pkg)
 		return
 	}
 
@@ -190,14 +190,14 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding test node (%s) with id (%d)", newTestNode.FriendlyName(), newTestNode.ID())
+	logger.Log.Debugf("Adding test node (%s) with id %d", newTestNode.FriendlyName(), newTestNode.ID())
 
 	// A "test" node has a dependency on its corresponding "build" node. This dependency is required
 	// to guarantee we will first check if the build node needs to be built or not before we make
 	// any decisions about running the tests.
 	err = g.AddEdge(newTestNode, newBuildNode)
 	if err != nil {
-		err = fmt.Errorf("failed to add test -> build edge for (%+v):\n%w", pkg.Provides, err)
+		err = fmt.Errorf("failed to add test -> build edge for %+v:\n%w", pkg.Provides, err)
 		return
 	}
 
@@ -209,10 +209,10 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 // addition failed.
 func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, dependency *pkgjson.PackageVer) (err error) {
 	var dependentNode *pkggraph.PkgNode
-	logger.Log.Tracef("Adding a dependency from (%+v) to (%+v)", packageNode.VersionedPkg, dependency)
+	logger.Log.Tracef("Adding a dependency from %+v to %+v", packageNode.VersionedPkg, dependency)
 	nodes, err := g.FindBestPkgNode(dependency)
 	if err != nil {
-		err = fmt.Errorf("failed to check lookup list for (%+v):\n%w", dependency, err)
+		err = fmt.Errorf("failed to check lookup list for %+v:\n%w", dependency, err)
 		return err
 	}
 
@@ -228,7 +228,7 @@ func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, de
 	}
 
 	if packageNode == dependentNode {
-		logger.Log.Debugf("Package (%+v) requires itself!", packageNode)
+		logger.Log.Debugf("Package %+v requires itself!", packageNode)
 		return nil
 	}
 
@@ -240,13 +240,13 @@ func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, de
 		dependentNode.Type == pkggraph.TypeLocalRun &&
 		packageNode.RpmPath == dependentNode.RpmPath {
 
-		logger.Log.Debugf("(%+v) requires (%+v) which is provided by the same RPM", packageNode, dependentNode)
+		logger.Log.Debugf("%+v requires %+v which is provided by the same RPM", packageNode, dependentNode)
 		return nil
 	}
 
 	err = g.AddEdge(packageNode, dependentNode)
 	if err != nil {
-		err = fmt.Errorf("failed to add edge between (%+v) and (%+v):\n%w", packageNode, dependency, err)
+		err = fmt.Errorf("failed to add edge between %+v and %+v:\n%w", packageNode, dependency, err)
 	}
 
 	return err
@@ -263,7 +263,7 @@ func addPkgDependencies(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (dependencie
 		return
 	}
 	if nodes == nil {
-		return dependenciesAdded, fmt.Errorf("can't add dependencies to a missing package (%+v)", pkg)
+		return dependenciesAdded, fmt.Errorf("can't add dependencies to a missing package %+v", pkg)
 	}
 
 	// For each run-, build-, and test-time dependency, add the edges
@@ -271,7 +271,7 @@ func addPkgDependencies(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (dependencie
 	for _, dependency := range pkg.Requires {
 		err = addSingleDependency(g, nodes.RunNode, dependency)
 		if err != nil {
-			err = fmt.Errorf("failed to add run-time dependencies for (%+v):\n%w", pkg, err)
+			err = fmt.Errorf("failed to add run-time dependencies for %+v:\n%w", pkg, err)
 			return
 		}
 		dependenciesAdded++
@@ -281,14 +281,14 @@ func addPkgDependencies(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (dependencie
 	for _, dependency := range pkg.BuildRequires {
 		err = addSingleDependency(g, nodes.BuildNode, dependency)
 		if err != nil {
-			err = fmt.Errorf("failed to add build-time dependencies for (%+v):\n%w", pkg, err)
+			err = fmt.Errorf("failed to add build-time dependencies for %+v:\n%w", pkg, err)
 			return
 		}
 		dependenciesAdded++
 	}
 
 	if nodes.TestNode == nil {
-		logger.Log.Debugf("No test node for package (%+v), skipping test dependencies", pkg)
+		logger.Log.Debugf("No test node for package %+v, skipping test dependencies", pkg)
 		return
 	}
 
@@ -296,7 +296,7 @@ func addPkgDependencies(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (dependencie
 	for _, dependency := range pkg.TestRequires {
 		err = addSingleDependency(g, nodes.TestNode, dependency)
 		if err != nil {
-			err = fmt.Errorf("failed to add test-time dependencies for (%+v):\n%w", pkg, err)
+			err = fmt.Errorf("failed to add test-time dependencies for %+v:\n%w", pkg, err)
 			return
 		}
 		dependenciesAdded++
@@ -321,7 +321,7 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 	for _, pkg := range packages {
 		foundDuplicate, err := addNodesForPackage(graph, pkg)
 		if err != nil {
-			err = fmt.Errorf("failed to add local package (%+v):\n%w", pkg, err)
+			err = fmt.Errorf("failed to add local package %+v:\n%w", pkg, err)
 			return err
 		}
 
@@ -329,7 +329,7 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 			uniquePackages[pkg] = true
 		}
 	}
-	logger.Log.Infof("\tAdded (%d) packages", len(packages))
+	logger.Log.Infof("\tAdded %d packages", len(packages))
 
 	timestamp.StopEvent(nil) // add package nodes
 	timestamp.StartEvent("add dependencies", nil)
@@ -340,12 +340,12 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 	for uniquePkg := range uniquePackages {
 		num, err := addPkgDependencies(graph, uniquePkg)
 		if err != nil {
-			err = fmt.Errorf("failed to add dependency (%+v):\n%w", uniquePkg, err)
+			err = fmt.Errorf("failed to add dependency %+v:\n%w", uniquePkg, err)
 			return err
 		}
 		dependenciesAdded += num
 	}
-	logger.Log.Infof("\tAdded (%d) dependencies", dependenciesAdded)
+	logger.Log.Infof("\tAdded %d dependencies", dependenciesAdded)
 
 	timestamp.StopEvent(nil) // add dependencies
 

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -157,7 +157,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	}
 
 	if nodes != nil {
-		logger.Log.Warnf(`Skipping duplicate package name for package %+v read from SRPM "%s". Original: %+v.`, pkg.Provides, pkg.SrpmPath, nodes.RunNode)
+		logger.Log.Warnf("Skipping duplicate package name for package (%+v) read from SRPM (%s). Original: (%+v)", pkg.Provides, pkg.SrpmPath, nodes.RunNode)
 		foundDuplicate = true
 		return
 	}
@@ -166,13 +166,13 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding run node '%s' with id %d.", newRunNode.FriendlyName(), newRunNode.ID())
+	logger.Log.Debugf("Adding run node (%s) with id (%d)", newRunNode.FriendlyName(), newRunNode.ID())
 
 	newBuildNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateBuild, pkggraph.TypeLocalBuild, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding build node '%s' with id %d.", newBuildNode.FriendlyName(), newBuildNode.ID())
+	logger.Log.Debugf("Adding build node (%s) with id (%d)", newBuildNode.FriendlyName(), newBuildNode.ID())
 
 	// A "run" node has an implicit dependency on its corresponding "build" node, encode that here.
 	err = g.AddEdge(newRunNode, newBuildNode)
@@ -182,7 +182,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	}
 
 	if !pkg.RunTests {
-		logger.Log.Debugf("Skipping adding a test node for package %+v", pkg)
+		logger.Log.Debugf("Skipping adding a test node for package (%+v)", pkg)
 		return
 	}
 
@@ -190,7 +190,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding test node '%s' with id %d.", newTestNode.FriendlyName(), newTestNode.ID())
+	logger.Log.Debugf("Adding test node (%s) with id (%d)", newTestNode.FriendlyName(), newTestNode.ID())
 
 	// A "test" node has a dependency on its corresponding "build" node. This dependency is required
 	// to guarantee we will first check if the build node needs to be built or not before we make
@@ -209,7 +209,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 // addition failed.
 func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, dependency *pkgjson.PackageVer) (err error) {
 	var dependentNode *pkggraph.PkgNode
-	logger.Log.Tracef("Adding a dependency from %+v to %+v", packageNode.VersionedPkg, dependency)
+	logger.Log.Tracef("Adding a dependency from (%+v) to (%+v)", packageNode.VersionedPkg, dependency)
 	nodes, err := g.FindBestPkgNode(dependency)
 	if err != nil {
 		err = fmt.Errorf("failed to check lookup list for (%+v):\n%w", dependency, err)
@@ -228,7 +228,7 @@ func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, de
 	}
 
 	if packageNode == dependentNode {
-		logger.Log.Debugf("Package %+v requires itself!", packageNode)
+		logger.Log.Debugf("Package (%+v) requires itself!", packageNode)
 		return nil
 	}
 
@@ -240,7 +240,7 @@ func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, de
 		dependentNode.Type == pkggraph.TypeLocalRun &&
 		packageNode.RpmPath == dependentNode.RpmPath {
 
-		logger.Log.Debugf("%+v requires %+v which is provided by the same RPM.", packageNode, dependentNode)
+		logger.Log.Debugf("(%+v) requires (%+v) which is provided by the same RPM", packageNode, dependentNode)
 		return nil
 	}
 
@@ -257,13 +257,13 @@ func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, de
 // could not be created.
 func addPkgDependencies(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (dependenciesAdded int, err error) {
 	// Find the current node in the lookup list.
-	logger.Log.Debugf("Adding dependencies for package %s", pkg.SrpmPath)
+	logger.Log.Debugf("Adding dependencies for package (%s)", pkg.SrpmPath)
 	nodes, err := g.FindExactPkgNodeFromPkg(pkg.Provides)
 	if err != nil {
 		return
 	}
 	if nodes == nil {
-		return dependenciesAdded, fmt.Errorf("can't add dependencies to a missing package %+v", pkg)
+		return dependenciesAdded, fmt.Errorf("can't add dependencies to a missing package (%+v)", pkg)
 	}
 
 	// For each run-, build-, and test-time dependency, add the edges
@@ -288,7 +288,7 @@ func addPkgDependencies(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (dependencie
 	}
 
 	if nodes.TestNode == nil {
-		logger.Log.Debugf("No test node for package %+v, skipping test dependencies", pkg)
+		logger.Log.Debugf("No test node for package (%+v), skipping test dependencies", pkg)
 		return
 	}
 
@@ -316,7 +316,7 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 	timestamp.StartEvent("add package node", nil)
 
 	// Scan and add each package we know about
-	logger.Log.Infof("Adding all packages from %s", *input)
+	logger.Log.Infof("Adding all packages from (%s)", *input)
 	uniquePackages := make(map[*pkgjson.Package]bool)
 	for _, pkg := range packages {
 		foundDuplicate, err := addNodesForPackage(graph, pkg)
@@ -329,13 +329,13 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 			uniquePackages[pkg] = true
 		}
 	}
-	logger.Log.Infof("\tAdded %d packages", len(packages))
+	logger.Log.Infof("\tAdded (%d) packages", len(packages))
 
 	timestamp.StopEvent(nil) // add package nodes
 	timestamp.StartEvent("add dependencies", nil)
 
 	// Rescan and add all the dependencies
-	logger.Log.Infof("Adding all dependencies from %s", *input)
+	logger.Log.Infof("Adding all dependencies from (%s)", *input)
 	dependenciesAdded := 0
 	for uniquePkg := range uniquePackages {
 		num, err := addPkgDependencies(graph, uniquePkg)
@@ -345,7 +345,7 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 		}
 		dependenciesAdded += num
 	}
-	logger.Log.Infof("\tAdded %d dependencies", dependenciesAdded)
+	logger.Log.Infof("\tAdded (%d) dependencies", dependenciesAdded)
 
 	timestamp.StopEvent(nil) // add dependencies
 

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -387,7 +387,7 @@ func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, buildNode *p
 		return err
 	}
 	if lookup == nil || lookup.RunNode == nil {
-		err = fmt.Errorf("failed to find run lookup (%v) in graph", lookup)
+		err = fmt.Errorf("failed to find run lookup %v in graph", lookup)
 		return err
 	}
 
@@ -474,7 +474,7 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 	}
 
 	if len(resolvedPackages) == 0 {
-		return fmt.Errorf("failed to find any packages providing (%v)", node.VersionedPkg)
+		return fmt.Errorf("failed to find any packages providing %v", node.VersionedPkg)
 	}
 
 	preBuilt := false
@@ -525,22 +525,22 @@ func assignRPMPath(node *pkggraph.PkgNode, outDir string, resolvedPackages []str
 	chosenRPMPath := rpmPaths[0]
 	if len(rpmPaths) > 1 {
 		var resolvedRPMs []string
-		logger.Log.Debugf("Found (%d) candidates. Resolving", len(rpmPaths))
+		logger.Log.Debugf("Found %d candidates. Resolving", len(rpmPaths))
 
 		resolvedRPMs, err = rpm.ResolveCompetingPackages(*tmpDir, rpmPaths...)
 		if err != nil {
-			err = fmt.Errorf("failed to pick an RPM providing (%s) from the following RPMs (%v):\n%w", node.VersionedPkg.Name, rpmPaths, err)
+			err = fmt.Errorf("failed to pick an RPM providing (%s) from the following RPMs %v:\n%w", node.VersionedPkg.Name, rpmPaths, err)
 			return
 		}
 
 		resolvedRPMsCount := len(resolvedRPMs)
 		if resolvedRPMsCount == 0 {
-			err = fmt.Errorf("failed to pick an RPM providing (%s). No RPM can be installed from the following (%v)", node.VersionedPkg.Name, rpmPaths)
+			err = fmt.Errorf("failed to pick an RPM providing (%s). No RPM can be installed from the following %v", node.VersionedPkg.Name, rpmPaths)
 			return
 		}
 
 		if resolvedRPMsCount > 1 {
-			logger.Log.Warnf("Found (%d) candidates to provide (%s). Picking the first one", resolvedRPMsCount, node.VersionedPkg.Name)
+			logger.Log.Warnf("Found %d candidates to provide (%s). Picking the first one", resolvedRPMsCount, node.VersionedPkg.Name)
 		}
 
 		chosenRPMPath = rpmPackageToRPMPath(resolvedRPMs[0], outDir)

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -277,7 +277,7 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile stri
 		// If an input summary file was provided, simply restore the cache using the file.
 		err = repoutils.RestoreClonedRepoContents(cloner, inputSummaryFile)
 		if err != nil {
-			return fmt.Errorf("failed to restore external packages cache from '%s':\n%w", inputSummaryFile, err)
+			return fmt.Errorf("failed to restore external packages cache from (%s):\n%w", inputSummaryFile, err)
 		}
 
 		previousEnabledRepos := cloner.GetEnabledRepos()
@@ -297,13 +297,13 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile stri
 		progressHeader := fmt.Sprintf("Cache progress %d%%", (i*100)/unresolvedNodesCount)
 		resolveErr := resolveSingleNode(cloner, n, downloadDependencies, toolchainPackages, fetchedPackages, prebuiltPackages, *outDir)
 		if resolveErr == nil {
-			logger.Log.Infof("%s: choosing '%s' to provide '%s'.", progressHeader, filepath.Base(n.RpmPath), n.VersionedPkg.Name)
+			logger.Log.Infof("(%s): choosing (%s) to provide (%s)", progressHeader, filepath.Base(n.RpmPath), n.VersionedPkg.Name)
 			continue
 		}
 
 		// Failing to clone a dependency should not halt a build.
 		// The build should continue and attempt best effort to build as many packages as possible.
-		logger.Log.Warnf("%s: failed to resolve graph node '%s':\n%s", progressHeader, n, resolveErr)
+		logger.Log.Warnf("(%s): failed to resolve graph node (%s):\n(%s)", progressHeader, n, resolveErr)
 		cachingSucceeded = false
 		errorMessage := strings.Builder{}
 		errorMessage.WriteString(fmt.Sprintf("Failed to resolve all nodes in the graph while resolving '%s'\n", n))
@@ -344,19 +344,19 @@ func downloadAllAvailableDeltaRPMs(realDependencyGraph, dependencyGraphDeltaCopy
 	for i, n := range buildNodes {
 		// If this node isn't part of the optimized graph, skip it.
 		if _, ok := srpmPaths[n.SrpmPath]; !ok {
-			logger.Log.Debugf("Skipping non-optimized delta build node %s", n)
+			logger.Log.Debugf("Skipping non-optimized delta build node (%s)", n)
 			continue
 		}
 
-		logger.Log.Debugf("Resolving build node %s", n)
+		logger.Log.Debugf("Resolving build node (%s)", n)
 		err = downloadSingleDeltaRPM(realDependencyGraph, n, cloner)
 		if err != nil {
-			return fmt.Errorf("failed to download delta RPM for build node %s:\n%w", n, err)
+			return fmt.Errorf("failed to download delta RPM for build node (%s):\n%w", n, err)
 		}
 		if n.State == pkggraph.StateDelta {
-			logger.Log.Infof("Delta Progress %d%%: delta RPM found for '%s-%s'.", (i*100)/len(buildNodes), n.VersionedPkg.Name, n.VersionedPkg.Version)
+			logger.Log.Infof("Delta Progress %d%%: delta RPM found for '(%s)-(%s)'", (i*100)/len(buildNodes), n.VersionedPkg.Name, n.VersionedPkg.Version)
 		} else {
-			logger.Log.Infof("Delta Progress %d%%: skipped getting delta RPM for '%s' at '%s'.", (i*100)/len(buildNodes), n.VersionedPkg.Name, n.RpmPath)
+			logger.Log.Infof("Delta Progress %d%%: skipped getting delta RPM for (%s) at (%s)", (i*100)/len(buildNodes), n.VersionedPkg.Name, n.RpmPath)
 		}
 	}
 
@@ -424,16 +424,16 @@ func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, buildNode *p
 		// Avoid any processing since we know the exact RPM we want to download
 		_, err = cloner.CloneByName(downloadDependencies, fullyQualifiedRpmName)
 		if err != nil {
-			logger.Log.Warnf("Can't find delta RPM to download for %s: %s (local copy may be newer than published version)", fullyQualifiedRpmName, err)
+			logger.Log.Warnf("Can't find delta RPM to download for (%s): (%s) (local copy may be newer than published version)", fullyQualifiedRpmName, err)
 			return nil
 		}
 	} else {
-		logger.Log.Debugf("Found pre-cached delta RPM for %s, skipping download", fullyQualifiedRpmName)
+		logger.Log.Debugf("Found pre-cached delta RPM for (%s), skipping download", fullyQualifiedRpmName)
 	}
 
 	foundCacheRPM, err = file.PathExists(cachedRPMPath)
 	if err != nil {
-		return fmt.Errorf("can't check if cached RPM '%s' exists:\n%w", cachedRPMPath, err)
+		return fmt.Errorf("can't check if cached RPM (%s) exists:\n%w", cachedRPMPath, err)
 	}
 	if foundCacheRPM {
 		buildNode.State = pkggraph.StateDelta
@@ -443,10 +443,10 @@ func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, buildNode *p
 		runNode.RpmPath = cachedRPMPath
 		buildNode.RpmPath = cachedRPMPath
 
-		logger.Log.Debugf("Converted delta build node is now: '%s'", buildNode)
-		logger.Log.Debugf("Converted delta run node is now: '%s'", runNode)
+		logger.Log.Debugf("Converted delta build node is now: (%s)", buildNode)
+		logger.Log.Debugf("Converted delta run node is now: (%s)", runNode)
 	} else {
-		logger.Log.Warnf("Delta download for '%s' did not generate the correct delta RPM: '%s'", buildNode, cachedRPMPath)
+		logger.Log.Warnf("Delta download for (%s) did not generate the correct delta RPM: (%s)", buildNode, cachedRPMPath)
 		return nil
 	}
 
@@ -456,9 +456,9 @@ func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, buildNode *p
 // resolveSingleNode caches the RPM for a single node.
 // It will modify fetchedPackages on a successful package clone.
 func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNode, cloneDeps bool, toolchainPackages []string, fetchedPackages, prebuiltPackages map[string]bool, outDir string) (err error) {
-	logger.Log.Debugf("Adding node %s to the cache", node.FriendlyName())
+	logger.Log.Debugf("Adding node (%s) to the cache", node.FriendlyName())
 
-	logger.Log.Debugf("Searching for a package which supplies: %s", node.VersionedPkg.Name)
+	logger.Log.Debugf("Searching for a package which supplies: (%s)", node.VersionedPkg.Name)
 	// Resolve nodes to exact package names so they can be referenced in the graph.
 	resolvedPackages, err := cloner.WhatProvides(node.VersionedPkg)
 	if err != nil {
@@ -474,7 +474,7 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 	}
 
 	if len(resolvedPackages) == 0 {
-		return fmt.Errorf("failed to find any packages providing '%v'", node.VersionedPkg)
+		return fmt.Errorf("failed to find any packages providing (%v)", node.VersionedPkg)
 	}
 
 	preBuilt := false
@@ -486,19 +486,19 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 
 			preBuilt, err = cloner.CloneByPackageVer(cloneDeps, desiredPackage)
 			if err != nil {
-				err = fmt.Errorf("failed to clone '%s' from RPM repo:\n%w", resolvedPackage, err)
+				err = fmt.Errorf("failed to clone (%s) from RPM repo:\n%w", resolvedPackage, err)
 				return
 			}
 			fetchedPackages[resolvedPackage] = true
 			prebuiltPackages[resolvedPackage] = preBuilt
 
-			logger.Log.Debugf("Fetched '%s' as potential candidate (is pre-built: %v).", resolvedPackage, prebuiltPackages[resolvedPackage])
+			logger.Log.Debugf("Fetched (%s) as potential candidate (is pre-built: %v)", resolvedPackage, prebuiltPackages[resolvedPackage])
 		}
 	}
 
 	err = assignRPMPath(node, outDir, resolvedPackages)
 	if err != nil {
-		err = fmt.Errorf("failed to find an RPM to provide '%s':\n%w", node.VersionedPkg.Name, err)
+		err = fmt.Errorf("failed to find an RPM to provide (%s):\n%w", node.VersionedPkg.Name, err)
 		return
 	}
 
@@ -525,7 +525,7 @@ func assignRPMPath(node *pkggraph.PkgNode, outDir string, resolvedPackages []str
 	chosenRPMPath := rpmPaths[0]
 	if len(rpmPaths) > 1 {
 		var resolvedRPMs []string
-		logger.Log.Debugf("Found %d candidates. Resolving.", len(rpmPaths))
+		logger.Log.Debugf("Found (%d) candidates. Resolving", len(rpmPaths))
 
 		resolvedRPMs, err = rpm.ResolveCompetingPackages(*tmpDir, rpmPaths...)
 		if err != nil {
@@ -540,7 +540,7 @@ func assignRPMPath(node *pkggraph.PkgNode, outDir string, resolvedPackages []str
 		}
 
 		if resolvedRPMsCount > 1 {
-			logger.Log.Warnf("Found %d candidates to provide '%s'. Picking the first one.", resolvedRPMsCount, node.VersionedPkg.Name)
+			logger.Log.Warnf("Found (%d) candidates to provide (%s). Picking the first one", resolvedRPMsCount, node.VersionedPkg.Name)
 		}
 
 		chosenRPMPath = rpmPackageToRPMPath(resolvedRPMs[0], outDir)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix log formatting in downloader, graphanalytics, grapher, graphpkgfetcher, graphPreprocessor

Test Methodology
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove leading and trailing whitespace
- Remove trailing '...'
- Replace enclosing variable output in '' with () for string variable
- Remove enclosing '' or () for non string variable output

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Rebuilt tools successfully