### PR TITLE
PTest Fix for python-editables

### DIFF
--- a/SPECS/python-editables/python-editables.spec
+++ b/SPECS/python-editables/python-editables.spec
@@ -1,6 +1,6 @@
 Name:           python-editables
 Version:        0.5
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Editable installations
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -8,9 +8,11 @@ License:        MIT
 URL:            https://github.com/pfmoore/editables
 Source:         %{url}/archive/%{version}/editables-%{version}.tar.gz
 BuildRequires:  python3-devel
+%if 0%{?with_check}
 BuildRequires:  python3-pytest
 BuildRequires:  python3-pip
 BuildRequires:  python3-flit-core
+%endif
 BuildArch:      noarch
 
 %global common_description %{expand:
@@ -43,6 +45,7 @@ Summary:        %{summary}
 
 
 %check
+pip3 install iniconfig
 %pytest
 
 
@@ -51,6 +54,9 @@ Summary:        %{summary}
 
 
 %changelog
+* Wed May 08 2024 Sam Meluch <sammeluch@microsoft.com> - 0.5-7
+- Add missing dependency for %check section
+
 * Fri Mar 29 2024 Riken Maharjan <rmaharjan@microsoft.com> - 0.5-6
 - Initial Azure Linux import from Fedora 41 (license: MIT).
 - License Verified.

--- a/SPECS/python-editables/python-editables.spec
+++ b/SPECS/python-editables/python-editables.spec
@@ -10,8 +10,8 @@ Source:         %{url}/archive/%{version}/editables-%{version}.tar.gz
 BuildRequires:  python3-devel
 %if 0%{?with_check}
 BuildRequires:  python3-pytest
-BuildRequires:  python3-flit-core
 %endif
+BuildRequires:  python3-flit-core
 BuildRequires:  python3-pip
 
 BuildArch:      noarch

--- a/SPECS/python-editables/python-editables.spec
+++ b/SPECS/python-editables/python-editables.spec
@@ -10,9 +10,10 @@ Source:         %{url}/archive/%{version}/editables-%{version}.tar.gz
 BuildRequires:  python3-devel
 %if 0%{?with_check}
 BuildRequires:  python3-pytest
-BuildRequires:  python3-pip
 BuildRequires:  python3-flit-core
 %endif
+BuildRequires:  python3-pip
+
 BuildArch:      noarch
 
 %global common_description %{expand:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
When python-editables was added to 3.0-dev the PTest was not passing. This PR resolves the issue


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add %with_check for pytest dep
- Add iniconfig as pip install for test

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=565948&view=results
