### PR TITLE
Upgrading `python-filelock` to `3.14.0`

### DIFF
--- a/SPECS/python-filelock/python-filelock.signatures.json
+++ b/SPECS/python-filelock/python-filelock.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "python-filelock-3.13.4.tar.gz": "9975e399b8ffd4f240a78908ee15b1caf6e2de3761367b51490132d21577c74d"
+  "python-filelock-3.14.0.tar.gz": "6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"
  }
 }

--- a/SPECS/python-filelock/python-filelock.signatures.json
+++ b/SPECS/python-filelock/python-filelock.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "python-filelock-3.0.12.tar.gz": "eafca6feda88295a054ccb3276adcc8d326318b116fa5e124522dd51dd62fd56"
+  "python-filelock-3.13.4.tar.gz": "d13f466618bfde72bd2c18255e269f72542c6e70e7bac83a0232d6b1cc5c8cf4"
  }
 }

--- a/SPECS/python-filelock/python-filelock.signatures.json
+++ b/SPECS/python-filelock/python-filelock.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "python-filelock-3.13.4.tar.gz": "d13f466618bfde72bd2c18255e269f72542c6e70e7bac83a0232d6b1cc5c8cf4"
+  "python-filelock-3.13.4.tar.gz": "9975e399b8ffd4f240a78908ee15b1caf6e2de3761367b51490132d21577c74d"
  }
 }

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -1,8 +1,8 @@
 %global srcname filelock
 Summary:        A platform independent file lock
 Name:           python-%{srcname}
-Version:        3.0.12
-Release:        13%{?dist}
+Version:        3.13.4
+Release:        1%{?dist}
 License:        Unlicense
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -71,6 +71,9 @@ python%{python3_version} test.py
 %{_mandir}/man1/py-%{srcname}.1.gz
 
 %changelog
+* Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 3.13.4-1
+- Upgrading version for 3.0
+
 * Fri Apr 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.12-13
 - Updating source URL.
 

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -1,6 +1,6 @@
 %global srcname filelock
 Summary:        A platform independent file lock
-Name:           python-%{srcname}
+Name:           python-filelock
 Version:        3.13.4
 Release:        1%{?dist}
 License:        Unlicense
@@ -73,6 +73,7 @@ python%{python3_version} test.py
 %changelog
 * Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 3.13.4-1
 - Upgrading version for 3.0
+- Using literal package name so autoupgrader can do its thing.
 
 * Fri Apr 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.12-13
 - Updating source URL.

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -36,6 +36,7 @@ BuildRequires:  python%{python3_pkgversion}-pathspec
 BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-pluggy
 BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-setuptools_scm
 BuildRequires:  python%{python3_pkgversion}-sphinx
 BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
 

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -17,15 +17,6 @@ file locking mechanism for Python.
 The lock includes a lock counter and is thread safe. This means, when locking
 the same lock object twice, it will not block.
 
-%package doc
-Summary:        Documentation for %{srcname}, %{summary}
-BuildRequires:  python%{python3_pkgversion}-devel
-BuildRequires:  python%{python3_pkgversion}-sphinx
-BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
-
-%description doc
-%{summary}
-
 %package -n python%{python3_pkgversion}-%{srcname}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Summary:        %{summary}
@@ -37,8 +28,8 @@ BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-pluggy
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-setuptools_scm
-BuildRequires:  python%{python3_pkgversion}-sphinx
-BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
+# BuildRequires:  python%{python3_pkgversion}-sphinx
+# BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
 BuildRequires:  python%{python3_pkgversion}-trove-classifiers
 
 %description -n python%{python3_pkgversion}-%{srcname}
@@ -57,12 +48,6 @@ the same lock object twice, it will not block.
 %build
 %pyproject_wheel
 
-ls .
-pushd docs
-PYTHONPATH=../src sphinx-build ./ html --color -b html -d doctrees
-rm html/.buildinfo
-popd
-
 %install
 %pyproject_install
 %pyproject_save_files -l %{srcname}
@@ -74,17 +59,14 @@ popd
 %pyproject_check_import
 %endif
 
