### PR TITLE
fix libxml2 CVE-2024-34459

### DIFF
--- a/SPECS/libxml2/CVE-2024-34459.patch
+++ b/SPECS/libxml2/CVE-2024-34459.patch
@@ -1,0 +1,26 @@
+From 8ddc7f13337c9fe7c6b6e616f404b0fffb8a5145 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Wed, 8 May 2024 11:49:31 +0200
+Subject: [PATCH] [CVE-2024-34459] Fix buffer overread with `xmllint --htmlout`
+
+Add a missing bounds check.
+---
+ xmllint.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xmllint.c b/xmllint.c
+index 0e433b721..62f6b0273 100644
+--- a/xmllint.c
++++ b/xmllint.c
+@@ -559,7 +559,7 @@ xmlHTMLPrintFileContext(xmlParserInputPtr input) {
+     len = strlen(buffer);
+     snprintf(&buffer[len], sizeof(buffer) - len, "\n");
+     cur = input->cur;
+-    while ((*cur == '\n') || (*cur == '\r'))
++    while ((cur > base) && ((*cur == '\n') || (*cur == '\r')))
+ 	cur--;
+     n = 0;
+     while ((cur != base) && (n++ < 80)) {
+-- 
+GitLab
+

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.10.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          System Environment/General Libraries
 URL:            https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home
 Source0:        https://gitlab.gnome.org/GNOME/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 Patch0:         CVE-2023-45322.patch
+Patch1:         CVE-2024-34459.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -79,6 +80,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Mon May 20 2024 Sudipta Pandit <sudpandit@microsoft.com> - 2.10.4-3
+- Apply patch for CVE-2024-34459
+
 * Mon Oct 30 2023 Suresh Thelkar <sthelkar@microsoft.com> - 2.10.4-2
 - Backport upstream patch to fix CVE-2023-45322
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -194,8 +194,8 @@ curl-8.5.0-2.cm2.aarch64.rpm
 curl-devel-8.5.0-2.cm2.aarch64.rpm
 curl-libs-8.5.0-2.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
-libxml2-2.10.4-2.cm2.aarch64.rpm
-libxml2-devel-2.10.4-2.cm2.aarch64.rpm
+libxml2-2.10.4-3.cm2.aarch64.rpm
+libxml2-devel-2.10.4-3.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -194,8 +194,8 @@ curl-8.5.0-2.cm2.x86_64.rpm
 curl-devel-8.5.0-2.cm2.x86_64.rpm
 curl-libs-8.5.0-2.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
-libxml2-2.10.4-2.cm2.x86_64.rpm
-libxml2-devel-2.10.4-2.cm2.x86_64.rpm
+libxml2-2.10.4-3.cm2.x86_64.rpm
+libxml2-devel-2.10.4-3.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -209,9 +209,9 @@ libtasn1-debuginfo-4.19.0-1.cm2.aarch64.rpm
 libtasn1-devel-4.19.0-1.cm2.aarch64.rpm
 libtool-2.4.6-8.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-8.cm2.aarch64.rpm
-libxml2-2.10.4-2.cm2.aarch64.rpm
-libxml2-debuginfo-2.10.4-2.cm2.aarch64.rpm
-libxml2-devel-2.10.4-2.cm2.aarch64.rpm
+libxml2-2.10.4-3.cm2.aarch64.rpm
+libxml2-debuginfo-2.10.4-3.cm2.aarch64.rpm
+libxml2-devel-2.10.4-3.cm2.aarch64.rpm
 libxslt-1.1.34-7.cm2.aarch64.rpm
 libxslt-debuginfo-1.1.34-7.cm2.aarch64.rpm
 libxslt-devel-1.1.34-7.cm2.aarch64.rpm
@@ -521,7 +521,7 @@ python3-gpg-1.16.0-2.cm2.aarch64.rpm
 python3-jinja2-3.0.3-3.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.aarch64.rpm
 python3-libs-3.9.19-1.cm2.aarch64.rpm
-python3-libxml2-2.10.4-2.cm2.aarch64.rpm
+python3-libxml2-2.10.4-3.cm2.aarch64.rpm
 python3-lxml-4.9.1-1.cm2.aarch64.rpm
 python3-magic-5.40-2.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -215,9 +215,9 @@ libtasn1-debuginfo-4.19.0-1.cm2.x86_64.rpm
 libtasn1-devel-4.19.0-1.cm2.x86_64.rpm
 libtool-2.4.6-8.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-8.cm2.x86_64.rpm
-libxml2-2.10.4-2.cm2.x86_64.rpm
-libxml2-debuginfo-2.10.4-2.cm2.x86_64.rpm
-libxml2-devel-2.10.4-2.cm2.x86_64.rpm
+libxml2-2.10.4-3.cm2.x86_64.rpm
+libxml2-debuginfo-2.10.4-3.cm2.x86_64.rpm
+libxml2-devel-2.10.4-3.cm2.x86_64.rpm
 libxslt-1.1.34-7.cm2.x86_64.rpm
 libxslt-debuginfo-1.1.34-7.cm2.x86_64.rpm
 libxslt-devel-1.1.34-7.cm2.x86_64.rpm
@@ -527,7 +527,7 @@ python3-gpg-1.16.0-2.cm2.x86_64.rpm
 python3-jinja2-3.0.3-3.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.x86_64.rpm
 python3-libs-3.9.19-1.cm2.x86_64.rpm
-python3-libxml2-2.10.4-2.cm2.x86_64.rpm
+python3-libxml2-2.10.4-3.cm2.x86_64.rpm
 python3-lxml-4.9.1-1.cm2.x86_64.rpm
 python3-magic-5.40-2.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fixes CVE-2024-34459 with a patch for libxlm2


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Apply patch for libxml2 CVE-2024-34459

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: (Submitted for full build)
