### PR TITLE
[2.0] zeromq: upgrade to 4.3.5

### DIFF
--- a/SPECS/zeromq/zeromq.signatures.json
+++ b/SPECS/zeromq/zeromq.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "zeromq-4.3.4.tar.gz": "c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5"
+  "zeromq-4.3.5.tar.gz": "6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43"
  }
 }

--- a/SPECS/zeromq/zeromq.spec
+++ b/SPECS/zeromq/zeromq.spec
@@ -2,7 +2,7 @@ Summary:        library for fast, message-based applications
 Name:           zeromq
 Version:        4.3.5
 Release:        1%{?dist}
-License:        LGPLv3+
+License:        MPLv2.0 AND BSD-3-Clause AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
@@ -60,6 +60,7 @@ make check
 %changelog
 * Mon Apr 29 2023 Andrew Phelps <anphel@microsoft.com> - 4.3.5-1
 - Upgrade to version 4.3.5
+- Update license
 
 * Thu Jun 03 2021 Nick Samson <nisamson@microsoft.com> - 4.3.4-1
 - Upgraded to 4.3.4 to address CVE-2021-20236, updated URL

--- a/SPECS/zeromq/zeromq.spec
+++ b/SPECS/zeromq/zeromq.spec
@@ -1,6 +1,6 @@
 Summary:        library for fast, message-based applications
 Name:           zeromq
-Version:        4.3.4
+Version:        4.3.5
 Release:        1%{?dist}
 License:        LGPLv3+
 Vendor:         Microsoft Corporation
@@ -48,8 +48,7 @@ make check
 
 %files
 %defattr(-,root,root)
-%license COPYING
-%{_bindir}/
+%license LICENSE
 %{_libdir}/libzmq.so.*
 
 %files devel
@@ -59,26 +58,29 @@ make check
 %{_includedir}/
 
 %changelog
+* Mon Apr 29 2023 Andrew Phelps <anphel@microsoft.com> - 4.3.5-1
+- Upgrade to version 4.3.5
+
 * Thu Jun 03 2021 Nick Samson <nisamson@microsoft.com> - 4.3.4-1
 - Upgraded to 4.3.4 to address CVE-2021-20236, updated URL
 
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 4.3.2-2
 - Added %%license line automatically
 
-*   Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 4.3.2-1
--   Update to 4.3.2. Source0 URL fixed. License verified.
+* Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 4.3.2-1
+- Update to 4.3.2. Source0 URL fixed. License verified.
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.2.3-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.2.3-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
 
-*   Thu Sep 13 2018 Siju Maliakkal <smaliakkal@vmware.com> 4.2.3-1
--   Updated to latest version
+* Thu Sep 13 2018 Siju Maliakkal <smaliakkal@vmware.com> 4.2.3-1
+- Updated to latest version
 
-*   Fri Sep 15 2017 Bo Gan <ganb@vmware.com> 4.1.4-3
--   Remove devpts mount
+* Fri Sep 15 2017 Bo Gan <ganb@vmware.com> 4.1.4-3
+- Remove devpts mount
 
-*   Mon Aug 07 2017 Chang Lee <changlee@vmware.com> 4.1.4-2
--   Fixed %check
+* Mon Aug 07 2017 Chang Lee <changlee@vmware.com> 4.1.4-2
+- Fixed %check
 
-*   Thu Apr 13 2017 Dheeraj Shetty <dheerajs@vmware.com> 4.1.4-1
--   Initial build. First version
+* Thu Apr 13 2017 Dheeraj Shetty <dheerajs@vmware.com> 4.1.4-1
+- Initial build. First version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -30880,8 +30880,8 @@
         "type": "other",
         "other": {
           "name": "zeromq",
-          "version": "4.3.4",
-          "downloadUrl": "https://github.com/zeromq/libzmq/releases/download/v4.3.4/zeromq-4.3.4.tar.gz"
+          "version": "4.3.5",
+          "downloadUrl": "https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
zeromq: upgrade to 4.3.5. This contains a [fix](https://github.com/zeromq/libzmq/pull/4215) for the following broken test (occasionally fails when run on heavily loaded ptest pipeline)
```
"./config/test-driver: line 112: 256129 Aborted                 (core dumped) \"$@\" >> \"$log_file\" 2>&1"
"FAIL: tests/test_inproc_connect"
```


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- zeromq: upgrade to 4.3.5

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 50444828](https://microsoft.visualstudio.com/OS/_workitems/edit/50444828): [2.0] zeromq test_inproc_connect.cpp fails

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=559971&view=results
