### PR TITLE
Sanitize licenses in core image packages

### DIFF
--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -67,9 +67,8 @@ for f in Copyright.txt cmcppdap/NOTICE cmcurl/COPYING cmlibrhash/COPYING cmlibuv
     mkdir -p ./Licenses/$dir_part
     mv %{buildroot}%{_prefix}/doc/%{name}-*/$f ./Licenses/$dir_part/$filename_part
     # If folder is now empty, remove it. Use realpath to handle dirname emitting '.' which rmdir doesn't like.
-    rmdir --ignore-fail-on-non-empty -p $(realpath %{buildroot}%{_prefix}/doc/%{name}-*/$dir_part)
 done
-
+find "%{buildroot}%{_prefix}/doc" -type d -empty -delete
 %check
 # Removing static libraries to fix issues with the "ParseImplicitLinkInfo" test runs for the "craype-C-Cray-8.7.input" and "craype-CXX-Cray-8.7.input" inputs.
 # Should be removed once the issue is fixed upstream and we apply the fix: https://gitlab.kitware.com/cmake/cmake/-/issues/22470.

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -66,9 +66,9 @@ for f in Copyright.txt cmcppdap/NOTICE cmcurl/COPYING cmlibrhash/COPYING cmlibuv
     dir_part=$(dirname $f)
     mkdir -p ./Licenses/$dir_part
     mv %{buildroot}%{_prefix}/doc/%{name}-*/$f ./Licenses/$dir_part/$filename_part
-    # If folder is now empty, remove it. Use realpath to handle dirname emitting '.' which rmdir doesn't like.
 done
 find "%{buildroot}%{_prefix}/doc" -type d -empty -delete
+
 %check
 # Removing static libraries to fix issues with the "ParseImplicitLinkInfo" test runs for the "craype-C-Cray-8.7.input" and "craype-CXX-Cray-8.7.input" inputs.
 # Should be removed once the issue is fixed upstream and we apply the fix: https://gitlab.kitware.com/cmake/cmake/-/issues/22470.

--- a/SPECS/cyrus-sasl-bootstrap/cyrus-sasl-bootstrap.spec
+++ b/SPECS/cyrus-sasl-bootstrap/cyrus-sasl-bootstrap.spec
@@ -5,7 +5,7 @@
 Summary:        Cyrus Simple Authentication Service Layer (SASL) library
 Name:           %{_base_name}-bootstrap
 Version:        2.1.28
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        BSD with advertising
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -89,7 +89,6 @@ make
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} install
 find %{buildroot} -type f -name "*.la" -delete -print
