### PR TITLE
systemd: adjust /lib/pam.d/systemd-user to include correct pam files

### DIFF
--- a/SPECS/systemd/azurelinux-use-system-auth-in-pam-systemd-user.patch
+++ b/SPECS/systemd/azurelinux-use-system-auth-in-pam-systemd-user.patch
@@ -3,6 +3,15 @@ From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
 Date: Wed, 14 Dec 2022 22:24:53 +0100
 Subject: [PATCH] fedora: use system-auth in pam systemd-user
 
+
+NOTE change for azurelinux:
+
+This patch from Fedora has been renamed to 'azurelinux-...', and
+adjusted to use 'system-account' and 'system-session' instead of the
+single 'system-auth'; in Fedora all the pam types are included in the
+single 'system-auth' file, while in azurelinux each pam type is in its
+own-named file (i.e. 'system-account', 'system-session', etc).
+
 ---
  src/login/systemd-user.in | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
@@ -16,7 +25,7 @@ index 8a3c9e0165..74ef5f2552 100644
  {% endif %}
  account  sufficient pam_unix.so no_pass_expiry
 -account  required   pam_permit.so
-+account  include    system-auth
++account  include    system-account
  
  {% if HAVE_SELINUX %}
  session  required   pam_selinux.so close
@@ -25,7 +34,7 @@ index 8a3c9e0165..74ef5f2552 100644
  {% endif %}
  session  optional   pam_umask.so silent
 -session  optional   pam_systemd.so
-+session  include    system-auth
++session  include    system-session
 -- 
 2.41.0
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        10%{?dist}
+Release:        11%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -127,7 +127,9 @@ Patch0001:      https://github.com/systemd/systemd/pull/26494.patch
 Patch0490:      use-bfq-scheduler.patch
 
 # Adjust upstream config to use our shared stack
-Patch0491:      fedora-use-system-auth-in-pam-systemd-user.patch
+# NOTE: the patch was based on the fedora patch, but renamed to
+# 'azurelinux-...' and modified for our 'system-*' pam files
+Patch0491:      azurelinux-use-system-auth-in-pam-systemd-user.patch
 
 # Patches for Azure Linux
 Patch0900:      do-not-test-openssl-sm3.patch
@@ -1190,6 +1192,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Wed Apr 24 2024 Dan Streetman <ddstreet@microsoft.com> - 255-11
+- adjust pam.d/systemd-user file to include correct pam files
+
 * Mon Apr 15 2024 Henry Li <lihl@microsoft.com> - 255-10
 - Add patch to allow configurability of "UseDomains=" for networkd
 


### PR DESCRIPTION
While Fedora uses a single 'system-auth' file to contain common configuration for all pam types, azurelinux uses separate files per pam type, i.e. 'system-account', 'system-session', etc.

This fixes the failure to start the systemd user service (i.e. `user@$UID.service`)