### PR TITLE
PTest Fix for python-cstruct

### DIFF
--- a/SPECS/python-cstruct/python-cstruct.spec
+++ b/SPECS/python-cstruct/python-cstruct.spec
@@ -48,6 +48,7 @@ pip3 install iniconfig
 
 %changelog
 * Tue May 07 2024 Sam Meluch <sammeluch@microsoft.com> - 5.2-2
+- Add missing iniconfig dependency for %check section
 
 * Tue Mar 08 2022 Dallas Delaney <dadelan@microsoft.com> - 5.2-1
 - Original version for CBL-Mariner

--- a/SPECS/python-cstruct/python-cstruct.spec
+++ b/SPECS/python-cstruct/python-cstruct.spec
@@ -6,7 +6,7 @@ methods for serializing/deserializing.}
 Summary:        C-style structs for Python
 Name:           python-%{srcname}
 Version:        5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -39,6 +39,7 @@ Requires:       python3
 %py3_install
 
 %check
+pip3 install iniconfig
 %pytest
 
 %files -n python3-%{srcname}
@@ -46,6 +47,8 @@ Requires:       python3
 %{python3_sitelib}/*
 
 %changelog
+* Tue May 07 2024 Sam Meluch <sammeluch@microsoft.com> - 5.2-2
+
 * Tue Mar 08 2022 Dallas Delaney <dadelan@microsoft.com> - 5.2-1
 - Original version for CBL-Mariner
 - License verified


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Package test for python-cstruct is failing on 3.0-dev, this PR resolves the test failure.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add missing python dependency to check section via pip install

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=565236&view=results
