### PR TITLE
Image Customizer: Improve docs for chroot.

### DIFF
--- a/toolkit/tools/imagecustomizer/README.md
+++ b/toolkit/tools/imagecustomizer/README.md
@@ -3,10 +3,10 @@
 The Azure Linux Image Customizer is a tool that can take an existing generic Azure Linux
 image and modify it to be suited for particular scenario.
 
-MIC uses [chroot](https://en.wikipedia.org/wiki/Chroot) (and loopback block devices) to
-customize the image.
-This is the same technology used to build the Azure Linux images (along with most other
-Linux distros).
+The Image Customizer uses [chroot](https://en.wikipedia.org/wiki/Chroot) (and loopback
+block devices) to customize the image.
+This is the same technology used to build the Azure Linux images, along with most other
+Linux distros.
 This is in contrast to some other image customization tools, like Packer, which
 customize the image by booting it inside a VM.
 
@@ -22,9 +22,8 @@ Advantages:
 
 Disadvantages:
 
-- Not all Linux tools play nicely when run under chroot. (Though most of the most
-  common tools do play nicely since they are used to build Linux images under chroot.)
-  So, some customizations aren't possible to do using MIC.
+- Not all Linux tools play nicely when run under chroot.
+  So, some customizations aren't possible using the Image Customizer.
   (For example, initializing a Kubernetes cluster node.)
 
 ## Getting started
@@ -83,3 +82,33 @@ Disadvantages:
    The customized image is placed in the file that you specified with the
    `--output-image-file` parameter. You can now use this image as you see fit.
    (For example, boot it in a Hyper-V VM.)
+
+## Things to avoid
+
+The Image Customizer tool provides the option to run custom scripts as part of the
+customization process.
+These can be used to handle scenarios not covered by the Image Customizer tool.
+However, these scripts are only run within a chroot environment, which while it is kind
+of similar to containers, is very explicitly not a sandbox environment.
+So, such scripts have the ability to modify the host build system.
+
+In particular, you should be very wary of commands that have the ability to change the
+runtime kernel settings.
+And even commands that only read runtime kernel settings are probably doing the wrong
+thing, since the host build system's kernel is likely entirely unrelated to the
+customized OS's kernel.
+
+Examples of commands to avoid:
+
+- `ip`
+- `iptables`
+- `iptables-save`
+- `ip6tables-save`
+- `sysctl`
+
+Instead, you should you make use of config files that set the runtime kernel settings
+during OS boot.
+
+Example config directories to use instead:
+
+- `/etc/sysctl.d` (`systemd-sysctl.service`)


### PR DESCRIPTION
In the Image Customizer README.md file, add a section that documents things to avoid in the user's custom scripts. In particular, it warns that chroot doesn't protect the build host kernel from being changed by the scripts.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- n/a
