### PR TITLE
Use legacy builder for distroless golden containers (#9041)

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -22,6 +22,13 @@ function DockerBuild {
 
     # Create container
     echo "+++ Create container $containerName"
+
+    # DOCKER_BUILDKIT=0 is set to avoid the unknown timeout error in the Azure DevOps pipeline.
+    # The error is likely caused by some BuildKit feature in version 24.0.9 of moby-engine.
+    # The error is not seen in the local environment.
+    # Setting DOCKER_BUILDKIT=0 disables BuildKit and uses the legacy builder.
+    # TODO: Remove this line once the issue is resolved.
+    export DOCKER_BUILDKIT=0
     docker build . \
         -t "$containerName" \
         -f "$marinaraSrcDir/dockerfiles/dockerfile-new-image" \
@@ -33,8 +40,7 @@ function DockerBuild {
         --build-arg USER_UID=$userUid \
         --build-arg RPMS="$rpmsDir" \
         --build-arg LOCAL_REPO_FILE="$marinaraSrcDir/local.repo" \
-        --no-cache \
-        --progress=plain
+        --no-cache
 }
 
 function create_distroless_container {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Cherry picking change from `main` into `fasttrack/2.0` to help with building the distroless golden containers.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- .pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

ADO bug to track this issue: https://microsoft.visualstudio.com/OS/_workitems/edit/50674863
