### PR TITLE
use DOCKER_BUILDKIT=0

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -22,7 +22,14 @@ function DockerBuild {
 
     # Create container
     echo "+++ Create container $containerName"
-    docker buildx build . \
+
+    # DOCKER_BUILDKIT=0 is set to avoid the unknown timeout error in the Azure DevOps pipeline.
+    # The error is likely caused by some BuildKit feature in version 24.0.9 of moby-engine.
+    # The error is not seen in the local environment.
+    # Setting DOCKER_BUILDKIT=0 disables BuildKit and uses the legacy builder.
+    # TODO: Remove this line once the issue is resolved.
+    export DOCKER_BUILDKIT=0
+    docker build . \
         -t "$containerName" \
         -f "$marinaraSrcDir/dockerfiles/dockerfile-new-image" \
         --build-arg AZL_VERSION="$azureLinuxVersion" \
@@ -33,8 +40,7 @@ function DockerBuild {
         --build-arg USER_UID=$userUid \
         --build-arg RPMS="$rpmsDir" \
         --build-arg LOCAL_REPO_FILE="$marinaraSrcDir/local.repo" \
-        --no-cache \
-        --progress=plain
+        --no-cache
 }
 
 function create_distroless_container {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR updates the distroless golden container build script to use the legacy builder in docker builds. There is an unidentified issue in the ADO pipeline that is halting the build process when executing the docker build for distroless golden containers. This issue started after the upgrade of moby-engine from 20.10.27 to 24.0.9.

Corresponding `main` branch PR: https://github.com/microsoft/azurelinux/pull/9041

ADO bug to track this issue: https://microsoft.visualstudio.com/OS/_workitems/edit/50674863

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- .pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
ADO Build_Golden_Containers_AMD64 pipeline [run](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=565692&view=results)
ADO Build_Golden_Containers_ARM64 pipeline [run](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=565691&view=results)