### PR TITLE
prometheus-adapter: Fix CVE-2024-24786

### DIFF
--- a/SPECS/prometheus-adapter/CVE-2024-24786.patch
+++ b/SPECS/prometheus-adapter/CVE-2024-24786.patch
@@ -1,0 +1,53 @@
+From 7b12da1a5079128b769ff99e950fa7a92af20aff Mon Sep 17 00:00:00 2001
+From: Rohit Rawat <xordux@gmail.com>
+Date: Thu, 16 May 2024 12:05:43 +0000
+Subject: [PATCH] protobuf-go: Fix CVE-2024-24786
+
+---
+ .../protobuf/encoding/protojson/well_known_types.go      | 9 +++++++++
+ .../protobuf/internal/encoding/json/decode.go            | 2 +-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 72924a9..9384f0b 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -328,6 +328,10 @@ func (d decoder) skipJSONValue() error {
+ 				if err := d.skipJSONValue(); err != nil {
+ 					return err
+ 				}
++			case json.EOF:
++				// This can only happen if there's a bug in Decoder.Read.
++				// Avoid an infinite loop if this does happen.
++				return errors.New("unexpected EOF")
+ 			}
+ 		}
+ 
+@@ -341,6 +345,11 @@ func (d decoder) skipJSONValue() error {
+ 			case json.ArrayClose:
+ 				d.Read()
+ 				return nil
++			case json.EOF:
++				// This can only happen if there's a bug in Decoder.Read.
++				// Avoid an infinite loop if this does happen.
++				return errors.New("unexpected EOF")
++			}
+ 			default:
+ 				// Skip array item.
+ 				if err := d.skipJSONValue(); err != nil {
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index b13fd29..b2be4e8 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
+ 
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}
+-- 
+2.33.8
+

--- a/SPECS/prometheus-adapter/CVE-2024-24786.patch
+++ b/SPECS/prometheus-adapter/CVE-2024-24786.patch
@@ -1,15 +1,15 @@
-From 7b12da1a5079128b769ff99e950fa7a92af20aff Mon Sep 17 00:00:00 2001
+From 6d8650a5d365c3f80dcf3cd32681dc9c33a04f2d Mon Sep 17 00:00:00 2001
 From: Rohit Rawat <xordux@gmail.com>
-Date: Thu, 16 May 2024 12:05:43 +0000
+Date: Thu, 16 May 2024 18:12:11 +0000
 Subject: [PATCH] protobuf-go: Fix CVE-2024-24786
 
 ---
- .../protobuf/encoding/protojson/well_known_types.go      | 9 +++++++++
- .../protobuf/internal/encoding/json/decode.go            | 2 +-
- 2 files changed, 10 insertions(+), 1 deletion(-)
+ .../protobuf/encoding/protojson/well_known_types.go       | 8 ++++++++
+ .../protobuf/internal/encoding/json/decode.go             | 2 +-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
-index 72924a9..9384f0b 100644
+index 72924a9..95562c0 100644
 --- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
 +++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
 @@ -328,6 +328,10 @@ func (d decoder) skipJSONValue() error {
@@ -23,7 +23,7 @@ index 72924a9..9384f0b 100644
  			}
  		}
  
-@@ -341,6 +345,11 @@ func (d decoder) skipJSONValue() error {
+@@ -341,6 +345,10 @@ func (d decoder) skipJSONValue() error {
  			case json.ArrayClose:
  				d.Read()
  				return nil
@@ -31,7 +31,6 @@ index 72924a9..9384f0b 100644
 +				// This can only happen if there's a bug in Decoder.Read.
 +				// Avoid an infinite loop if this does happen.
 +				return errors.New("unexpected EOF")
-+			}
  			default:
  				// Skip array item.
  				if err := d.skipJSONValue(); err != nil {

--- a/SPECS/prometheus-adapter/prometheus-adapter.spec
+++ b/SPECS/prometheus-adapter/prometheus-adapter.spec
@@ -1,12 +1,13 @@
 Summary:        Kubernetes Custom, Resource, and External Metric APIs implemented to work with Prometheus.
 Name:           prometheus-adapter
 Version:        0.10.0
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/kubernetes-sigs/prometheus-adapter
 Source0:        https://github.com/kubernetes-sigs/%{name}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-24786.patch
 BuildRequires:  golang
 
 %description
@@ -41,6 +42,9 @@ make test
 %doc README.md RELEASE.md
 
 %changelog
+* Thu May 16 2024 Rohit Rawat <rohitrawat@microsoft.com> - 0.10.0-12
+- Fix CVE-2024-24786
+
 * Fri Feb 02 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.10.0-11
 - Bump release to rebuild with go 1.21.6
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2024-24786 in prometheus-adapter

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2024-24786

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-24786

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [571039](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=571039&view=results)
