### PR TITLE
Add the cloud-utils-growpart package to the cloud-init package list.

### DIFF
--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.28.4
-Release:        6%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -94,7 +94,8 @@ Pause component for Microsoft Kubernetes %{version}.
 
 %prep
 %setup -q -c -n %{name}
-%autopatch -p1
+%patch 0 -p1
+%patch 1 -p1
 
 %build
 # set version information using KUBE_GIT_VERSION
@@ -267,9 +268,6 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
-* Tue Apr 24 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 1.28.4-6
-- Use autopatch instead of individual patch
-
 * Mon Apr 08 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 1.28.4-5
 - Address CVE-2023-5408
 

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.28.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -94,8 +94,7 @@ Pause component for Microsoft Kubernetes %{version}.
 
 %prep
 %setup -q -c -n %{name}
-%patch 0 -p1
-%patch 1 -p1
+%autopatch -p1
 
 %build
 # set version information using KUBE_GIT_VERSION
@@ -268,6 +267,9 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Tue Apr 24 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 1.28.4-6
+- Use autopatch instead of individual patch
+
 * Mon Apr 08 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 1.28.4-5
 - Address CVE-2023-5408
 

--- a/toolkit/imageconfigs/packagelists/cloud-init-packages.json
+++ b/toolkit/imageconfigs/packagelists/cloud-init-packages.json
@@ -1,5 +1,6 @@
 {
     "packages": [
-        "cloud-init"
+        "cloud-init",
+        "cloud-utils-growpart"
     ]
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
cloud-utils-growpart is necessary for container host scenarios where the image is distributed with minimal free diskspace but then it is expected to expand on deployment. The expansion is powered by cloud-utils-growpart which enables cloud-init to grow the partitions on the first boot.
This change added the cloud-utils-growpart package to the cloud-init list since it's almost always that we want both to be installed together.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- [Add cloud-utils-growpart of the cloud-init package list to allow for automatic expansion.](https://github.com/microsoft/azurelinux/commit/9be4a7fba59f884f52306aa26fc95f48043df075)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- No

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build baremetal image locally.
- Using qemu-img, converted the vhdx to qcow2, and resize the disk.
- Created a VM and attached cloud-init data.
- Booted the image and verified that the root partition has been expanded.
