### PR TITLE
qtbase: upgrade to version 6.6.2 to fix CVE-2023-51714

### DIFF
--- a/SPECS/qtbase/qtbase.signatures.json
+++ b/SPECS/qtbase/qtbase.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "macros.qtbase": "033a4124b7dbb211068a64b6e500427fb645825f6c94a5f49afbd764e9d65543",
   "qconfig-multilib.h": "2d01cdbfd11a887a1729f1ce2c4e0ad0c080509cc009279090bd68521845be93",
-  "qtbase-everywhere-src-6.6.1.tar.xz": "450c5b4677b2fe40ed07954d7f0f40690068e80a94c9df86c2c905ccd59d02f7",
+  "qtbase-everywhere-src-6.6.2.tar.xz": "b89b426b9852a17d3e96230ab0871346574d635c7914480a2a27f98ff942677b",
   "qtlogging.ini": "7493edc0df47c1bb9040331694922d4500b897b30515d698ec482c866ee5d9d3"
  }
 }

--- a/SPECS/qtbase/qtbase.spec
+++ b/SPECS/qtbase/qtbase.spec
@@ -34,7 +34,7 @@
 
 Name:         qtbase
 Summary:      Qt6 - QtBase components
-Version:      6.6.1
+Version:      6.6.2
 Release:      1%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:      GFDL AND LGPLv3 AND GPLv2 AND GPLv3 with exceptions AND QT License Agreement 4.0

--- a/SPECS/qtbase/qtbase.spec
+++ b/SPECS/qtbase/qtbase.spec
@@ -700,7 +700,10 @@ fi
 %{_qt_plugindir}/platformthemes/libqxdgdesktopportal.so
 
 %changelog
-* Tue Jan 02 2024 Sam Meluch <sammeluch@micrsoft.com> - 6.6.1
+* Fri May 17 2024 Neha Agarwal <nehaagarwal@micrsoft.com> - 6.6.2-1
+- Upgrade to version 6.6.2 to fix CVE-2023-51714
+
+* Tue Jan 02 2024 Sam Meluch <sammeluch@micrsoft.com> - 6.6.1-1
 - Upgrade to version 6.6.1 for Azure Linux 3.0
 
 * Tue Aug 01 2023 Thien Trung Vuong <tvuong@microsoft.com> - 5.12.11-9

--- a/SPECS/qtbase/qtbase.spec
+++ b/SPECS/qtbase/qtbase.spec
@@ -344,9 +344,9 @@ install -m 644 src/plugins/platforms/xcb/*.h %{buildroot}%{_qt_headerdir}/QtXcb/
 
 
 %check
-# verify Qt5.pc
+# verify Qt6.pc
 export PKG_CONFIG_PATH=%{buildroot}%{_libdir}/pkgconfig
-test "$(pkg-config --modversion Qt5)" = "%{version}"
+test "$(pkg-config --modversion Qt6)" = "%{version}"
 %if 0%{?tests}
 ## see tests/README for expected environment (running a plasma session essentially)
 ## we are not quite there yet
@@ -476,7 +476,7 @@ fi
 # mostly empty for now, consider: filesystem/dir ownership, licenses
 %{rpm_macros_dir}/macros.qtbase
 
-	
+
 %files devel
 %{_bindir}/androiddeployqt
 %{_bindir}/androiddeployqt6

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -25183,8 +25183,8 @@
         "type": "other",
         "other": {
           "name": "qtbase",
-          "version": "6.6.1",
-          "downloadUrl": "https://download.qt.io/archive/qt/6.6/6.6.1/submodules/qtbase-everywhere-src-6.6.1.tar.xz"
+          "version": "6.6.2",
+          "downloadUrl": "https://download.qt.io/archive/qt/6.6/6.6.2/submodules/qtbase-everywhere-src-6.6.2.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
qtbase: upgrade to version 6.6.2 to fix CVE-2023-51714

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- qtbase: upgrade to version 6.6.2 to fix CVE-2023-51714

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-51714

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Successfully built buddy build pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=577491&view=results
- Test passed after fix:
![image](https://github.com/microsoft/azurelinux/assets/58672330/89bb58a5-8641-4d1a-922a-acbdac9f32f7)