### PR TITLE
Specialcased 5XX errors during package downloads. (CP: #7445)

### DIFF
--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/buildpipeline"
@@ -16,6 +17,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/packagerepo/repocloner"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/pkgjson"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/retry"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/tdnf"
@@ -48,6 +50,11 @@ const (
 
 	useSingleTransaction    = true
 	useMultipleTransactions = !useSingleTransaction
+)
+
+var (
+	serverErrorsRegex    = regexp.MustCompile(`(?m)Error: (5\d{2}) when downloading`)
+	serverErrorCodeIndex = 1
 )
 
 // RpmRepoCloner represents an RPM repository cloner.
@@ -595,11 +602,6 @@ func (r *RpmRepoCloner) Close() error {
 // clonePackage clones a given package using pre-populated arguments.
 // It will gradually enable more repos to consider until the package is found.
 func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err error) {
-	const (
-		unresolvedOutputPrefix  = "No package"
-		toyboxConflictsPrefix   = "toybox conflicts"
-		unresolvedOutputPostfix = "available"
-	)
 
 	releaseverCliArg, err := tdnf.GetReleaseverCliArg()
 	if err != nil {
@@ -613,40 +615,23 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err erro
 
 		finalArgs := append(baseArgs, reposArgs...)
 
-		var (
-			stdout string
-			stderr string
-		)
-		stdout, stderr, err = shell.Execute("tdnf", finalArgs...)
-
-		logger.Log.Debugf("stdout: %s", stdout)
-		logger.Log.Debugf("stderr: %s", stderr)
-
-		if err != nil {
-			logger.Log.Debugf("tdnf error (will continue if the only errors are toybox conflicts):\n '%s'", stderr)
-		}
-
-		// ============== TDNF SPECIFIC IMPLEMENTATION ==============
-		// Check if TDNF could not resolve a given package. If TDNF does not find a requested package,
-		// it will not error. Instead it will print a message to stdout. Check for this message.
-		//
-		// *NOTE*: TDNF will attempt best effort. If N packages are requested, and 1 cannot be found,
-		// it will still download N-1 packages while also printing the message.
-		splitStdout := strings.Split(stdout, "\n")
-		for _, line := range splitStdout {
-			trimmedLine := strings.TrimSpace(line)
-			// Toybox conflicts are a known issue, reset the err value if encountered
-			if strings.HasPrefix(trimmedLine, toyboxConflictsPrefix) {
-				logger.Log.Warn("Ignoring known toybox conflict")
-				err = nil
-				continue
+		// We run in a retry loop on errors deemed retriable.
+		cancel := make(chan struct{})
+		retryNum := 1
+		_, err = retry.RunWithDefaultDownloadBackoff(func() error {
+			downloadErr, retriable := tdnfDownload(finalArgs...)
+			if downloadErr != nil {
+				if retriable {
+					logger.Log.Debugf("Package cloning attempt %d/%d failed with a retriable error.", retryNum, retry.DefaultDownloadRetryAttempts)
+				} else {
+					logger.Log.Debugf("Package cloning attempt %d/%d failed with an unrecoverable error. Cancelling.", retryNum, retry.DefaultDownloadRetryAttempts)
+					close(cancel)
+				}
 			}
-			// If a package was not available, update err
-			if strings.HasPrefix(trimmedLine, unresolvedOutputPrefix) && strings.HasSuffix(trimmedLine, unresolvedOutputPostfix) {
-				err = fmt.Errorf(trimmedLine)
-				break
-			}
-		}
+
+			retryNum++
+			return downloadErr
+		}, cancel)
 
 		if err == nil {
 			preBuilt = r.reposArgsHaveOnlyLocalSources(reposArgs)
@@ -807,4 +792,51 @@ func (r *RpmRepoCloner) reposArgsHaveOnlyLocalSources(reposArgs []string) bool {
 	}
 
 	return true
+}
+
+func tdnfDownload(args ...string) (err error, retriable bool) {
+	const (
+		unresolvedOutputPrefix = "No package"
+		unresolvedOutputSuffix = "available"
+	)
+
+	stdout, stderr, err := shell.Execute("tdnf", args...)
+
+	logger.Log.Debugf("stdout: %s", stdout)
+	logger.Log.Debugf("stderr: %s", stderr)
+
+	// ============== TDNF SPECIFIC IMPLEMENTATION ==============
+	//
+	// Check if TDNF could not resolve a given package. If TDNF does not find a requested package,
+	// it will not error. Instead it will print a message to stdout. Check for this message.
+	//
+	// *NOTE*: TDNF will attempt best effort. If N packages are requested, and 1 cannot be found,
+	// it will still download N-1 packages while also printing the message.
+	splitStdout := strings.Split(stdout, "\n")
+	for _, line := range splitStdout {
+		trimmedLine := strings.TrimSpace(line)
+		// If a package was not available, update err
+		if strings.HasPrefix(trimmedLine, unresolvedOutputPrefix) && strings.HasSuffix(trimmedLine, unresolvedOutputSuffix) {
+			err = fmt.Errorf(trimmedLine)
+			return
+		}
+	}
+
+	//
+	// *NOTE*: There are cases in which some of our upstream package repositories are hosted
+	// on services that are prone to intermittent errors (e.g., HTTP 502 errors). We
+	// specifically look for such known cases and apply some retry logic in hopes of getting
+	// a better result; note that we don't indiscriminately retry because there are legitimate
+	// cases in which the upstream repo doesn't contain the package and a 404 error is to be
+	// expected. This involves scraping through stderr, but it's better than not doing so.
+	//
+	if err != nil {
+		serverErrorMatch := serverErrorsRegex.FindStringSubmatch(stderr)
+		if len(serverErrorMatch) > serverErrorCodeIndex {
+			logger.Log.Debugf("Encountered possibly intermittent HTTP %s error.", serverErrorMatch[serverErrorCodeIndex])
+			retriable = true
+		}
+	}
+
+	return
 }

--- a/toolkit/tools/pkg/downloader/downloader.go
+++ b/toolkit/tools/pkg/downloader/downloader.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"time"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/network"
@@ -17,32 +16,24 @@ import (
 )
 
 func DownloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls.Certificate) (err error) {
-	const (
-		// With 6 attempts, initial delay of 1 second, and a backoff factor of 3.0 the total time spent retrying will be
-		// 1 + 3 + 9 + 27 + 81 = 121 seconds.
-		downloadRetryAttempts = 6
-		failureBackoffBase    = 3.0
-		downloadRetryDuration = time.Second
-	)
 	cancel := make(chan struct{})
-
 	retryNum := 1
-	_, err = retry.RunWithExpBackoff(func() error {
+	_, err = retry.RunWithDefaultDownloadBackoff(func() error {
 		netErr := network.DownloadFile(srcUrl, dstFile, caCerts, tlsCerts)
 		if netErr != nil {
 			// Check if the error contains the string "invalid response: 404", we should print a warning in that case so the
 			// sees it even if we are running with --no-verbose. 404's are unlikely to fix themselves on retry, give up.
 			if netErr.Error() == "invalid response: 404" {
-				logger.Log.Warnf("Attempt %d/%d: Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Warnf("Attempt %d/%d: Failed to download (%s) with error: (%s)", retryNum, retry.DefaultDownloadRetryAttempts, srcUrl, netErr)
 				logger.Log.Warnf("404 errors are likely unrecoverable, will not retry")
 				close(cancel)
 			} else {
-				logger.Log.Infof("Attempt %d/%d: Failed to download (%s) with error: (%s)", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Infof("Attempt %d/%d: Failed to download (%s) with error: (%s)", retryNum, retry.DefaultDownloadRetryAttempts, srcUrl, netErr)
 			}
 		}
 		retryNum++
 		return netErr
-	}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, cancel)
+	}, cancel)
 
 	if err != nil {
 		err = fmt.Errorf("failed to download (%s) to (%s):\n%w", srcUrl, dstFile, err)

--- a/toolkit/tools/precacher/precacher.go
+++ b/toolkit/tools/precacher/precacher.go
@@ -214,13 +214,6 @@ func monitorProgress(total int, results chan downloadResult, doneChannel chan st
 // responsible for removing itself from the wait group. As much processing as possible is done before acquiring the
 // network operations semaphore to minimize the time spent holding it.
 func precachePackage(pkg *repocloner.RepoPackage, packagesAvailableFromRepos map[string]string, outDir string, wg *sync.WaitGroup, results chan<- downloadResult, netOpsSemaphore chan struct{}) {
-	const (
-		// With 5 attempts, initial delay of 1 second, and a backoff factor of 2.0 the total time spent retrying will be
-		// ~30 seconds.
-		downloadRetryAttempts = 5
-		failureBackoffBase    = 2.0
-		downloadRetryDuration = time.Second
-	)
 	var noCancel chan struct{} = nil
 
 	// File names are of the form "<name>-<version>.<distro>.<arch>.rpm"
@@ -262,13 +255,13 @@ func precachePackage(pkg *repocloner.RepoPackage, packagesAvailableFromRepos map
 	}()
 
 	logger.Log.Debugf("Pre-caching '%s' from '%s'", fileName, url)
-	_, err = retry.RunWithExpBackoff(func() error {
+	_, err = retry.RunWithDefaultDownloadBackoff(func() error {
 		err := network.DownloadFile(url, fullFilePath, nil, nil)
 		if err != nil {
 			logger.Log.Warnf("Attempt to download (%s) failed. Error: %s", url, err)
 		}
 		return err
-	}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, noCancel)
+	}, noCancel)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -14,7 +14,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/buildpipeline"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/directory"
@@ -912,13 +911,6 @@ func tryToHydrateFromLocalSource(fileHydrationState map[string]bool, newSourceDi
 // hydrateFromRemoteSource will update fileHydrationState.
 // Will alter `currentSignatures`.
 func hydrateFromRemoteSource(fileHydrationState map[string]bool, newSourceDir string, srcConfig sourceRetrievalConfiguration, skipSignatureHandling bool, currentSignatures map[string]string, cancel <-chan struct{}, netOpsSemaphore chan struct{}) (err error) {
-	const (
-		// With 5 attempts, initial delay of 1 second, and a backoff factor of 2.0 the total time spent retrying will be
-		// ~30 seconds.
-		downloadRetryAttempts = 5
-		failureBackoffBase    = 2.0
-		downloadRetryDuration = time.Second
-	)
 	errPackerCancelReceived := fmt.Errorf("packer cancel signal received")
 
 	for fileName, alreadyHydrated := range fileHydrationState {
@@ -942,14 +934,14 @@ func hydrateFromRemoteSource(fileHydrationState map[string]bool, newSourceDir st
 			}
 		}
 
-		cancelled, internalErr := retry.RunWithExpBackoff(func() error {
+		cancelled, internalErr := retry.RunWithDefaultDownloadBackoff(func() error {
 			downloadErr := network.DownloadFile(url, destinationFile, srcConfig.caCerts, srcConfig.tlsCerts)
 			if downloadErr != nil {
 				logger.Log.Debugf("Failed an attempt to download (%s). Error: %s.", url, downloadErr)
 			}
 
 			return downloadErr
-		}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, cancel)
+		}, cancel)
 
 		if netOpsSemaphore != nil {
 			// Clear the channel to allow another operation to start


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Cherry-pick of 2.0's #7445.

We continue to intermittently see HTTP 502 errors (Bad Gateway) when TDNF downloads packages from packages.microsoft.com, usually in build pipelines. This PR introduces granular retry logic for that specific failure case. (We can't retry on any HTTP error, as 404 is an expected error that shows up in normal execution.)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update the `rpmrepcloner` to inspect stderr on TDNF download failure. If an error string indicating a 5XX error is found, then we retry with exponential backoff.
- Unified the retry logic for network downloads.
- Removed outdated logic from `rpmrepocloner` looking for errors related with the `toybox` package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #7373
- #7445

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Fast-track PR check build simulating building the extended packages (tends to fail due to PMC issues)](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=490221&view=results). I was able to observe a few `Package cloning attempt 1/5 failed with a retriable error.` messages in the logs followed by a successful download.