### PR TITLE
hvloader: resolve CVEs in edk2's bundled openssl

### DIFF
--- a/SPECS-SIGNED/hvloader-signed/hvloader-signed.spec
+++ b/SPECS-SIGNED/hvloader-signed/hvloader-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed HvLoader.efi for %{buildarch} systems
 Name:           hvloader-signed-%{buildarch}
 Version:        1.0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -69,6 +69,9 @@ popd
 /boot/efi/HvLoader.efi
 
 %changelog
+* Fri May 10 2024 Archana Choudhary <archana1@microsoft.com> - 1.0.1-2.cm2
+- Update version for consistency with hvloader spec
+
 * Thu Jan 04 2024 Cameron Baird <cameronbaird@microsoft.com> - 1.0.1-1
 - Original version for CBL-Mariner.
 - License verified

--- a/SPECS/hvloader/hvloader.signatures.json
+++ b/SPECS/hvloader/hvloader.signatures.json
@@ -1,7 +1,7 @@
 {
  "Signatures": {
   "hvloader-1.0.1.tar.gz": "4e0a15cfab98a89a0a93f747df876ea3ee5366c3ffbd158c28e296bf52c7dfba",
-  "edk2-submodules-edk2-stable202211.tar.gz": "81a84900be864fab94935637278ac4db47b06bad1d00c1d1738c294c7caf23c7",
+  "edk2-stable202302-submodules.tar.gz": "6e0c992145070d4f9e907a2baf9441b264927902537e888d20d2749055d52f20",
   "target-x86.txt": "fcf4f427d3b80e67296be2a1d17ec124d65f673d4f6ea37d238f8d3fc1ddc4b8"
 }
 }

--- a/SPECS/hvloader/hvloader.spec
+++ b/SPECS/hvloader/hvloader.spec
@@ -1,17 +1,18 @@
 %define  debug_package %{nil}
 %define  name_github   HvLoader
-%define  edk2_tag      edk2-stable202211
+%define  edk2_tag      edk2-stable202302
 Summary:        HvLoader.efi is an EFI application for loading an external hypervisor loader.
 Name:           hvloader
 Version:        1.0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
 URL:            https://github.com/microsoft/HvLoader
 Source0:        https://github.com/microsoft/HvLoader/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Source1:        https://github.com/tianocore/edk2/archive/refs/tags/%{edk2_tag}.tar.gz#/edk2-submodules-%{edk2_tag}.tar.gz
+# Instructions to generate edk2 submodules: https://github.com/tianocore/edk2/tree/edk2-stable202302?tab=readme-ov-file#submodules
+Source1:        https://github.com/tianocore/edk2/archive/refs/tags/%{edk2_tag}.tar.gz#/%{edk2_tag}-submodules.tar.gz
 Source2:        target-x86.txt
 BuildRequires:  bc
 BuildRequires:  gcc
@@ -57,6 +58,11 @@ cp ./Build/MdeModule/RELEASE_GCC5/X64/MdeModulePkg/Application/%{name_github}-%{
 /boot/efi/HvLoader.efi
 
 %changelog
+* Wed May 08 2024 Archana Choudhary <archana1@microsoft.com> - 1.0.1-2
+- Update edk2_tag to edk2-stable202302
+- Publish edk2-stable202302-submodules source
+- Address openssl related CVEs (CVE-2023-0286, CVE-2023-0215, CVE-2022-4450, CVE-2022-4304)
+
 * Tue May 02 2023 Cameron Baird <cameronbaird@microsoft.com> - 1.0.1-1
 - Add hvloader.spec
 - License verified


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This patch addresses following openssl related CVEs affecting hvloader package:
- CVE-2023-0286
- CVE-2023-0215
- CVE-2022-4450
- CVE-2022-4304
 Updates edk2 submodules dependency to edk2-stable202302 tag.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-0286
- https://nvd.nist.gov/vuln/detail/CVE-2023-0215
- https://nvd.nist.gov/vuln/detail/CVE-2022-4450
- https://nvd.nist.gov/vuln/detail/CVE-2022-4304

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=567115&view=results