### PR TITLE
Image Customizer: Improve package install error messages.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -5,6 +5,7 @@ package imagecustomizerlib
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
@@ -12,6 +13,15 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+)
+
+const (
+	tdnfInstallPrefix = "Installing/Updating: "
+	tdnfRemovePrefix  = "Removing: "
+)
+
+var (
+	tdnfTransactionError = regexp.MustCompile(`^Found \d+ problems$`)
 )
 
 func addRemoveAndUpdatePackages(buildDir string, baseConfigPath string, config *imagecustomizerapi.OS,
@@ -103,32 +113,13 @@ func removePackages(allPackagesToRemove []string, imageChroot *safechroot.Chroot
 	for _, packageName := range allPackagesToRemove {
 		tnfRemoveArgs[len(tnfRemoveArgs)-1] = packageName
 
-		err := imageChroot.Run(func() error {
-			return shell.ExecuteLiveWithCallback(tdnfRemoveStdoutFilter, logger.Log.Debug, false, "tdnf",
-				tnfRemoveArgs...)
-		})
+		err := callTdnf(tnfRemoveArgs, tdnfRemovePrefix, imageChroot)
 		if err != nil {
 			return fmt.Errorf("failed to remove package (%s):\n%w", packageName, err)
 		}
 	}
 
 	return nil
-}
-
-// Process the stdout of a `tdnf install -v` call and send the list of installed packages to the debug log.
-func tdnfRemoveStdoutFilter(args ...interface{}) {
-	const tdnfInstallPrefix = "Removing: "
-
-	if len(args) == 0 {
-		return
-	}
-
-	line := args[0].(string)
-	if !strings.HasPrefix(line, tdnfInstallPrefix) {
-		return
-	}
-
-	logger.Log.Debug(line)
 }
 
 func updateAllPackages(imageChroot *safechroot.Chroot) error {
@@ -139,10 +130,7 @@ func updateAllPackages(imageChroot *safechroot.Chroot) error {
 		"--setopt", fmt.Sprintf("reposdir=%s", rpmsMountParentDirInChroot),
 	}
 
-	err := imageChroot.Run(func() error {
-		return shell.ExecuteLiveWithCallback(tdnfInstallOrUpdateStdoutFilter, logger.Log.Debug, false, "tdnf",
-			tnfUpdateArgs...)
-	})
+	err := callTdnf(tnfUpdateArgs, tdnfInstallPrefix, imageChroot)
 	if err != nil {
 		return fmt.Errorf("failed to update packages:\n%w", err)
 	}
@@ -166,10 +154,7 @@ func installOrUpdatePackages(action string, allPackagesToAdd []string, imageChro
 	for _, packageName := range allPackagesToAdd {
 		tnfInstallArgs[len(tnfInstallArgs)-1] = packageName
 
-		err := imageChroot.Run(func() error {
-			return shell.ExecuteLiveWithCallback(tdnfInstallOrUpdateStdoutFilter, logger.Log.Debug, false, "tdnf",
-				tnfInstallArgs...)
-		})
+		err := callTdnf(tnfInstallArgs, tdnfInstallPrefix, imageChroot)
 		if err != nil {
 			return fmt.Errorf("failed to %s package (%s):\n%w", action, packageName, err)
 		}
@@ -178,18 +163,30 @@ func installOrUpdatePackages(action string, allPackagesToAdd []string, imageChro
 	return nil
 }
 
-// Process the stdout of a `tdnf install -v` call and send the list of installed packages to the debug log.
-func tdnfInstallOrUpdateStdoutFilter(args ...interface{}) {
-	const tdnfInstallPrefix = "Installing/Updating: "
+func callTdnf(tnfArgs []string, tdnfMessagePrefix string, imageChroot *safechroot.Chroot) error {
+	seenTransactionErrorMessage := false
+	stdoutCallback := func(args ...interface{}) {
+		if len(args) == 0 {
+			return
+		}
 
-	if len(args) == 0 {
-		return
+		line := args[0].(string)
+
+		if !seenTransactionErrorMessage {
+			// Check if this line marks the start of a transaction error message.
+			seenTransactionErrorMessage = tdnfTransactionError.MatchString(line)
+		}
+
+		if seenTransactionErrorMessage {
+			// Report all of the transaction error message (i.e. the remainder of stdout) to WARN.
+			logger.Log.Warn(line)
+		} else if strings.HasPrefix(line, tdnfMessagePrefix) {
+			logger.Log.Debug(line)
+		}
 	}
 
-	line := args[0].(string)
-	if !strings.HasPrefix(line, tdnfInstallPrefix) {
-		return
-	}
-
-	logger.Log.Debug(line)
+	return imageChroot.Run(func() error {
+		return shell.ExecuteLiveWithErrAndCallbacks(1, stdoutCallback, logger.Log.Debug, "tdnf",
+			tnfArgs...)
+	})
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/install-package-disk-space.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/install-package-disk-space.yaml
@@ -1,0 +1,36 @@
+storage:
+  disks:
+  - partitionTableType: gpt
+
+    # Create a small-ish disk.
+    maxSize: 768M
+    partitions:
+    - id: esp
+      type: esp
+      start: 1M
+      end: 9M
+
+    - id: rootfs
+      start: 9M
+
+  bootType: efi
+
+  fileSystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: rootfs
+    type: ext4
+    mountPoint:
+      path: /
+
+os:
+  resetBootLoaderType: hard-reset
+
+  packages:
+    install:
+      # Install a large-ish package.
+    - gcc


### PR DESCRIPTION
The `tdnf` tool reports a high-level error message to `stderr`. This change ensures that this error message is included in the image customizer's error message.

However, when `tdnf` hits an installation failure due to insufficient disk space, the error message is the unhelpful and overly generic message of "rpm transaction failed". Fortunately, `tdnf` does report more details in `stdout`. This change detects when `tdnf` has added RPM transaction error details to `stdout` and logs them as WARN messages.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

