### PR TITLE
Upgrading `memcached` to `1.6.27` & splitting the service into a subpackage

### DIFF
--- a/SPECS/memcached/memcached.signatures.json
+++ b/SPECS/memcached/memcached.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
     "memcached.sysconfig": "31f7d20fad86bdd2bc5692619928af8785dc0e9f858863aeece67cff0e4edfd2",
-    "memcached-1.6.21.tar.gz": "c788980efc417dd5d93c442b1c8b8769fb2018896c29de3887d22a2f143da2ee"
+    "memcached-1.6.27.tar.gz": "74fe1447c8668adf910fa7a929fb6358aaf4a66ef734e751c5b8128071b0f7b5"
   }
 }

--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -6,7 +6,7 @@
 %bcond_with seccomp
 Summary:        High Performance, Distributed Memory Object Cache
 Name:           memcached
-Version:        1.6.21
+Version:        1.6.27
 Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
@@ -119,6 +119,9 @@ exit 0
 %{_includedir}/memcached/*
 
 %changelog
+* Wed May 08 2024 Osama Esmail <osamaesmail@microsoft.com> - 1.6.27-1
+- Upgrading to 1.6.27
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.6.21-1
 - Auto-upgrade to 1.6.21 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -129,6 +129,7 @@ exit 0
 %changelog
 * Wed May 08 2024 Osama Esmail <osamaesmail@microsoft.com> - 1.6.27-1
 - Upgrading to 1.6.27
+- Separating out memcached-service into a subpackage
 
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.6.21-1
 - Auto-upgrade to 1.6.21 - Azure Linux 3.0 - package upgrades

--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -36,6 +36,7 @@ BuildRequires:  libseccomp-devel
 %if %{with tls}
 BuildRequires:  openssl-devel
 %endif
+Requires:       openssl-libs
 
 %description
 memcached is a high-performance, distributed memory object caching

--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -54,6 +54,7 @@ access to the memcached binary include files.
 %package        service
 Summary:        This package automatically runs scripts to set up memcached as a service.
 Requires(pre):  shadow-utils
+Requires:       %{name} = %{version}-%{release}
 %{?systemd_requires}
 
 %description service

--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -36,8 +36,6 @@ BuildRequires:  libseccomp-devel
 %if %{with tls}
 BuildRequires:  openssl-devel
 %endif
-Requires(pre):  shadow-utils
-%{?systemd_requires}
 
 %description
 memcached is a high-performance, distributed memory object caching
@@ -51,6 +49,14 @@ Requires:       %{name} = %{version}-%{release}
 %description devel
 Install memcached-devel if you are developing C/C++ applications that require
 access to the memcached binary include files.
+
+%package        service
+Summary:        This package automatically runs scripts to set up memcached as a service.
+Requires(pre):  shadow-utils
+%{?systemd_requires}
+
+%description service
+Install memcached-service if you want to run memcached as a service automatically.
 
 %prep
 %autosetup -p1
@@ -89,20 +95,20 @@ install -Dp -m0644 %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 %check
 %make_build test
 
-%pre
+%pre service
 getent group %{groupname} >/dev/null || groupadd -r %{groupname}
 getent passwd %{username} >/dev/null || \
 useradd -r -g %{groupname} -d /run/memcached \
     -s /sbin/nologin -c "Memcached daemon" %{username}
 exit 0
 
-%post
+%post service
 %systemd_post memcached.service
 
-%preun
+%preun service
 %systemd_preun memcached.service
 
-%postun
+%postun service
 %systemd_postun_with_restart memcached.service
 
 %files
@@ -113,10 +119,12 @@ exit 0
 %{_bindir}/memcached
 %{_mandir}/man1/memcached-tool.1*
 %{_mandir}/man1/memcached.1*
-%{_unitdir}/memcached.service
 
 %files devel
 %{_includedir}/memcached/*
+
+%files service
+%{_unitdir}/memcached.service
 
 %changelog
 * Wed May 08 2024 Osama Esmail <osamaesmail@microsoft.com> - 1.6.27-1

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -12961,8 +12961,8 @@
         "type": "other",
         "other": {
           "name": "memcached",
-          "version": "1.6.21",
-          "downloadUrl": "https://www.memcached.org/files/memcached-1.6.21.tar.gz"
+          "version": "1.6.27",
+          "downloadUrl": "https://www.memcached.org/files/memcached-1.6.27.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrading `memcached` to `1.6.27` & splitting the service into a subpackage. Upgrade addresses CVEs & the split is to make the base package smaller for our containers.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updating `memcached` to `1.6.27`
- Separating out service functionality into a subpackage
- Fixes CVE-2023-46853
- Fixes CVE-2023-46852

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-46853
- https://nvd.nist.gov/vuln/detail/CVE-2023-46852

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 574804
