### PR TITLE
moby-engine: add back-compat symlink for docker-proxy

### DIFF
--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -3,7 +3,7 @@
 Summary: The open-source application container engine
 Name:    moby-engine
 Version: 24.0.9
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -89,6 +89,7 @@ install -p -m 755 ./bundles/dynbinary-daemon/dockerd %{buildroot}%{_bindir}/dock
 
 mkdir -p %{buildroot}%{_libexecdir}
 install -p -m 755 ./bundles/dynbinary-daemon/docker-proxy %{buildroot}%{_libexecdir}/docker-proxy
+ln -s %{_libexecdir}/docker-proxy %{buildroot}/%{_bindir}/docker-proxy
 
 mkdir -p %{buildroot}%{_sysconfdir}/udev/rules.d
 install -p -m 644 contrib/udev/80-docker.rules %{buildroot}%{_sysconfdir}/udev/rules.d/80-docker.rules
@@ -115,6 +116,8 @@ fi
 %files
 %license LICENSE NOTICE
 %{_bindir}/dockerd
+# docker-proxy symlink in bindir to fix back-compat
+%{_bindir}/docker-proxy
 %{_libexecdir}/docker-proxy
 %dir %{_sysconfdir}/docker
 %config(noreplace) %{_sysconfdir}/docker/daemon.json
@@ -122,6 +125,9 @@ fi
 %{_unitdir}/*
 
 %changelog
+* Wed May 01 2024 Henry Beberman <henry.beberman@microsoft.com> - 24.0.9-2
+- Symlink /usr/bin/docker-proxy to /usr/libexec/docker-proxy for back-compat
+
 * Mon Mar 25 2024 Muhammad Falak <mwani@microsoft.com> - 24.0.9-1
 - Bump version to 24.X
 - Drop un-needed patches


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrading moby-engine to 24.0.9 included moving docker-proxy from /usr/bin/docker-proxy into /usr/libexec/docker-proxy

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Symlink /usr/bin/docker-proxy to /usr/libexec/docker-proxy for back-compat

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Bug 50492689

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Package build succeeded
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=561171&view=results
- Installed the new package on an Azure VM. Verified that containers run and that `which docker-proxy` returns `/usr/bin/docker-proxy` as expected.
