### PR TITLE
Fix PTest for python-repoze-lru

### DIFF
--- a/SPECS/python-repoze-lru/python-repoze-lru.spec
+++ b/SPECS/python-repoze-lru/python-repoze-lru.spec
@@ -1,12 +1,10 @@
-%{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
 %define pkgname repoze-lru
 %define pypiname repoze.lru
 
 Summary:        A tiny LRU cache implementation and decorator
 Name:           python-%{pkgname}
 Version:        0.7
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        BSD
 URL:            https://github.com/repoze/repoze.lru
 Vendor:         Microsoft Corporation
@@ -27,7 +25,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 BuildRequires:  python3-setuptools
 Requires:       python3
-%if %{with check}
+%if 0%{with_check}
 BuildRequires:  python3-pip
 %endif
 
@@ -44,8 +42,7 @@ python3 setup.py build
 python3 setup.py install --root=%{buildroot}
 
 %check
-pip3 install tox
-LANG=en_US.UTF-8 tox -e py%{python3_version_nodots}
+python3 setup.py test
 
 %files -n python3-%{pkgname}
 %license LICENSE.txt
@@ -53,6 +50,9 @@ LANG=en_US.UTF-8 tox -e py%{python3_version_nodots}
 %{python3_sitelib}/*
 
 %changelog
+* Wed May 15 2024 Sam Meluch <sammeluch@microsoft.com> - 0.7-6
+- fix with_check macro, remove sitelibs redef to fix tests
+
 * Wed Apr 27 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.7-5
 - Updating source URL.
 

--- a/SPECS/python-repoze-lru/python-repoze-lru.spec
+++ b/SPECS/python-repoze-lru/python-repoze-lru.spec
@@ -25,7 +25,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 BuildRequires:  python3-setuptools
 Requires:       python3
-%if 0%{with_check}
+%if 0%{?with_check}
 BuildRequires:  python3-pip
 %endif
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix the package test for python-repoze-lru for 3.0 with python 3.12

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Call test script directly through setup.py
- remove redef of sitelibs macro

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=570560&view=results
