### PR TITLE
Image Customizer: Warn on low free disk space.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/userutils"
 	"golang.org/x/sys/unix"
 )
@@ -547,13 +548,7 @@ func selinuxSetFiles(selinuxMode imagecustomizerapi.SELinuxMode, imageChroot *sa
 
 	// Get the list of mount points.
 	mountPointToFsTypeMap := make(map[string]string, 0)
-	for _, mountPoint := range imageChroot.GetMountPoints() {
-		switch mountPoint.GetTarget() {
-		case "/dev", "/proc", "/sys", "/run", "/dev/pts":
-			// Skip special directories.
-			continue
-		}
-
+	for _, mountPoint := range getNonSpecialChrootMountPoints(imageChroot) {
 		mountPointToFsTypeMap[mountPoint.GetTarget()] = mountPoint.GetFSType()
 	}
 
@@ -564,4 +559,19 @@ func selinuxSetFiles(selinuxMode imagecustomizerapi.SELinuxMode, imageChroot *sa
 	}
 
 	return nil
+}
+
+func getNonSpecialChrootMountPoints(imageChroot *safechroot.Chroot) []*safechroot.MountPoint {
+	return sliceutils.FindMatches(imageChroot.GetMountPoints(),
+		func(mountPoint *safechroot.MountPoint) bool {
+			switch mountPoint.GetTarget() {
+			case "/dev", "/proc", "/sys", "/run", "/dev/pts":
+				// Skip special directories.
+				return false
+
+			default:
+				return true
+			}
+		},
+	)
 }


### PR DESCRIPTION
Create debug logs for reporting the free disk space after OS customization, including after errors. In addition, report a warning if the free space on a disk/partition is below a certain threshold.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.
