### PR TITLE
keda: upgrade from 2.4.0 to 2.14.0

### DIFF
--- a/SPECS/keda/keda.signatures.json
+++ b/SPECS/keda/keda.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "keda-2.4.0-vendor.tar.gz": "bf5f2e19aac2c178a868aa1b1245b11d5ed4a51b0713d1f41154987f062f986e",
-  "keda-2.4.0.tar.gz": "e3a44a7be2d80369fb490898fb3f5605170a2848c8f30c6c24eb68fb57cfd3e0"
+  "keda-2.14.0-vendor.tar.gz": "36e62d59b865b119070868c5d237e935bd633eacad31b1dc91e9bdcb3d5fd3cf",
+  "keda-2.14.0.tar.gz": "f99bf7540a70cf44d5450146737e62c5860276a14fadfa020ad05b6c1f1c8f8a"
  }
 }

--- a/SPECS/keda/keda.spec
+++ b/SPECS/keda/keda.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes-based Event Driven Autoscaling
 Name:           keda
-Version:        2.4.0
-Release:        15%{?dist}
+Version:        2.14.0
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -36,25 +36,33 @@ It provides event driven scale for any container running in Kubernetes
 tar -xf %{SOURCE1} --no-same-owner
 export LDFLAGS="-X=github.com/kedacore/keda/v2/version.GitCommit= -X=github.com/kedacore/keda/v2/version.Version=main"
 
-go build -ldflags "$LDFLAGS" -mod=vendor -v -o bin/keda main.go
+go build -ldflags "$LDFLAGS" -mod=vendor -v -o bin/keda cmd/operator/main.go
 
 gofmt -l -w -s .
 go vet ./...
 
-go build -ldflags "$LDFLAGS" -mod=vendor -v -o bin/keda-adapter adapter/main.go
+go build -ldflags "$LDFLAGS" -mod=vendor -v -o bin/keda-adapter cmd/adapter/main.go
+
+go build -ldflags "$LDFLAGS" -mod=vendor -v -o bin/keda-admission-webhooks cmd/webhooks/main.go
 
 %install
 mkdir -p %{buildroot}%{_bindir}
 cp ./bin/keda %{buildroot}%{_bindir}
 cp ./bin/keda-adapter %{buildroot}%{_bindir}
+cp ./bin/keda-admission-webhooks %{buildroot}%{_bindir}
 
 %files
 %defattr(-,root,root)
 %license LICENSE
 %{_bindir}/%{name}
 %{_bindir}/%{name}-adapter
+%{_bindir}/%{name}-admission-webhooks
 
 %changelog
+* Mon May 06 2024 Sean Dougherty <sdougherty@microsoft.com> - 2.14.0-1
+- Upgrade to 2.14.0 for Azure Linux 3.0
+- Added keda-admission-webhooks binary, added to KEDA in v2.10.0
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.0-15
 - Bump release to rebuild with go 1.20.10
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8121,8 +8121,8 @@
         "type": "other",
         "other": {
           "name": "keda",
-          "version": "2.4.0",
-          "downloadUrl": "https://github.com/kedacore/keda/archive/refs/tags/v2.4.0.tar.gz"
+          "version": "2.14.0",
+          "downloadUrl": "https://github.com/kedacore/keda/archive/refs/tags/v2.14.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR will upgrade the Kubernetes Event Driven Autoscaling package from 2.4.0 to 2.14.0 
The only notable change (packaging-wise) is that this adds the new binary `keda-admission-webhooks` which was added in [2.10.0](https://github.com/kedacore/keda/releases#:~:text=New%20admission%20webhook%20for%20validating%20ScaledObjects)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade keda from 2.4.0 to 2.14.0
- Add the keda-webhook-admissions binary to Keda rpm


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=564289&view=results
- Local build 
