### PR TITLE
Allow a custom path to be specified for custom snapshot for the pre-cacher

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -121,6 +121,8 @@ RPMS_DIR        ?= $(OUT_DIR)/RPMS
 SRPMS_DIR       ?= $(OUT_DIR)/SRPMS
 IMAGES_DIR      ?= $(OUT_DIR)/images
 
+PRECACHER_SNAPSHOT   ?= $(rpms_snapshot)
+
 # External source server
 SOURCE_URL         ?= https://cblmarinerstorage.blob.core.windows.net/sources/core
 

--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -873,6 +873,7 @@ To reproduce an ISO build, run the same make invocation as before, but set:
 | RPMS_DIR                      | `$(OUT_DIR)`/RPMS                                                                                      | Directory to place RPMs in
 | SRPMS_DIR                     | `$(OUT_DIR)`/SRPMS                                                                                     | Directory to place SRPMs in
 | IMAGES_DIR                    | `$(OUT_DIR)`/images                                                                                    | Directory to place images in
+| PRECACHER_SNAPSHOT            | `$(OUT_DIR)`/rpms_snapshot.json                                                                        | Location of snapshot file for the pre-cacher
 
 ---
 

--- a/toolkit/scripts/precache.mk
+++ b/toolkit/scripts/precache.mk
@@ -26,13 +26,13 @@ clean-precache:
 # it does, so add the phony target as a dependency to the flag file
 .PHONY: precache_always_run_phony
 pre-cache: $(STATUS_FLAGS_DIR)/precache.flag
-$(STATUS_FLAGS_DIR)/precache.flag: $(go-precacher) $(chroot_worker) $(rpms_snapshot) precache_always_run_phony 
+$(STATUS_FLAGS_DIR)/precache.flag: $(go-precacher) $(chroot_worker) $(PRECACHER_SNAPSHOT) precache_always_run_phony
 	@if [ "$(DISABLE_UPSTREAM_REPOS)" = "y" ]; then \
 		echo "ERROR: Upstream repos are disabled (DISABLE_UPSTREAM_REPOS=y), cannot precache RPMs"; \
 		exit 1; \
 	fi
 	$(go-precacher) \
-		--snapshot "$(rpms_snapshot)" \
+		--snapshot "$(PRECACHER_SNAPSHOT)" \
 		--output-dir "$(remote_rpms_cache_dir)" \
 		--output-summary-file "$(precache_downloaded_files)" \
 		--repo-urls-file "$(repo_urls_file)" \


### PR DESCRIPTION
Allow a custom path to be specified for the rpm snapshot summary file.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
`make rpm_snapshot ...` generates the RPMs snapshot under a specific folder, with a hard coded name (rpms_snapshot.json) and `make pre-cache ...` refers to that generated snapshot file without any consideration for a custom file path/name. This is an inconvenience for builds that run on different platform architecture, that we often prefer to have the arch as part of the file name.
This PR allows setting PRECACHER_SNAPSHOT parameter for `make pre-cache`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Tested in Azure Linux derivative image, where rpms snapshot is implemented and pre-cacher uses a custom path for the snapshot.
- Pipeline build id: xxxx
