### PR TITLE
Image Customizer: Verity on 3.0 images.

### DIFF
--- a/toolkit/tools/internal/grub/commands.go
+++ b/toolkit/tools/internal/grub/commands.go
@@ -21,13 +21,7 @@ func SplitTokensIntoLines(tokens []Token) []Line {
 
 		switch token.Type {
 		case NEWLINE, SEMICOLON:
-			if len(lineTokens) > 0 {
-				line := Line{
-					Tokens:   lineTokens,
-					EndToken: &token,
-				}
-				lines = append(lines, line)
-			}
+			lines = appendNewLine(lines, lineTokens, &token)
 			lineTokens = nil
 
 		default:
@@ -35,14 +29,20 @@ func SplitTokensIntoLines(tokens []Token) []Line {
 		}
 	}
 
-	if len(lineTokens) > 0 {
-		line := Line{
-			Tokens:   lineTokens,
-			EndToken: nil,
-		}
-		lines = append(lines, line)
+	lines = appendNewLine(lines, lineTokens, nil)
+	return lines
+}
+
+func appendNewLine(lines []Line, tokens []Token, endToken *Token) []Line {
+	if len(tokens) <= 0 {
+		return lines
 	}
 
+	line := Line{
+		Tokens:   tokens,
+		EndToken: endToken,
+	}
+	lines = append(lines, line)
 	return lines
 }
 

--- a/toolkit/tools/internal/grub/commands.go
+++ b/toolkit/tools/internal/grub/commands.go
@@ -3,33 +3,43 @@
 
 package grub
 
-type Command struct {
-	Name string
-	Args []Token
+type Line struct {
+	Tokens   []Token
+	EndToken *Token
 }
 
 // Split the tokens into lines, using (unescaped) newlines and semicolons as separator tokens.
 // Note: Technically this is incorrect, since some constructs (e.g. "then") supporting having the subsequent command on
 // the same line. But to avoid needing to write a full parser, this code instead assumes that the grub config files are
 // at least somewhat sensibly formatted.
-func SplitTokensIntoLines(tokens []Token) [][]Token {
-	lines := [][]Token(nil)
-	line := []Token(nil)
+func SplitTokensIntoLines(tokens []Token) []Line {
+	lines := []Line(nil)
+	lineTokens := []Token(nil)
 
-	for _, token := range tokens {
+	for i := range tokens {
+		token := tokens[i]
+
 		switch token.Type {
 		case NEWLINE, SEMICOLON:
-			if len(line) > 0 {
+			if len(lineTokens) > 0 {
+				line := Line{
+					Tokens:   lineTokens,
+					EndToken: &token,
+				}
 				lines = append(lines, line)
 			}
-			line = nil
+			lineTokens = nil
 
 		default:
-			line = append(line, token)
+			lineTokens = append(lineTokens, token)
 		}
 	}
 
-	if len(line) > 0 {
+	if len(lineTokens) > 0 {
+		line := Line{
+			Tokens:   lineTokens,
+			EndToken: nil,
+		}
 		lines = append(lines, line)
 	}
 
@@ -45,11 +55,11 @@ func IsTokenKeyword(token Token, keyword string) bool {
 }
 
 // FindCommandAll looks for all the lines that contain a command with the provided name.
-func FindCommandAll(lines [][]Token, command string) [][]Token {
-	commandLines := [][]Token(nil)
+func FindCommandAll(lines []Line, command string) []Line {
+	commandLines := []Line(nil)
 
 	for _, line := range lines {
-		if len(line) >= 1 && IsTokenKeyword(line[0], command) {
+		if len(line.Tokens) >= 1 && IsTokenKeyword(line.Tokens[0], command) {
 			commandLines = append(commandLines, line)
 		}
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -44,6 +44,11 @@ func NewBootCustomizer(imageChroot *safechroot.Chroot) (*BootCustomizer, error) 
 	return b, nil
 }
 
+// Returns whether or not the OS uses grub-mkconfig.
+func (b *BootCustomizer) IsGrubMkconfigImage() bool {
+	return b.isGrubMkconfig
+}
+
 // Inserts new kernel command-line args into the grub config file.
 func (b *BootCustomizer) AddKernelCommandLine(extraCommandLine string) error {
 	extraCommandLine = strings.TrimSpace(extraCommandLine)
@@ -149,6 +154,30 @@ func (b *BootCustomizer) UpdateKernelCommandLineArgs(defaultGrubFileVarName defa
 		}
 
 		b.grubCfgContent = grubCfgContent
+	}
+
+	return nil
+}
+
+// Makes changes to the /etc/default/grub file that are needed/useful for enabling verity.
+func (b *BootCustomizer) PrepareForVerity() error {
+	if b.isGrubMkconfig {
+		// Force root command-line arg to be referenced by /dev path instead of by UUID.
+		defaultGrubFileContent, err := updateDefaultGrubFileVariable(b.defaultGrubFileContent, "GRUB_DISABLE_UUID",
+			"true")
+		if err != nil {
+			return err
+		}
+
+		// Disable recovery menu entry, to avoid having more than 1 linux command in the grub.cfg file.
+		// This will make it easier to modify the grub.cfg file to add the verity args.
+		defaultGrubFileContent, err = updateDefaultGrubFileVariable(defaultGrubFileContent, "GRUB_DISABLE_RECOVERY",
+			"true")
+		if err != nil {
+			return err
+		}
+
+		b.defaultGrubFileContent = defaultGrubFileContent
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
@@ -146,6 +146,33 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 }
 
+func TestBootCustomizerVerity20(t *testing.T) {
+	b := createBootCustomizerFor20(t)
+
+	err := b.PrepareForVerity()
+	assert.NoError(t, err)
+
+	checkDiffs20(t, b, "", "")
+}
+
+func TestBootCustomizerVerity30(t *testing.T) {
+	b := createBootCustomizerFor30(t)
+
+	err := b.PrepareForVerity()
+	assert.NoError(t, err)
+
+	expectedDefaultGrubFileDiff := `6a7,8
+> GRUB_DISABLE_UUID="true"
+> GRUB_DISABLE_RECOVERY="true"
+`
+	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
+
+	// Do it again to make sure there aren't any changes.
+	err = b.PrepareForVerity()
+	assert.NoError(t, err)
+	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
+}
+
 func checkDiffs20(t *testing.T, b *BootCustomizer, expectedGrubCfgDiff string, expectedDefaultGrubFileDiff string) {
 	checkDiffs(t, b, filepath.Join(testDir, sampleGrubCfg20Path), filepath.Join(testDir, sampleDefaultGrub20Path),
 		expectedGrubCfgDiff, expectedDefaultGrubFileDiff)

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -357,7 +357,7 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 
 	if ic.config.OS.Verity != nil {
 		// Customize image for dm-verity, setting up verity metadata and security features.
-		err = customizeVerityImageHelper(ic.buildDirAbs, ic.configPath, ic.config, ic.rawImageFile, ic.rpmsSources, ic.useBaseImageRpmRepos)
+		err = customizeVerityImageHelper(ic.buildDirAbs, ic.configPath, ic.config, ic.rawImageFile)
 		if err != nil {
 			return err
 		}
@@ -673,7 +673,7 @@ func shrinkFilesystemsHelper(buildImageFile string) error {
 }
 
 func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	buildImageFile string, rpmsSources []string, useBaseImageRpmRepos bool,
+	buildImageFile string,
 ) error {
 	var err error
 
@@ -702,11 +702,13 @@ func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *
 	}
 
 	// Extract the partition block device path.
-	dataPartition, err := idToPartitionBlockDevicePath(config.OS.Verity.DataPartition.IdType, config.OS.Verity.DataPartition.Id, nbdDevice, diskPartitions)
+	dataPartition, err := idToPartitionBlockDevicePath(config.OS.Verity.DataPartition.IdType,
+		config.OS.Verity.DataPartition.Id, nbdDevice, diskPartitions)
 	if err != nil {
 		return err
 	}
-	hashPartition, err := idToPartitionBlockDevicePath(config.OS.Verity.HashPartition.IdType, config.OS.Verity.HashPartition.Id, nbdDevice, diskPartitions)
+	hashPartition, err := idToPartitionBlockDevicePath(config.OS.Verity.HashPartition.IdType,
+		config.OS.Verity.HashPartition.Id, nbdDevice, diskPartitions)
 	if err != nil {
 		return err
 	}
@@ -752,7 +754,7 @@ func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *
 		return fmt.Errorf("failed to stat file (%s):\n%w", grubCfgFullPath, err)
 	}
 
-	err = updateGrubConfig(config.OS.Verity.DataPartition.IdType, config.OS.Verity.DataPartition.Id,
+	err = updateGrubConfigForVerity(config.OS.Verity.DataPartition.IdType, config.OS.Verity.DataPartition.Id,
 		config.OS.Verity.HashPartition.IdType, config.OS.Verity.HashPartition.Id, config.OS.Verity.CorruptionOption,
 		rootHash, grubCfgFullPath)
 	if err != nil {


### PR DESCRIPTION
Fix the handling of the grub config file when provisioning verity on images that use grub-mkconfig (e.g. Azure Linux 3.0).

Known issues: Network provisioning fails during boot on verity enabled Azure Linux 3.0 images.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.
- Added UTs.

