### PR TITLE
systemd: suppress debug messages to console by default

### DIFF
--- a/SPECS/systemd/10-console-messages.conf
+++ b/SPECS/systemd/10-console-messages.conf
@@ -1,0 +1,2 @@
+# Suppress debug messages on console
+kernel.printk = 4 4 1 7

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "10-console-messages.conf": "6cfc12931ac75df710aa1d323cdb98592935692cd9d32260d6118f9ad03a42e2",
   "10-map-count.conf": "bad4f0bbf268860582402bb4131b7b3586bf1f098a8bf89a6adf503191bc8913",
   "10-oomd-defaults.conf": "f7c8e9d3455bf54795063e3914956b4e15ba52f493b0f2304abef6326a80c6cb",
   "10-oomd-per-slice-defaults.conf": "3f0d6882312affecddfdc5a204a44c34b90c573839f2a4850a26b44f528520bd",

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        12%{?dist}
+Release:        13%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -96,6 +96,7 @@ Source14:       10-oomd-defaults.conf
 Source15:       10-oomd-per-slice-defaults.conf
 Source16:       10-timeout-abort.conf
 Source17:       10-map-count.conf
+Source18:       10-console-messages.conf
 
 Source21:       macros.sysusers
 Source22:       sysusers.attr
@@ -856,6 +857,8 @@ install -Dm0644 10-timeout-abort.conf.user %{buildroot}%{user_unit_dir}/service.
 # https://fedoraproject.org/wiki/Changes/IncreaseVmMaxMapCount
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE17}
 
+install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE18}
+
 sed -i 's|#!/usr/bin/env python3|#!%{__python3}|' %{buildroot}/usr/lib/systemd/tests/run-unit-tests.py
 
 install -m 0644 -D -t %{buildroot}%{_rpmconfigdir}/macros.d/ %{SOURCE21}
@@ -1192,6 +1195,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Thu May 02 2024 Rachel Menge <rachelmenge@microsoft.com> - 255-13
+- Supply 10-console-messages.conf sysctl to lower the default kernel messages to the console
+
 * Thu Apr 18 2024 Dan Streetman <ddstreet@microsoft.com> - 255-12
 - move libidn2 recommends from core package to systemd-networkd
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -857,7 +857,9 @@ install -Dm0644 10-timeout-abort.conf.user %{buildroot}%{user_unit_dir}/service.
 # https://fedoraproject.org/wiki/Changes/IncreaseVmMaxMapCount
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE17}
 
+%if 0%{?azl}
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE18}
+%endif
 
 sed -i 's|#!/usr/bin/env python3|#!%{__python3}|' %{buildroot}/usr/lib/systemd/tests/run-unit-tests.py
 

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/10-console-messages.conf
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/10-console-messages.conf
@@ -1,2 +1,0 @@
-# Suppress debug messages on console
-kernel.printk = 4 4 1 7

--- a/toolkit/resources/imageconfigs/iso_initrd.json
+++ b/toolkit/resources/imageconfigs/iso_initrd.json
@@ -37,8 +37,7 @@
                 "additionalfiles/iso_initrd/usr/lib/mariner/terminfo/mariner-installer": "/usr/lib/mariner/terminfo/m/mariner-installer",
                 "additionalfiles/iso_initrd/usr/lib/systemd/system/getty@.service": "/usr/lib/systemd/system/getty@.service",
                 "additionalfiles/iso_initrd/usr/lib/systemd/system/serial-getty@.service": "/usr/lib/systemd/system/serial-getty@.service",
-                "../manifests/image/local.repo": "/etc/yum.repos.d/mariner-iso.repo",
-                "additionalfiles/iso_initrd/10-console-messages.conf": "/etc/sysctl.d/10-console-messages.conf"
+                "../manifests/image/local.repo": "/etc/yum.repos.d/mariner-iso.repo"
             },
             "Users": [
                 {

--- a/toolkit/resources/imageconfigs/iso_initrd_arm64.json
+++ b/toolkit/resources/imageconfigs/iso_initrd_arm64.json
@@ -32,8 +32,7 @@
                 "additionalfiles/iso_initrd/usr/lib/mariner/terminfo/mariner-installer": "/usr/lib/mariner/terminfo/m/mariner-installer",
                 "additionalfiles/iso_initrd/usr/lib/systemd/system/getty@.service": "/usr/lib/systemd/system/getty@.service",
                 "additionalfiles/iso_initrd/usr/lib/systemd/system/serial-getty@.service": "/usr/lib/systemd/system/serial-getty@.service",
-                "../manifests/image/local.repo": "/etc/yum.repos.d/mariner-iso.repo",
-                "additionalfiles/iso_initrd/10-console-messages.conf": "/etc/sysctl.d/10-console-messages.conf"
+                "../manifests/image/local.repo": "/etc/yum.repos.d/mariner-iso.repo"
             },
             "Users": [
                 {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
During normal use, many low level debug messages are printing to the console which is causing usability issues for the user. To deal with this, install a sysctl configuration to run on boot which will change the default kernel printk value to "4 4 1 7".

This PR is based off of findings from: https://github.com/microsoft/azurelinux/pull/8331
and expands this [PR's ](https://github.com/microsoft/azurelinux/blob/3.0-dev/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/10-console-messages.conf)changes from specifically iso images to all images 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Supply 10-console-messages.conf sysctl to lower the default kernel messages to the console

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/50587114

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=562026&view=results

Build after azl https://dev.azure.com/mariner-org/mariner/_build/results?buildId=567237&view=logs&j=bac295d9-f2e0-5165-e63e-e76f383e1a27
