### PR TITLE
python-virt-firmware: package upgrade to 24.4

### DIFF
--- a/SPECS/python-virt-firmware/python-virt-firmware.signatures.json
+++ b/SPECS/python-virt-firmware/python-virt-firmware.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "python-virt-firmware-24.4.tar.gz": "aea85a28339010e8fa6dc473dea649f9ae321b5a930bd4948eec4c8599679b05"
+  "virt-firmware-24.4.tar.gz": "aea85a28339010e8fa6dc473dea649f9ae321b5a930bd4948eec4c8599679b05"
  }
 }

--- a/SPECS/python-virt-firmware/python-virt-firmware.signatures.json
+++ b/SPECS/python-virt-firmware/python-virt-firmware.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "python-virt-firmware-23.5.tar.gz": "4939452892d9cfda40c0adccd3b065f7b3b6f7aedaf75d5f021cd9db2a14c5d9"
+  "python-virt-firmware-24.4.tar.gz": "aea85a28339010e8fa6dc473dea649f9ae321b5a930bd4948eec4c8599679b05"
  }
 }

--- a/SPECS/python-virt-firmware/python-virt-firmware.spec
+++ b/SPECS/python-virt-firmware/python-virt-firmware.spec
@@ -11,22 +11,23 @@ Distribution:   Azure Linux
 }%{?-e:.%{-e*}}%{?-s:.%{-s*}}%{!?-n:%{?dist}}
 ## END: Set by rpmautospec
 
-%global pypi_version 23.5
+%global pypi_version 24.4
 
 Name:           python-virt-firmware
 Version:        %{pypi_version}
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        Tools for virtual machine firmware volumes
 
-License:        GPLv2
+License:        GPL-2.0-only
 URL:            https://pypi.org/project/virt-firmware/
-Source0:        https://files.pythonhosted.org/packages/c2/f8/204dc513d2d3f0f3d3aead03600f7db1b763cf02998ad7b35e7ac5ef6849/virt-firmware-%{pypi_version}.tar.gz#/python-virt-firmware-%{pypi_version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/ea/8d/b3417567c9b532879357fb2b6b6fc50a6b0b311f95b16b4845054852e062/virt-firmware-%{pypi_version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(cryptography)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  make help2man
+BuildRequires:  systemd systemd-rpm-macros
 
 %description
 Tools for ovmf / armvirt firmware volumes This is a small collection of tools
@@ -38,20 +39,16 @@ to enroll secure boot certificates.
 Summary:        %{summary}
 %{?python_provide:%python_provide python3-virt-firmware}
 Provides:       virt-firmware
+Conflicts:      python3-virt-firmware-peutils < 23.9
+Obsoletes:      python3-virt-firmware-peutils < 23.9
 Requires:       python3dist(cryptography)
 Requires:       python3dist(setuptools)
+Requires:       python3dist(pefile)
 %description -n python3-virt-firmware
 Tools for ovmf / armvirt firmware volumes This is a small collection of tools
 for edk2 firmware images. They support decoding and printing the content of
 firmware volumes. Variable stores (OVMF_VARS.fd) can be modified, for example
 to enroll secure boot certificates.
-
-%package -n     python3-virt-firmware-peutils
-Summary:        %{summary} - peutils
-Requires:       python3dist(pefile)
-Conflicts:      python3-virt-firmware < 1.6
-%description -n python3-virt-firmware-peutils
-Some utilities to inspect efi (pe) binaries.
 
 %if %{with tests}
 %package -n     python3-virt-firmware-tests
@@ -89,15 +86,17 @@ cp -ar tests %{buildroot}%{_datadir}/%{name}
 %{_bindir}/virt-fw-vars
 %{_bindir}/virt-fw-sigdb
 %{_bindir}/migrate-vars
-%{_mandir}/man1/virt-*.1*
-%{python3_sitelib}/virt/firmware
-%{python3_sitelib}/virt_firmware-%{pypi_version}-py%{python3_version}.egg-info
-
-%files -n python3-virt-firmware-peutils
-%{python3_sitelib}/virt/peutils
 %{_bindir}/pe-dumpinfo
 %{_bindir}/pe-listsigs
 %{_bindir}/pe-addsigs
