### PR TITLE
Add patch to add network interface renaming support for CAPM3 Met

### DIFF
--- a/SPECS/cloud-init/Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
+++ b/SPECS/cloud-init/Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
@@ -17,12 +17,12 @@ the specification.
 ---
  cloudinit/sources/helpers/openstack.py        | 11 +--
  .../sources/helpers/test_openstack.py         |  8 +-
- tests/unittests/sources/test_configdrive.py   | 83 ++++++++++---------
- tests/unittests/test_net.py                   | 80 ++++++------------
- 4 files changed, 79 insertions(+), 103 deletions(-)
+ tests/unittests/sources/test_configdrive.py   | 80 ++++++++++---------
+ tests/unittests/test_net.py                   | 79 ++++++------------
+ 4 files changed, 77 insertions(+), 101 deletions(-)
 
 diff --git a/cloudinit/sources/helpers/openstack.py b/cloudinit/sources/helpers/openstack.py
-index ebdeedd37..6d2810160 100644
+index d2260baa0..f995ce4b1 100644
 --- a/cloudinit/sources/helpers/openstack.py
 +++ b/cloudinit/sources/helpers/openstack.py
 @@ -596,13 +596,14 @@ def convert_net_json(network_json=None, known_macs=None):
@@ -74,7 +74,7 @@ index ac8e2a354..143c12796 100644
                          {
                              "type": "static",
 diff --git a/tests/unittests/sources/test_configdrive.py b/tests/unittests/sources/test_configdrive.py
-index 83f4621b4..a7e20c1fb 100644
+index 70da4812a..462733a98 100644
 --- a/tests/unittests/sources/test_configdrive.py
 +++ b/tests/unittests/sources/test_configdrive.py
 @@ -731,16 +731,16 @@ class TestNetJson(CiTestCase):
@@ -177,7 +177,7 @@ index 83f4621b4..a7e20c1fb 100644
  
      def test_bond_conversion(self):
          # light testing of bond conversion and eni rendering of bond
-@@ -961,24 +963,27 @@ class TestConvertNetworkData(CiTestCase):
+@@ -961,22 +963,24 @@ class TestConvertNetworkData(CiTestCase):
              ]
          )
          self.assertEqual(
@@ -198,26 +198,22 @@ index 83f4621b4..a7e20c1fb 100644
 +        # self.assertNotIn("eth1", words)
  
 -        # oeth0 and oeth1 are the interface names for eni.
-+        # We should be seeing eth0 and eth1 as the names for the physical interfaces
-+        # as we have named them based on the link id and not on the known_macs.
-         # bond0 will be generated for the bond. Each should be auto.
+-        # bond0 will be generated for the bond. Each should be auto.
 -        self.assertIn("auto oeth0", eni_rendering)
 -        self.assertIn("auto oeth1", eni_rendering)
++        # We should be seeing eth0 and eth1 as the names for the physical interfaces
++        # as we have named them based on the link id and not on the known_macs.
 +        self.assertIn("auto eth0", eni_rendering)
 +        self.assertIn("auto eth1", eni_rendering)
          self.assertIn("auto bond0", eni_rendering)
 -        # The bond should have the given mac address
--        pos = eni_rendering.find("auto bond0")
--        self.assertIn(BOND_MAC, eni_rendering[pos:])
-+        
++
 +        # Since we are setting the mac address for all interfaces to none, we 
 +        # are commenting the check down below.
-+        # pos = eni_rendering.find("auto bond0")
-+        # self.assertIn(BOND_MAC, eni_rendering[pos:])
+         pos = eni_rendering.find("auto bond0")
+         self.assertIn(BOND_MAC, eni_rendering[pos:])
  
-     def test_vlan(self):
-         # light testing of vlan config conversion and eni rendering
-@@ -994,9 +999,9 @@ class TestConvertNetworkData(CiTestCase):
+@@ -994,9 +998,9 @@ class TestConvertNetworkData(CiTestCase):
          ) as f:
              eni_rendering = f.read()
  
@@ -229,7 +225,7 @@ index 83f4621b4..a7e20c1fb 100644
  
      def test_mac_addrs_can_be_upper_case(self):
          # input mac addresses on rackspace may be upper case
-@@ -1012,8 +1017,8 @@ class TestConvertNetworkData(CiTestCase):
+@@ -1012,8 +1016,8 @@ class TestConvertNetworkData(CiTestCase):
  
          expected = {
              "nic0": "fa:16:3e:05:30:fe",
@@ -240,7 +236,7 @@ index 83f4621b4..a7e20c1fb 100644
          }
          self.assertEqual(expected, config_name2mac)
  
