### PR TITLE
xxhash: fix build issue with x86-64-v3

### DIFF
--- a/SPECS/xxhash/xxhash.spec
+++ b/SPECS/xxhash/xxhash.spec
@@ -1,7 +1,7 @@
 Summary:        Extremely fast hash algorithm
 Name:           xxhash
 Version:        0.8.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD AND GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -59,8 +59,10 @@ Documentation files for the xxhash library
 %global dispatch 0
 %endif
 
-%make_build MOREFLAGS="%{__global_cflags} %{?__global_ldflags}" \
-        DISPATCH=%{dispatch}
+%make_build
+    MOREFLAGS="%{__global_cflags} %{?__global_ldflags}" \
+    DISPATCH=%{dispatch} \
+    XXH_X86DISPATCH_ALLOW_AVX=1
 doxygen
 
 %install
@@ -94,6 +96,9 @@ rm %{buildroot}/%{_libdir}/libxxhash.a
 %doc doxygen/html
 
 %changelog
+* Thu Apr 25 2024 Andrew Phelps <anphel@microsoft.com> - 0.8.2-2
+- Set XXH_X86DISPATCH_ALLOW_AVX to support compiling with x86-64-v3
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.8.2-1
 - Auto-upgrade to 0.8.2 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Modify `xxhash` to build with `XXH_X86DISPATCH_ALLOW_AVX` set, which is need after PR #8846 changed gcc to use `-march=x86-64-v3`. This should be ok for us since we will not support v2 or earlier architecture levels, so AVX should always be available. For more details see: `https://github.com/Cyan4973/xxHash/issues/839`
Fixes error:
```
ERROR - xxh_x86dispatch.c:93:4: error: #error \"Error: if xxh_x86dispatch.c is compiled with AVX enabled, the resulting binary will crash on sse2-only cpus !! \" \"If you nonetheless want to do that, please enable the XXH_X86DISPATCH_ALLOW_AVX build variable\" 
INFO - 93 | # error \"Error: if xxh_x86dispatch.c is compiled with AVX enabled, the resulting binary will crash on sse2-only cpus !! \" \\ 
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- xxhash: fix build issue with x86-64-v3

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=557781&view=results