+%{_bindir}/pe-inspect
+%{_mandir}/man1/virt-*.1*
+%{_mandir}/man1/kernel-bootcfg.1*
+%{_mandir}/man1/uefi-boot-menu.1*
+%{_mandir}/man1/pe-*.1*
+%{python3_sitelib}/virt/firmware
+%{python3_sitelib}/virt/peutils
+%{python3_sitelib}/virt_firmware-%{pypi_version}-py%{python3_version}.egg-info
 
 %if %{with tests}
 %files -n python3-virt-firmware-tests
@@ -105,6 +104,9 @@ cp -ar tests %{buildroot}%{_datadir}/%{name}
 %endif
 
 %changelog
+* Mon May 13 2024 Elaine Zhao <elainezhao@microsoft.com> - 24.4-1
+- update to version 24.4
+
 * Fri Jun 02 2023 Vince Perri <viperri@microsoft.com> - 23.5-2
 - License verified.
 - Initial CBL-Mariner import from Fedora 39 (license: MIT).

--- a/SPECS/python-virt-firmware/python-virt-firmware.spec
+++ b/SPECS/python-virt-firmware/python-virt-firmware.spec
@@ -91,9 +91,6 @@ cp -ar tests %{buildroot}%{_datadir}/%{name}
 %{_bindir}/pe-addsigs
 %{_bindir}/pe-inspect
 %{_mandir}/man1/virt-*.1*
-%{_mandir}/man1/kernel-bootcfg.1*
-%{_mandir}/man1/uefi-boot-menu.1*
-%{_mandir}/man1/pe-*.1*
 %{python3_sitelib}/virt/firmware
 %{python3_sitelib}/virt/peutils
 %{python3_sitelib}/virt_firmware-%{pypi_version}-py%{python3_version}.egg-info

--- a/SPECS/python-virt-firmware/python-virt-firmware.spec
+++ b/SPECS/python-virt-firmware/python-virt-firmware.spec
@@ -90,7 +90,12 @@ cp -ar tests %{buildroot}%{_datadir}/%{name}
 %{_bindir}/pe-listsigs
 %{_bindir}/pe-addsigs
 %{_bindir}/pe-inspect
+%{_bindir}/kernel-bootcfg
+%{_bindir}/uefi-boot-menu
 %{_mandir}/man1/virt-*.1*
+%{_mandir}/man1/kernel-bootcfg.1*
+%{_mandir}/man1/uefi-boot-menu.1*
+%{_mandir}/man1/pe-*.1*
 %{python3_sitelib}/virt/firmware
 %{python3_sitelib}/virt/peutils
 %{python3_sitelib}/virt_firmware-%{pypi_version}-py%{python3_version}.egg-info

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -24773,8 +24773,8 @@
         "type": "other",
         "other": {
           "name": "python-virt-firmware",
-          "version": "23.5",
-          "downloadUrl": "https://files.pythonhosted.org/packages/c2/f8/204dc513d2d3f0f3d3aead03600f7db1b763cf02998ad7b35e7ac5ef6849/virt-firmware-23.5.tar.gz"
+          "version": "24.4",
+          "downloadUrl": "https://files.pythonhosted.org/packages/ea/8d/b3417567c9b532879357fb2b6b6fc50a6b0b311f95b16b4845054852e062/virt-firmware-24.4.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -24772,7 +24772,7 @@
       "component": {
         "type": "other",
         "other": {
-          "name": "python-virt-firmware",
+          "name": "virt-firmware",
           "version": "24.4",
           "downloadUrl": "https://files.pythonhosted.org/packages/ea/8d/b3417567c9b532879357fb2b6b6fc50a6b0b311f95b16b4845054852e062/virt-firmware-24.4.tar.gz"
         }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -24772,7 +24772,7 @@
       "component": {
         "type": "other",
         "other": {
-          "name": "virt-firmware",
+          "name": "python-virt-firmware",
           "version": "24.4",
           "downloadUrl": "https://files.pythonhosted.org/packages/ea/8d/b3417567c9b532879357fb2b6b6fc50a6b0b311f95b16b4845054852e062/virt-firmware-24.4.tar.gz"
         }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
python-virt-firmware upgrade to 24.4 to unblock edk2 build
latest ver: https://src.fedoraproject.org/rpms/python-virt-firmware/blob/f40/f/python-virt-firmware.spec 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
python-virt-firmware upgrade to 24.4 to unblock edk2 build

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=569960&view=results
