### PR TITLE
Image Customizer: Handle removal of mkinitrd in 3.0.

### DIFF
--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -432,7 +432,7 @@ func EnumerateDirFiles(dirPath string) (filePaths []string, err error) {
 }
 
 func CommandExists(name string) (bool, error) {
-	_, err := exec.LookPath("mkinitrd")
+	_, err := exec.LookPath(name)
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return false, nil

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
@@ -428,4 +429,15 @@ func EnumerateDirFiles(dirPath string) (filePaths []string, err error) {
 		return nil, fmt.Errorf("failed to enumerate files under %s:\n%w", dirPath, err)
 	}
 	return filePaths, nil
+}
+
+func CommandExists(name string) (bool, error) {
+	_, err := exec.LookPath("mkinitrd")
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/toolkit/tools/internal/file/file_test.go
+++ b/toolkit/tools/internal/file/file_test.go
@@ -237,3 +237,15 @@ func ListFiles(dir string) ([]string, error) {
 
 	return files, nil
 }
+
+func TestCommandExists(t *testing.T) {
+	exists, err := CommandExists("ls")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestCommandExistsMissing(t *testing.T) {
+	exists, err := CommandExists("contoso")
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}


### PR DESCRIPTION
In Azure Linux 3.0, the `mkinitrd` script was removed in favor of using `dracut` directly. This change fixes the image customizer tool so that it uses the appropriate tool for updating the initramfs file depending on the base image being used.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