-install -D -m644 COPYING %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
 %{_fixperms} %{buildroot}/*
 
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
@@ -147,7 +146,6 @@ make %{?_smp_mflags} check
 /lib/systemd/system/saslauthd.service
 %{_libdir}/systemd/system-preset/50-saslauthd.preset
 %{_sbindir}/*
-%{_datadir}/licenses/%{name}/LICENSE
 %{_mandir}/man8/*
 
 %files devel
@@ -194,6 +192,9 @@ make %{?_smp_mflags} check
 %exclude %{_plugindir2}/libsql.so.%{_soversion}*
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 2.1.28-7
+- Sanitize license files
+
 * Mon Feb 05 2024 Dan Streetman <ddstreet@ieee.org> - 2.1.28-6
 - workaround "circular dependencies" from build tooling
 

--- a/SPECS/cyrus-sasl/cyrus-sasl.spec
+++ b/SPECS/cyrus-sasl/cyrus-sasl.spec
@@ -4,7 +4,7 @@
 Summary:        Cyrus Simple Authentication Service Layer (SASL) library
 Name:           cyrus-sasl
 Version:        2.1.28
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        BSD with advertising
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -195,7 +195,6 @@ make
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} install
 find %{buildroot} -type f -name "*.la" -delete -print
-install -D -m644 COPYING %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
 %{_fixperms} %{buildroot}/*
 
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
@@ -253,7 +252,6 @@ make %{?_smp_mflags} check
 /lib/systemd/system/saslauthd.service
 %{_libdir}/systemd/system-preset/50-saslauthd.preset
 %{_sbindir}/*
-%{_datadir}/licenses/%{name}/LICENSE
 %{_mandir}/man8/*
 
 %files devel
@@ -311,6 +309,9 @@ make %{?_smp_mflags} check
 %{_plugindir2}/libsql.so.%{_soversion}*
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 2.1.28-7
+- Sanitize license files
+
 * Mon Feb 05 2024 Dan Streetman <ddstreet@ieee.org> - 2.1.28-6
 - match bootstrap version
 

--- a/SPECS/ethtool/ethtool.spec
+++ b/SPECS/ethtool/ethtool.spec
@@ -1,7 +1,7 @@
 Summary:	    Standard Linux utility for controlling network drivers and hardware
 Name:		    ethtool
 Version:        6.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:	    GPLv2
 URL:		    https://www.kernel.org/pub/software/network/ethtool/
 Group:		    Productivity/Networking/Diagnostic
@@ -30,14 +30,17 @@ make install DESTDIR=%{buildroot}
 make %{?_smp_mflags} check
 
 %files
-%doc AUTHORS COPYING NEWS README ChangeLog
+%license COPYING LICENSE
+%doc AUTHORS NEWS README ChangeLog
 %defattr(-,root,root)
-%license LICENSE
 /sbin/*
 %{_mandir}
 %{_datadir}/bash-completion/completions/ethtool
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 6.4-2
+- Sanitize license files
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.4-1
 - Auto-upgrade to 6.4 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/libdb/libdb.spec
+++ b/SPECS/libdb/libdb.spec
@@ -1,7 +1,7 @@
 Summary:        The Berkley DB database library for C
 Name:           libdb
 Version:        5.3.28
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -60,15 +60,12 @@ pushd build_unix
 make DESTDIR=%{buildroot} docdir=%{_docdir}/%{name}-%{version} install
 popd
 find %{buildroot} -type f -name "*.la" -delete -print
-install -v -d -m755 %{buildroot}/%{_datadir}/licenses/
-install -D -m755 LICENSE %{buildroot}/%{_datadir}/licenses/LICENSE
-install -D -m755 README %{buildroot}/%{_datadir}/licenses/README
 
 %files
 %defattr(-,root,root)
 %license LICENSE
+%doc README
 %{_libdir}/*.so
-%{_datadir}/licenses/*
 
 %files docs
 %defattr(-,root,root)
@@ -95,6 +92,9 @@ install -D -m755 README %{buildroot}/%{_datadir}/licenses/README
 %{_bindir}/db*_tuner
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 5.3.28-8
+- Sanitize license files
+
 * Tue Apr 12 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 5.3.28-7
 - Align with CBL-Mariner 1.0 to address following CVEs:
 - Patch CVE-2019-2708

--- a/SPECS/librdkafka/librdkafka.spec
+++ b/SPECS/librdkafka/librdkafka.spec
@@ -5,7 +5,7 @@
 Summary:        The Apache Kafka C library
 Name:           librdkafka
 Version:        2.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 # files like src/crc32c.c are under zlib license
 # files like win32/wingetopt.c are under ISC
 # files like src/rdfnv1a.c are under Public Domain
@@ -66,6 +66,9 @@ make check
 %install
 DESTDIR=%{buildroot} make install
 
+# Remove extraneous license files from docs
+rm %{buildroot}%{_docdir}/librdkafka/LICENSE %{buildroot}%{_docdir}/librdkafka/LICENSES.txt
+
 %post   -n %{name}%{soname} -p /sbin/ldconfig
 %postun -n %{name}%{soname} -p /sbin/ldconfig
 
@@ -79,8 +82,8 @@ DESTDIR=%{buildroot} make install
 %doc %{_docdir}/librdkafka/INTRODUCTION.md
 %doc %{_docdir}/librdkafka/STATISTICS.md
 %doc %{_docdir}/librdkafka/CHANGELOG.md
-%license %{_docdir}/librdkafka/LICENSE
-%doc %{_docdir}/librdkafka/LICENSES.txt
+%license LICENSE
+%license LICENSES.txt
 
 %files -n %{name}-devel
 %defattr(-,root,root)
@@ -97,6 +100,9 @@ DESTDIR=%{buildroot} make install
 %{_libdir}/pkgconfig/rdkafka++-static.pc
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 2.3.0-2
+- Sanitize license files
+
 * Thu Dec 21 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 2.3.0-1
 - Update to v2.3.0
 

--- a/SPECS/lmdb/lmdb.spec
+++ b/SPECS/lmdb/lmdb.spec
@@ -1,7 +1,7 @@
 Summary:        Lightning memory-mapped database
 Name:           lmdb
 Version:        0.9.31
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        OpenLDAP
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -43,8 +43,6 @@ make prefix=%{_prefix} DESTDIR=%{buildroot} install
 mkdir -p %{buildroot}%{_docdir}/%{name}
 mkdir -p %{buildroot}%{_defaultlicensedir}/%{name}
 mkdir -p %{buildroot}%{_libdir}/pkgconfig
-install -m0644 COPYRIGHT %{buildroot}%{_docdir}/%{name}
-install -m0644 LICENSE %{buildroot}%{_defaultlicensedir}/%{name}
 install -m0755 %{SOURCE1} %{buildroot}%{_libdir}/pkgconfig
 
 %post
@@ -55,7 +53,6 @@ install -m0755 %{SOURCE1} %{buildroot}%{_libdir}/pkgconfig
     # First argument is 2 => Upgrade
 
 %files
-%license libraries/liblmdb/LICENSE
 %{_mandir}/*
 %{_bindir}/*
 
@@ -65,11 +62,14 @@ install -m0755 %{SOURCE1} %{buildroot}%{_libdir}/pkgconfig
 %{_libdir}/pkgconfig/%{name}.pc
 
 %files libs
-%{_docdir}/%{name}/COPYRIGHT
-%{_defaultlicensedir}/%{name}/LICENSE
+%license libraries/liblmdb/COPYRIGHT
+%license libraries/liblmdb/LICENSE
 %{_libdir}/*.so
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 0.9.31-2
+- Sanitize license files
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.9.31-1
 - Auto-upgrade to 0.9.31 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -438,7 +438,7 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 8.2.0
-Release: 6%{?dist}
+Release: 7%{?dist}
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -2127,7 +2127,7 @@ install -D -p -m 0644 %{modprobe_kvm_conf} %{buildroot}%{_sysconfdir}/modprobe.d
 %endif
 
 # Copy some static data into place
-install -D -p -m 0644 -t %{buildroot}%{qemudocdir} README.rst COPYING COPYING.LIB LICENSE docs/interop/qmp-spec.rst
+install -D -p -m 0644 -t %{buildroot}%{qemudocdir} README.rst docs/interop/qmp-spec.rst
 install -D -p -m 0644 qemu.sasl %{buildroot}%{_sysconfdir}/sasl2/%{name}.conf
 
 install -m 0644 scripts/dump-guest-memory.py %{buildroot}%{_datadir}/%{name}
@@ -2523,7 +2523,8 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 %endif
 
 %files -n qemu-guest-agent
-%doc COPYING README.rst
+%license COPYING COPYING.LIB LICENSE
+%doc README.rst
 %{_bindir}/qemu-ga
 %if ! %{azl}
 %{_mandir}/man8/qemu-ga.8*
@@ -3467,6 +3468,9 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 8.2.0-7
+- Sanitize license files
+
 * Mon May 13 2024 Chris Co <chrco@microsoft.com> - 8.2.0-6
 - Update to build dep latest glibc-static version
 

--- a/SPECS/userspace-rcu/userspace-rcu.spec
+++ b/SPECS/userspace-rcu/userspace-rcu.spec
@@ -1,7 +1,7 @@
 Summary:        user space RCU (read-copy-update)
 Name:           userspace-rcu
 Version:        0.14.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -39,23 +39,28 @@ make %{?_smp_mflags}
 %install
 make DESTDIR=%{buildroot} install
 find %{buildroot} -type f -name "*.la" -delete -print
+# Don't duplicate LICENSE file in the doc directory
+rm %{buildroot}%{_datadir}/doc/userspace-rcu/LICENSE
 
 %check
 make %{?_smp_mflags} check
 
 %files
+%license LICENSE
 %{_libdir}/*.so.*
 %{_includedir}/*
 %{_datadir}/*
 
 %files devel
 %defattr(-,root,root)
-%license LICENSE
 %{_libdir}/pkgconfig/*
 %{_libdir}/*.so
 %{_includedir}/*
 
 %changelog
+* Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 0.14.0-2
+- Sanitize license files
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.14.0-1
 - Auto-upgrade to 0.14.0 - Azure Linux 3.0 - package upgrades
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -45,8 +45,8 @@ check-debuginfo-0.15.2-1.azl3.aarch64.rpm
 chkconfig-1.25-1.azl3.aarch64.rpm
 chkconfig-debuginfo-1.25-1.azl3.aarch64.rpm
 chkconfig-lang-1.25-1.azl3.aarch64.rpm
-cmake-3.28.2-2.azl3.aarch64.rpm
-cmake-debuginfo-3.28.2-2.azl3.aarch64.rpm
+cmake-3.28.2-3.azl3.aarch64.rpm
+cmake-debuginfo-3.28.2-3.azl3.aarch64.rpm
 coreutils-9.4-2.azl3.aarch64.rpm
 coreutils-debuginfo-9.4-2.azl3.aarch64.rpm
 coreutils-lang-9.4-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -46,8 +46,8 @@ check-debuginfo-0.15.2-1.azl3.x86_64.rpm
 chkconfig-1.25-1.azl3.x86_64.rpm
 chkconfig-debuginfo-1.25-1.azl3.x86_64.rpm
 chkconfig-lang-1.25-1.azl3.x86_64.rpm
-cmake-3.28.2-2.azl3.x86_64.rpm
-cmake-debuginfo-3.28.2-2.azl3.x86_64.rpm
+cmake-3.28.2-3.azl3.x86_64.rpm
+cmake-debuginfo-3.28.2-3.azl3.x86_64.rpm
 coreutils-9.4-2.azl3.x86_64.rpm
 coreutils-debuginfo-9.4-2.azl3.x86_64.rpm
 coreutils-lang-9.4-2.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
As part of https://github.com/microsoft/azurelinux/pull/8776 we would like to disable documentation on specific size-constrained images. However, there is a complication: many packages do not use the `%license` tag in their `%files` section to accurately tag license files. If such an image was distributed it would run afoul of open source licensing requirements (ie it would not include the required license files with the corresponding binary files). A tool was created that attempts to detect these cases (early draft here: https://github.com/microsoft/azurelinux/pull/9060) and will be integrated into the normal build flow in the future.

In the mean time, to unblock the configurable documentation PR, the packages which both apear in the no-documentation images, and have critical license issues, are fixed in this PR.
- cmake: cmake contains licenses from several sub-projects. Move all these license files out of `/usr/doc/cmake-3.28/<subproject>/*` into the already used `Licenses` folder.  It turns out these license files were the only documentation included in our package, so remove the empty dir.
- cyrus-sasl: `COPYING` was being manually copied/renamed into `/usr/share/licenses/%{name}/LICENSE` during install, and was marked as a normal file. The package already uses the `%license` tag on the original file directly.
- ethtool: Split `COPYING` out of the `%doc` section into `%license`.
- libdb: Also manually installed both license and readme files, use `%doc` and `%license` on the originals instead.
- librdkafka: The `make install` step places a concatenated license file into `/usr/share/docs/librdkafka/LICENSES.txt`, clean that up and use the `%license` macro instead.
- lmdb: Don't manually install files, don't duplicate `LICENSE` in the base package, `lmdb-libs` is a requirement and already had them. Use `%license`.
- qemu: Don't manually install license files, use %license instead. Add them to `qemu-guest-agent`, `qemu-common` already has all of them listed.
- userspace-rcu: `make install` places a LICENSE file, use the local copy with `%license` instead. It should be in the core package, not `userspace-rcu-devel` as well.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Sanitize license files for packages used in core images.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/50220148
- https://microsoft.visualstudio.com/OS/_workitems/edit/50982283


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds checked against the tool in https://github.com/microsoft/azurelinux/pull/9060
- Full build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=571671&view=results