-%files doc
-%license LICENSE
-%doc docs/build/html
-
 %files -n python%{python3_pkgversion}-%{srcname} -f %{pyproject_files}
 %doc README.md
+%license LICENSE
 
 %changelog
 * Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 3.14.0-1
 - Lot of redoing to use pyproject
-- Upgrading version for 3.0
+- Removing 'docs' subpackage since the new src doesn't include that folder
 - Using literal package name so autoupgrader can do its thing.
 - Updating package folder name in %%autosetup
 

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -30,6 +30,7 @@ BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Summary:        %{summary}
 BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-hatchling
 BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-sphinx

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -42,7 +42,7 @@ The lock includes a lock counter and is thread safe. This means, when locking
 the same lock object twice, it will not block.
 
 %prep
-%autosetup -p1
+%autosetup -p1 -n %{srcname}-%{version}
 
 %build
 %py3_build
@@ -74,6 +74,7 @@ python%{python3_version} test.py
 * Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 3.13.4-1
 - Upgrading version for 3.0
 - Using literal package name so autoupgrader can do its thing.
+- Updating package folder name in %%autosetup
 
 * Fri Apr 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.12-13
 - Updating source URL.

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -6,8 +6,8 @@ Release:        1%{?dist}
 License:        Unlicense
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
-URL:            https://github.com/benediktschmitt/py-filelock
-Source0:        https://github.com/benediktschmitt/py-%{srcname}/archive/v%{version}/py-%{srcname}-%{version}.tar.gz#/%{name}-%{version}.tar.gz
+URL:            https://github.com/toxdev/filelock
+Source0:        https://github.com/toxdev/%{srcname}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
 %description

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -39,6 +39,7 @@ BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-setuptools_scm
 BuildRequires:  python%{python3_pkgversion}-sphinx
 BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
+BuildRequires:  python%{python3_pkgversion}-trove-classifiers
 
 %description -n python%{python3_pkgversion}-%{srcname}
 This package contains a single module, which implements a platform independent

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -33,6 +33,7 @@ BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-hatchling
 BuildRequires:  python%{python3_pkgversion}-pathspec
 BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  python%{python3_pkgversion}-pluggy
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-sphinx
 BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -29,13 +29,10 @@ BuildRequires:  python%{python3_pkgversion}-pluggy
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-setuptools_scm
 BuildRequires:  python%{python3_pkgversion}-trove-classifiers
-%if %{with_check}
-BuildRequires:  python%{python3_pkgversion}-iniconfig
+%if %{with check}
+BuildRequires:  python%{python3_pkgversion}-pytest
+BuildRequires:  python%{python3_pkgversion}-pytest-mock
 %endif
-
-# %if %{with check}
-# BuildRequires:  python%{python3_pkgversion}-pytest
-# %endif
 
 %description -n python%{python3_pkgversion}-%{srcname}
 This package contains a single module, which implements a platform independent
@@ -58,16 +55,12 @@ the same lock object twice, it will not block.
 %pyproject_save_files %{srcname}
 
 %check
-<<<<<<< HEAD
 pip3 install iniconfig
-=======
-%if %{with check}
->>>>>>> 0b60e6d8a7e63bf6264cc92662b59a2b896e7b5a
 %pytest
 
 %files -n python%{python3_pkgversion}-%{srcname} -f %{pyproject_files}
 %doc README.md
-%license licenses
+%license %{python3_sitelib}/%{srcname}-%{version}.dist-info/licenses/LICENSE
 
 %changelog
 * Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 3.14.0-1

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -30,6 +30,7 @@ BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Summary:        %{summary}
 BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-sphinx
 BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -31,6 +31,7 @@ BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
 Summary:        %{summary}
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-hatchling
+BuildRequires:  python%{python3_pkgversion}-hatch-vcs
 BuildRequires:  python%{python3_pkgversion}-pathspec
 BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-pluggy

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -57,6 +57,7 @@ the same lock object twice, it will not block.
 %build
 %pyproject_wheel
 
