### PR TITLE
Image Customizer: Increase timeout for loopback detach

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -379,7 +379,7 @@ func WaitForLoopbackToDetach(devicePath string, diskPath string) error {
 	}
 
 	delay := 100 * time.Millisecond
-	attempts := 10
+	attempts := 8
 	for failures := 0; failures < attempts; failures++ {
 		stdout, _, err := shell.Execute("losetup", "--list", "--json", "--output", "NAME,BACK-FILE")
 		if err != nil {

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -379,7 +379,7 @@ func WaitForLoopbackToDetach(devicePath string, diskPath string) error {
 	}
 
 	delay := 100 * time.Millisecond
-	attempts := 5
+	attempts := 10
 	for failures := 0; failures < attempts; failures++ {
 		stdout, _, err := shell.Execute("losetup", "--list", "--json", "--output", "NAME,BACK-FILE")
 		if err != nil {


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Issues are reported when detaching the loopback devices where it will timeout before the detach is completely done.
```
2024/05/01 23:02:48 image customization failed: timed out waiting for loopback device (/dev/loop36) for disk (/customizer/image.raw) to close
```
The change increments the number of attempts which also increases the delay with each and overall timeout.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/**NO****

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local testing, no repro anymore with the change.
