### PR TITLE
Image Customizer: Fix ISO gen without changes.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -272,7 +272,6 @@ func convertInputImageToWriteableFormat(ic *ImageCustomizerParameters) (*LiveOSI
 	logger.Log.Infof("Converting input image to a writeable format")
 
 	if ic.inputIsIso {
-
 		inputIsoArtifacts, err := createIsoBuilderFromIsoImage(ic.buildDir, ic.buildDirAbs, ic.inputImageFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load input iso artifacts:\n%w", err)
@@ -288,17 +287,17 @@ func convertInputImageToWriteableFormat(ic *ImageCustomizerParameters) (*LiveOSI
 				return nil, fmt.Errorf("failed to create writeable image:\n%w", err)
 			}
 		}
-		return inputIsoArtifacts, nil
 
+		return inputIsoArtifacts, nil
 	} else {
 		logger.Log.Infof("Creating raw base image: %s", ic.rawImageFile)
 		err := shell.ExecuteLiveWithErr(1, "qemu-img", "convert", "-O", "raw", ic.inputImageFile, ic.rawImageFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert image file to raw format:\n%w", err)
 		}
-	}
 
-	return nil, nil
+		return nil, nil
+	}
 }
 
 func customizeOSContents(ic *ImageCustomizerParameters) error {
@@ -383,7 +382,6 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 }
 
 func convertWriteableFormatToOutputImage(ic *ImageCustomizerParameters, inputIsoArtifacts *LiveOSIsoBuilder) error {
-
 	logger.Log.Infof("Converting customized OS partitions into the final image")
 
 	// Create final output image file if requested.
@@ -395,8 +393,9 @@ func convertWriteableFormatToOutputImage(ic *ImageCustomizerParameters, inputIso
 		if err != nil {
 			return fmt.Errorf("failed to convert image file to format: %s:\n%w", ic.outputImageFormat, err)
 		}
+
 	case ImageFormatIso:
-		if ic.customizeOSPartitions {
+		if ic.customizeOSPartitions || inputIsoArtifacts == nil {
 			err := createLiveOSIsoImage(ic.buildDir, ic.configPath, inputIsoArtifacts, ic.config.Iso, ic.rawImageFile, ic.outputImageDir, ic.outputImageBase)
 			if err != nil {
 				return fmt.Errorf("failed to create LiveOS iso image:\n%w", err)


### PR DESCRIPTION
Fix a crash for when an ISO is generated from an image file (e.g. vhdx) and no changes are made to the OS.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.
