### PR TITLE
Add new compress-toolchain-final-rpms target to makefile

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -110,6 +110,12 @@ compress-toolchain:
 	tar -cvp -f $(final_toolchain) -C $(toolchain_build_dir) built_rpms_all
 	$(if $(CACHE_DIR), cp $(raw_toolchain) $(final_toolchain) $(CACHE_DIR))
 
+# Creates a toolchain archive from the final toolchain rpms placed in ./build/toolchain_rpms, regardless of their source. This may be used with both locally built or downloaded toolchains.
+# The archive is placed in ./otut/toolchain_final_extracted_rpms.tar.gz and may be used with TOOLCHAIN_ARCHIVE= to populate a toolchain during subsequent builds.
+compress-toolchain-final-rpms:
+	tar -I $(ARCHIVE_TOOL) -cvf $(OUT_DIR)/toolchain_final_extracted_rpms.tar.gz --transform='s`/*[^/]*/``' -C $(TOOLCHAIN_RPMS_DIR) .
+	echo "Created $(OUT_DIR)/toolchain_final_extracted_rpms.tar.gz"
+
 # After hydrating the toolchain run
 # "sudo touch build/toolchain/toolchain_from_container.tar.gz" (should really check for existence of files in toolchain_*.txt)
 # "sudo make toolchain REBUILD_TOOLCHAIN=y INCREMENTAL_TOOLCHAIN=y"

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -111,7 +111,7 @@ compress-toolchain:
 	$(if $(CACHE_DIR), cp $(raw_toolchain) $(final_toolchain) $(CACHE_DIR))
 
 # Creates a toolchain archive from the final toolchain rpms placed in ./build/toolchain_rpms, regardless of their source. This may be used with both locally built or downloaded toolchains.
-# The archive is placed in ./otut/toolchain_final_extracted_rpms.tar.gz and may be used with TOOLCHAIN_ARCHIVE= to populate a toolchain during subsequent builds.
+# The archive is placed in ./out/toolchain_final_extracted_rpms.tar.gz and may be used with TOOLCHAIN_ARCHIVE= to populate a toolchain during subsequent builds.
 compress-toolchain-final-rpms:
 	tar -I $(ARCHIVE_TOOL) -cvf $(OUT_DIR)/toolchain_final_extracted_rpms.tar.gz --transform='s`/*[^/]*/``' -C $(TOOLCHAIN_RPMS_DIR) .
 	echo "Created $(OUT_DIR)/toolchain_final_extracted_rpms.tar.gz"


### PR DESCRIPTION
`make toolchain && make compress-toolchain-final-rpms` will create out/toolchain_final_extracted_rpms.tar.gz.

This may be used with future calls to `make ... TOOLCHAIN_ARCHIVE=toolchain_final_extracted_rpms.tar.gz` to hydrate a toolchain.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
make toolchain && make compress-toolchain-final-rpms will create out/toolchain_final_extracted_rpms.tar.gz.
This command facilitates creating a toolchain archive.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
