### PR TITLE
Upgrading `python-jwt` from `2.4.0` to `2.8.0`

### DIFF
--- a/SPECS/python-jwt/python-jwt.signatures.json
+++ b/SPECS/python-jwt/python-jwt.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "PyJWT-2.4.0.tar.gz": "d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba"
+  "PyJWT-2.8.0.tar.gz": "57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"
  }
 }

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -37,7 +37,7 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-cryptography >= 3
 Requires:       python3-cryptography >= 3
 %if 0%{?with_check}
-BuildRequires:  python3-pip
+BuildRequires:  python3-tox
 BuildRequires:  python3-atomicwrites
 %endif
 %{?python_provide:%python_provide python3-%{pkgname}}
@@ -59,7 +59,7 @@ rm -rf %{eggname}.egg-info
 %py3_install
 
 %check
-pip3 install tox
+# pip3 install tox
 %tox
 # pip3 install coverage[toml]==5.0.4 pytest==6.0.0
 # PATH=%{buildroot}%{_bindir}:${PATH} \

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -50,7 +50,6 @@ BuildRequires:  python3-pip
 rm -rf %{eggname}.egg-info
 
 %generate_buildrequires
-# %pyproject_buildrequires %{?with_check:-t}
 %pyproject_buildrequires
 
 %build
@@ -62,10 +61,6 @@ rm -rf %{eggname}.egg-info
 %check
 pip3 install tox
 tox
-# pip3 install coverage[toml]==5.0.4 pytest==6.0.0
-# PATH=%{buildroot}%{_bindir}:${PATH} \
-# PYTHONPATH=%{buildroot}%{python3_sitelib} \
-#     python%{python3_version} -m pytest -v
 
 %if %{with python3}
 %files -n python3-%{pkgname}

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -49,6 +49,9 @@ BuildRequires:  python3-atomicwrites
 %autosetup -n %{srcname}-%{version}
 rm -rf %{eggname}.egg-info
 
+%generate_buildrequires
+%pyproject_buildrequires -t
+
 %build
 %py3_build
 

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -56,7 +56,7 @@ rm -rf %{eggname}.egg-info
 %py3_install
 
 %check
-pip3 install coverage[toml]==5.0.4 pytest==6.2.5
+pip3 install coverage[toml]==5.0.4 pytest==6.0.0
 PATH=%{buildroot}%{_bindir}:${PATH} \
 PYTHONPATH=%{buildroot}%{python3_sitelib} \
     python%{python3_version} -m pytest -v

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -56,7 +56,7 @@ rm -rf %{eggname}.egg-info
 %py3_install
 
 %check
-pip3 install coverage[toml]==5.0.4 pytest==6
+pip3 install coverage[toml]==5.0.4 pytest==6.2.5
 PATH=%{buildroot}%{_bindir}:${PATH} \
 PYTHONPATH=%{buildroot}%{python3_sitelib} \
     python%{python3_version} -m pytest -v

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -74,6 +74,7 @@ tox
 * Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 2.8.0-1
 - Updating to 2.8.0-1 for 3.0
 - Using literal package name so auto-upgrader can do its thing
+- Adding buildrequires & replacing check section with simple tox command
 
 * Fri Sep 30 2022 Saul Paredes <saulparedes@microsoft.com> - 2.4.0-2
 - Updating to 2.4.0-2 to fix CVE-2022-39227 (no patch, false positive confusion with python-jwt. Scanning tool to be updated).

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -17,14 +17,14 @@ claims to be transferred between two parties encoded as digitally signed and
 encrypted JSON objects.}
 
 Name:           python-%{pkgname}
-Version:        2.4.0
-Release:        2%{?dist}
+Version:        2.8.0
+Release:        1%{?dist}
 Summary:        JSON Web Token implementation in Python
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://github.com/jpadilla/pyjwt
-Source0:        https://files.pythonhosted.org/packages/d8/6b/6287745054dbcccf75903630346be77d4715c594402cec7c2518032416c2/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/30/72/8259b2bccfe4673330cea843ab23f86858a419d8f1493f66d413a76c7e3b/PyJWT-2.8.0.tar.gz
 BuildArch:      noarch
 
 %description %{common_description}
@@ -70,6 +70,9 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %endif
 
 %changelog
+* Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 2.8.0-1
+- Updating to 2.8.0-1 for 3.0
+
 * Fri Sep 30 2022 Saul Paredes <saulparedes@microsoft.com> - 2.4.0-2
 - Updating to 2.4.0-2 to fix CVE-2022-39227 (no patch, false positive confusion with python-jwt. Scanning tool to be updated).
 

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -38,6 +38,7 @@ BuildRequires:  python3-cryptography >= 3
 Requires:       python3-cryptography >= 3
 %if 0%{?with_check}
 BuildRequires:  python3-atomicwrites
+BuildRequires:  python3-pip
 %endif
 %{?python_provide:%python_provide python3-%{pkgname}}
 

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -16,7 +16,7 @@ means of representing signed content using JSON data structures, including
 claims to be transferred between two parties encoded as digitally signed and
 encrypted JSON objects.}
 
-Name:           python-%{pkgname}
+Name:           python-jwt
 Version:        2.8.0
 Release:        1%{?dist}
 Summary:        JSON Web Token implementation in Python
@@ -72,6 +72,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %changelog
 * Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 2.8.0-1
 - Updating to 2.8.0-1 for 3.0
+- Using literal package name so auto-upgrader can do its thing
 
 * Fri Sep 30 2022 Saul Paredes <saulparedes@microsoft.com> - 2.4.0-2
 - Updating to 2.4.0-2 to fix CVE-2022-39227 (no patch, false positive confusion with python-jwt. Scanning tool to be updated).

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -37,7 +37,6 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-cryptography >= 3
 Requires:       python3-cryptography >= 3
 %if 0%{?with_check}
-BuildRequires:  python3-tox
 BuildRequires:  python3-atomicwrites
 %endif
 %{?python_provide:%python_provide python3-%{pkgname}}
@@ -50,7 +49,8 @@ BuildRequires:  python3-atomicwrites
 rm -rf %{eggname}.egg-info
 
 %generate_buildrequires
-%pyproject_buildrequires -t
+# %pyproject_buildrequires %{?with_check:-t}
+%pyproject_buildrequires
 
 %build
 %py3_build
@@ -59,7 +59,7 @@ rm -rf %{eggname}.egg-info
 %py3_install
 
 %check
-# pip3 install tox
+pip3 install tox
 %tox
 # pip3 install coverage[toml]==5.0.4 pytest==6.0.0
 # PATH=%{buildroot}%{_bindir}:${PATH} \

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -61,7 +61,7 @@ rm -rf %{eggname}.egg-info
 
 %check
 pip3 install tox
-%tox
+tox
 # pip3 install coverage[toml]==5.0.4 pytest==6.0.0
 # PATH=%{buildroot}%{_bindir}:${PATH} \
 # PYTHONPATH=%{buildroot}%{python3_sitelib} \

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -56,10 +56,11 @@ rm -rf %{eggname}.egg-info
 %py3_install
 
 %check
-pip3 install coverage[toml]==5.0.4 pytest==6.0.0
-PATH=%{buildroot}%{_bindir}:${PATH} \
-PYTHONPATH=%{buildroot}%{python3_sitelib} \
-    python%{python3_version} -m pytest -v
+%tox
+# pip3 install coverage[toml]==5.0.4 pytest==6.0.0
+# PATH=%{buildroot}%{_bindir}:${PATH} \
+# PYTHONPATH=%{buildroot}%{python3_sitelib} \
+#     python%{python3_version} -m pytest -v
 
 %if %{with python3}
 %files -n python3-%{pkgname}

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -56,6 +56,7 @@ rm -rf %{eggname}.egg-info
 %py3_install
 
 %check
+pip3 install tox
 %tox
 # pip3 install coverage[toml]==5.0.4 pytest==6.0.0
 # PATH=%{buildroot}%{_bindir}:${PATH} \

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22853,8 +22853,8 @@
         "type": "other",
         "other": {
           "name": "python-jwt",
-          "version": "2.4.0",
-          "downloadUrl": "https://files.pythonhosted.org/packages/d8/6b/6287745054dbcccf75903630346be77d4715c594402cec7c2518032416c2/PyJWT-2.4.0.tar.gz"
+          "version": "2.8.0",
+          "downloadUrl": "https://files.pythonhosted.org/packages/30/72/8259b2bccfe4673330cea843ab23f86858a419d8f1493f66d413a76c7e3b/PyJWT-2.8.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrading `python-jwt` from `2.4.0` to `2.8.0` for 3.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrading `python-jwt` from `2.4.0` to `2.8.0`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 562003