### PR TITLE
fix: ephemeral-disk-warning service not running on boot

### DIFF
--- a/SPECS/azurelinux-release/90-default.preset
+++ b/SPECS/azurelinux-release/90-default.preset
@@ -184,3 +184,5 @@ enable cloud-init.service
 enable cloud-init-local.service
 
 enable waagent.service
+
+enable ephemeral-disk-warning.service

--- a/SPECS/azurelinux-release/azurelinux-release.signatures.json
+++ b/SPECS/azurelinux-release/azurelinux-release.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "90-default.preset": "307a6d6ab554caa22f9067cccda74afc0db0c10f0e80bdd8d0668f1bd5e3c3cc",
+  "90-default.preset": "50ed546e79e3c9f5c4f2d4a9796255537f4900d5d1d78c0564fbe7362634531b",
   "90-default-user.preset": "7cf8f4d2ca1760e04ff46bd2444609cfd27a7ab456be2f9e73b0f89c284e134d",
   "99-default-disable.preset": "3127b197b9eae62eb84eeed69b0413419612238332006183e36a3fba89578378",
   "15-azurelinux-default.conf": "63a46ecbed4b92f996718ea9202e914ff119c2c06fdaeed3d1e2710aabc663b4"

--- a/SPECS/azurelinux-release/azurelinux-release.spec
+++ b/SPECS/azurelinux-release/azurelinux-release.spec
@@ -5,7 +5,7 @@
 Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        %{dist_version}.0
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -118,6 +118,9 @@ install -Dm0644 %{SOURCE4} -t %{buildroot}%{_sysctldir}/
 %{_sysctldir}/*.conf
 
 %changelog
+* Tue May 07 2024 Sudipta Pandit <sudpandit@microsoft.com> - 3.0-11
+- Enable ephemeral-disk-warning.service in 90-default-target
+
 * Wed Apr 24 2024 Sam Meluch <sammeluch@microsoft.com> - 3.0-10
 - Azure Linux 3.0 April Preview Release 4
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In Azure Linux 3.0 the systemd's default behavior was overridden by introducing default presets. In this PR we add ephemeral-disk-warning.service to the default systemd presets to enable it during boot.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- fix ephemeral-disk-warning.service not running on boot

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**



###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [BuddyBuild](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=566424&view=results)
