### PR TITLE
Use legacy builder for distroless golden containers

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -59,6 +59,10 @@ function create_distroless_container {
     echo "+++ Clone marinara repo"
     git clone "https://github.com/microsoft/$marinara.git" "$WORK_DIR/$marinaraSrcDir"
 
+    pushd "$WORK_DIR/$marinaraSrcDir" > /dev/null
+    git checkout bfdeca86c0834c1ea9c27c9c4b3ae74eb23e815e
+    popd > /dev/null 
+
     # It is important to operate from the $WORK_DIR to ensure that docker can access the files.
     pushd "$WORK_DIR" > /dev/null
 

--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -22,6 +22,7 @@ function DockerBuild {
 
     # Create container
     echo "+++ Create container $containerName"
+    export DOCKER_BUILDKIT=0
     docker build . \
         -t "$containerName" \
         -f "$marinaraSrcDir/dockerfiles/dockerfile-new-image" \

--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -22,6 +22,11 @@ function DockerBuild {
 
     # Create container
     echo "+++ Create container $containerName"
+
+    # DOCKER_BUILDKIT=0 is set to avoid the unknown timeout error in the Azure DevOps pipeline.
+    # The error is likely caused by some BuildKit feature in version 24.0.9 of moby-engine.
+    # The error is not seen in the local environment.
+    # TODO: Remove this line once the issue is resolved.
     export DOCKER_BUILDKIT=0
     docker build . \
         -t "$containerName" \

--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -22,7 +22,7 @@ function DockerBuild {
 
     # Create container
     echo "+++ Create container $containerName"
-    docker buildx build . \
+    docker build . \
         -t "$containerName" \
         -f "$marinaraSrcDir/dockerfiles/dockerfile-new-image" \
         --build-arg AZL_VERSION="$azureLinuxVersion" \
@@ -59,9 +59,9 @@ function create_distroless_container {
     echo "+++ Clone marinara repo"
     git clone "https://github.com/microsoft/$marinara.git" "$WORK_DIR/$marinaraSrcDir"
 
-    pushd "$WORK_DIR/$marinaraSrcDir" > /dev/null
-    git checkout bfdeca86c0834c1ea9c27c9c4b3ae74eb23e815e
-    popd > /dev/null 
+    # pushd "$WORK_DIR/$marinaraSrcDir" > /dev/null
+    # git checkout bfdeca86c0834c1ea9c27c9c4b3ae74eb23e815e
+    # popd > /dev/null 
 
     # It is important to operate from the $WORK_DIR to ensure that docker can access the files.
     pushd "$WORK_DIR" > /dev/null

--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -26,6 +26,7 @@ function DockerBuild {
     # DOCKER_BUILDKIT=0 is set to avoid the unknown timeout error in the Azure DevOps pipeline.
     # The error is likely caused by some BuildKit feature in version 24.0.9 of moby-engine.
     # The error is not seen in the local environment.
+    # Setting DOCKER_BUILDKIT=0 disables BuildKit and uses the legacy builder.
     # TODO: Remove this line once the issue is resolved.
     export DOCKER_BUILDKIT=0
     docker build . \

--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -34,8 +34,7 @@ function DockerBuild {
         --build-arg USER_UID=$userUid \
         --build-arg RPMS="$rpmsDir" \
         --build-arg LOCAL_REPO_FILE="$marinaraSrcDir/local.repo" \
-        --no-cache \
-        --progress=plain
+        --no-cache
 }
 
 function create_distroless_container {

--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -59,10 +59,6 @@ function create_distroless_container {
     echo "+++ Clone marinara repo"
     git clone "https://github.com/microsoft/$marinara.git" "$WORK_DIR/$marinaraSrcDir"
 
-    # pushd "$WORK_DIR/$marinaraSrcDir" > /dev/null
-    # git checkout bfdeca86c0834c1ea9c27c9c4b3ae74eb23e815e
-    # popd > /dev/null 
-
     # It is important to operate from the $WORK_DIR to ensure that docker can access the files.
     pushd "$WORK_DIR" > /dev/null
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR updates the distroless golden container build script to use the legacy builder in docker builds. There is an unidentified issue in the ADO pipeline that is halting the build process when executing the docker build for distroless golden containers. This issue started after the upgrade of moby-engine from `20.10.27` to `24.0.9`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- .pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- ADO Build_Golden_Containers_AMD64 pipeline run: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=565692&view=results
- ADO Build_Golden_Containers_ARM64 pipeline run: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=565691&view=results
