### PR TITLE
Removing nsswitch.conf from Dockerfile for building Kubevirt Golden Containers

### DIFF
--- a/.pipelines/containerSourceData/kubevirt/Dockerfile-kubevirt-virt-launcher
+++ b/.pipelines/containerSourceData/kubevirt/Dockerfile-kubevirt-virt-launcher
@@ -22,7 +22,6 @@ RUN  cd /var && rm -rf run && ln -s ../run . \
 
 RUN cp /usr/share/kube-virt/virt-launcher/qemu.conf /etc/libvirt/
 RUN cp /usr/share/kube-virt/virt-launcher/virtqemud.conf /etc/libvirt/
-RUN cp /usr/share/kube-virt/virt-launcher/nsswitch.conf /etc/
 
 #simple smoke test
 RUN ls /usr/bin/virt-launcher

--- a/SPECS/cryptsetup/cryptsetup.spec
+++ b/SPECS/cryptsetup/cryptsetup.spec
@@ -2,7 +2,7 @@
 Summary:        A utility for setting up encrypted disks
 Name:           cryptsetup
 Version:        2.4.3
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2+ AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -139,7 +139,6 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %files libs -f cryptsetup.lang
 %license COPYING COPYING.LGPL
 %{_libdir}/libcryptsetup.so.*
-%{_tmpfilesdir}/cryptsetup.conf
 %ghost %dir /run/cryptsetup
 
 %files ssh-token

--- a/SPECS/cryptsetup/cryptsetup.spec
+++ b/SPECS/cryptsetup/cryptsetup.spec
@@ -148,6 +148,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_sbindir}/cryptsetup-ssh
 
 %changelog
+* Fri May 24 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 2.4.3-6
+- Cherry picking a change to circumvent cryptsetup build error
+
 * Tue Mar 19 2024 Dan Streetman <ddstreet@microsoft.com> - 2.4.3-5
 - enable ssh-token
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/50691749

Kubevirt golden container build fails with the following error:
```
#11 [7/8] RUN cp /usr/share/kube-virt/virt-launcher/nsswitch.conf /etc/
#11 0.283 cp: cannot stat '/usr/share/kube-virt/virt-launcher/nsswitch.conf': No such file or directory
#11 ERROR: executor failed running [/bin/sh -c cp /usr/share/kube-virt/virt-launcher/nsswitch.conf /etc/]: exit code: 1
------
 > [7/8] RUN cp /usr/share/kube-virt/virt-launcher/nsswitch.conf /etc/:
#11 0.283 cp: cannot stat '/usr/share/kube-virt/virt-launcher/nsswitch.conf': No such file or directory
------
dockerfile:43
--------------------
  41 |     RUN cp /usr/share/kube-virt/virt-launcher/qemu.conf /etc/libvirt/
  42 |     RUN cp /usr/share/kube-virt/virt-launcher/virtqemud.conf /etc/libvirt/
  43 | >>> RUN cp /usr/share/kube-virt/virt-launcher/nsswitch.conf /etc/
  44 |     
  45 |     #simple smoke test
--------------------
```

This is because after the upgrade in 3.0-dev, the file that is being expected no longer exists. Hence it needs to be removed from the dockerfile which is why this change is put in.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/50691749
- Removing nsswitch.conf from Dockerfile

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #[50691749](https://microsoft.visualstudio.com/OS/_workitems/edit/50691749)
- #[7702](https://dev.azure.com/mariner-org/ECF/_workitems/edit/7702)

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id with passing golden container creation: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=574231&view=results
