### PR TITLE
Fall back to using all repo files in precacher for repoquery

### DIFF
--- a/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
@@ -166,7 +166,6 @@ func copyRepoFile(repoSrcPath string, chroot *safechroot.Chroot) (err error) {
 	err = chroot.AddFiles(chrootRepoFile...)
 	if err != nil {
 		return fmt.Errorf("failed to add files to chroot:\n%w", err)
-
 	}
 	return nil
 }

--- a/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	chrootRepoDir = "/etc/yum.repos.d/"
+	chrootRepoDir       = "/etc/yum.repos.d/"
+	dnfUtilsPackageName = "dnf-utils"
 )
 
 // GetAllRepoData returns a map of package names to URLs for all packages
@@ -32,7 +33,7 @@ func GetAllRepoData(repoURLs, repoFiles []string, workerTar, buildDir, repoUrlsF
 	timestamp.StartEvent("pull available package data from repos", nil)
 	defer timestamp.StopEvent(nil)
 
-	queryChroot, err := createChroot(workerTar, buildDir, leaveChrootOnDisk)
+	queryChroot, err := createChroot(workerTar, buildDir, repoFiles, leaveChrootOnDisk)
 	if err != nil {
 		err = fmt.Errorf("failed to create chroot:\n%w", err)
 		return nil, err
@@ -58,11 +59,7 @@ func GetAllRepoData(repoURLs, repoFiles []string, workerTar, buildDir, repoUrlsF
 	for _, repoFile := range repoFiles {
 		// Replace the existing repo file (if it exists) with the one that we want to query
 		logger.Log.Infof("Will query package data from %s", repoFile)
-		destFile := path.Join(chrootRepoDir, path.Base(repoFile))
-		chrootRepoFile := []safechroot.FileToCopy{
-			{Src: repoFile, Dest: destFile},
-		}
-		err = queryChroot.AddFiles(chrootRepoFile...)
+		err = copyRepoFile(repoFile, queryChroot)
 		if err != nil {
 			err = fmt.Errorf("failed to add files to chroot:\n%w", err)
 			return
@@ -102,11 +99,9 @@ func GetAllRepoData(repoURLs, repoFiles []string, workerTar, buildDir, repoUrlsF
 
 // createChroot creates a network-enabled chroot to run repoquery in. The caller is expected to call Close() on the
 // returned chroot unless an error is returned, in which case the chroot will be closed by this function.
-func createChroot(workerTar, chrootDir string, leaveChrootOnDisk bool) (queryChroot *safechroot.Chroot, err error) {
-	const (
-		dnfUtilsPackageName = "dnf-utils"
-		rootDir             = "/"
-	)
+// The created chroot will attempt to use any additional repos provided in repoFiles if the default repos fail to
+// install the repoquery package. Once complete ALL repos will be removed from the chroot.
+func createChroot(workerTar, chrootDir string, repoFiles []string, leaveChrootOnDisk bool) (queryChroot *safechroot.Chroot, err error) {
 	timestamp.StartEvent("creating repoquery chroot", nil)
 	defer timestamp.StopEvent(nil)
 	logger.Log.Info("Creating chroot for repoquery")
@@ -138,23 +133,66 @@ func createChroot(workerTar, chrootDir string, leaveChrootOnDisk bool) (queryChr
 	}
 
 	// Install the repoquery package from upstream, then clean up any existing repos
+	// For preference we start with the default repos from the chroot, then add extra
+	// ones if that fails.
 	logger.Log.Infof("Installing '%s' package to get 'repoquery' command", dnfUtilsPackageName)
-	err = queryChroot.Run(func() error {
-		_, chrootErr := installutils.TdnfInstall(dnfUtilsPackageName, rootDir)
-		if chrootErr != nil {
-			chrootErr = fmt.Errorf("failed to install '%s':\n%w", dnfUtilsPackageName, err)
-			return chrootErr
-		}
-
-		// Remove all existing repos, we will be adding the repo files we want to query later
-		chrootErr = os.RemoveAll("/etc/yum.repos.d")
-		return chrootErr
-	})
+	err = installRepoQuery(queryChroot, nil)
+	if len(repoFiles) > 0 && err != nil {
+		logger.Log.Warnf("Failed to install '%s' package, trying with additional repos.", dnfUtilsPackageName)
+		logger.Log.Warnf("Initial error: %s", err.Error())
+		err = installRepoQuery(queryChroot, repoFiles)
+	}
 	if err != nil {
-		err = fmt.Errorf("failed to install '%s' in chroot:\n%w", dnfUtilsPackageName, err)
+		err = fmt.Errorf("failed to install '%s' package:\n%w", dnfUtilsPackageName, err)
 		return
 	}
+
+	// Remove all existing repos, we will be adding the repo files we want to query later
+	err = queryChroot.Run(func() error {
+		return os.RemoveAll("/etc/yum.repos.d")
+	})
+	if err != nil {
+		return queryChroot, fmt.Errorf("failed to remove existing repos:\n%w", err)
+	}
+
 	return
+}
+
+func copyRepoFile(repoSrcPath string, chroot *safechroot.Chroot) (err error) {
+	destFile := path.Join(chrootRepoDir, path.Base(repoSrcPath))
+	chrootRepoFile := []safechroot.FileToCopy{
+		{Src: repoSrcPath, Dest: destFile},
+	}
+	err = chroot.AddFiles(chrootRepoFile...)
+	if err != nil {
+		return fmt.Errorf("failed to add files to chroot:\n%w", err)
+
+	}
+	return nil
+}
+
+func installRepoQuery(chroot *safechroot.Chroot, additionalRepos []string) (err error) {
+	const rootDir = "/"
+	// Add any additional repos to the chroot
+	for _, repoFile := range additionalRepos {
+		err = copyRepoFile(repoFile, chroot)
+		if err != nil {
+			return fmt.Errorf("failed to copy repo file to chroot:\n%w", err)
+		}
+	}
+
+	err = chroot.Run(func() error {
+		_, chrootErr := installutils.TdnfInstall(dnfUtilsPackageName, rootDir)
+		if chrootErr != nil {
+			chrootErr = fmt.Errorf("failed to install '%s':\n%w", dnfUtilsPackageName, chrootErr)
+			return chrootErr
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to install '%s' in chroot:\n%w", dnfUtilsPackageName, err)
+	}
+	return nil
 }
 
 // getPackageRepoPathsFromUrl returns a list of packages available in the given repoUrl by running repoquery


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There is a window when we do not have a fully released repo, but we DO have a preview repo, available. By default the worker chroot will look to the base repo for packages. The `precacher` tool needs to install `dnf-utils` to get the `repoquery` tool. In this situation that package is only available as a preview package. We need the precacher tool to be able to check more places for repoquery.

By default we should continue to use the default repo in the chroot, but now there is a fallback to enables all the other repos the user passes if that install fails.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Allow `precacher` to install `repoquery` from `REPO_LIST` sources (like preview).

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/50674830

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with custom build gnugp2 package to work around additional preview issues, using preview repo files copied from the spec folder manually.
