### PR TITLE
Add patch in cri-o for CVE-2024-21626

### DIFF
--- a/SPECS/cri-o/CVE-2023-44487.patch
+++ b/SPECS/cri-o/CVE-2023-44487.patch
@@ -226,6 +226,14 @@ index 00000000000..df79755f325
 +		t.Fatal("Received unexpected RPC error:", err)
 +	}
 +}
+From 800a8eaba7f25bd223fefe6e7613e39a5d7f1eeb Mon Sep 17 00:00:00 2001
+From: Monis Khan <i@monis.app>
+Date: Sat, 7 Oct 2023 21:50:37 -0400
+Subject: [PATCH] Prevent rapid reset http2 DOS on API server
+
+---
+ .../apimachinery/pkg/util/runtime/runtime.go  |  15 +-
+
 diff --git a/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go b/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go
 index 035c52811..c3241ea0d 100644
 --- a/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go

--- a/SPECS/cri-o/CVE-2023-44487.patch
+++ b/SPECS/cri-o/CVE-2023-44487.patch
@@ -226,3 +226,31 @@ index 00000000000..df79755f325
 +		t.Fatal("Received unexpected RPC error:", err)
 +	}
 +}
+diff --git a/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go b/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+index 035c52811..c3241ea0d 100644
+--- a/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go
++++ b/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+@@ -125,14 +125,17 @@ type rudimentaryErrorBackoff struct {
+ // OnError will block if it is called more often than the embedded period time.
+ // This will prevent overly tight hot error loops.
+ func (r *rudimentaryErrorBackoff) OnError(error) {
++	now := time.Now() // start the timer before acquiring the lock
+ 	r.lastErrorTimeLock.Lock()
+-	defer r.lastErrorTimeLock.Unlock()
+-	d := time.Since(r.lastErrorTime)
+-	if d < r.minPeriod {
+-		// If the time moves backwards for any reason, do nothing
+-		time.Sleep(r.minPeriod - d)
+-	}
++	d := now.Sub(r.lastErrorTime)
+ 	r.lastErrorTime = time.Now()
++	r.lastErrorTimeLock.Unlock()
++
++	// Do not sleep with the lock held because that causes all callers of HandleError to block.
++	// We only want the current goroutine to block.
++	// A negative or zero duration causes time.Sleep to return immediately.
++	// If the time moves backwards for any reason, do nothing.
++	time.Sleep(r.minPeriod - d)
+ }
+ 
+ // GetCaller returns the caller of the function that calls it.

--- a/SPECS/cri-o/CVE-2024-21626.patch
+++ b/SPECS/cri-o/CVE-2024-21626.patch
@@ -1,0 +1,91 @@
+From 8e1cd2f56d518f8d6292b8bb39f0d0932e4b6c2a Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <cyphar@cyphar.com>
+Date: Tue, 26 Dec 2023 23:53:07 +1100
+Subject: [PATCH 1/5] init: verify after chdir that cwd is inside the container
+
+If a file descriptor of a directory in the host's mount namespace is
+leaked to runc init, a malicious config.json could use /proc/self/fd/...
+as a working directory to allow for host filesystem access after the
+container runs. This can also be exploited by a container process if it
+knows that an administrator will use "runc exec --cwd" and the target
+--cwd (the attacker can change that cwd to be a symlink pointing to
+/proc/self/fd/... and wait for the process to exec and then snoop on
+/proc/$pid/cwd to get access to the host). The former issue can lead to
+a critical vulnerability in Docker and Kubernetes, while the latter is a
+container breakout.
+
+We can (ab)use the fact that getcwd(2) on Linux detects this exact case,
+and getcwd(3) and Go's Getwd() return an error as a result. Thus, if we
+just do os.Getwd() after chdir we can easily detect this case and error
+out.
+
+In runc 1.1, a /sys/fs/cgroup handle happens to be leaked to "runc
+init", making this exploitable. On runc main it just so happens that the
+leaked /sys/fs/cgroup gets clobbered and thus this is only consistently
+exploitable for runc 1.1.
+
+Fixes: GHSA-xr7r-f8xq-vfvv CVE-2024-21626
+Co-developed-by: lifubang <lifubang@acmcoder.com>
+Signed-off-by: lifubang <lifubang@acmcoder.com>
+[refactored the implementation and added more comments]
+Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>
+
+Adapted for Azure Linux
+
+ .../libcontainer/cgroups/fscommon/open.go     | 13 ++--
+ .../runc/libcontainer/utils/utils_unix.go     | 74 ++++++++++++++++---
+ 2 files changed, 72 insertions(+), 15 deletions(-)
+
+diff --git a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fscommon/open.go b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fscommon/open.go
+index 49af83b3c..a178b349a 100644
+--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fscommon/open.go
++++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fscommon/open.go
+@@ -19,7 +19,7 @@ var (
+ 	// TestMode is set to true by unit tests that need "fake" cgroupfs.
+ 	TestMode bool
+ 
+-	cgroupFd     int = -1
++	cgroupRootHandle *os.File
+ 	prepOnce     sync.Once
+ 	prepErr      error
+ 	resolveFlags uint64
+@@ -28,7 +28,7 @@ var (
+ func prepareOpenat2() error {
+ 	prepOnce.Do(func() {
+ 		fd, err := unix.Openat2(-1, cgroupfsDir, &unix.OpenHow{
+-			Flags: unix.O_DIRECTORY | unix.O_PATH})
++			Flags: unix.O_DIRECTORY | unix.O_PATH | unix.O_CLOEXEC})
+ 		if err != nil {
+ 			prepErr = &os.PathError{Op: "openat2", Path: cgroupfsDir, Err: err}
+ 			if err != unix.ENOSYS {
+@@ -38,15 +38,16 @@ func prepareOpenat2() error {
+ 			}
+ 			return
+ 		}
++		file := os.NewFile(uintptr(fd), cgroupfsDir)
++
+ 		var st unix.Statfs_t
+-		if err = unix.Fstatfs(fd, &st); err != nil {
++		if err := unix.Fstatfs(int(file.Fd()), &st); err != nil {
+ 			prepErr = &os.PathError{Op: "statfs", Path: cgroupfsDir, Err: err}
+ 			logrus.Warnf("falling back to securejoin: %s", prepErr)
+ 			return
+ 		}
+ 
+-		cgroupFd = fd
+-
++		cgroupRootHandle = file
+ 		resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_MAGICLINKS
+ 		if st.Type == unix.CGROUP2_SUPER_MAGIC {
+ 			// cgroupv2 has a single mountpoint and no "cpu,cpuacct" symlinks
+@@ -79,7 +80,7 @@ func OpenFile(dir, file string, flags int) (*os.File, error) {
+ 	}
+ 
+ 	relname := reldir + "/" + file
+-	fd, err := unix.Openat2(cgroupFd, relname,
++	fd, err := unix.Openat2(int(cgroupRootHandle.Fd()), relname,
+ 		&unix.OpenHow{
+ 			Resolve: resolveFlags,
+ 			Flags:   uint64(flags) | unix.O_CLOEXEC,
+-- 
+2.25.1

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.21.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,6 +62,7 @@ Patch6:         CVE-2021-44716.patch
 Patch7:         CVE-2022-21698.patch
 Patch8:         CVE-2023-44487.patch
 Patch9:         CVE-2024-28180.patch
+Patch10:        CVE-2024-21626.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  fdupes
@@ -214,6 +215,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Fri Apr 26 2024 Dallas Delaney <dadelan@microsoft.com> - 1.21.7-3
+- Apply patch to fix CVE-2024-21626 and update patch for CVE-2023-44487
+
 * Tue Apr 16 2024 Cameron Baird <cameronbaird@microsoft.com> - 1.21.7-2
 - Apply patches to fix CVE-2021-3602, CVE-2022-27651, CVE-2022-2995, CVE-2023-42821
 - CVE-2021-44716, CVE-2022-29526, CVE-2022-21698, CVE-2023-44487, CVE-2024-28180


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch cri-o for CVE-2024-21626 and patch additional file for CVE-2023-44487

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch cri-o for CVE-2024-21626 and patch additional file for CVE-2023-44487

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-21626

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=561328&view=results
