### PR TITLE
dracut: Patch microcode output check based on CONFIG_MICROCODE_AMD/INTEL

### DIFF
--- a/SPECS/dracut/0010-fix-remove-microcode-check-based-on-CONFIG_MICROCODE_AMD-INTEL.patch
+++ b/SPECS/dracut/0010-fix-remove-microcode-check-based-on-CONFIG_MICROCODE_AMD-INTEL.patch
@@ -1,0 +1,45 @@
+From 6c80408c8644a0add1907b0593eb83f90d6247b1 Mon Sep 17 00:00:00 2001
+From: Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
+Date: Mon, 14 Aug 2023 12:28:11 +0200
+Subject: [PATCH] fix(dracut.sh): remove microcode check based on
+ CONFIG_MICROCODE_[AMD|INTEL]
+
+`CONFIG_MICROCODE_AMD` and `CONFIG_MICROCODE_INTEL` are hidden since
+https://lore.kernel.org/all/20230810160805.081212701@linutronix.de/, therefore
+this check is wrong and early microcode is always disabled.
+---
+ dracut.sh | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/dracut.sh b/dracut.sh
+index e0abdb3b0..3b292910f 100755
+--- a/dracut.sh
++++ b/dracut.sh
+@@ -1561,23 +1561,20 @@ fi
+ 
+ if [[ $early_microcode == yes ]]; then
+     if [[ $hostonly ]]; then
+-        if [[ $(get_cpu_vendor) == "AMD" ]]; then
+-            check_kernel_config CONFIG_MICROCODE_AMD || unset early_microcode
+-        elif [[ $(get_cpu_vendor) == "Intel" ]]; then
+-            check_kernel_config CONFIG_MICROCODE_INTEL || unset early_microcode
++        if [[ $(get_cpu_vendor) == "AMD" || $(get_cpu_vendor) == "Intel" ]]; then
++            check_kernel_config CONFIG_MICROCODE || unset early_microcode
+         else
+             unset early_microcode
+         fi
+     else
+-        ! check_kernel_config CONFIG_MICROCODE_AMD \
+-            && ! check_kernel_config CONFIG_MICROCODE_INTEL \
++        ! check_kernel_config CONFIG_MICROCODE \
+             && unset early_microcode
+     fi
+     # Do not complain on non-x86 architectures as it makes no sense
+     case "${DRACUT_ARCH:-$(uname -m)}" in
+         x86_64 | i?86)
+             [[ $early_microcode != yes ]] \
+-                && dwarn "Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE_[AMD|INTEL]!=y"
++                && dwarn "Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE!=y"
+             ;;
+         *) ;;
+     esac

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        059
-Release:        16%{?dist}
+Release:        17%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -32,6 +32,7 @@ Patch:          0006-dracut.sh-validate-instmods-calls.patch
 Patch:          0007-feat-dracut.sh-support-multiple-config-dirs.patch
 Patch:          0008-fix-dracut-systemd-rootfs-generator-cannot-write-out.patch
 Patch:          0009-install-systemd-executor.patch
+Patch:          0010-fix-remove-microcode-check-based-on-CONFIG_MICROCODE_AMD-INTEL.patch
 
 BuildRequires:  bash
 BuildRequires:  kmod-devel
@@ -216,6 +217,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Thu May 03 2024 Rachel Menge <rachelmenge@microsoft.com> - 059-17
+- Patch microcode output check based on CONFIG_MICROCODE_AMD/INTEL
+
 * Wed Mar 27 2024 Cameron Baird <cameronbaird@microsoft.com> - 059-16
 - Remove x86-specific xen-acpi-processor driver from defaults
 


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When installing a new kernel, dracut spits out this message while generating initramfs: "dracut: Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE_(AMD|INTEL)!=y"

![image](https://github.com/microsoft/azurelinux/assets/10325590/cec58d64-3c34-4dba-87fa-9a560dccc31a)

However, these config options were removed in commit e6bcfdd "x86/microcode: Hide the config knob". Additionally, the kernel enables "CONFIG_MICROCODE" https://github.com/microsoft/CBL-Mariner-Linux-Kernel/commit/e6bcfdd75d53390a67f67237f4eafc77d9772056

Therefore, take upstream dracut patch ([6c80408](https://github.com/dracutdevs/dracut/commit/6c80408c8644a0add1907b0593eb83f90d6247b1)) which fixes microcode check.
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch microcode output check based on CONFIG_MICROCODE_AMD/INTEL

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/50575187

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=566155&view=results