-@@ -1031,8 +1036,8 @@ class TestConvertNetworkData(CiTestCase):
+@@ -1031,8 +1035,8 @@ class TestConvertNetworkData(CiTestCase):
  
          expected = {
              "nic0": "fa:16:3e:05:30:fe",
@@ -252,25 +248,19 @@ index 83f4621b4..a7e20c1fb 100644
          self.assertEqual(expected, config_name2mac)
  
 diff --git a/tests/unittests/test_net.py b/tests/unittests/test_net.py
-index 5eab3b3c4..168ce5d00 100644
+index c5509536a..45439007f 100644
 --- a/tests/unittests/test_net.py
 +++ b/tests/unittests/test_net.py
-@@ -534,13 +534,12 @@ OS_SAMPLES = [
+@@ -534,7 +534,7 @@ OS_SAMPLES = [
          },
          "out_sysconfig_opensuse": [
              (
 -                "etc/sysconfig/network/ifcfg-eth0",
 +                "etc/sysconfig/network/ifcfg-tap1a81968a-79",
                  """
- # Created by cloud-init on instance boot automatically, do not edit.
+ # Created by cloud-init automatically, do not edit.
  #
- BOOTPROTO=static
- IPADDR=172.19.1.34
--LLADDR=fa:16:3e:ed:9a:59
- NETMASK=255.255.252.0
- STARTMODE=auto
- """.lstrip(),
-@@ -564,25 +563,20 @@ dns = none
+@@ -564,25 +564,20 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
@@ -289,7 +279,7 @@ index 5eab3b3c4..168ce5d00 100644
 -                "etc/sysconfig/network-scripts/ifcfg-eth0",
 +                "etc/sysconfig/network-scripts/ifcfg-tap1a81968a-79",
                  """
- # Created by cloud-init on instance boot automatically, do not edit.
+ # Created by cloud-init automatically, do not edit.
  #
  BOOTPROTO=none
  DEFROUTE=yes
@@ -300,7 +290,7 @@ index 5eab3b3c4..168ce5d00 100644
  IPADDR=172.19.1.34
  NETMASK=255.255.252.0
  NM_CONTROLLED=no
-@@ -610,12 +604,8 @@ dns = none
+@@ -610,12 +605,8 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/70-persistent-net.rules",
@@ -315,7 +305,7 @@ index 5eab3b3c4..168ce5d00 100644
              ),
          ],
          "expected_network_manager": [
-@@ -623,23 +613,23 @@ dns = none
+@@ -623,23 +614,23 @@ dns = none
                  "".join(
                      [
                          "etc/NetworkManager/system-connections",
@@ -330,7 +320,7 @@ index 5eab3b3c4..168ce5d00 100644
 -id=cloud-init eth0
 -uuid=1dd9a779-d327-56e1-8454-c65e2556c12c
 +id=cloud-init tap1a81968a-79
-+uuid=2e85b264-dffb-5635-9b6c-616838eb1130
++uuid=2e85b264-dffb-5635-9b6c-616838eb113
  autoconnect-priority=120
  type=ethernet
 +interface-name=tap1a81968a-79
@@ -343,14 +333,14 @@ index 5eab3b3c4..168ce5d00 100644
  
  [ipv4]
  method=manual
-@@ -695,14 +685,13 @@ route1=0.0.0.0/0,172.19.3.254
+@@ -695,14 +686,13 @@ route1=0.0.0.0/0,172.19.3.254
          },
          "out_sysconfig_opensuse": [
              (
 -                "etc/sysconfig/network/ifcfg-eth0",
 +                "etc/sysconfig/network/ifcfg-tap1a81968a-79",
                  """
- # Created by cloud-init on instance boot automatically, do not edit.
+ # Created by cloud-init automatically, do not edit.
  #
  BOOTPROTO=static
  IPADDR=172.19.1.34
@@ -359,7 +349,7 @@ index 5eab3b3c4..168ce5d00 100644
  NETMASK=255.255.252.0
  NETMASK1=255.255.255.0
  STARTMODE=auto
-@@ -727,25 +716,20 @@ dns = none
+@@ -727,25 +717,20 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
@@ -378,7 +368,7 @@ index 5eab3b3c4..168ce5d00 100644
 -                "etc/sysconfig/network-scripts/ifcfg-eth0",
 +                "etc/sysconfig/network-scripts/ifcfg-tap1a81968a-79",
                  """
- # Created by cloud-init on instance boot automatically, do not edit.
+ # Created by cloud-init automatically, do not edit.
  #
  BOOTPROTO=none
  DEFROUTE=yes
@@ -389,7 +379,7 @@ index 5eab3b3c4..168ce5d00 100644
  IPADDR=172.19.1.34
  IPADDR1=10.0.0.10
  NETMASK=255.255.252.0
-@@ -775,12 +759,8 @@ dns = none
+@@ -775,12 +760,8 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/70-persistent-net.rules",
@@ -404,16 +394,16 @@ index 5eab3b3c4..168ce5d00 100644
              ),
          ],
      },
-@@ -852,7 +832,7 @@ dns = none
+@@ -852,7 +833,7 @@ dns = none
          },
          "out_sysconfig_opensuse": [
              (
 -                "etc/sysconfig/network/ifcfg-eth0",
 +                "etc/sysconfig/network/ifcfg-tap1a81968a-79",
                  """
- # Created by cloud-init on instance boot automatically, do not edit.
+ # Created by cloud-init automatically, do not edit.
  #
-@@ -861,7 +841,6 @@ IPADDR=172.19.1.34
+@@ -861,7 +842,6 @@ IPADDR=172.19.1.34
  IPADDR6=2001:DB8::10/64
  IPADDR6_1=2001:DB9::10/64
  IPADDR6_2=2001:DB10::10/64
@@ -421,7 +411,7 @@ index 5eab3b3c4..168ce5d00 100644
  NETMASK=255.255.252.0
  STARTMODE=auto
  """.lstrip(),
-@@ -885,25 +864,20 @@ dns = none
+@@ -885,25 +865,20 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
@@ -440,7 +430,7 @@ index 5eab3b3c4..168ce5d00 100644
 -                "etc/sysconfig/network-scripts/ifcfg-eth0",
 +                "etc/sysconfig/network-scripts/ifcfg-tap1a81968a-79",
                  """
- # Created by cloud-init on instance boot automatically, do not edit.
+ # Created by cloud-init automatically, do not edit.
  #
  BOOTPROTO=none
  DEFROUTE=yes
@@ -451,7 +441,7 @@ index 5eab3b3c4..168ce5d00 100644
  IPADDR=172.19.1.34
  IPV6ADDR=2001:DB8::10/64
  IPV6ADDR_SECONDARIES="2001:DB9::10/64 2001:DB10::10/64"
-@@ -937,12 +911,8 @@ dns = none
+@@ -937,12 +912,8 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/70-persistent-net.rules",
@@ -467,4 +457,4 @@ index 5eab3b3c4..168ce5d00 100644
          ],
      },
 -- 
-2.25.1
+2.34.1

--- a/SPECS/cloud-init/Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
+++ b/SPECS/cloud-init/Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
@@ -1,0 +1,470 @@
+From b2e6b0381f6cc23191053854ea7db5ac78c1ec82 Mon Sep 17 00:00:00 2001
+From: Vince Perri <viperri@microsoft.com>
+Date: Thu, 22 Dec 2022 15:17:32 +0000
+Subject: [PATCH] Add Network Interface Renaming Support for CAPM3
+ Metal3DataTemplates
+
+The CAPM3 Metal3DataTemplate specification doesn't allow the "name" attribute in
+networkData.links.ethernets, but the OpenStack cloud-init provider
+implementation uses this attribute to (re)name network interfaces. This means
+that when using CAPM3 Metal3DataTemplates, renaming network interfaces isn't
+possible.
+
+This patch fixes this by providing a means through which to rename network
+interfaces by using the "id" attribute found in the CAPM3 Metal3DataTemplate
+specification. This is a temporary fix until the "name" attribute is added to
+the specification.
+---
+ cloudinit/sources/helpers/openstack.py        | 11 +--
+ .../sources/helpers/test_openstack.py         |  8 +-
+ tests/unittests/sources/test_configdrive.py   | 83 ++++++++++---------
+ tests/unittests/test_net.py                   | 80 ++++++------------
+ 4 files changed, 79 insertions(+), 103 deletions(-)
+
+diff --git a/cloudinit/sources/helpers/openstack.py b/cloudinit/sources/helpers/openstack.py
+index ebdeedd37..6d2810160 100644
+--- a/cloudinit/sources/helpers/openstack.py
++++ b/cloudinit/sources/helpers/openstack.py
+@@ -596,13 +596,14 @@ def convert_net_json(network_json=None, known_macs=None):
+         # present.  The 'id' in the spec is currently implemented as the host
+         # nic's name, meaning something like 'tap-adfasdffd'.  We do not want
+         # to name guest devices with such ugly names.
++        link_mac_addr = None
+         if "name" in link:
+             cfg["name"] = link["name"]
+-
+-        link_mac_addr = None
+-        if link.get("ethernet_mac_address"):
+-            link_mac_addr = link.get("ethernet_mac_address").lower()
+-            link_id_info[link["id"]] = link_mac_addr
++            if link.get("ethernet_mac_address"):
++                link_mac_addr = link.get("ethernet_mac_address").lower()
++                link_id_info[link["id"]] = link_mac_addr
++        elif "name" not in link:
++            cfg["name"] = link["id"]
+ 
+         curinfo = {
+             "name": cfg.get("name"),
+diff --git a/tests/unittests/sources/helpers/test_openstack.py b/tests/unittests/sources/helpers/test_openstack.py
+index ac8e2a354..143c12796 100644
+--- a/tests/unittests/sources/helpers/test_openstack.py
++++ b/tests/unittests/sources/helpers/test_openstack.py
+@@ -42,9 +42,9 @@ class TestConvertNetJson(test_helpers.CiTestCase):
+             "version": 1,
+             "config": [
+                 {
+-                    "mac_address": "fa:16:3e:9c:bf:3d",
++                    "mac_address": None,
+                     "mtu": None,
+-                    "name": "eth0",
++                    "name": "tapcd9f6d46-4a",
+                     "subnets": [{"type": "dhcp4"}],
+                     "type": "physical",
+                 },
+@@ -94,9 +94,9 @@ class TestConvertNetJson(test_helpers.CiTestCase):
+             "version": 1,
+             "config": [
+                 {
+-                    "mac_address": "fa:16:3e:9c:bf:3d",
++                    "mac_address": None,
+                     "mtu": None,
+-                    "name": "eth0",
++                    "name": "tapcd9f6d46-4a",
+                     "subnets": [
+                         {
+                             "type": "static",
+diff --git a/tests/unittests/sources/test_configdrive.py b/tests/unittests/sources/test_configdrive.py
+index 83f4621b4..a7e20c1fb 100644
+--- a/tests/unittests/sources/test_configdrive.py
++++ b/tests/unittests/sources/test_configdrive.py
+@@ -731,16 +731,16 @@ class TestNetJson(CiTestCase):
+             "version": 1,
+             "config": [
+                 {
+-                    "mac_address": "fa:16:3e:69:b0:58",
++                    "mac_address": None,
+                     "mtu": None,
+-                    "name": "enp0s1",
++                    "name": "tap2ecc7709-b3",
+                     "subnets": [{"type": "ipv6_dhcpv6-stateless"}],
+                     "type": "physical",
+                 },
+                 {
+-                    "mac_address": "fa:16:3e:d4:57:ad",
++                    "mac_address": None,
+                     "mtu": None,
+-                    "name": "enp0s2",
++                    "name": "tap2f88d109-5b",
+                     "subnets": [{"type": "ipv6_dhcpv6-stateful"}],
+                     "type": "physical",
+                     "accept-ra": True,
+@@ -792,15 +792,15 @@ class TestNetJson(CiTestCase):
+                     {
+                         "subnets": [{"type": "dhcp4"}],
+                         "type": "physical",
+-                        "mac_address": "fa:16:3e:69:b0:58",
+-                        "name": "enp0s1",
++                        "mac_address": None,
++                        "name": "tap2ecc7709-b3",
+                         "mtu": None,
+                     },
+                     {
+                         "subnets": [{"type": "dhcp4"}],
+                         "type": "physical",
+-                        "mac_address": "fa:16:3e:d4:57:ad",
+-                        "name": "enp0s2",
++                        "mac_address": None,
++                        "name": "tap2f88d109-5b",
+                         "mtu": None,
+                     },
+                     {
+@@ -824,8 +824,8 @@ class TestNetJson(CiTestCase):
+                 "version": 1,
+                 "config": [
+                     {
+-                        "name": "foo3",
+-                        "mac_address": "fa:16:3e:ed:9a:59",
++                        "name": "tap1a81968a-79",
++                        "mac_address": None,
+                         "mtu": None,
+                         "type": "physical",
+                         "subnets": [
+@@ -877,7 +877,7 @@ class TestConvertNetworkData(CiTestCase):
+ 
+     def test_conversion_fills_names(self):
+         ncfg = openstack.convert_net_json(NETWORK_DATA, known_macs=KNOWN_MACS)
+-        expected = set(["nic0", "enp0s1", "enp0s2"])
++        expected = set(["nic0", "tap2ecc7709-b3", "tap2f88d109-5b"])
+         found = self._getnames_in_config(ncfg)
+         self.assertEqual(found, expected)
+ 
+@@ -890,18 +890,20 @@ class TestConvertNetworkData(CiTestCase):
+         get_interfaces_by_mac.return_value = macs
+ 
+         ncfg = openstack.convert_net_json(NETWORK_DATA)
+-        expected = set(["nic0", "ens1", "enp0s2"])
++        expected = set(["nic0", "tap2ecc7709-b3", "tap2f88d109-5b"])
+         found = self._getnames_in_config(ncfg)
+         self.assertEqual(found, expected)
+ 
+-    def test_convert_raises_value_error_on_missing_name(self):
+-        macs = {"aa:aa:aa:aa:aa:00": "ens1"}
+-        self.assertRaises(
+-            ValueError,
+-            openstack.convert_net_json,
+-            NETWORK_DATA,
+-            known_macs=macs,
+-        )
++    # Commenting this function out since we have modified the code to always add
++    # a name irrespective of it is present in the link info or not.
++    # def test_convert_raises_value_error_on_missing_name(self):
++    #     macs = {"aa:aa:aa:aa:aa:00": "ens1"}
++    #     self.assertRaises(
++    #         ValueError,
++    #         openstack.convert_net_json,
++    #         NETWORK_DATA,
++    #         known_macs=macs,
++    #     )
+ 
+     def test_conversion_with_route(self):
+         ncfg = openstack.convert_net_json(
+@@ -935,7 +937,7 @@ class TestConvertNetworkData(CiTestCase):
+         for i in ncfg["config"]:
+             if i.get("type") == "physical":
+                 physicals.add(i["name"])
+-        self.assertEqual(physicals, set(("foo1", "foo2")))
++        self.assertEqual(physicals, set(("tap77a0dc5b-72", "tap7d6b7bec-93")))
+ 
+     def test_bond_conversion(self):
+         # light testing of bond conversion and eni rendering of bond
+@@ -961,24 +963,27 @@ class TestConvertNetworkData(CiTestCase):
+             ]
+         )
+         self.assertEqual(
+-            sorted(["oeth0", "oeth1", "bond0", "bond0.602", "bond0.612"]),
++            sorted(["eth0", "eth1", "bond0", "bond0.602", "bond0.612"]),
+             interfaces,
+         )
+ 
+-        words = eni_rendering.split()
+-        # 'eth0' and 'eth1' are the ids. because their mac adresses
+-        # map to other names, we should not see them in the ENI
+-        self.assertNotIn("eth0", words)
+-        self.assertNotIn("eth1", words)
++        # Because we set the name to link["id"] if it is not encountered,
++        # we should see eth0 or eth1 in the eni rendering. Hence this check does not hold good.
++        # words = eni_rendering.split()
++        # self.assertNotIn("eth0", words)
++        # self.assertNotIn("eth1", words)
+ 
+-        # oeth0 and oeth1 are the interface names for eni.
++        # We should be seeing eth0 and eth1 as the names for the physical interfaces
++        # as we have named them based on the link id and not on the known_macs.
+         # bond0 will be generated for the bond. Each should be auto.
+-        self.assertIn("auto oeth0", eni_rendering)
+-        self.assertIn("auto oeth1", eni_rendering)
++        self.assertIn("auto eth0", eni_rendering)
++        self.assertIn("auto eth1", eni_rendering)
+         self.assertIn("auto bond0", eni_rendering)
+-        # The bond should have the given mac address
+-        pos = eni_rendering.find("auto bond0")
+-        self.assertIn(BOND_MAC, eni_rendering[pos:])
++        
++        # Since we are setting the mac address for all interfaces to none, we 
++        # are commenting the check down below.
++        # pos = eni_rendering.find("auto bond0")
++        # self.assertIn(BOND_MAC, eni_rendering[pos:])
+ 
+     def test_vlan(self):
+         # light testing of vlan config conversion and eni rendering
+@@ -994,9 +999,9 @@ class TestConvertNetworkData(CiTestCase):
+         ) as f:
+             eni_rendering = f.read()
+ 
+-        self.assertIn("iface enp0s1", eni_rendering)
++        self.assertIn("iface eth0", eni_rendering)
+         self.assertIn("address 10.0.1.5", eni_rendering)
+-        self.assertIn("auto enp0s1.602", eni_rendering)
++        self.assertIn("auto eth0.602", eni_rendering)
+ 
+     def test_mac_addrs_can_be_upper_case(self):
+         # input mac addresses on rackspace may be upper case
+@@ -1012,8 +1017,8 @@ class TestConvertNetworkData(CiTestCase):
+ 
+         expected = {
+             "nic0": "fa:16:3e:05:30:fe",
+-            "enp0s1": "fa:16:3e:69:b0:58",
+-            "enp0s2": "fa:16:3e:d4:57:ad",
++            "tap2ecc7709-b3": None,
++            "tap2f88d109-5b": None,
+         }
+         self.assertEqual(expected, config_name2mac)
+ 
+@@ -1031,8 +1036,8 @@ class TestConvertNetworkData(CiTestCase):
+ 
+         expected = {
+             "nic0": "fa:16:3e:05:30:fe",
+-            "enp0s1": "fa:16:3e:69:b0:58",
+-            "enp0s2": "fa:16:3e:d4:57:ad",
++            "tap2ecc7709-b3": None,
++            "tap2f88d109-5b": None,
+         }
+         self.assertEqual(expected, config_name2mac)
+ 
+diff --git a/tests/unittests/test_net.py b/tests/unittests/test_net.py
+index 5eab3b3c4..168ce5d00 100644
+--- a/tests/unittests/test_net.py
++++ b/tests/unittests/test_net.py
+@@ -534,13 +534,12 @@ OS_SAMPLES = [
+         },
+         "out_sysconfig_opensuse": [
+             (
+-                "etc/sysconfig/network/ifcfg-eth0",
++                "etc/sysconfig/network/ifcfg-tap1a81968a-79",
+                 """
+ # Created by cloud-init on instance boot automatically, do not edit.
+ #
+ BOOTPROTO=static
+ IPADDR=172.19.1.34
+-LLADDR=fa:16:3e:ed:9a:59
+ NETMASK=255.255.252.0
+ STARTMODE=auto
+ """.lstrip(),
+@@ -564,25 +563,20 @@ dns = none
+             ),
+             (
+                 "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
+-                "".join(
+-                    [
+-                        'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ',
+-                        'ATTR{address}=="fa:16:3e:ed:9a:59", NAME="eth0"\n',
+-                    ]
+-                ),
++                # Since we do not set mac address, we are expecting the content to be nil
++                "",
+             ),
+         ],
+         "out_sysconfig_rhel": [
+             (
+-                "etc/sysconfig/network-scripts/ifcfg-eth0",
++                "etc/sysconfig/network-scripts/ifcfg-tap1a81968a-79",
+                 """
+ # Created by cloud-init on instance boot automatically, do not edit.
+ #
+ BOOTPROTO=none
+ DEFROUTE=yes
+-DEVICE=eth0
++DEVICE=tap1a81968a-79
+ GATEWAY=172.19.3.254
+-HWADDR=fa:16:3e:ed:9a:59
+ IPADDR=172.19.1.34
+ NETMASK=255.255.252.0
+ NM_CONTROLLED=no
+@@ -610,12 +604,8 @@ dns = none
+             ),
+             (
+                 "etc/udev/rules.d/70-persistent-net.rules",
+-                "".join(
+-                    [
+-                        'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ',
+-                        'ATTR{address}=="fa:16:3e:ed:9a:59", NAME="eth0"\n',
+-                    ]
+-                ),
++                # Since we do not set mac address, we are expecting the content to be nil
++                "",
+             ),
+         ],
+         "expected_network_manager": [
+@@ -623,23 +613,23 @@ dns = none
+                 "".join(
+                     [
+                         "etc/NetworkManager/system-connections",
+-                        "/cloud-init-eth0.nmconnection",
++                        "/cloud-init-tap1a81968a-79.nmconnection",
+                     ]
+                 ),
+                 """
+ # Generated by cloud-init. Changes will be lost.
+ 
+ [connection]
+-id=cloud-init eth0
+-uuid=1dd9a779-d327-56e1-8454-c65e2556c12c
++id=cloud-init tap1a81968a-79
++uuid=2e85b264-dffb-5635-9b6c-616838eb1130
+ autoconnect-priority=120
+ type=ethernet
++interface-name=tap1a81968a-79
+ 
+ [user]
+ org.freedesktop.NetworkManager.origin=cloud-init
+ 
+ [ethernet]
+-mac-address=FA:16:3E:ED:9A:59
+ 
+ [ipv4]
+ method=manual
+@@ -695,14 +685,13 @@ route1=0.0.0.0/0,172.19.3.254
+         },
+         "out_sysconfig_opensuse": [
+             (
+-                "etc/sysconfig/network/ifcfg-eth0",
++                "etc/sysconfig/network/ifcfg-tap1a81968a-79",
+                 """
+ # Created by cloud-init on instance boot automatically, do not edit.
+ #
+ BOOTPROTO=static
+ IPADDR=172.19.1.34
+ IPADDR1=10.0.0.10
+-LLADDR=fa:16:3e:ed:9a:59
+ NETMASK=255.255.252.0
+ NETMASK1=255.255.255.0
+ STARTMODE=auto
+@@ -727,25 +716,20 @@ dns = none
+             ),
+             (
+                 "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
+-                "".join(
+-                    [
+-                        'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ',
+-                        'ATTR{address}=="fa:16:3e:ed:9a:59", NAME="eth0"\n',
+-                    ]
+-                ),
++                # Since we do not set mac address, we are expecting the content to be nil
++                "",
+             ),
+         ],
+         "out_sysconfig_rhel": [
+             (
+-                "etc/sysconfig/network-scripts/ifcfg-eth0",
++                "etc/sysconfig/network-scripts/ifcfg-tap1a81968a-79",
+                 """
+ # Created by cloud-init on instance boot automatically, do not edit.
+ #
+ BOOTPROTO=none
+ DEFROUTE=yes
+-DEVICE=eth0
++DEVICE=tap1a81968a-79
+ GATEWAY=172.19.3.254
+-HWADDR=fa:16:3e:ed:9a:59
+ IPADDR=172.19.1.34
+ IPADDR1=10.0.0.10
+ NETMASK=255.255.252.0
+@@ -775,12 +759,8 @@ dns = none
+             ),
+             (
+                 "etc/udev/rules.d/70-persistent-net.rules",
+-                "".join(
+-                    [
+-                        'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ',
+-                        'ATTR{address}=="fa:16:3e:ed:9a:59", NAME="eth0"\n',
+-                    ]
+-                ),
++                # Since we do not set mac address, we are expecting the content to be nil
++                "",
+             ),
+         ],
+     },
+@@ -852,7 +832,7 @@ dns = none
+         },
+         "out_sysconfig_opensuse": [
+             (
+-                "etc/sysconfig/network/ifcfg-eth0",
++                "etc/sysconfig/network/ifcfg-tap1a81968a-79",
+                 """
+ # Created by cloud-init on instance boot automatically, do not edit.
+ #
+@@ -861,7 +841,6 @@ IPADDR=172.19.1.34
+ IPADDR6=2001:DB8::10/64
+ IPADDR6_1=2001:DB9::10/64
+ IPADDR6_2=2001:DB10::10/64
+-LLADDR=fa:16:3e:ed:9a:59
+ NETMASK=255.255.252.0
+ STARTMODE=auto
+ """.lstrip(),
+@@ -885,25 +864,20 @@ dns = none
+             ),
+             (
+                 "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
+-                "".join(
+-                    [
+-                        'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ',
+-                        'ATTR{address}=="fa:16:3e:ed:9a:59", NAME="eth0"\n',
+-                    ]
+-                ),
++                # Since we do not set mac address, we are expecting the content to be nil
++                "",
+             ),
+         ],
+         "out_sysconfig_rhel": [
+             (
+-                "etc/sysconfig/network-scripts/ifcfg-eth0",
++                "etc/sysconfig/network-scripts/ifcfg-tap1a81968a-79",
+                 """
+ # Created by cloud-init on instance boot automatically, do not edit.
+ #
+ BOOTPROTO=none
+ DEFROUTE=yes
+-DEVICE=eth0
++DEVICE=tap1a81968a-79
+ GATEWAY=172.19.3.254
+-HWADDR=fa:16:3e:ed:9a:59
+ IPADDR=172.19.1.34
+ IPV6ADDR=2001:DB8::10/64
+ IPV6ADDR_SECONDARIES="2001:DB9::10/64 2001:DB10::10/64"
+@@ -937,12 +911,8 @@ dns = none
+             ),
+             (
+                 "etc/udev/rules.d/70-persistent-net.rules",
+-                "".join(
+-                    [
+-                        'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ',
+-                        'ATTR{address}=="fa:16:3e:ed:9a:59", NAME="eth0"\n',
+-                    ]
+-                ),
++                # Since we do not set mac address, we are expecting the content to be nil
++                "",
+             ),
+         ],
+     },
+-- 
+2.25.1

--- a/SPECS/cloud-init/Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
+++ b/SPECS/cloud-init/Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
@@ -17,9 +17,9 @@ the specification.
 ---
  cloudinit/sources/helpers/openstack.py        | 11 +--
  .../sources/helpers/test_openstack.py         |  8 +-
- tests/unittests/sources/test_configdrive.py   | 80 ++++++++++---------
- tests/unittests/test_net.py                   | 79 ++++++------------
- 4 files changed, 77 insertions(+), 101 deletions(-)
+ tests/unittests/sources/test_configdrive.py   | 84 ++++++++++---------
+ tests/unittests/test_net.py                   | 80 ++++++------------
+ 4 files changed, 79 insertions(+), 104 deletions(-)
 
 diff --git a/cloudinit/sources/helpers/openstack.py b/cloudinit/sources/helpers/openstack.py
 index d2260baa0..f995ce4b1 100644
@@ -74,7 +74,7 @@ index ac8e2a354..143c12796 100644
                          {
                              "type": "static",
 diff --git a/tests/unittests/sources/test_configdrive.py b/tests/unittests/sources/test_configdrive.py
-index 70da4812a..462733a98 100644
+index 70da4812a..e0afa2936 100644
 --- a/tests/unittests/sources/test_configdrive.py
 +++ b/tests/unittests/sources/test_configdrive.py
 @@ -731,16 +731,16 @@ class TestNetJson(CiTestCase):
@@ -177,7 +177,7 @@ index 70da4812a..462733a98 100644
  
      def test_bond_conversion(self):
          # light testing of bond conversion and eni rendering of bond
-@@ -961,22 +963,24 @@ class TestConvertNetworkData(CiTestCase):
+@@ -961,24 +963,26 @@ class TestConvertNetworkData(CiTestCase):
              ]
          )
          self.assertEqual(
@@ -207,12 +207,16 @@ index 70da4812a..462733a98 100644
 +        self.assertIn("auto eth1", eni_rendering)
          self.assertIn("auto bond0", eni_rendering)
 -        # The bond should have the given mac address
+-        pos = eni_rendering.find("auto bond0")
+-        self.assertIn(BOND_MAC, eni_rendering[pos:])
 +
 +        # Since we are setting the mac address for all interfaces to none, we 
 +        # are commenting the check down below.
-         pos = eni_rendering.find("auto bond0")
-         self.assertIn(BOND_MAC, eni_rendering[pos:])
++        # pos = eni_rendering.find("auto bond0")
++        # self.assertIn(BOND_MAC, eni_rendering[pos:])
  
+     def test_vlan(self):
+         # light testing of vlan config conversion and eni rendering
 @@ -994,9 +998,9 @@ class TestConvertNetworkData(CiTestCase):
          ) as f:
              eni_rendering = f.read()
@@ -248,10 +252,10 @@ index 70da4812a..462733a98 100644
          self.assertEqual(expected, config_name2mac)
  
 diff --git a/tests/unittests/test_net.py b/tests/unittests/test_net.py
-index c5509536a..45439007f 100644
+index c5509536a..eb14c5db3 100644
 --- a/tests/unittests/test_net.py
 +++ b/tests/unittests/test_net.py
-@@ -534,7 +534,7 @@ OS_SAMPLES = [
+@@ -534,13 +534,12 @@ OS_SAMPLES = [
          },
          "out_sysconfig_opensuse": [
              (
@@ -260,7 +264,13 @@ index c5509536a..45439007f 100644
                  """
  # Created by cloud-init automatically, do not edit.
  #
-@@ -564,25 +564,20 @@ dns = none
+ BOOTPROTO=static
+ IPADDR=172.19.1.34
+-LLADDR=fa:16:3e:ed:9a:59
+ NETMASK=255.255.252.0
+ STARTMODE=auto
+ """.lstrip(),
+@@ -564,25 +563,20 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
@@ -290,7 +300,7 @@ index c5509536a..45439007f 100644
  IPADDR=172.19.1.34
  NETMASK=255.255.252.0
  NM_CONTROLLED=no
-@@ -610,12 +605,8 @@ dns = none
+@@ -610,12 +604,8 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/70-persistent-net.rules",
@@ -305,7 +315,7 @@ index c5509536a..45439007f 100644
              ),
          ],
          "expected_network_manager": [
-@@ -623,23 +614,23 @@ dns = none
+@@ -623,23 +613,23 @@ dns = none
                  "".join(
                      [
                          "etc/NetworkManager/system-connections",
@@ -320,7 +330,7 @@ index c5509536a..45439007f 100644
 -id=cloud-init eth0
 -uuid=1dd9a779-d327-56e1-8454-c65e2556c12c
 +id=cloud-init tap1a81968a-79
-+uuid=2e85b264-dffb-5635-9b6c-616838eb113
++uuid=2e85b264-dffb-5635-9b6c-616838eb1130
  autoconnect-priority=120
  type=ethernet
 +interface-name=tap1a81968a-79
@@ -333,7 +343,7 @@ index c5509536a..45439007f 100644
  
  [ipv4]
  method=manual
-@@ -695,14 +686,13 @@ route1=0.0.0.0/0,172.19.3.254
+@@ -695,14 +685,13 @@ route1=0.0.0.0/0,172.19.3.254
          },
          "out_sysconfig_opensuse": [
              (
@@ -349,7 +359,7 @@ index c5509536a..45439007f 100644
  NETMASK=255.255.252.0
  NETMASK1=255.255.255.0
  STARTMODE=auto
-@@ -727,25 +717,20 @@ dns = none
+@@ -727,25 +716,20 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
@@ -379,7 +389,7 @@ index c5509536a..45439007f 100644
  IPADDR=172.19.1.34
  IPADDR1=10.0.0.10
  NETMASK=255.255.252.0
-@@ -775,12 +760,8 @@ dns = none
+@@ -775,12 +759,8 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/70-persistent-net.rules",
@@ -394,7 +404,7 @@ index c5509536a..45439007f 100644
              ),
          ],
      },
-@@ -852,7 +833,7 @@ dns = none
+@@ -852,7 +832,7 @@ dns = none
          },
          "out_sysconfig_opensuse": [
              (
@@ -403,7 +413,7 @@ index c5509536a..45439007f 100644
                  """
  # Created by cloud-init automatically, do not edit.
  #
-@@ -861,7 +842,6 @@ IPADDR=172.19.1.34
+@@ -861,7 +841,6 @@ IPADDR=172.19.1.34
  IPADDR6=2001:DB8::10/64
  IPADDR6_1=2001:DB9::10/64
  IPADDR6_2=2001:DB10::10/64
@@ -411,7 +421,7 @@ index c5509536a..45439007f 100644
  NETMASK=255.255.252.0
  STARTMODE=auto
  """.lstrip(),
-@@ -885,25 +865,20 @@ dns = none
+@@ -885,25 +864,20 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/85-persistent-net-cloud-init.rules",
@@ -441,7 +451,7 @@ index c5509536a..45439007f 100644
  IPADDR=172.19.1.34
  IPV6ADDR=2001:DB8::10/64
  IPV6ADDR_SECONDARIES="2001:DB9::10/64 2001:DB10::10/64"
-@@ -937,12 +912,8 @@ dns = none
+@@ -937,12 +911,8 @@ dns = none
              ),
              (
                  "etc/udev/rules.d/70-persistent-net.rules",

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -9,7 +9,7 @@ Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
 Source0:        https://github.com/canonical/%{name}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
-Patch0:          0001-Add-new-distro-azurelinux-for-Microsoft-Azure-Linux.patch
+Patch0:         0001-Add-new-distro-azurelinux-for-Microsoft-Azure-Linux.patch
 Patch1:         Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -144,7 +144,7 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
-* Thu May 9 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 1:23.3-3
+* Thu May 9 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 23.4.3-2
 - Add patch to add network interface renaming support for CAPM3 Met.
 
 * Mon Feb 26 2024 Dan Streetman <ddstreet@microsoft.com> - 23.4.3-1

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        23.4.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -9,7 +9,8 @@ Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
 Source0:        https://github.com/canonical/%{name}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
-Patch:          0001-Add-new-distro-azurelinux-for-Microsoft-Azure-Linux.patch
+Patch0:          0001-Add-new-distro-azurelinux-for-Microsoft-Azure-Linux.patch
+Patch1:         Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus
@@ -143,6 +144,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Thu May 9 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 1:23.3-3
+- Add patch to add network interface renaming support for CAPM3 Met.
+
 * Mon Feb 26 2024 Dan Streetman <ddstreet@microsoft.com> - 23.4.3-1
 - update to 23.4.3
 - Use new 'azurelinux' cloud-init distro


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Add patch to add network interface renaming support for CAPM3 Met.
This patch is being attached from our internal afo-packages for now, however, we want it to be applied to AZL directly.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch to add network interface renaming support for CAPM3 Met.
- Make changes to the pkg tests to work with the patch introduced

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline run: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=566667&view=results
