### PR TITLE
Upgrading `python-libclang` from `14.0.6` from `18.1.1`

### DIFF
--- a/SPECS/python-libclang/python-libclang.signatures.json
+++ b/SPECS/python-libclang/python-libclang.signatures.json
@@ -1,5 +1,5 @@
 {
     "Signatures": {
-     "libclang-14.0.6.tar.gz": "9052a8284d8846984f6fa826b1d7460a66d3b23a486d782633b42b6e3b418789"
+     "libclang-18.1.1.tar.gz": "a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250"
     }
    }

--- a/SPECS/python-libclang/python-libclang.spec
+++ b/SPECS/python-libclang/python-libclang.spec
@@ -42,3 +42,4 @@ This library makes it easier to install clang's python bindings.
 
 * Mon Oct 17 2022 Riken Maharjan <rmaharjan@microsoft.com> - 14.0.6-1
 - Original version for CBL-Mariner. License Verified.
+

--- a/SPECS/python-libclang/python-libclang.spec
+++ b/SPECS/python-libclang/python-libclang.spec
@@ -2,7 +2,7 @@
 
 Summary:        Clang's python bindings
 Name:           python-%{pypi_name}
-Version:        14.0.6
+Version:        18.1.1
 Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
@@ -37,5 +37,8 @@ This library makes it easier to install clang's python bindings.
 %{python3_sitelib}/*
 
 %changelog
+* Thu Apr 25 2024 Osama Esmail <osamaesmail@microsoft.com> - 18.1.1-1
+- Upgrading version for 3.0-dev
+
 * Mon Oct 17 2022 Riken Maharjan <rmaharjan@microsoft.com> - 14.0.6-1
 - Original version for CBL-Mariner. License Verified.

--- a/SPECS/python-libclang/python-libclang.spec
+++ b/SPECS/python-libclang/python-libclang.spec
@@ -1,7 +1,7 @@
 %global pypi_name libclang
 
 Summary:        Clang's python bindings
-Name:           python-%{pypi_name}
+Name:           python-libclang
 Version:        18.1.1
 Release:        1%{?dist}
 License:        ASL 2.0
@@ -39,7 +39,7 @@ This library makes it easier to install clang's python bindings.
 %changelog
 * Thu Apr 25 2024 Osama Esmail <osamaesmail@microsoft.com> - 18.1.1-1
 - Upgrading version for 3.0-dev
+- Using actual package name so auto-upgrader can read the spec
 
 * Mon Oct 17 2022 Riken Maharjan <rmaharjan@microsoft.com> - 14.0.6-1
 - Original version for CBL-Mariner. License Verified.
-

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22954,7 +22954,7 @@
         "other": {
           "name": "python-libclang",
           "version": "18.1.1",
-          "downloadUrl": "https://files.pythonhosted.org/packages/source/l/libclang/libclang-14.0.6.tar.gz"
+          "downloadUrl": "https://files.pythonhosted.org/packages/source/l/libclang/libclang-18.1.1.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22953,7 +22953,7 @@
         "type": "other",
         "other": {
           "name": "python-libclang",
-          "version": "14.0.6",
+          "version": "18.1.1",
           "downloadUrl": "https://files.pythonhosted.org/packages/source/l/libclang/libclang-14.0.6.tar.gz"
         }
       }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrades `python-libclang` from `14.0.6` to `18.1.1`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgraded `python-libclang` from `14.0.6` to `18.1.1`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 557817
