### PR TITLE
php-pecl-zip: fix runtime requirements to match php 8.3.4

### DIFF
--- a/SPECS/php-pecl-zip/php-pecl-zip.spec
+++ b/SPECS/php-pecl-zip/php-pecl-zip.spec
@@ -13,7 +13,7 @@
 Summary:        A ZIP archive management extension
 Name:           php-pecl-zip
 Version:        1.22.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        PHP
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -27,8 +27,8 @@ BuildRequires:  pkg-config
 BuildRequires:  tzdata
 BuildRequires:  zlib-devel
 BuildRequires:  pkgconfig(libzip) >= 1.0.0
-Requires:       php(api) = 20210902-%{__isa_bits}
-Requires:       php(zend-abi) = 20210902-%{__isa_bits}
+Requires:       php(api) = 20230831-%{__isa_bits}
+Requires:       php(zend-abi) = 20230831-%{__isa_bits}
 Requires:       tzdata
 # Supposed to use these macros from SPECS/php/macros.php
 #Requires:     php(zend-abi) = %{php_zend_api}
@@ -154,6 +154,9 @@ TEST_PHP_EXECUTABLE=%{_bindir}/zts-php \
 %endif
 
 %changelog
+* Thu Apr 25 2024 Andrew Phelps <anphel@microsoft.com> - 1.22.3-2
+- Update `php(abi)` and `php(zend-abi)` requires for php 8.3.4
+
 * Fri Mar 29 2024 Andrew Phelps <anphel@microsoft.com> - 1.22.3-1
 - Upgrade to version 1.22.3
 - Add tzdata BR and requires.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The runtime requirements for `php-pecl-zip` were not met after `php` was upgraded to version 8.3.4 in #8888. This PR fixes them to match the versions specified in the php 8.3.4 source:
```
Zend/zend_modules.h:34:#define ZEND_MODULE_API_NO 20230831
main/php.h:25:#define PHP_API_VERSION 20230831
```

This fixes the following unresolved dependencies:
```
"Unresolved dependencies:" 
"--> php(api):C:'='V:'20210902-64',C2:''V2:''" 
"--> php(zend-abi):C:'='V:'20210902-64',C2:''V2:''" 
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- php-pecl-zip: fix runtime requirements to match php 8.3.4

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=558062&view=results
