### PR TITLE
Upgrade php to 8.1.28 to fix CVE-2024-2756, CVE-2024-3096

### DIFF
--- a/SPECS/php/php.signatures.json
+++ b/SPECS/php/php.signatures.json
@@ -14,6 +14,6 @@
     "php.conf": "e2388be032eccf7c0197d597ba72259a095bf8434438a184e6a640edb4b59de2",
     "php.ini": "8fd5a4d891c19320c07010fbbbac982c886b422bc8d062acaeae49d70c136fc8",
     "php.modconf": "dc7303ea584452d2f742d002a648abe74905025aabf240259c7e8bd01746d278",
-    "php-8.1.22.tar.xz": "9ea4f4cfe775cb5866c057323d6b320f3a6e0adb1be41a068ff7bfec6f83e71d"
+    "php-8.1.28.tar.xz": "95d0b2e9466108fd750dab5c30a09e5c67f5ad2cb3b1ffb3625a038a755ad080"
   }
 }

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -1518,6 +1518,7 @@ systemctl try-restart php-fpm.service >/dev/null 2>&1 || :
 %changelog
 * Fri May 03 2024 Gary Swalling <gaswal@microsoft.com> - 8.1.28-1
 - Upgrade to 8.1.28 to fix CVE-2024-2756, CVE-2024-3096
+- Update BuildRequires, libpq is now provided by postgresql
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 8.1.22-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -221,7 +221,7 @@ Provides:       php-exif
 Provides:       php-exif%{?_isa}
 Provides:       php-fileinfo
 Provides:       php-fileinfo%{?_isa}
-Provides:       bundled(libmagic) = 5.29
+Provides:       bundled(libmagic) = 5.40
 Provides:       php-filter
 Provides:       php-filter%{?_isa}
 Provides:       php-ftp

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -1516,7 +1516,7 @@ systemctl try-restart php-fpm.service >/dev/null 2>&1 || :
 
 %changelog
 * Mon Apr 29 2024 Gary Swalling <gaswal@microsoft.com> - 8.1.28-1
-- Upgrade to 8.1.28 to fix CVE-2024-1874, CVE-2024-2756, CVE-2024-2757, CVE-2024-3096
+- Upgrade to 8.1.28 to fix CVE-2024-2756, CVE-2024-3096
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 8.1.22-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -32,8 +32,8 @@
 %global with_qdbm     0
 Summary:        PHP scripting language for creating dynamic web sites
 Name:           php
-Version:        8.1.22
-Release:        2%{?dist}
+Version:        8.1.28
+Release:        1%{?dist}
 # All files licensed under PHP version 3.01, except
 # Zend is licensed under Zend
 # TSRM is licensed under BSD
@@ -1515,6 +1515,9 @@ systemctl try-restart php-fpm.service >/dev/null 2>&1 || :
 %dir %{_datadir}/php/preload
 
 %changelog
+* Mon Apr 29 2024 Gary Swalling <gaswal@microsoft.com> - 8.1.28-1
+- Upgrade to 8.1.28 to fix CVE-2024-1874, CVE-2024-2756, CVE-2024-2757, CVE-2024-3096
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 8.1.22-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -386,7 +386,8 @@ Summary:        A PostgreSQL database module for PHP
 # All files licensed under PHP version 3.01
 License:        PHP
 BuildRequires:  krb5-devel
-BuildRequires:  libpq-devel
+# PostgreSQL provides libpq and obsoletes older versions (see postgresql.spec)
+BuildRequires:  postgresql-devel
 BuildRequires:  openssl-devel
 Requires:       php-pdo%{?_isa} = %{version}-%{release}
 Provides:       php_database

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -1516,7 +1516,7 @@ systemctl try-restart php-fpm.service >/dev/null 2>&1 || :
 %dir %{_datadir}/php/preload
 
 %changelog
-* Mon Apr 29 2024 Gary Swalling <gaswal@microsoft.com> - 8.1.28-1
+* Fri May 03 2024 Gary Swalling <gaswal@microsoft.com> - 8.1.28-1
 - Upgrade to 8.1.28 to fix CVE-2024-2756, CVE-2024-3096
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 8.1.22-2

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21105,7 +21105,7 @@
         "other": {
           "name": "php",
           "version": "8.1.22",
-          "downloadUrl": "https://www.php.net/distributions/php-8.1.22.tar.xz"
+          "downloadUrl": "https://www.php.net/distributions/php-8.1.28.tar.xz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21104,7 +21104,7 @@
         "type": "other",
         "other": {
           "name": "php",
-          "version": "8.1.22",
+          "version": "8.1.28",
           "downloadUrl": "https://www.php.net/distributions/php-8.1.28.tar.xz"
         }
       }


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade php from 8.1.22 to 8.1.28 to fix CVE-2024-2756 and CVE-2024-3096

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade php from 8.1.22 to 8.1.28 to fix CVE-2024-2756 and CVE-2024-3096
- Update BuildRequires, libpq is now provided by postgresql

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-2756
- https://nvd.nist.gov/vuln/detail/CVE-2024-3096

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 561390
