### PR TITLE
refactor depsearch

### DIFF
--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -4,20 +4,14 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
-	"sort"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/exe"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/pkggraph"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/pkg/depsearch"
-	"github.com/microsoft/azurelinux/toolkit/tools/scheduler/schedulerutils"
 
-	"gonum.org/v1/gonum/graph"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -14,14 +14,11 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/pkggraph"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/azurelinux/toolkit/tools/pkg/depsearch"
 	"github.com/microsoft/azurelinux/toolkit/tools/scheduler/schedulerutils"
 
 	"gonum.org/v1/gonum/graph"
 	"gopkg.in/alecthomas/kingpin.v2"
-)
-
-const (
-	defaultFilterPath = "./resources/manifests/package/toolchain_x86_64.txt"
 )
 
 var (
@@ -73,7 +70,7 @@ func main() {
 	}
 
 	// We can color the entries when using --tree, or limit the output in all modes with --rpm-filter
-	configureFilterFiles(filterFile, filter)
+	depsearch.ConfigureFilterFiles(filterFile, filter)
 	if len(*filterFile) > 0 && (*filter || *printTree) {
 		logger.Log.Infof("Applying package filter from (%s)", *filterFile)
 	} else {
@@ -90,9 +87,9 @@ func main() {
 	}
 
 	// Generate a list of nodes to search from
-	nodeListPkg := searchForPkg(graph, pkgSearchList)
-	nodeListSpec := searchForSpec(graph, specSearchList)
-	nodeListGoal := searchForGoal(graph, goalSearchList)
+	nodeListPkg := depsearch.SearchForPkg(graph, pkgSearchList)
+	nodeListSpec := depsearch.SearchForSpec(graph, specSearchList)
+	nodeListGoal := depsearch.SearchForGoal(graph, goalSearchList)
 
 	nodeLists := append(nodeListPkg, append(nodeListSpec, nodeListGoal...)...)
 	nodeSet := sliceutils.RemoveDuplicatesFromSlice(nodeLists)
@@ -105,350 +102,19 @@ func main() {
 
 	if *reverseSearch {
 		logger.Log.Infof("Reversed search will list all the dependencies of the provided packages")
-		outputGraph, root, err = buildRequiresGraph(graph, nodeSet)
+		outputGraph, root, err = depsearch.BuildRequiresGraph(graph, nodeSet)
 	} else {
 		logger.Log.Infof("Forward search will list all dependants which rely on any of the provided packages")
-		outputGraph, root, err = buildDependsOnGraph(graph, nodeSet)
+		outputGraph, root, err = depsearch.BuildDependsOnGraph(graph, nodeSet)
 	}
 
 	if err != nil {
 		logger.Log.Panicf("Failed to generate graph to run depsearch on: %s", err)
 	}
 
-	printSpecs(outputGraph, *printTree, *filter, *filterFile, *printDuplicates, *verbosity, *maxDepth, *runtimeFilterLevel, root)
+	depsearch.PrintSpecs(outputGraph, *printTree, *filter, *filterFile, *printDuplicates, *verbosity, *maxDepth, *runtimeFilterLevel, root)
 
 	if len(*outputGraphFile) > 0 {
 		pkggraph.WriteDOTGraphFile(outputGraph, *outputGraphFile)
-	}
-}
-
-func configureFilterFiles(filterFile *string, filter *bool) {
-	setDefault := false
-	if len(*filterFile) == 0 {
-		*filterFile = defaultFilterPath
-		setDefault = true
-	}
-	isFile, err := file.PathExists(*filterFile)
-	if err != nil {
-		logger.Log.Panicf("Failed to query if filter file (%s) exists: %s", *filterFile, err)
-	}
-
-	// If we are just trying to use the default, its fine if its missing.
-	if !isFile && setDefault {
-		logger.Log.Warnf("Default toolchain filter file (%s) not found, setting to ''", *filterFile)
-		*filterFile = ""
-	}
-
-	if len(*filterFile) == 0 && *filter {
-		logger.Log.Panic("Must pass a --rpm-filter-file to use the filter function, consider './resources/manifests/package/toolchain_x86_64.txt'")
-	}
-}
-
-func searchForGoal(graph *pkggraph.PkgGraph, goals []string) (list []*pkggraph.PkgNode) {
-	for _, goal := range goals {
-		n := graph.FindGoalNode(goal)
-		if n != nil {
-			list = append(list, n)
-		}
-	}
-	return
-}
-
-func searchForPkg(graph *pkggraph.PkgGraph, packages []string) (list []*pkggraph.PkgNode) {
-	for _, n := range graph.AllPreferredRunNodes() {
-		nodeName := n.VersionedPkg.Name
-		for _, searchName := range packages {
-			if nodeName == searchName {
-				list = append(list, n)
-			}
-		}
-	}
-	return
-}
-
-func searchForSpec(graph *pkggraph.PkgGraph, specs []string) (list []*pkggraph.PkgNode) {
-	for _, n := range graph.AllPreferredRunNodes() {
-		nodeSpec := n.SpecName()
-		for _, searchSpec := range specs {
-			if nodeSpec == searchSpec {
-				list = append(list, n)
-			}
-		}
-	}
-	return
-}
-
-func buildRequiresGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, root *pkggraph.PkgNode, err error) {
-	// Make a copy of the graph
-	newGraph, err := graphIn.DeepCopy()
-	if err != nil {
-		return
-	}
-
-	// Add a goal node to all the things we care about
-	root = newGraph.AddMetaNode(nil, nodeList)
-	graphOut, err = newGraph.CreateSubGraph(root)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
-func buildDependsOnGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, root *pkggraph.PkgNode, err error) {
-	// Make a copy of the graph
-	reversedGraph, err := graphIn.DeepCopy()
-	if err != nil {
-		return
-	}
-
-	// Then reverse every edge in the graph
-	for _, edge := range graph.EdgesOf(reversedGraph.Edges()) {
-		reversedGraph.RemoveEdge(edge.From().ID(), edge.To().ID())
-		reversedGraph.SetEdge(edge.ReversedEdge())
-	}
-
-	// Add a goal node to all the things we care about
-	root = reversedGraph.AddMetaNode(nil, nodeList)
-	graphOut, err = reversedGraph.CreateSubGraph(root)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
-const (
-	colorReset = "\033[0m"
-	colorRed   = "\033[31m"
-)
-
-var (
-	reservedFiles map[string]bool
-)
-
-func formatNode(n *pkggraph.PkgNode, verbosity int) string {
-	switch verbosity {
-	case 1:
-		return n.SpecName()
-	case 2:
-		return filepath.Base(n.RpmPath)
-	case 3:
-		return fmt.Sprintf("'%s' from node '%s'", filepath.Base(n.RpmPath), n.FriendlyName())
-	case 4:
-		return fmt.Sprintf("(%v)'%#v'", n.VersionedPkg, *n)
-	default:
-		logger.Log.Fatalf("Invalid verbosity level %v", verbosity)
-	}
-	return ""
-}
-
-func isFilteredFile(path, filterFile string) bool {
-	if len(filterFile) > 0 {
-		if len(reservedFiles) == 0 {
-			reservedFileList, err := schedulerutils.ReadReservedFilesList(filterFile)
-			if err != nil {
-				logger.Log.Fatalf("Failed to load filter file (%s): %s", filterFile, err)
-			}
-			reservedFiles = sliceutils.SliceToSet[string](reservedFileList)
-		}
-		base := filepath.Base(path)
-
-		return len(path) > 0 && reservedFiles[base]
-	} else {
-		return false
-	}
-}
-
-type treeNode struct {
-	lines []string
-}
-
-type treeSearch struct {
-	graph *pkggraph.PkgGraph
-
-	// Don't print a node twice, just add '...' instead to save space
-	alreadyAdded map[*pkggraph.PkgNode]bool
-	// These nodes were caught by the filter and should be marked
-	filteredNodes map[*pkggraph.PkgNode]bool
-	// These nodes are not in the filter list
-	normalNodes map[*pkggraph.PkgNode]bool
-
-	nodesVisited, nodesTotal int
-}
-
-func createSearch(g *pkggraph.PkgGraph, root *pkggraph.PkgNode) (t *treeSearch, err error) {
-	newSearch := &treeSearch{
-		graph:         g,
-		alreadyAdded:  make(map[*pkggraph.PkgNode]bool),
-		filteredNodes: make(map[*pkggraph.PkgNode]bool),
-		normalNodes:   make(map[*pkggraph.PkgNode]bool),
-		nodesVisited:  0,
-	}
-
-	//Calculate the number of nodes we might visit:
-	subGraph, err := g.CreateSubGraph(root)
-	if err != nil {
-		logger.Log.Fatalf("Failed to calculate number of nodes: %s", err)
-	}
-
-	//This is the worst case possible number of searche to make
-	possibleEdges := subGraph.Edges().Len() * subGraph.Nodes().Len()
-	newSearch.nodesTotal = possibleEdges
-
-	return newSearch, nil
-}
-
-func (t *treeSearch) FilteredNodes() (nodes []*pkggraph.PkgNode) {
-	nodes = []*pkggraph.PkgNode{}
-	for n := range t.filteredNodes {
-		nodes = append(nodes, n)
-	}
-	return nodes
-}
-
-func (t *treeSearch) NonFilteredNodes() (nodes []*pkggraph.PkgNode) {
-	nodes = []*pkggraph.PkgNode{}
-	for n := range t.normalNodes {
-		nodes = append(nodes, n)
-	}
-	return nodes
-}
-
-// Call this ever time a node is processed, will print an update ever 100 nodes
-func (t *treeSearch) printProgress() {
-	if t.nodesVisited%10000 == 0 {
-		logger.Log.Infof("Scanned %d nodes", t.nodesVisited)
-	}
-	t.nodesVisited++
-}
-
-// Run a DFS and generate a string representation of the tree. Optionally ignore all branches that only container nodes in
-//
-//	the filter list (ie given the toolchain manifest, only print those branches which container non-toolchain packages)
-func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, filter bool, filterFile string, verbosity int, generateStrings, printDuplicates bool, runtimeFilterLevel int) (lines []string, hasNonToolchain bool) {
-	t.printProgress()
-	// We only care about run nodes for the purposes of detecting toolchain files
-	hasNonToolchain = n.Type == pkggraph.TypeLocalBuild && !isFilteredFile(n.RpmPath, filterFile)
-
-	if !printDuplicates && t.alreadyAdded[n] {
-		return []string{}, false
-	} else {
-		t.alreadyAdded[n] = true
-	}
-
-	thisNode := formatNode(n, verbosity)
-	if isFilteredFile(n.RpmPath, filterFile) {
-		// Highlight nodes that are in the filter file list in red, and add them to the list
-		if generateStrings {
-			lines = append(lines, "__"+colorRed+thisNode+colorReset)
-		}
-		if n.Type == pkggraph.TypeLocalRun {
-			// We only want to record run nodes for the purposes of listing packages in non-tree mode
-			t.filteredNodes[n] = true
-		}
-	} else {
-		// Non filtered files print normally
-		if generateStrings {
-			lines = append(lines, "__"+thisNode)
-		}
-		if n.Type == pkggraph.TypeLocalRun {
-			// We only want to record run nodes for the purposes of listing packages in non-tree mode
-			t.normalNodes[n] = true
-		}
-	}
-
-	var childrenTreeNodes []treeNode
-	nodes := t.graph.From(n.ID())
-	// Bail out early if we exceed max depth, maxDepth of -1 means no limit.
-	if depth < maxDepth || maxDepth == -1 {
-		var (
-			childLines                  []string
-			childHasMissingToolchainPkg = false
-			haveDuplicatedEntry         = false
-		)
-		for nodes.Next() {
-			child := nodes.Node().(*pkggraph.PkgNode)
-
-			// If we are only looking for runtime, skip build nodes (except for the root nodes: goal + each package node we care about)
-			if runtimeFilterLevel != -1 && depth > runtimeFilterLevel && child.Type == pkggraph.TypeLocalBuild {
-				continue
-			}
-			childLines, childHasMissingToolchainPkg = t.treeNodeToString(child, depth+1, maxDepth, filter, filterFile, verbosity, generateStrings, printDuplicates, runtimeFilterLevel)
-			hasNonToolchain = hasNonToolchain || childHasMissingToolchainPkg
-
-			// A child will return an empty string list if it, and all its children, are either duplicates or have been filtered out
-			if len(childLines) > 0 {
-				tn := treeNode{lines: childLines}
-				childrenTreeNodes = append(childrenTreeNodes, tn)
-			} else {
-				haveDuplicatedEntry = true
-			}
-		}
-
-		// If we have duplicated entires (ie empty strings), and we aren't removing all non-filtered entries, represent them with a '...'
-		//  as the last entry instead of the node name.
-		if haveDuplicatedEntry && !filter {
-			childrenTreeNodes = append(childrenTreeNodes, treeNode{lines: []string{"..."}})
-		}
-
-		if len(childrenTreeNodes) > 0 && generateStrings {
-			firstN := childrenTreeNodes[:len(childrenTreeNodes)-1]
-			last := childrenTreeNodes[len(childrenTreeNodes)-1]
-			for _, tn := range firstN {
-				for _, l := range tn.lines {
-					lines = append(lines, "   |"+l)
-				}
-			}
-			lines = append(lines, "   |"+last.lines[0])
-			for _, l := range last.lines[1:] {
-				lines = append(lines, "   "+l)
-			}
-		}
-	} else {
-		lines = append(lines, "   |-->")
-		// We are bailing out early, we don't know if this should be filtered, assume the worst
-		hasNonToolchain = true
-	}
-
-	if !hasNonToolchain && filter && depth > 0 {
-		return []string{}, false
-	}
-
-	return lines, hasNonToolchain
-}
-
-func printSpecs(graph *pkggraph.PkgGraph, tree, filter bool, filterFile string, printDuplicates bool, verbosity, maxDepth, runtimeFilterLevel int, root *pkggraph.PkgNode) {
-	t, err := createSearch(graph, root)
-	if err != nil {
-		logger.Log.Fatalf("Failed to start search: %s", err)
-	}
-	// May as well use the tree searh to parse all the filtered packages etc, even if we are
-	//    just printing a list
-	lines, _ := t.treeNodeToString(root, 0, maxDepth, filter, filterFile, verbosity, tree, printDuplicates, runtimeFilterLevel)
-	if tree {
-		for _, l := range lines {
-			fmt.Println(l)
-		}
-	} else {
-		results := make(map[string]bool)
-		if !filter {
-			// Only include toolchain packages if we aren't trying to find packages that have
-			// infiltrated the toolchain
-			for _, n := range t.FilteredNodes() {
-				results[formatNode(n, verbosity)] = true
-			}
-		}
-		// Always include normal nodes
-		for _, n := range t.NonFilteredNodes() {
-			results[formatNode(n, verbosity)] = true
-		}
-
-		// Contert to list and sort
-		printLines := sliceutils.SetToSlice[string](results)
-		sort.Strings(printLines)
-		for _, l := range printLines {
-			fmt.Println(l)
-		}
 	}
 }

--- a/toolkit/tools/pkg/depsearch/depsearch.go
+++ b/toolkit/tools/pkg/depsearch/depsearch.go
@@ -1,0 +1,351 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package depsearch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/pkggraph"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/azurelinux/toolkit/tools/scheduler/schedulerutils"
+
+	"gonum.org/v1/gonum/graph"
+)
+
+const (
+	defaultFilterPath = "./resources/manifests/package/toolchain_x86_64.txt"
+	colorReset = "\033[0m"
+	colorRed   = "\033[31m"
+)
+
+var (
+	reservedFiles map[string]bool
+)
+
+type treeNode struct {
+	lines []string
+}
+
+type treeSearch struct {
+	graph *pkggraph.PkgGraph
+
+	// Don't print a node twice, just add '...' instead to save space
+	alreadyAdded map[*pkggraph.PkgNode]bool
+	// These nodes were caught by the filter and should be marked
+	filteredNodes map[*pkggraph.PkgNode]bool
+	// These nodes are not in the filter list
+	normalNodes map[*pkggraph.PkgNode]bool
+
+	nodesVisited, nodesTotal int
+}
+
+func ConfigureFilterFiles(filterFile *string, filter *bool) {
+	setDefault := false
+	if len(*filterFile) == 0 {
+		*filterFile = defaultFilterPath
+		setDefault = true
+	}
+	isFile, err := file.PathExists(*filterFile)
+	if err != nil {
+		logger.Log.Panicf("Failed to query if filter file (%s) exists: %s", *filterFile, err)
+	}
+
+	// If we are just trying to use the default, its fine if its missing.
+	if !isFile && setDefault {
+		logger.Log.Warnf("Default toolchain filter file (%s) not found, setting to ''", *filterFile)
+		*filterFile = ""
+	}
+
+	if len(*filterFile) == 0 && *filter {
+		logger.Log.Panic("Must pass a --rpm-filter-file to use the filter function, consider './resources/manifests/package/toolchain_x86_64.txt'")
+	}
+}
+
+func SearchForGoal(graph *pkggraph.PkgGraph, goals []string) (list []*pkggraph.PkgNode) {
+	for _, goal := range goals {
+		n := graph.FindGoalNode(goal)
+		if n != nil {
+			list = append(list, n)
+		}
+	}
+	return
+}
+
+func SearchForPkg(graph *pkggraph.PkgGraph, packages []string) (list []*pkggraph.PkgNode) {
+	for _, n := range graph.AllPreferredRunNodes() {
+		nodeName := n.VersionedPkg.Name
+		for _, searchName := range packages {
+			if nodeName == searchName {
+				list = append(list, n)
+			}
+		}
+	}
+	return
+}
+
+func SearchForSpec(graph *pkggraph.PkgGraph, specs []string) (list []*pkggraph.PkgNode) {
+	for _, n := range graph.AllPreferredRunNodes() {
+		nodeSpec := n.SpecName()
+		for _, searchSpec := range specs {
+			if nodeSpec == searchSpec {
+				list = append(list, n)
+			}
+		}
+	}
+	return
+}
+
+func BuildRequiresGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, root *pkggraph.PkgNode, err error) {
+	// Make a copy of the graph
+	newGraph, err := graphIn.DeepCopy()
+	if err != nil {
+		return
+	}
+
+	// Add a goal node to all the things we care about
+	root = newGraph.AddMetaNode(nil, nodeList)
+	graphOut, err = newGraph.CreateSubGraph(root)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func BuildDependsOnGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, root *pkggraph.PkgNode, err error) {
+	// Make a copy of the graph
+	reversedGraph, err := graphIn.DeepCopy()
+	if err != nil {
+		return
+	}
+
+	// Then reverse every edge in the graph
+	for _, edge := range graph.EdgesOf(reversedGraph.Edges()) {
+		reversedGraph.RemoveEdge(edge.From().ID(), edge.To().ID())
+		reversedGraph.SetEdge(edge.ReversedEdge())
+	}
+
+	// Add a goal node to all the things we care about
+	root = reversedGraph.AddMetaNode(nil, nodeList)
+	graphOut, err = reversedGraph.CreateSubGraph(root)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func formatNode(n *pkggraph.PkgNode, verbosity int) string {
+	switch verbosity {
+	case 1:
+		return n.SpecName()
+	case 2:
+		return filepath.Base(n.RpmPath)
+	case 3:
+		return fmt.Sprintf("'%s' from node '%s'", filepath.Base(n.RpmPath), n.FriendlyName())
+	case 4:
+		return fmt.Sprintf("(%v)'%#v'", n.VersionedPkg, *n)
+	default:
+		logger.Log.Fatalf("Invalid verbosity level %v", verbosity)
+	}
+	return ""
+}
+
+func isFilteredFile(path, filterFile string) bool {
+	if len(filterFile) > 0 {
+		if len(reservedFiles) == 0 {
+			reservedFileList, err := schedulerutils.ReadReservedFilesList(filterFile)
+			if err != nil {
+				logger.Log.Fatalf("Failed to load filter file (%s): %s", filterFile, err)
+			}
+			reservedFiles = sliceutils.SliceToSet[string](reservedFileList)
+		}
+		base := filepath.Base(path)
+
+		return len(path) > 0 && reservedFiles[base]
+	} else {
+		return false
+	}
+}
+
+func createSearch(g *pkggraph.PkgGraph, root *pkggraph.PkgNode) (t *treeSearch, err error) {
+	newSearch := &treeSearch{
+		graph:         g,
+		alreadyAdded:  make(map[*pkggraph.PkgNode]bool),
+		filteredNodes: make(map[*pkggraph.PkgNode]bool),
+		normalNodes:   make(map[*pkggraph.PkgNode]bool),
+		nodesVisited:  0,
+	}
+
+	//Calculate the number of nodes we might visit:
+	subGraph, err := g.CreateSubGraph(root)
+	if err != nil {
+		logger.Log.Fatalf("Failed to calculate number of nodes: %s", err)
+	}
+
+	//This is the worst case possible number of searche to make
+	possibleEdges := subGraph.Edges().Len() * subGraph.Nodes().Len()
+	newSearch.nodesTotal = possibleEdges
+
+	return newSearch, nil
+}
+
+func (t *treeSearch) FilteredNodes() (nodes []*pkggraph.PkgNode) {
+	nodes = []*pkggraph.PkgNode{}
+	for n := range t.filteredNodes {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+func (t *treeSearch) NonFilteredNodes() (nodes []*pkggraph.PkgNode) {
+	nodes = []*pkggraph.PkgNode{}
+	for n := range t.normalNodes {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+// Call this ever time a node is processed, will print an update ever 100 nodes
+func (t *treeSearch) printProgress() {
+	if t.nodesVisited%10000 == 0 {
+		logger.Log.Infof("Scanned %d nodes", t.nodesVisited)
+	}
+	t.nodesVisited++
+}
+
+// Run a DFS and generate a string representation of the tree. Optionally ignore all branches that only container nodes in
+//
+//	the filter list (ie given the toolchain manifest, only print those branches which container non-toolchain packages)
+func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, filter bool, filterFile string, verbosity int, generateStrings, printDuplicates bool, runtimeFilterLevel int) (lines []string, hasNonToolchain bool) {
+	t.printProgress()
+	// We only care about run nodes for the purposes of detecting toolchain files
+	hasNonToolchain = n.Type == pkggraph.TypeLocalBuild && !isFilteredFile(n.RpmPath, filterFile)
+
+	if !printDuplicates && t.alreadyAdded[n] {
+		return []string{}, false
+	} else {
+		t.alreadyAdded[n] = true
+	}
+
+	thisNode := formatNode(n, verbosity)
+	if isFilteredFile(n.RpmPath, filterFile) {
+		// Highlight nodes that are in the filter file list in red, and add them to the list
+		if generateStrings {
+			lines = append(lines, "__"+colorRed+thisNode+colorReset)
+		}
+		if n.Type == pkggraph.TypeLocalRun {
+			// We only want to record run nodes for the purposes of listing packages in non-tree mode
+			t.filteredNodes[n] = true
+		}
+	} else {
+		// Non filtered files print normally
+		if generateStrings {
+			lines = append(lines, "__"+thisNode)
+		}
+		if n.Type == pkggraph.TypeLocalRun {
+			// We only want to record run nodes for the purposes of listing packages in non-tree mode
+			t.normalNodes[n] = true
+		}
+	}
+
+	var childrenTreeNodes []treeNode
+	nodes := t.graph.From(n.ID())
+	// Bail out early if we exceed max depth, maxDepth of -1 means no limit.
+	if depth < maxDepth || maxDepth == -1 {
+		var (
+			childLines                  []string
+			childHasMissingToolchainPkg = false
+			haveDuplicatedEntry         = false
+		)
+		for nodes.Next() {
+			child := nodes.Node().(*pkggraph.PkgNode)
+
+			// If we are only looking for runtime, skip build nodes (except for the root nodes: goal + each package node we care about)
+			if runtimeFilterLevel != -1 && depth > runtimeFilterLevel && child.Type == pkggraph.TypeLocalBuild {
+				continue
+			}
+			childLines, childHasMissingToolchainPkg = t.treeNodeToString(child, depth+1, maxDepth, filter, filterFile, verbosity, generateStrings, printDuplicates, runtimeFilterLevel)
+			hasNonToolchain = hasNonToolchain || childHasMissingToolchainPkg
+
+			// A child will return an empty string list if it, and all its children, are either duplicates or have been filtered out
+			if len(childLines) > 0 {
+				tn := treeNode{lines: childLines}
+				childrenTreeNodes = append(childrenTreeNodes, tn)
+			} else {
+				haveDuplicatedEntry = true
+			}
+		}
+
+		// If we have duplicated entires (ie empty strings), and we aren't removing all non-filtered entries, represent them with a '...'
+		//  as the last entry instead of the node name.
+		if haveDuplicatedEntry && !filter {
+			childrenTreeNodes = append(childrenTreeNodes, treeNode{lines: []string{"..."}})
+		}
+
+		if len(childrenTreeNodes) > 0 && generateStrings {
+			firstN := childrenTreeNodes[:len(childrenTreeNodes)-1]
+			last := childrenTreeNodes[len(childrenTreeNodes)-1]
+			for _, tn := range firstN {
+				for _, l := range tn.lines {
+					lines = append(lines, "   |"+l)
+				}
+			}
+			lines = append(lines, "   |"+last.lines[0])
+			for _, l := range last.lines[1:] {
+				lines = append(lines, "   "+l)
+			}
+		}
+	} else {
+		lines = append(lines, "   |-->")
+		// We are bailing out early, we don't know if this should be filtered, assume the worst
+		hasNonToolchain = true
+	}
+
+	if !hasNonToolchain && filter && depth > 0 {
+		return []string{}, false
+	}
+
+	return lines, hasNonToolchain
+}
+
+func PrintSpecs(graph *pkggraph.PkgGraph, tree, filter bool, filterFile string, printDuplicates bool, verbosity, maxDepth, runtimeFilterLevel int, root *pkggraph.PkgNode) {
+	t, err := createSearch(graph, root)
+	if err != nil {
+		logger.Log.Fatalf("Failed to start search: %s", err)
+	}
+	// May as well use the tree searh to parse all the filtered packages etc, even if we are
+	//    just printing a list
+	lines, _ := t.treeNodeToString(root, 0, maxDepth, filter, filterFile, verbosity, tree, printDuplicates, runtimeFilterLevel)
+	if tree {
+		for _, l := range lines {
+			fmt.Println(l)
+		}
+	} else {
+		results := make(map[string]bool)
+		if !filter {
+			// Only include toolchain packages if we aren't trying to find packages that have
+			// infiltrated the toolchain
+			for _, n := range t.FilteredNodes() {
+				results[formatNode(n, verbosity)] = true
+			}
+		}
+		// Always include normal nodes
+		for _, n := range t.NonFilteredNodes() {
+			results[formatNode(n, verbosity)] = true
+		}
+
+		// Contert to list and sort
+		printLines := sliceutils.SetToSlice[string](results)
+		sort.Strings(printLines)
+		for _, l := range printLines {
+			fmt.Println(l)
+		}
+	}
+}

--- a/toolkit/tools/pkg/depsearch/depsearch.go
+++ b/toolkit/tools/pkg/depsearch/depsearch.go
@@ -5,7 +5,6 @@ package depsearch
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 
@@ -20,8 +19,8 @@ import (
 
 const (
 	defaultFilterPath = "./resources/manifests/package/toolchain_x86_64.txt"
-	colorReset = "\033[0m"
-	colorRed   = "\033[31m"
+	colorReset        = "\033[0m"
+	colorRed          = "\033[31m"
 )
 
 var (


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
refactor depsearch into tool and utils

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- refactor depsearch into tool and utils
- part of series of similar changes across the toolkit

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built package successfully with REBUILD_TOOLS=y
- Built all tools (make go-tools REBUILD_TOOLS=y)
- Ran depsearch tool to make sure it runs