+ls .
 pushd docs
 PYTHONPATH=../src sphinx-build ./ html --color -b html -d doctrees
 rm html/.buildinfo

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -31,7 +31,9 @@ BuildRequires:  python%{python3_pkgversion}-setuptools_scm
 # BuildRequires:  python%{python3_pkgversion}-sphinx
 # BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
 BuildRequires:  python%{python3_pkgversion}-trove-classifiers
-
+%if %{with_check}
+BuildRequires:  python%{python3_pkgversion}-iniconfig
+%endif
 %description -n python%{python3_pkgversion}-%{srcname}
 This package contains a single module, which implements a platform independent
 file locking mechanism for Python.
@@ -50,14 +52,11 @@ the same lock object twice, it will not block.
 
 %install
 %pyproject_install
-%pyproject_save_files -l %{srcname}
+%pyproject_save_files %{srcname}
 
 %check
-%if %{with tests}
+pip3 install iniconfig
 %pytest
-%else
-%pyproject_check_import
-%endif
 
 %files -n python%{python3_pkgversion}-%{srcname} -f %{pyproject_files}
 %doc README.md
@@ -69,6 +68,7 @@ the same lock object twice, it will not block.
 - Removing 'docs' subpackage since the new src doesn't include that folder
 - Using literal package name so autoupgrader can do its thing.
 - Updating package folder name in %%autosetup
+- Adding python-iniconfig in check section
 
 * Fri Apr 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.12-13
 - Updating source URL.

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -1,13 +1,13 @@
 %global srcname filelock
 Summary:        A platform independent file lock
 Name:           python-filelock
-Version:        3.13.4
+Version:        3.14.0
 Release:        1%{?dist}
 License:        Unlicense
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://github.com/toxdev/filelock
-Source0:        https://github.com/toxdev/%{srcname}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
 %description
@@ -80,7 +80,7 @@ popd
 %doc README.md
 
 %changelog
-* Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 3.13.4-1
+* Fri Apr 26 2024 Osama Esmail <osamaesmail@microsoft.com> - 3.14.0-1
 - Lot of redoing to use pyproject
 - Upgrading version for 3.0
 - Using literal package name so autoupgrader can do its thing.

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -31,6 +31,7 @@ BuildRequires:  python%{python3_pkgversion}-sphinx-theme-alabaster
 Summary:        %{summary}
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-hatchling
+BuildRequires:  python%{python3_pkgversion}-pathspec
 BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-sphinx

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -42,7 +42,7 @@ The lock includes a lock counter and is thread safe. This means, when locking
 the same lock object twice, it will not block.
 
 %prep
-%autosetup -p1 -n py-%{srcname}-%{version}
+%autosetup -p1
 
 %build
 %py3_build

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22363,8 +22363,8 @@
         "type": "other",
         "other": {
           "name": "python-filelock",
-          "version": "3.13.4",
-          "downloadUrl": "https://github.com/tox-dev/filelock/archive/refs/tags/3.13.4.tar.gz"
+          "version": "3.14.0",
+          "downloadUrl": "https://files.pythonhosted.org/packages/source/f/filelock/filelock-3.14.0.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22363,8 +22363,8 @@
         "type": "other",
         "other": {
           "name": "python-filelock",
-          "version": "3.0.12",
-          "downloadUrl": "https://github.com/benediktschmitt/py-filelock/archive/v3.0.12/py-filelock-3.0.12.tar.gz"
+          "version": "3.13.4",
+          "downloadUrl": "https://github.com/benediktschmitt/py-filelock/archive/v3.13.4/py-filelock-3.13.4.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22364,7 +22364,7 @@
         "other": {
           "name": "python-filelock",
           "version": "3.13.4",
-          "downloadUrl": "https://github.com/benediktschmitt/py-filelock/archive/v3.13.4/py-filelock-3.13.4.tar.gz"
+          "downloadUrl": "https://github.com/tox-dev/filelock/archive/refs/tags/3.13.4.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrading `python-filelock` to `3.13.4`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrading `python-filelock` to `3.13.4`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 566032
