### PR TITLE
Fixing epoch matching in 'InstallPackageRegex'. (CP #9131)

### DIFF
--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -14,14 +14,14 @@ import (
 var (
 	// Every valid line will be of the form: <package_name> <architecture> <version>.<dist> <repo_id>
 	// For:
-	//     X aarch64	1.1b.8_X-22~rc1.azl3		fetcher-cloned-repo
+	//     X aarch64	5:1.1b.8_X-22~rc1.azl3		fetcher-cloned-repo
 	//
 	// We'd get:
 	//   - package_name:    X
 	//   - architecture:    aarch64
-	//   - version:         1.1b.8_X-22~rc1
+	//   - version:         5:1.1b.8_X-22~rc1
 	//   - dist:            azl3
-	InstallPackageRegex = regexp.MustCompile(`^\s*([[:alnum:]_.+-]+)\s+([[:alnum:]_+-]+)\s+([[:alnum:]._+~-]+)\.([[:alpha:]]+[[:digit:]]+)`)
+	InstallPackageRegex = regexp.MustCompile(`^\s*([[:alnum:]_.+-]+)\s+([[:alnum:]_+-]+)\s+((?:[[:digit:]]:)?[[:alnum:]._+~-]+)\.([[:alpha:]]+[[:digit:]]+)`)
 
 	// Every valid line pair will be of the form:
 	//		<package>-<version>.<arch> : <Description>

--- a/toolkit/tools/internal/tdnf/tdnf_test.go
+++ b/toolkit/tools/internal/tdnf/tdnf_test.go
@@ -72,3 +72,84 @@ func TestGetMajorVersionFromString_RejectTrailingDot(t *testing.T) {
 	_, err := getMajorVersionFromString(fullVersion)
 	assert.Error(t, err)
 }
+
+func TestInstallPackageRegex_MatchesPackageName(t *testing.T) {
+	const line = "X aarch64 1.1b.8_X-22~rc1.azl3 fetcher-cloned-repo"
+
+	matches := InstallPackageRegex.FindStringSubmatch(line)
+
+	assert.Len(t, matches, InstallMaxMatchLen)
+	assert.Equal(t, "X", matches[InstallPackageName])
+}
+
+func TestInstallPackageRegex_FailsForMissingPackageName(t *testing.T) {
+	const line = " aarch64 1.1b.8_X-22~rc1.azl3 fetcher-cloned-repo"
+
+	assert.False(t, InstallPackageRegex.MatchString(line))
+}
+
+func TestInstallPackageRegex_MatchesPackageArch(t *testing.T) {
+	const line = "X aarch64 1.1b.8_X-22~rc1.azl3 fetcher-cloned-repo"
+
+	matches := InstallPackageRegex.FindStringSubmatch(line)
+
+	assert.Len(t, matches, InstallMaxMatchLen)
+	assert.Equal(t, "aarch64", matches[InstallPackageArch])
+}
+
+func TestInstallPackageRegex_FailsForMissingArch(t *testing.T) {
+	const line = "X  1.1b.8_X-22~rc1.azl3 fetcher-cloned-repo"
+
+	assert.False(t, InstallPackageRegex.MatchString(line))
+}
+
+func TestInstallPackageRegex_MatchesPackageVersionNoEpoch(t *testing.T) {
+	const line = "X aarch64 1.1b.8_X-22~rc1.azl3 fetcher-cloned-repo"
+
+	matches := InstallPackageRegex.FindStringSubmatch(line)
+
+	assert.Len(t, matches, InstallMaxMatchLen)
+	assert.Equal(t, "1.1b.8_X-22~rc1", matches[InstallPackageVersion])
+}
+
+func TestInstallPackageRegex_MatchesPackageVersionWithEpoch(t *testing.T) {
+	const line = "X aarch64 5:1.1b.8_X-22~rc1.azl3 fetcher-cloned-repo"
+
+	matches := InstallPackageRegex.FindStringSubmatch(line)
+
+	assert.Len(t, matches, InstallMaxMatchLen)
+	assert.Equal(t, "5:1.1b.8_X-22~rc1", matches[InstallPackageVersion])
+}
+
+func TestInstallPackageRegex_FailsForMissingVersion(t *testing.T) {
+	const line = "X aarch64 .azl3 fetcher-cloned-repo"
+
+	assert.False(t, InstallPackageRegex.MatchString(line))
+}
+
+func TestInstallPackageRegex_MatchesPackageDist(t *testing.T) {
+	const line = "X aarch64 1.1b.8_X-22~rc1.azl3 fetcher-cloned-repo"
+
+	matches := InstallPackageRegex.FindStringSubmatch(line)
+
+	assert.Len(t, matches, InstallMaxMatchLen)
+	assert.Equal(t, "azl3", matches[InstallPackageDist])
+}
+
+func TestInstallPackageRegex_FailsForMissingDist(t *testing.T) {
+	const line = "X aarch64 1.1b.8_X-22~rc1 fetcher-cloned-repo"
+
+	assert.False(t, InstallPackageRegex.MatchString(line))
+}
+
+func TestInstallPackageRegex_MatchesRandomWhiteSpaces(t *testing.T) {
+	const line = "X   aarch64  1.1b.8_X-22~rc1.azl3          	fetcher-cloned-repo"
+
+	assert.True(t, InstallPackageRegex.MatchString(line))
+}
+
+func TestInstallPackageRegex_DoesNotMatchInvalidLine(t *testing.T) {
+	const line = "Invalid line"
+
+	assert.False(t, InstallPackageRegex.MatchString(line))
+}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Cherry-pick of 2.0's #9131.

Fixing a but where the `tdnf.InstallPackageRegex` regular expression was filtering out packages with a non-zero epoch.

Opening against fast-track to fix test triggering in the fast-track pipelines.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local tooling tests.
- Image build tests by @anphel31.