### PR TITLE
libuv: update to v1.48.0 to fix CVE-2023-24806

### DIFF
--- a/SPECS/libuv/libuv.signatures.json
+++ b/SPECS/libuv/libuv.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "libuv-v1.46.0.tar.gz": "111f83958b9fdc65f1489195d25f342b9f7a3e683140c60e62c00fbaccddddce"
-  }
+ "Signatures": {
+  "libuv-v1.48.0.tar.gz": "7f1db8ac368d89d1baf163bac1ea5fe5120697a73910c8ae6b2fffb3551d59fb"
+ }
 }

--- a/SPECS/libuv/libuv.spec
+++ b/SPECS/libuv/libuv.spec
@@ -1,6 +1,6 @@
 Summary:        Cross-platform asynchronous I/O
 Name:           libuv
-Version:        1.46.0
+Version:        1.48.0
 Release:        1%{?dist}
 License:        MIT AND CC-BY
 Vendor:         Microsoft Corporation
@@ -75,6 +75,9 @@ sudo -u test make -k check
 %{_libdir}/%{name}.a
 
 %changelog
+* Mon May 20 2024 Neha Agarwal <nehaagarwal@micrsoft.com> - 1.48.0-1
+- Upgrade to version 1.48.0 to fix CVE-2024-24806
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.46.0-1
 - Auto-upgrade to 1.46.0 - Azure Linux 3.0 - package upgrades
 
@@ -82,8 +85,8 @@ sudo -u test make -k check
 - Upgrade to version 1.43.0
 - License Verified
 
-*   Fri Dec 04 2020 Andrew Phelps <anphel@microsoft.com> - 1.38.0-2
--   Fix check tests.
+* Fri Dec 04 2020 Andrew Phelps <anphel@microsoft.com> - 1.38.0-2
+- Fix check tests.
 
-*   Wed May 27 2020 Daniel McIlvaney <damcilva@microsoft.com> - 1.38.0-1
--   Original version for CBL-Mariner
+* Wed May 27 2020 Daniel McIlvaney <damcilva@microsoft.com> - 1.38.0-1
+- Original version for CBL-Mariner

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11371,8 +11371,8 @@
         "type": "other",
         "other": {
           "name": "libuv",
-          "version": "1.46.0",
-          "downloadUrl": "https://dist.libuv.org/dist/v1.46.0/libuv-v1.46.0.tar.gz"
+          "version": "1.48.0",
+          "downloadUrl": "https://dist.libuv.org/dist/v1.48.0/libuv-v1.48.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
libuv: update to v1.48.0 to fix CVE-2023-24806

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- libuv: update to v1.48.0 to fix CVE-2023-24806

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-24806

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build