### PR TITLE
openssh: update to 9.7p1

### DIFF
--- a/SPECS/openssh/openssh.signatures.json
+++ b/SPECS/openssh/openssh.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "openssh-9.5p1.tar.gz": "f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b",
+  "openssh-9.7p1.tar.gz": "490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd",
   "pam_ssh_agent_auth-0.10.3.tar.bz2": "3c53d358d6eaed1b211239df017c27c6f9970995d14102ae67bae16d4f47a763",
   "pam_ssh_agent-rmheaders": "468ed01777cae90b31244130d66dfcf7dad9d5cafd9746e6f155440d8c9b16d7",
   "sshd-keygen.service": "331515a4fb37951122ac8447111b126368386a49ac429f500fe3819ba25a70be",

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -1,9 +1,9 @@
-%global openssh_ver 9.5p1
+%global openssh_ver 9.7p1
 %global pam_ssh_agent_ver 0.10.3
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh
 Version:        %{openssh_ver}
-Release:        2%{?dist}
+Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -261,6 +261,9 @@ fi
 %{_mandir}/man8/ssh-sk-helper.8.gz
 
 %changelog
+* Thu May 02 2024 Tobias Brick <tobiasb@microsoft.com> - 9.7p1-1
+- Upgrade to version 9.7p1
+
 * Fri Feb 02 2024 Dan Streetman <ddstreet@ieee.org> - 9.5p1-2
 - workaround "circular dependencies" from build tooling
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -15223,8 +15223,8 @@
         "type": "other",
         "other": {
           "name": "openssh",
-          "version": "9.5p1",
-          "downloadUrl": "https://ftp.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.5p1.tar.gz"
+          "version": "9.7p1",
+          "downloadUrl": "https://ftp.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.7p1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Update openssh to 9.7p1.

###### Change Log  <!-- REQUIRED -->
- Update openssh to 9.7p1.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Builds locally
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=561867&view=results
NOTE: Check section has failed since original update to 9.5p1.
