### PR TITLE
systemtap stap fails to build stp, cannot find stapio

### DIFF
--- a/SPECS/systemtap/0001-runtime-adapt-to-Werror-implicit-fallthrough-5.patch
+++ b/SPECS/systemtap/0001-runtime-adapt-to-Werror-implicit-fallthrough-5.patch
@@ -1,0 +1,379 @@
+From ebb60f75d3c49ea6eb3f2f9d22563205fc2f1a05 Mon Sep 17 00:00:00 2001
+From: "Frank Ch. Eigler" <fche@redhat.com>
+Date: Thu, 22 Jul 2021 19:16:12 -0400
+Subject: [PATCH 1/4] runtime: adapt to -Werror=implicit-fallthrough=5
+
+Linux kbuild commit d936eb23874 sets $subject CFLAGS, so to play
+catch-up, we also need to use gcc attribute(fallthrough) to label such
+spots in switch() statements in our runtime / tapset.  Tested on
+linux5.14 gcc11 rawhide and linux3.10 gcc4 rhel7.
+---
+ runtime/linux/runtime.h       | 16 +++++++++
+ runtime/map-gen.c             |  4 +--
+ runtime/syscall.h             | 64 +++++++++++++++++------------------
+ runtime/unwind.c              |  6 ++--
+ runtime/unwind/unwind.h       |  4 +--
+ runtime/vsprintf.c            |  8 ++---
+ tapset/linux/aux_syscalls.stp | 12 +++----
+ 7 files changed, 65 insertions(+), 49 deletions(-)
+
+diff --git a/runtime/linux/runtime.h b/runtime/linux/runtime.h
+index 035f0bd97..e57d10a8a 100644
+--- a/runtime/linux/runtime.h
++++ b/runtime/linux/runtime.h
+@@ -65,6 +65,22 @@
+ static void *kallsyms_copy_to_kernel_nofault;
+ #endif
+ 
++
++/* A fallthrough; macro to let the runtime survive -Wimplicit-fallthrough=5 */
++/* from <linux/compiler_attribute.h> */
++#ifndef fallthrough
++#if __GNUC__ < 5
++# define fallthrough                    do {} while (0)  /* fallthrough */
++#else
++#if __has_attribute(__fallthrough__)
++# define fallthrough                    __attribute__((__fallthrough__))
++#else
++# define fallthrough                    do {} while (0)  /* fallthrough */
++#endif
++#endif
++#endif
++
++
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,23)
+ #include <linux/user_namespace.h>
+ #endif
+diff --git a/runtime/map-gen.c b/runtime/map-gen.c
+index aeeab38bf..47317d61f 100644
+--- a/runtime/map-gen.c
++++ b/runtime/map-gen.c
+@@ -112,9 +112,9 @@
+                 k1 = 0; \
+                 switch(mylen & 3) {                \
+                 case 3: k1 ^= tail[2] << 16; \
+-                        /* fallthrough */ \
++                        fallthrough; \
+                 case 2: k1 ^= tail[1] << 8; \
+-                        /* fallthrough */ \
++                        fallthrough; \
+                 case 1: k1 ^= tail[0]; \
+                         k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1; \
+                 } \
+diff --git a/runtime/syscall.h b/runtime/syscall.h
+index 6b4b3071a..f5b473b04 100644
+--- a/runtime/syscall.h
++++ b/runtime/syscall.h
+@@ -351,23 +351,23 @@ _stp_syscall_get_arguments(struct task_struct *task, struct pt_regs *regs,
+ 		case 0:
+ 			if (!n--) break;
+ 			*args++ = regs->bx;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 1:
+ 			if (!n--) break;
+ 			*args++ = regs->cx;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 2:
+ 			if (!n--) break;
+ 			*args++ = regs->dx;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 3:
+ 			if (!n--) break;
+ 			*args++ = regs->si;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 4:
+ 			if (!n--) break;
+ 			*args++ = regs->di;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 5:
+ 			if (!n--) break;
+ 			*args++ = regs->bp;
+@@ -375,23 +375,23 @@ _stp_syscall_get_arguments(struct task_struct *task, struct pt_regs *regs,
+ 		case 0:
+ 			if (!n--) break;
+ 			*args++ = regs->rbx;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 1:
+ 			if (!n--) break;
+ 			*args++ = regs->rcx;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 2:
+ 			if (!n--) break;
+ 			*args++ = regs->rdx;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 3:
+ 			if (!n--) break;
+ 			*args++ = regs->rsi;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 4:
+ 			if (!n--) break;
+ 			*args++ = regs->rdi;
+-			/* fallthrough */
++                        fallthrough;
+ 		case 5:
+ 			if (!n--) break;
+ 			*args++ = regs->rbp;
+@@ -405,23 +405,23 @@ _stp_syscall_get_arguments(struct task_struct *task, struct pt_regs *regs,
+ 	case 0:
+ 		if (!n--) break;
+ 		*args++ = regs->di;
+-		/* fallthrough */
++                fallthrough;
+ 	case 1:
+ 		if (!n--) break;
+ 		*args++ = regs->si;
+-		/* fallthrough */
++                fallthrough;
+ 	case 2:
+ 		if (!n--) break;
+ 		*args++ = regs->dx;
+-		/* fallthrough */
++                fallthrough;
+ 	case 3:
+ 		if (!n--) break;
+ 		*args++ = regs->r10;
+-		/* fallthrough */
++                fallthrough;
+ 	case 4:
+ 		if (!n--) break;
+ 		*args++ = regs->r8;
+-		/* fallthrough */
++                fallthrough;
+ 	case 5:
+ 		if (!n--) break;
+ 		*args++ = regs->r9;
+@@ -429,23 +429,23 @@ _stp_syscall_get_arguments(struct task_struct *task, struct pt_regs *regs,
+ 	case 0:
+ 		if (!n--) break;
+ 		*args++ = regs->rdi;
+-		/* fallthrough */
++                fallthrough;
+ 	case 1:
+ 		if (!n--) break;
+ 		*args++ = regs->rsi;
+-		/* fallthrough */
++                fallthrough;
+ 	case 2:
+ 		if (!n--) break;
+ 		*args++ = regs->rdx;
+-		/* fallthrough */
++                fallthrough;
+ 	case 3:
+ 		if (!n--) break;
+ 		*args++ = regs->r10;
+-		/* fallthrough */
++                fallthrough;
+ 	case 4:
+ 		if (!n--) break;
+ 		*args++ = regs->r8;
+-		/* fallthrough */
++                fallthrough;
+ 	case 5:
+ 		if (!n--) break;
+ 		*args++ = regs->r9;
+@@ -575,30 +575,30 @@ static inline void _stp_syscall_get_arguments(struct task_struct *task,
+ 		case 6:
+ 			if (!n--) break;
+ 			*args++ = regs->r13;
+-			/* fallthrough */
++			fallthrough;
+ 		case 5:
+ 			if (!n--) break;
+ 			*args++ = regs->r15;
+-			/* fallthrough */
++			fallthrough;
+ 		case 4:
+ 			if (!n--) break;
+ 			*args++ = regs->r14;
+-			/* fallthrough */
++			fallthrough;
+ 		case 3:
+ 			if (!n--) break;
+ 			*args++ = regs->r10;
+-			/* fallthrough */
++			fallthrough;
+ 		case 2:
+ 			if (!n--) break;
+ 			*args++ = regs->r9;
+-			/* fallthrough */
++			fallthrough;
+ 		case 1:
+ 			if (!n--) break;
+ 			*args++ = regs->r11;
+-			/* fallthrough */
++			fallthrough;
+ 		case 0:
+ 			if (!n--) break;
+-			/* fallthrough */
++			fallthrough;
+ 		default:
+ 			BUG();
+ 			break;
+@@ -630,23 +630,23 @@ _stp_syscall_get_arguments(struct task_struct *task, struct pt_regs *regs,
+ 	case 0:
+ 		if (!n--) break;
+ 		*args++ = regs->orig_gpr2 & mask;
+-		/* fallthrough */
++		fallthrough;
+ 	case 1:
+ 		if (!n--) break;
+ 		*args++ = regs->gprs[3] & mask;
+-		/* fallthrough */
++		fallthrough;
+ 	case 2:
+ 		if (!n--) break;
+ 		*args++ = regs->gprs[4] & mask;
+-		/* fallthrough */
++		fallthrough;
+ 	case 3:
+ 		if (!n--) break;
+ 		*args++ = regs->gprs[5] & mask;
+-		/* fallthrough */
++		fallthrough;
+ 	case 4:
+ 		if (!n--) break;
+ 		*args++ = regs->gprs[6] & mask;
+-		/* fallthrough */
++		fallthrough;
+ 	case 5:
+ 		if (!n--) break;
+ 		*args++ = regs->args[0] & mask;
+diff --git a/runtime/unwind.c b/runtime/unwind.c
+index dba16a724..6916d2e96 100644
+--- a/runtime/unwind.c
++++ b/runtime/unwind.c
+@@ -527,7 +527,7 @@ static int processCFI(const u8 *start, const u8 *end, unsigned long targetLoc,
+ 					REG_STATE.cfa.reg = value;
+ 					dbug_unwind(1, "DW_CFA_def_cfa reg=%ld\n", REG_STATE.cfa.reg);
+ 				}
+-				/* fallthrough */
++				fallthrough;
+ 			case DW_CFA_def_cfa_offset:
+ 				if (REG_STATE.cfa_is_expr != 0) {
+ 					_stp_warn("Unexpected DW_CFA_def_cfa_offset\n");
+@@ -549,7 +549,7 @@ static int processCFI(const u8 *start, const u8 *end, unsigned long targetLoc,
+ 						    value, DWARF_REG_MAP(value));
+ 					REG_STATE.cfa.reg = value;
+ 				}
+-				/* fallthrough */
++				fallthrough;
+ 			case DW_CFA_def_cfa_offset_sf:
+ 				if (REG_STATE.cfa_is_expr != 0) {
+ 					_stp_warn("Unexpected DW_CFA_def_cfa_offset_sf\n");
+@@ -922,7 +922,7 @@ static int compute_expr(const u8 *expr, struct unwind_frame_info *frame,
+ 		case DW_OP_bra:
+ 			if (POP == 0)
+ 				break;
+-			/* Fall through.  */
++                        fallthrough;
+ 		case DW_OP_skip:
+ 			NEED(sizeof(u.s16));
+ 			memcpy(&u.s16, expr, sizeof(u.s16));
+diff --git a/runtime/unwind/unwind.h b/runtime/unwind/unwind.h
+index a9586a338..5c68a5f03 100644
+--- a/runtime/unwind/unwind.h
++++ b/runtime/unwind/unwind.h
+@@ -154,13 +154,13 @@ static unsigned long read_ptr_sect(const u8 **pLoc, const void *end,
+ 				value = _stp_get_unaligned(ptr.p32u++);
+ 			break;
+ 		}
+-		/* fallthrough */
++                fallthrough;
+ 	case DW_EH_PE_data8:
+ 		BUILD_BUG_ON(sizeof(u64) != sizeof(value));
+ #else
+ 		BUILD_BUG_ON(sizeof(u32) != sizeof(value));
+ #endif
+-		/* fallthrough */
++                fallthrough;
+ 	case DW_EH_PE_absptr:
+ 		if (compat_task)
+ 		{
+diff --git a/runtime/vsprintf.c b/runtime/vsprintf.c
+index 417d9f7f3..cd31a938b 100644
+--- a/runtime/vsprintf.c
++++ b/runtime/vsprintf.c
+@@ -641,7 +641,7 @@ _stp_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
+ 
+                     case 'X':
+                             flags |= STP_LARGE;
+-			    /* fallthru */
++			    fallthrough;
+                     case 'x':
+                             base = 16;
+                             break;
+@@ -649,7 +649,7 @@ _stp_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
+                     case 'd':
+                     case 'i':
+                             flags |= STP_SIGN;
+-			    /* fallthru */
++			    fallthrough;
+                     case 'u':
+                             break;
+ 
+@@ -835,7 +835,7 @@ _stp_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
+ 
+ 		case 'X':
+ 			flags |= STP_LARGE;
+-			/* fallthru */
++                        fallthrough;
+ 		case 'x':
+ 			base = 16;
+ 			break;
+@@ -843,7 +843,7 @@ _stp_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
+ 		case 'd':
+ 		case 'i':
+ 			flags |= STP_SIGN;
+-			/* fallthru */
++                        fallthrough;
+ 		case 'u':
+ 			break;
+ 
+diff --git a/tapset/linux/aux_syscalls.stp b/tapset/linux/aux_syscalls.stp
+index ad8a89898..09fb9ff41 100644
+--- a/tapset/linux/aux_syscalls.stp
++++ b/tapset/linux/aux_syscalls.stp
+@@ -156,11 +156,11 @@ sigset_from_compat(sigset_t *set, compat_sigset_t *compat)
+ {
+ 	switch (_NSIG_WORDS) {
+ 	case 4: set->sig[3] = compat->sig[6] | (((long)compat->sig[7]) << 32 );
+-	  /*fallthrough*/
++          fallthrough;
+ 	case 3: set->sig[2] = compat->sig[4] | (((long)compat->sig[5]) << 32 );
+-	  /*fallthrough*/
++          fallthrough;
+ 	case 2: set->sig[1] = compat->sig[2] | (((long)compat->sig[3]) << 32 );
+-	  /*fallthrough*/
++          fallthrough;
+ 	case 1: set->sig[0] = compat->sig[0] | (((long)compat->sig[1]) << 32 );
+ 	}
+ }
+@@ -3627,13 +3627,13 @@ function _struct_sigaction32_u:string(uaddr:long)
+ 	    {
+ 	    case 4: act.sa_mask.sig[3] = act32.sa_mask.sig[6]
+ 		| (((long)act32.sa_mask.sig[7]) << 32);
+-	      /* fallthrough */
++              fallthrough;
+ 	    case 3: act.sa_mask.sig[2] = act32.sa_mask.sig[4]
+ 		| (((long)act32.sa_mask.sig[5]) << 32);
+-	      /* fallthrough */
++              fallthrough;
+ 	    case 2: act.sa_mask.sig[1] = act32.sa_mask.sig[2]
+ 		| (((long)act32.sa_mask.sig[3]) << 32);
+-	      /* fallthrough */
++              fallthrough;
+ 	    case 1: act.sa_mask.sig[0] = act32.sa_mask.sig[0]
+ 		| (((long)act32.sa_mask.sig[1]) << 32);
+ 	    }
+-- 
+2.34.1
+

--- a/SPECS/systemtap/0002-runtime-linux-5.14-compat-linux-panic_notifier.h.patch
+++ b/SPECS/systemtap/0002-runtime-linux-5.14-compat-linux-panic_notifier.h.patch
@@ -1,0 +1,53 @@
+From b03adce8d8b5cf434b38908fc6a496ef8b860bc6 Mon Sep 17 00:00:00 2001
+From: "Frank Ch. Eigler" <fche@redhat.com>
+Date: Tue, 13 Jul 2021 19:34:50 -0400
+Subject: [PATCH 2/4] runtime: linux 5.14 compat: <linux/panic_notifier.h>
+
+Linux commit f39650de687e3 moved some kernel decls around.
+---
+ buildrun.cxx                       | 3 ++-
+ runtime/linux/autoconf-514-panic.c | 3 +++
+ runtime/transport/transport.c      | 3 +++
+ 3 files changed, 8 insertions(+), 1 deletion(-)
+ create mode 100644 runtime/linux/autoconf-514-panic.c
+
+diff --git a/buildrun.cxx b/buildrun.cxx
+index ba3daa0a0..b050e35b1 100644
+--- a/buildrun.cxx
++++ b/buildrun.cxx
+@@ -383,7 +383,8 @@ compile_pass (systemtap_session& s)
+   output_exportconf(s, o2, "cpu_khz", "STAPCONF_CPU_KHZ");
+   output_exportconf(s, o2, "__module_text_address", "STAPCONF_MODULE_TEXT_ADDRESS");
+   output_exportconf(s, o2, "add_timer_on", "STAPCONF_ADD_TIMER_ON");
+-
++  output_autoconf(s, o, cs, "autoconf-514-panic.c", "STAPCONF_514_PANIC", NULL);
++  
+   output_dual_exportconf(s, o2, "probe_kernel_read", "probe_kernel_write", "STAPCONF_PROBE_KERNEL");
+   output_autoconf(s, o, cs, "autoconf-hw_breakpoint_context.c",
+ 		  "STAPCONF_HW_BREAKPOINT_CONTEXT", NULL);
+diff --git a/runtime/linux/autoconf-514-panic.c b/runtime/linux/autoconf-514-panic.c
+new file mode 100644
+index 000000000..57b1a0026
+--- /dev/null
++++ b/runtime/linux/autoconf-514-panic.c
+@@ -0,0 +1,3 @@
++#include <linux/panic_notifier.h>
++
++void* c = & panic_notifier_list;
+diff --git a/runtime/transport/transport.c b/runtime/transport/transport.c
+index 32ef99da6..9b9d6cbe2 100644
+--- a/runtime/transport/transport.c
++++ b/runtime/transport/transport.c
+@@ -24,6 +24,9 @@
+ #ifdef STAPCONF_LOCKDOWN_DEBUGFS
+ #include <linux/security.h>
+ #endif
++#ifdef STAPCONF_514_PANIC
++#include <linux/panic_notifier.h>
++#endif
+ #include "../uidgid_compatibility.h"
+ 
+ static int _stp_exit_flag = 0;
+-- 
+2.34.1
+

--- a/SPECS/systemtap/0003-PR28079-Adapt-to-kernel-5.14-task_struct.__state-cha.patch
+++ b/SPECS/systemtap/0003-PR28079-Adapt-to-kernel-5.14-task_struct.__state-cha.patch
@@ -1,0 +1,81 @@
+From fface03033853a265d8282d6846d0ee8df0fdce8 Mon Sep 17 00:00:00 2001
+From: Stan Cox <scox@redhat.com>
+Date: Sun, 18 Jul 2021 21:32:51 -0400
+Subject: [PATCH 3/4] PR28079: Adapt to kernel 5.14 task_struct.__state change
+
+Use signal_wake_up_state for the 5.14 kernel which changed volatile long state to unsigned int __state.
+---
+ buildrun.cxx                        |  3 +++
+ runtime/linux/autoconf-task-state.c | 18 ++++++++++++++++++
+ runtime/stp_utrace.c                |  7 +++++--
+ 3 files changed, 26 insertions(+), 2 deletions(-)
+ create mode 100644 runtime/linux/autoconf-task-state.c
+
+diff --git a/buildrun.cxx b/buildrun.cxx
+index b050e35b1..ae27ddea4 100644
+--- a/buildrun.cxx
++++ b/buildrun.cxx
+@@ -521,6 +521,9 @@ compile_pass (systemtap_session& s)
+ 		  "STAPCONF_ATOMIC_FETCH_ADD_UNLESS", NULL);
+   output_autoconf(s, o, cs, "autoconf-lockdown-debugfs.c", "STAPCONF_LOCKDOWN_DEBUGFS", NULL);
+   output_autoconf(s, o, cs, "autoconf-lockdown-kernel.c", "STAPCONF_LOCKDOWN_KERNEL", NULL);
++  output_autoconf(s, o, cs, "autoconf-hlist_add_tail_rcu.c",
++		  "STAPCONF_HLIST_ADD_TAIL_RCU", NULL);
++  output_autoconf(s, o, cs, "autoconf-task-state.c", "STAPCONF_TASK_STATE", NULL);
+   
+   // used by runtime/linux/netfilter.c
+   output_exportconf(s, o2, "nf_register_hook", "STAPCONF_NF_REGISTER_HOOK");
+diff --git a/runtime/linux/autoconf-task-state.c b/runtime/linux/autoconf-task-state.c
+new file mode 100644
+index 000000000..27a1d7c13
+--- /dev/null
++++ b/runtime/linux/autoconf-task-state.c
+@@ -0,0 +1,18 @@
++/*
++ * Is this a kernel prior to the following kernel commit:
++ *
++ * commit	2f064a59a11ff9bc22e52e9678bc601404c7cb34
++ * Author:	Peter Zijlstra <peterz@infradead.org>
++ * Date:	2021-06-11 10:28:17 +0200
++ *
++ * sched: Change task_struct::state
++ * Change the type and name of task_struct::state. Drop the volatile and
++ * shrink it to an 'unsigned int'. Rename it in order to find all uses
++ * such that we can use READ_ONCE/WRITE_ONCE as appropriate.
++ */
++
++#include <linux/sched.h>
++
++unsigned int bar (struct task_struct *foo) { 
++  return (foo->state = 0); 
++}
+diff --git a/runtime/stp_utrace.c b/runtime/stp_utrace.c
+index ff8c5549d..d63e6366c 100644
+--- a/runtime/stp_utrace.c
++++ b/runtime/stp_utrace.c
+@@ -33,9 +33,12 @@
+ #if defined(__set_task_state)
+ #define __stp_set_task_state(tsk, state_value)		\
+ 	__set_task_state((tsk), (state_value))
+-#else
++#elif defined(STAPCONF_TASK_STATE)
+ #define __stp_set_task_state(tsk, state_value)		\
+ 	do { (tsk)->state = (state_value); } while (0)
++#else
++#define __stp_set_task_state(tsk, state_value)		\
++	signal_wake_up_state((tsk), (state_value))
+ #endif
+ 
+ // For now, disable the task_work_queue on non-RT kernels.
+@@ -1263,7 +1266,7 @@ static void utrace_wakeup(struct task_struct *target, struct utrace *utrace)
+ 	spin_lock_irq(&target->sighand->siglock);
+ 	if (target->signal->flags & SIGNAL_STOP_STOPPED ||
+ 	    target->signal->group_stop_count)
+-		target->state = TASK_STOPPED;
++	        __stp_set_task_state(target, TASK_STOPPED);
+ 	else
+ 		stp_wake_up_state(target, __TASK_TRACED);
+ 	spin_unlock_irq(&target->sighand->siglock);
+-- 
+2.34.1
+

--- a/SPECS/systemtap/0004-Use-task_state-tapset-function-to-avoid-task_struct-.patch
+++ b/SPECS/systemtap/0004-Use-task_state-tapset-function-to-avoid-task_struct-.patch
@@ -1,0 +1,81 @@
+From 5ec01e15cd7e05d107483f1a1999dc03be773fbc Mon Sep 17 00:00:00 2001
+From: William Cohen <wcohen@redhat.com>
+Date: Mon, 13 Sep 2021 21:32:38 -0400
+Subject: [PATCH 4/4] Use task_state tapset function to avoid task_struct
+ changes
+
+The Linux 5.14 kernel's task_struct changed the state field to
+__state.  The task_state tapset function selects the appropriate
+version.  Make the scheduler.stp tapset and schedtimes.stp example use
+the task_state function rather than directly trying to access the
+task_struct state field (and get it wrong for newer kernels).
+---
+ tapset/linux/scheduler.stp                          | 10 +++++-----
+ testsuite/systemtap.examples/process/schedtimes.stp |  2 +-
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/tapset/linux/scheduler.stp b/tapset/linux/scheduler.stp
+index 7338e9008..4667ab53a 100644
+--- a/tapset/linux/scheduler.stp
++++ b/tapset/linux/scheduler.stp
+@@ -138,7 +138,7 @@ probe scheduler.ctxswitch = kernel.trace("sched_switch") !,
+ 		prev_tid = $prev_p->pid
+ 		prev_task = $prev_p
+ 		prev_task_name = task_execname($prev_p)
+-		prevtsk_state = $prev_p->state
++		prevtsk_state = task_state($prev_p)
+ 	}
+ 	else {
+ 		prev_priority = $prev->prio
+@@ -146,7 +146,7 @@ probe scheduler.ctxswitch = kernel.trace("sched_switch") !,
+ 		prev_tid = $prev->pid
+ 		prev_task = $prev
+ 		prev_task_name = task_execname($prev)
+-		prevtsk_state = $prev->state
++		prevtsk_state = task_state($prev)
+ 	}
+ 
+ 	if (@defined($next)) {
+@@ -155,7 +155,7 @@ probe scheduler.ctxswitch = kernel.trace("sched_switch") !,
+ 		next_tid = $next->pid
+ 		next_task = $next
+ 		next_task_name = task_execname($next)
+-		nexttsk_state = $next->state
++		nexttsk_state = task_state($next)
+ 	}
+ 	else if (@defined($next_p)) {
+ 		next_priority = $next_p->prio
+@@ -163,7 +163,7 @@ probe scheduler.ctxswitch = kernel.trace("sched_switch") !,
+ 		next_tid = $next_p->pid
+ 		next_task = $next_p
+ 		next_task_name = task_execname($next_p)
+-		nexttsk_state = $next_p->state
++		nexttsk_state = task_state($next_p)
+ 	}
+ 	else {
+ 		next_priority = $new->prio
+@@ -171,7 +171,7 @@ probe scheduler.ctxswitch = kernel.trace("sched_switch") !,
+ 		next_tid = $new->pid
+ 		next_task = $new
+ 		next_task_name = task_execname($new)
+-		nexttsk_state = $new->state
++		nexttsk_state = task_state($new)
+ 	}
+ }
+ 
+diff --git a/testsuite/systemtap.examples/process/schedtimes.stp b/testsuite/systemtap.examples/process/schedtimes.stp
+index 4e422c893..ee1053045 100755
+--- a/testsuite/systemtap.examples/process/schedtimes.stp
++++ b/testsuite/systemtap.examples/process/schedtimes.stp
+@@ -99,7 +99,7 @@ probe kernel.trace("sched_switch")
+   // Task $prev is scheduled off this cpu
+   if (task_targeted($prev)) {
+     pid = $prev->pid
+-    state = $prev->state
++    state = task_state($prev)
+     update_times(pid, timestamp())
+ 
+     if (state > 0) {
+-- 
+2.34.1
+

--- a/SPECS/systemtap/systemtap.spec
+++ b/SPECS/systemtap/systemtap.spec
@@ -16,6 +16,13 @@ Distribution:   Mariner
 Group:          Development/System
 URL:            https://sourceware.org/systemtap/
 Source0:        https://sourceware.org/systemtap/ftp/releases/%{name}-%{version}.tar.gz
+
+# Patches to fix stap build errors
+Patch0:         0001-runtime-adapt-to-Werror-implicit-fallthrough-5.patch
+Patch1:         0002-runtime-linux-5.14-compat-linux-panic_notifier.h.patch
+Patch2:         0003-PR28079-Adapt-to-kernel-5.14-task_struct.__state-cha.patch
+Patch3:         0004-Use-task_state-tapset-function-to-avoid-task_struct-.patch
+
 BuildRequires:  elfutils-devel
 BuildRequires:  elfutils-libelf-devel
 BuildRequires:  glibc-devel
@@ -45,6 +52,10 @@ BuildRequires:  rpm-devel
 %endif
 Requires:       elfutils
 Requires:       gcc
+%if %{with_check}
+BuildRequires:  kernel-devel
+BuildRequires:  kernel-headers
+%endif
 Requires:       kernel-devel
 Requires:       make
 Requires:       %{name}-runtime = %{version}-%{release}
@@ -107,6 +118,7 @@ SystemTap server is the server component of an instrumentation system for system
 
 %prep
 %setup -q
+%autopatch -p1
 sed -i "s#"kernel"#"linux"#g" stap-prep
 sed -i "s#"devel"#"dev"#g" stap-prep
 
@@ -142,6 +154,7 @@ sed -i "s#"devel"#"dev"#g" stap-prep
 make
 
 %install
+make DESTDIR=$RPM_BUILD_ROOT install
 [ %{buildroot} != / ] && rm -rf ""
 %makeinstall
 
@@ -315,8 +328,10 @@ fi
 %files runtime
 %defattr(-,root,root)
 %attr(4111,root,root) %{_bindir}/staprun
+%dir %{_libexecdir}/systemtap
 %{_libexecdir}/systemtap/stap-env
 %{_libexecdir}/systemtap/stap-authorize-cert
+%{_libexecdir}/systemtap/stapio
 %if %{with_crash}
 %{_libdir}/systemtap/staplog.so*
 %endif
@@ -331,6 +346,7 @@ fi
 %files server
 %defattr(-,root,root)
 %{_bindir}/stap-server
+%dir %{_libexecdir}/systemtap
 %{_libexecdir}/systemtap/stap-serverd
 %{_libexecdir}/systemtap/stap-start-server
 %{_libexecdir}/systemtap/stap-stop-server

--- a/SPECS/systemtap/systemtap.spec
+++ b/SPECS/systemtap/systemtap.spec
@@ -9,7 +9,7 @@
 Summary:        Programmable system-wide instrumentation system
 Name:           systemtap
 Version:        4.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -365,6 +365,10 @@ fi
 %{_mandir}/man8/systemtap-service.8*
 
 %changelog
+* Mon May 13 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 4.5-4
+- Ensure that stapio is installed
+- Cherry-pick changes from upstream 4.6 to allow stp files to build
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 4.5-3
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---


###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
stap does not work currently.

The command reports build failures when ingesting the stp files. 
 See https://bugzilla.redhat.com/show_bug.cgi?id=2010385.
 
 Also stapio is not installed by RPMs.

###### Change Log  <!-- REQUIRED -->
- Apply patches found in systemtap 4.6 to get stp files to build
- Configure DESTDIR so that stapio is installed

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
- 

###### Links to CVEs  <!-- optional -->
- 

###### Test Methodology
- Check section does not exercise stap, but manually tested with buddy build RPMs using this command: `stap -c hostname -e 'probe begin { printf("hello\n"); exit() }'`
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=569864&view=results
