### PR TITLE
rocksdb: fix compilation issue with x86-64-v3 architecture

### DIFF
--- a/SPECS/rocksdb/rocksdb.spec
+++ b/SPECS/rocksdb/rocksdb.spec
@@ -38,7 +38,7 @@ Development files for %{name}
 mkdir build
 cd build
 %ifarch x86_64
-PORTABLE_OPTION=x86-64-v3
+PORTABLE_OPTION=haswell
 %else
 PORTABLE_OPTION=1
 %endif

--- a/SPECS/rocksdb/rocksdb.spec
+++ b/SPECS/rocksdb/rocksdb.spec
@@ -3,7 +3,7 @@
 Name:           rocksdb
 Summary:        A library that provides an embeddable, persistent key-value store for fast storage.
 Version:        8.9.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+ and ASL 2.0 and BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -37,7 +37,12 @@ Development files for %{name}
 %build
 mkdir build
 cd build
-%cmake -DPORTABLE=1 ..
+%ifarch x86_64
+PORTABLE_OPTION=x86-64-v3
+%else
+PORTABLE_OPTION=1
+%endif
+%cmake -DPORTABLE=$PORTABLE_OPTION ..
 make %{?_smp_mflags}
 
 %install
@@ -58,16 +63,21 @@ make install DESTDIR=%{buildroot}
 %{_libdir}/pkgconfig/rocksdb.pc
 
 %changelog
+* Mon Apr 29 2024 Andrew Phelps <anphel@microsoft.com> - 8.9.1-2
+- Fix build issue with -march=x86-64-v3
+
 * Wed Dec 13 2023 Andrew Phelps <anphel@microsoft.com> - 8.9.1-1
 - Upgrade to 8.9.1
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 6.26.0-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 
-*   Thu Nov 11 2021 Andrew Phelps <anphel@microsoft.com> 6.26.0-1
--   Update to version 6.26.0
-*   Thu Oct 08 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 6.7.3-2
--   Fixed 'Source0' URL.
--   License verified.
-*   Mon Mar 30 2020 Jonathan Chiu <jochi@microsoft.com> 6.7.3-1
--   Original version for CBL-Mariner.
+* Thu Nov 11 2021 Andrew Phelps <anphel@microsoft.com> 6.26.0-1
+- Update to version 6.26.0
+
+* Thu Oct 08 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 6.7.3-2
+- Fixed 'Source0' URL.
+- License verified.
+
+* Mon Mar 30 2020 Jonathan Chiu <jochi@microsoft.com> 6.7.3-1
+- Original version for CBL-Mariner.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
rocksdb: fix compilation issue with x86-64-v3 architecture
rocksdb is failing to compile with the recent change to use -march=x86-64-v3. (PR #8846)
```
INFO -                  from /usr/src/azl/BUILD/rocksdb-8.9.1/util/math.h:13,
INFO -                  from /usr/src/azl/BUILD/rocksdb-8.9.1/util/crc32c.cc:22:
INFO - In function '__m128i _mm_clmulepi64_si128(__m128i, __m128i, int)',
INFO -     inlined from 'uint64_t rocksdb::crc32c::CombineCRC(size_t, uint64_t, uint64_t, uint64_t, const uint64_t*)' at /usr/src/azl/BUILD/rocksdb-8.9.1/util/crc32c.cc:555:41,
INFO -     inlined from 'uint32_t rocksdb::crc32c::crc32c_3way(uint32_t, const char*, size_t)' at /usr/src/azl/BUILD/rocksdb-8.9.1/util/crc32c.cc:997:32:
ERROR - /usr/lib/gcc/x86_64-pc-linux-gnu/13.2.0/include/wmmintrin.h:118:10: error: '__builtin_ia32_pclmulqdq128' needs isa option -mpclmul -msse2
INFO -   118 |   return (__m128i) __builtin_ia32_pclmulqdq128 ((__v2di)__X,
INFO -       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO -   119 |                                                 (__v2di)__Y, __I);
INFO -       |                                                 ~~~~~~~~~~~~~~~~~
INFO - In function '__m128i _mm_clmulepi64_si128(__m128i, __m128i, int)',
```
Fix the build by specifying `PORTABLE=haswell` for x86-64 builds, which ensures the ISA options for PCLMUL and SSE2 are available. For more info see [here](https://gcc.gnu.org/onlinedocs/gcc-4.4.7/gcc/i386-and-x86_002d64-Options.html) and [here](https://github.com/facebook/rocksdb/blob/8.9.fb/INSTALL.md)


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- rocksdb: fix compilation issue with x86-64-v3 architecture

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=559882&view=results
