### PR TITLE
ceph: patch multiple CVEs

### DIFF
--- a/SPECS/ceph/CVE-2021-24032.patch
+++ b/SPECS/ceph/CVE-2021-24032.patch
@@ -1,0 +1,64 @@
+Use umask() to Constrain Created File Permissions
+
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+diff -Naur a/src/zstd/programs/fileio.c b/src/zstd/programs/fileio.c
+--- a/src/zstd/programs/fileio.c	2020-05-22 05:04:00.000000000 +0000
++++ b/src/zstd/programs/fileio.c	2024-05-08 21:47:49.022437794 +0000
+@@ -611,14 +611,11 @@
+             FIO_remove(dstFileName);
+     }   }
+ 
+-    {   FILE* const f = fopen( dstFileName, "wb" );
++    {   const int old_umask = UTIL_umask(0177); /* u-x,go-rwx */
++        FILE* const f = fopen( dstFileName, "wb" );
++        UTIL_umask(old_umask);
+         if (f == NULL) {
+             DISPLAYLEVEL(1, "zstd: %s: %s\n", dstFileName, strerror(errno));
+-        } else if (srcFileName != NULL
+-               && strcmp (srcFileName, stdinmark)
+-               && strcmp(dstFileName, nulmark) ) {
+-            /* reduce rights on newly created dst file while compression is ongoing */
+-            UTIL_chmod(dstFileName, 00600);
+         }
+         return f;
+     }
+diff -Naur a/src/zstd/programs/util.c b/src/zstd/programs/util.c
+--- a/src/zstd/programs/util.c	2020-05-22 05:04:00.000000000 +0000
++++ b/src/zstd/programs/util.c	2024-05-08 21:48:42.615068035 +0000
+@@ -137,6 +137,15 @@
+     return chmod(filename, permissions);
+ }
+ 
++int UTIL_umask(int mode) {
++#if PLATFORM_POSIX_VERSION > 0
++    return umask(mode);
++#else
++    /* do nothing, fake return value */
++    return mode;
++#endif
++}
++
+ int UTIL_setFileStat(const char *filename, stat_t *statbuf)
+ {
+     int res = 0;
+diff -Naur a/src/zstd/programs/util.h b/src/zstd/programs/util.h
+--- a/src/zstd/programs/util.h	2020-05-22 05:04:00.000000000 +0000
++++ b/src/zstd/programs/util.h	2024-05-08 21:50:01.135938005 +0000
+@@ -22,7 +22,7 @@
+ #include "platform.h"     /* PLATFORM_POSIX_VERSION, ZSTD_NANOSLEEP_SUPPORT, ZSTD_SETPRIORITY_SUPPORT */
+ #include <stddef.h>       /* size_t, ptrdiff_t */
+ #include <sys/types.h>    /* stat, utime */
+-#include <sys/stat.h>     /* stat, chmod */
++#include <sys/stat.h>     /* stat, chmod, umask */
+ #include "../lib/common/mem.h"          /* U64 */
+ 
+ 
+@@ -119,6 +119,7 @@
+ int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
+ int UTIL_setFileStat(const char* filename, stat_t* statbuf);
+ int UTIL_chmod(char const* filename, mode_t permissions);   /*< like chmod, but avoid changing permission of /dev/null */
++int UTIL_umask(int mode);
+ int UTIL_compareStr(const void *p1, const void *p2);
+ const char* UTIL_getFileExtension(const char* infilename);
+ 

--- a/SPECS/ceph/CVE-2021-28361.patch
+++ b/SPECS/ceph/CVE-2021-28361.patch
@@ -1,0 +1,42 @@
+From f3fd56fc3c73ee7595bbe7c69cf8048fe2577e1a Mon Sep 17 00:00:00 2001
+From: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+Date: Mon, 8 Feb 2021 10:28:44 -0500
+Subject: [PATCH] lib/iscsi: return immediately from iscsi_parse_params if len
+ is 0
+
+The spec does not disallow TEXT PDUs with no data.  In that
+case, just return immediately from iscsi_parse_params.
+
+This avoids a NULL pointer dereference with a TEXT PDU that has
+no data, but CONTINUE flag is set.
+
+Signed-off-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+Signed-off-by: Jim Harris <james.r.harris@intel.com>
+Change-Id: I2605293daf171633a45132d7b5532fdfc9128aff
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/6319
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Ziye Yang <ziye.yang@intel.com>
+Reviewed-by: Shuhei Matsumoto <shuhei.matsumoto.xt@hitachi.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
+Reviewed-by: Paul Luse <paul.e.luse@intel.com>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+diff -Naur a/src/spdk/lib/iscsi/param.c b/src/spdk/lib/iscsi/param.c
+--- a/src/spdk/lib/iscsi/param.c	2020-07-31 07:07:10.000000000 +0000
++++ b/src/spdk/lib/iscsi/param.c	2024-05-09 17:34:00.036617778 +0000
+@@ -315,6 +315,16 @@
+ 	char *p;
+ 	int i;
+ 
++	/* Spec does not disallow TEXT PDUs with zero length, just return
++	 * immediately in that case, since there is no param data to parse
++	 * and any existing partial parameter would remain as-is.
++	 */
++	if (len == 0) {
++		return 0;
++	}
++
++	assert(data != NULL);
++
+ 	/* strip the partial text parameters if previous PDU have C enabled */
+ 	if (partial_parameter && *partial_parameter) {
+ 		for (i = 0; i < len && data[i] != '\0'; i++) {

--- a/SPECS/ceph/CVE-2022-3650.patch
+++ b/SPECS/ceph/CVE-2022-3650.patch
@@ -1,0 +1,255 @@
+From e6f1f52409c52c3fd9434015a04065c89d762a21 Mon Sep 17 00:00:00 2001
+From: Guillaume Abrioux <gabrioux@redhat.com>
+Date: Thu, 24 Feb 2022 17:39:10 +0100
+Subject: [PATCH 1/6] Revert "src/ceph-crash.in: remove unused frame in
+ handler()"
+
+This reverts commit 432c766a99f70884049bf7a1f268287a5a809777.
+
+unused but required:
+
+```
+Traceback (most recent call last):
+File "/usr/bin/ceph-crash", line 102, in <module>
+main()
+File "/usr/bin/ceph-crash", line 98, in main
+time.sleep(args.delay * 60)
+TypeError: handler() takes exactly 1 argument (2 given)
+```
+
+Fixes: https://tracker.ceph.com/issues/54422
+
+Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
+Signed-off-by-: Henry Beberman <henry.beberman@microsoft.com>
+(cherry picked from commit 02e8e7d6e6d31b4735115f7820e015fc54997d9f)
+---
+ src/ceph-crash.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ceph-crash.in b/src/ceph-crash.in
+index ae0e4f516464f..4502618fcf7aa 100755
+--- a/src/ceph-crash.in
++++ b/src/ceph-crash.in
+@@ -79,7 +79,7 @@ def scrape_path(path):
+                     (metapath, p, os.path.join('posted/', p))
+                 )
+ 
+-def handler(signum):
++def handler(signum, frame):
+     print('*** Interrupted with signal %d ***' % signum)
+     sys.exit(0)
+ 
+
+From 50d16ef5e4be857ddc2dcad1bed190c725efef1f Mon Sep 17 00:00:00 2001
+From: Guillaume Abrioux <gabrioux@redhat.com>
+Date: Thu, 24 Feb 2022 17:45:41 +0100
+Subject: [PATCH 2/6] ceph-crash: fix some flake8 issues
+
+ceph-crash.in:21:1: E302 expected 2 blank lines, found 1
+ceph-crash.in:32:80: E501 line too long (86 > 79 characters)
+ceph-crash.in:82:1: E302 expected 2 blank lines, found 1
+ceph-crash.in:86:1: E302 expected 2 blank lines, found 1
+
+Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
+(cherry picked from commit 0aee76965f92865d7f6e28b73b46dbdb5f1f9463)
+---
+ src/ceph-crash.in | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/ceph-crash.in b/src/ceph-crash.in
+index 4502618fcf7aa..916f0664a9456 100755
+--- a/src/ceph-crash.in
++++ b/src/ceph-crash.in
+@@ -18,6 +18,7 @@ auth_names = ['client.crash.%s' % socket.gethostname(),
+               'client.crash',
+               'client.admin']
+ 
++
+ def parse_args():
+     parser = argparse.ArgumentParser()
+     parser.add_argument(
+@@ -29,7 +30,8 @@ def parse_args():
+     )
+     parser.add_argument(
+         '--name', '-n',
+-        help='ceph name to authenticate as (default: try client.crash, client.admin)')
++        help='ceph name to authenticate as '
++             '(default: try client.crash, client.admin)')
+     parser.add_argument(
+         '--log-level', '-l',
+         help='log level output (default: INFO), support INFO or DEBUG')
+@@ -79,10 +81,12 @@ def scrape_path(path):
+                     (metapath, p, os.path.join('posted/', p))
+                 )
+ 
++
+ def handler(signum, frame):
+     print('*** Interrupted with signal %d ***' % signum)
+     sys.exit(0)
+ 
++
+ def main():
+     global auth_names
+     # exit code 0 on SIGINT, SIGTERM
+
+From 544f5035a6c7880756149c59a8f1b793d1dfd14b Mon Sep 17 00:00:00 2001
+From: Tim Serong <tserong@suse.com>
+Date: Wed, 2 Nov 2022 14:23:20 +1100
+Subject: [PATCH 3/6] ceph-crash: fix stderr handling
+
+Popen.communicate() returns a tuple (stdout, stderr), and stderr
+will be of type bytes, hence the need to decode it before checking
+if it's an empty string or not.
+
+Fixes: a77b47eeeb5770eeefcf4619ab2105ee7a6a003e
+Signed-off-by: Tim Serong <tserong@suse.com>
+(cherry picked from commit 45915540559126a652f8d9d105723584cfc63439)
+---
+ src/ceph-crash.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/ceph-crash.in b/src/ceph-crash.in
+index 916f0664a9456..453efb7aa10d0 100755
+--- a/src/ceph-crash.in
++++ b/src/ceph-crash.in
+@@ -50,7 +50,8 @@ def post_crash(path):
+             stderr=subprocess.PIPE,
+         )
+         f = open(os.path.join(path, 'meta'), 'rb')
+-        stderr = pr.communicate(input=f.read())
++        (_, stderr) = pr.communicate(input=f.read())
++        stderr = stderr.decode()
+         rc = pr.wait()
+         f.close()
+         if rc != 0 or stderr != "":
+
+From d2a9a539d72e01750dcc245a11962fe574777cc0 Mon Sep 17 00:00:00 2001
+From: Tim Serong <tserong@suse.com>
+Date: Wed, 2 Nov 2022 14:27:47 +1100
+Subject: [PATCH 4/6] ceph-crash: drop privleges to run as "ceph" user, rather
+ than root
+
+If privileges cannot be dropped, log an error and exit.  This commit
+also catches and logs exceptions when scraping the crash path, without
+which ceph-crash would just exit if it encountered an error.
+
+Fixes: CVE-2022-3650
+Fixes: https://tracker.ceph.com/issues/57967
+Signed-off-by: Tim Serong <tserong@suse.com>
+(cherry picked from commit 130c9626598bc3a75942161e6cce7c664c447382)
+---
+ src/ceph-crash.in | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/src/ceph-crash.in b/src/ceph-crash.in
+index 453efb7aa10d0..d5c7260614e49 100755
+--- a/src/ceph-crash.in
++++ b/src/ceph-crash.in
+@@ -3,8 +3,10 @@
+ # vim: ts=4 sw=4 smarttab expandtab
+ 
+ import argparse
++import grp
+ import logging
+ import os
++import pwd
+ import signal
+ import socket
+ import subprocess
+@@ -88,8 +90,25 @@ def handler(signum, frame):
+     sys.exit(0)
+ 
+ 
++def drop_privs():
++    if os.getuid() == 0:
++        try:
++            ceph_uid = pwd.getpwnam("ceph").pw_uid
++            ceph_gid = grp.getgrnam("ceph").gr_gid
++            os.setgroups([])
++            os.setgid(ceph_gid)
++            os.setuid(ceph_uid)
++        except Exception as e:
++            log.error(f"Unable to drop privileges: {e}")
++            sys.exit(1)
++
++
+ def main():
+     global auth_names
++
++    # run as unprivileged ceph user
++    drop_privs()
++
+     # exit code 0 on SIGINT, SIGTERM
+     signal.signal(signal.SIGINT, handler)
+     signal.signal(signal.SIGTERM, handler)
+@@ -108,7 +127,10 @@ def main():
+ 
+     log.info("monitoring path %s, delay %ds" % (args.path, args.delay * 60.0))
+     while True:
+-        scrape_path(args.path)
++        try:
++            scrape_path(args.path)
++        except Exception as e:
++            log.error(f"Error scraping {args.path}: {e}")
+         if args.delay == 0:
+             sys.exit(0)
+         time.sleep(args.delay * 60)
+
+From 1a990887fc604674bb64e2b85b971522c72d7cd0 Mon Sep 17 00:00:00 2001
+From: Tim Serong <tserong@suse.com>
+Date: Thu, 8 Dec 2022 11:09:16 +1100
+Subject: [PATCH 5/6] qa/workunits/rados/test_crash: chown crash files to ceph
+ user
+
+Fixes: https://tracker.ceph.com/issues/58098
+Signed-off-by: Tim Serong <tserong@suse.com>
+(cherry picked from commit 93c0456159a87bb9c28b9b60998baeba1600af5f)
+---
+ qa/workunits/rados/test_crash.sh | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/qa/workunits/rados/test_crash.sh b/qa/workunits/rados/test_crash.sh
+index 6608d7872e232..26a4c9bdc151f 100755
+--- a/qa/workunits/rados/test_crash.sh
++++ b/qa/workunits/rados/test_crash.sh
+@@ -24,6 +24,11 @@ for f in $(find $TESTDIR/archive/coredump -type f); do
+ 	fi
+ done
+ 
++# ceph-crash runs as the unprivileged "ceph" user, but when under test
++# the ceph osd daemons are running as root, so their crash files aren't
++# readable.  let's chown them so they behave as they would in real life.
++sudo chown -R ceph:ceph /var/lib/ceph/crash
++
+ # let daemon find crashdumps on startup
+ sudo systemctl restart ceph-crash
+ sleep 30
+
+From 541ad16f64c93fc966ee167b9ef1ace1f5156678 Mon Sep 17 00:00:00 2001
+From: Tim Serong <tserong@suse.com>
+Date: Thu, 8 Dec 2022 11:54:17 +1100
+Subject: [PATCH 6/6] ceph-crash: log warning if crash directory unreadable
+
+This is to aid in debugging in case crashes aren't posted as expected
+(see https://tracker.ceph.com/issues/58098 for discussion).
+
+Signed-off-by: Tim Serong <tserong@suse.com>
+(cherry picked from commit d139f6d112e6118f0f458dbfff9550b3ce312d20)
+---
+ src/ceph-crash.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/ceph-crash.in b/src/ceph-crash.in
+index d5c7260614e49..74e50e2b253f3 100755
+--- a/src/ceph-crash.in
++++ b/src/ceph-crash.in
+@@ -66,6 +66,9 @@ def post_crash(path):
+ def scrape_path(path):
+     for p in os.listdir(path):
+         crashpath = os.path.join(path, p)
++        if not os.access(crashpath, os.R_OK):
++            log.warning('unable to read crash path %s' % (crashpath))
++            continue
+         metapath = os.path.join(crashpath, 'meta')
+         donepath = os.path.join(crashpath, 'done')
+         if os.path.isfile(metapath):

--- a/SPECS/ceph/CVE-2022-3854.patch
+++ b/SPECS/ceph/CVE-2022-3854.patch
@@ -1,0 +1,72 @@
+From e40ce4a3511e669e761da5f39d81b14e6cdbdeba Mon Sep 17 00:00:00 2001
+From: "Adam C. Emerson" <aemerson@redhat.com>
+Date: Mon, 11 Jul 2022 11:52:09 -0400
+Subject: [PATCH 1/2] rgw: Fix `rgw::sal::Bucket::empty` static method
+ signatures
+
+`unique_ptr` overload should take by reference.
+
+Both should be const.
+
+Signed-off-by: Adam C. Emerson <aemerson@redhat.com>
+(cherry picked from commit b1d3e6c00674ebf6bde08968789a426d65db73d9)
+
+Conflicts:
+	src/rgw/rgw_sal.h
+ - `unique_ptr` overload of empty
+
+Fixes: https://tracker.ceph.com/issues/56585
+Signed-off-by: Adam C. Emerson <aemerson@redhat.com>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+---
+ src/rgw/rgw_sal.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+From f0da8c00a849ab739ba2adfa600616ce921a2055 Mon Sep 17 00:00:00 2001
+From: "Adam C. Emerson" <aemerson@redhat.com>
+Date: Fri, 8 Jul 2022 14:58:16 -0400
+Subject: [PATCH 2/2] rgw: Guard against malformed bucket URLs
+
+Misplaced colons can result in radosgw thinking is has a bucket URL
+but with no bucket name, leading to a crash later on.
+
+Fixes: https://tracker.ceph.com/issues/55765
+Signed-off-by: Adam C. Emerson <aemerson@redhat.com>
+(cherry picked from commit 3ee9a3b41a289a926fed8b8927ca2a93b4f120a6)
+Fixes: https://tracker.ceph.com/issues/56585
+Signed-off-by: Adam C. Emerson <aemerson@redhat.com>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+---
+ src/rgw/rgw_common.cc | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+
+diff -Naur a/src/rgw/rgw_common.cc b/src/rgw/rgw_common.cc
+--- a/src/rgw/rgw_common.cc	2022-07-21 17:28:56.000000000 +0000
++++ b/src/rgw/rgw_common.cc	2024-05-10 19:40:34.022882572 +0000
+@@ -1279,6 +1279,11 @@
+ 
+ bool verify_bucket_permission(const DoutPrefixProvider* dpp, struct req_state * const s, const uint64_t op)
+ {
++  if (rgw::sal::Bucket::empty(s->bucket)) {
++    // request is missing a bucket name
++    return false;
++  }
++
+   perm_state_from_req_state ps(s);
+ 
+   return verify_bucket_permission(dpp, 
+diff -Naur a/src/rgw/rgw_sal.h b/src/rgw/rgw_sal.h
+--- a/src/rgw/rgw_sal.h	2022-07-21 17:28:56.000000000 +0000
++++ b/src/rgw/rgw_sal.h	2024-05-10 19:39:53.094700848 +0000
+@@ -280,7 +280,9 @@
+       ent.convert(b);
+     }
+ 
+-    static bool empty(RGWBucket* b) { return (!b || b->empty()); }
++    static bool empty(const RGWBucket* b) { return (!b || b->empty()); }
++    /** Check if a Bucket unique pointer is empty */
++    static bool empty(const std::unique_ptr<RGWBucket>& b) { return (!b || b->empty()); }
+     virtual std::unique_ptr<RGWBucket> clone() = 0;
+ 
+     /* dang - This is temporary, until the API is completed */

--- a/SPECS/ceph/CVE-2022-3854.patch
+++ b/SPECS/ceph/CVE-2022-3854.patch
@@ -40,15 +40,14 @@ Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
  src/rgw/rgw_common.cc | 5 +++++
  1 file changed, 5 insertions(+)
 
-
 diff -Naur a/src/rgw/rgw_common.cc b/src/rgw/rgw_common.cc
 --- a/src/rgw/rgw_common.cc	2022-07-21 17:28:56.000000000 +0000
-+++ b/src/rgw/rgw_common.cc	2024-05-10 19:40:34.022882572 +0000
++++ b/src/rgw/rgw_common.cc	2024-05-10 22:05:42.398233127 +0000
 @@ -1279,6 +1279,11 @@
  
  bool verify_bucket_permission(const DoutPrefixProvider* dpp, struct req_state * const s, const uint64_t op)
  {
-+  if (rgw::sal::Bucket::empty(s->bucket)) {
++  if (rgw::sal::RGWBucket::empty(s->bucket)) {
 +    // request is missing a bucket name
 +    return false;
 +  }

--- a/SPECS/ceph/ceph.spec
+++ b/SPECS/ceph/ceph.spec
@@ -5,12 +5,16 @@
 Summary:        User space components of the Ceph file system
 Name:           ceph
 Version:        16.2.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2 and LGPLv3 and CC-BY-SA and GPLv2 and Boost and BSD and MIT and Public Domain and GPLv3 and ASL-2.0
 URL:            https://ceph.io/
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://download.ceph.com/tarballs/%{name}-%{version}.tar.gz
+Patch0:         CVE-2021-24032.patch
+Patch1:         CVE-2021-28361.patch
+Patch2:         CVE-2022-3650.patch
+Patch3:         CVE-2022-3854.patch
 
 #
 # Copyright (C) 2004-2019 The Ceph Project Developers. See COPYING file
@@ -847,6 +851,7 @@ ${CMAKE} .. \
     -DWITH_MANPAGE=ON \
     -DWITH_PYTHON3=%{python3_version} \
     -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
+    -DWITH_SEASTAR=OFF \
 %if 0%{without mgr_diskprediction}
     -DMGR_DISABLED_MODULES=diskprediction_local\
 %endif
@@ -1803,6 +1808,10 @@ exit 0
 %config %{_sysconfdir}/prometheus/ceph/ceph_default_alerts.yml
 
 %changelog
+* Fri May 10 2024 Henry Beberman <henry.beberman@microsoft.com> - 16.2.10-3
+- Patch CVE-2021-24032, CVE-2021-28361, CVE-2022-3650, CVE-2022-3854
+- Explicitly disable seastar to ensure disputed uncompiled CVEs dont get enabled.
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 16.2.10-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/SPECS/ceph/ceph.spec
+++ b/SPECS/ceph/ceph.spec
@@ -838,6 +838,7 @@ env | sort
 mkdir build
 cd build
 CMAKE=cmake
+# WITH_SEASTAR is explicitly disabled to prevent numerous vendored CVEs
 ${CMAKE} .. \
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
     -DCMAKE_INSTALL_LIBDIR=%{_libdir} \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Patch ceph to fix CVE-2021-24032, CVE-2021-28361, CVE-2022-3650, CVE-2022-3854
Explicitly disable seastar (it was implicit before) to ensure disputed CVEs don't sneak in.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch ceph to fix CVE-2021-24032, CVE-2021-28361, CVE-2022-3650, CVE-2022-3854

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-24032
- https://nvd.nist.gov/vuln/detail/CVE-2021-28361
- https://nvd.nist.gov/vuln/detail/CVE-2022-3650
- https://nvd.nist.gov/vuln/detail/CVE-2022-3854

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=567500&view=results
