### PR TITLE
selinux-policy: Add fix for cloud-init growpart.

### DIFF
--- a/SPECS/selinux-policy/0043-cloudinit-Add-support-for-cloud-init-growpart.patch
+++ b/SPECS/selinux-policy/0043-cloudinit-Add-support-for-cloud-init-growpart.patch
@@ -1,0 +1,40 @@
+From 2f6ac01a96f7b0de7464474ddff51bee596007a6 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <chpebeni@linux.microsoft.com>
+Date: Mon, 29 Apr 2024 16:36:05 -0400
+Subject: [PATCH 43/43] cloudinit: Add support for cloud-init-growpart.
+
+Signed-off-by: Chris PeBenito <chpebeni@linux.microsoft.com>
+---
+ policy/modules/admin/cloudinit.te | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/policy/modules/admin/cloudinit.te b/policy/modules/admin/cloudinit.te
+index bbc92f30d..10d26bc30 100644
+--- a/policy/modules/admin/cloudinit.te
++++ b/policy/modules/admin/cloudinit.te
+@@ -10,6 +10,13 @@ gen_require(`
+ # Declarations
+ #
+ 
++## <desc>
++## <p>
++## Enable support for the cloud-init-growpart module.
++## </p>
++## </desc>
++gen_tunable(cloudinit_growpart, false)
++
+ ## <desc>
+ ## <p>
+ ## Enable support for cloud-init to manage all non-security files.
+@@ -129,6 +136,8 @@ ssh_setattr_home_dirs(cloud_init_t)
+ # Read public keys
+ ssh_read_server_keys(cloud_init_t)
+ 
++storage_raw_read_fixed_disk_cond(cloud_init_t, cloudinit_growpart)
++
+ sysnet_run_ifconfig(cloud_init_t, system_r)
+ 
+ term_write_console(cloud_init_t)
+-- 
+2.45.0
+

--- a/SPECS/selinux-policy/booleans_targeted.conf
+++ b/SPECS/selinux-policy/booleans_targeted.conf
@@ -1,2 +1,5 @@
+# enable cloud-init-growpart support
+cloudinit_growpart = true
+
 # Enable this to allow unconfined to log in over ssh
 ssh_sysadm_login = true

--- a/SPECS/selinux-policy/selinux-policy.signatures.json
+++ b/SPECS/selinux-policy/selinux-policy.signatures.json
@@ -1,7 +1,7 @@
 {
  "Signatures": {
   "Makefile.devel": "cd065e896d7eb11e238a05b9102359ea370ec75b27785a81935c985899ed2df6",
-  "booleans_targeted.conf": "bdefca5cc433e5fd372cd68105412db279673140f6477148744ea22c7395fec1",
+  "booleans_targeted.conf": "009f880c7179a007569dfdbf40ef64ae41671ad33cc2717eebbdaeb8ab431d12",
   "macros.selinux-policy": "027f5d27441a7262365c26076dc3b7ab1f1ac62026ae94514020e0607e53a73a",
   "modules_targeted.conf": "0a3444baa54aef35220e9954d1175da091155f240bf989caa7dfb9ef64302a76",
   "refpolicy-2.20221101.tar.bz2": "44f88e62c8efcef54d019b9ca077520d5993de580926bd7575788cfa78515396"

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,7 @@ Patch39:        0039-modutils-Temporary-fix-for-mkinitrd-dracut.patch
 Patch40:        0040-For-systemd-hostnamed-service-to-run.patch
 Patch41:        0041-docker-Silence-io.containerd.internal.v1.opt-opt-con.patch
 Patch42:        0042-getty-grant-checkpoint_restore.patch
+Patch43:        0043-cloudinit-Add-support-for-cloud-init-growpart.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -346,6 +347,9 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Tue May 14 2024 Chris PeBenito <chpebeni@microsoft.com> - 2.20221101-7
+- Add fix for cloud-init growpart.
+
 * Tue Apr 23 2024 Chris PeBenito <chpebeni@microsoft.com> - 2.20221101-6
 - Add getty fix for new check in kernel 6.7
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add SELinux policy rules to allow cloud-init growpart to work.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add SELinux policy rules to allow cloud-init growpart to work.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 569807
- Local test
- SELinux BVT