### PR TITLE
fix python-jinja2 CVE-2024-34064

### DIFF
--- a/SPECS/python-jinja2/CVE-2024-34064.patch
+++ b/SPECS/python-jinja2/CVE-2024-34064.patch
@@ -1,0 +1,97 @@
+From 5dcbbc98a404f70b4cedc8b3ff92a1859cc4cce5 Mon Sep 17 00:00:00 2001
+From: Sudipta Pandit <sudpandit@microsoft.com>
+Date: Wed, 22 May 2024 16:44:03 +0530
+Subject: [PATCH] Backport upstream change for CVE-2024-34064
+
+Backported from https://github.com/pallets/jinja/commit/0668239dc6b44ef38e7a6c9f91f312fd4ca581cb
+based on existing patch for CVE-2024-22195
+
+Original patch:
+From d655030770081e2dfe46f90e27620472a502289d Mon Sep 17 00:00:00 2001
+From: David Lord <davidism@gmail.com>
+Date: Thu, 2 May 2024 09:14:00 -0700
+Subject: [PATCH] disallow invalid characters in keys to xmlattr filter
+---
+ src/jinja2/filters.py | 22 +++++++++++++++++-----
+ tests/test_filters.py | 11 ++++++-----
+ 2 files changed, 23 insertions(+), 10 deletions(-)
+
+diff --git a/src/jinja2/filters.py b/src/jinja2/filters.py
+index 4f90bfe..28199e1 100644
+--- a/src/jinja2/filters.py
++++ b/src/jinja2/filters.py
+@@ -271,7 +271,9 @@ def do_lower(s: str) -> str:
+     return soft_str(s).lower()
+ 
+ 
+-_space_re = re.compile(r"\s", flags=re.ASCII)
++# Check for characters that would move the parser state from key to value.
++# https://html.spec.whatwg.org/#attribute-name-state
++_attr_key_re = re.compile(r"[\s/>=]", flags=re.ASCII)
+ 
+ 
+ @pass_eval_context
+@@ -282,8 +284,14 @@ def do_xmlattr(
+     All values that are neither `none` nor `undefined` are automatically
+     escaped:
+ 
+-    If any key contains a space, this fails with a ``ValueError``. Values that
+-    are neither ``none`` nor ``undefined`` are automatically escaped.
++    **Values** that are neither ``none`` nor ``undefined`` are automatically
++    escaped, safely allowing untrusted user input.
++
++    User input should not be used as **keys** to this filter. If any key
++    contains a space, ``/`` solidus, ``>`` greater-than sign, or ``=`` equals
++    sign, this fails with a ``ValueError``. Regardless of this, user input
++    should never be used as keys to this filter, or must be separately validated
++    first.
+ 
+     .. sourcecode:: html+jinja
+ 
+@@ -303,6 +311,10 @@ def do_xmlattr(
+     As you can see it automatically prepends a space in front of the item
+     if the filter returned something unless the second parameter is false.
+ 
++    .. versionchanged:: 3.1.4
++    Keys with ``/`` solidus, ``>`` greater-than sign, or ``=`` equals sign
++    are not allowed.
++
+     .. versionchanged:: 3.1.3
+         Keys with spaces are not allowed. (patched for 3.0.3)
+     """
+@@ -312,8 +324,8 @@ def do_xmlattr(
+         if value is None or isinstance(value, Undefined):
+             continue
+ 
+-        if _space_re.search(key) is not None:
+-            raise ValueError(f"Spaces are not allowed in attributes: '{key}'")
++        if _attr_key_re.search(key) is not None:
++            raise ValueError(f"Invalid character in attribute name: {key!r}")
+ 
+         items.append(f'{escape(key)}="{escape(value)}"')
+ 
+diff --git a/tests/test_filters.py b/tests/test_filters.py
+index 45843fd..6533370 100644
+--- a/tests/test_filters.py
++++ b/tests/test_filters.py
+@@ -463,11 +463,12 @@ class TestFilter:
+         assert 'bar="23"' in out
+         assert 'blub:blub="&lt;?&gt;"' in out
+ 
+-    def test_xmlattr_key_with_spaces(self, env):
+-        with pytest.raises(ValueError, match="Spaces are not allowed"):
+-            env.from_string(
+-                "{{ {'src=1 onerror=alert(1)': 'my_class'}|xmlattr }}"
+-            ).render()
++    @pytest.mark.parametrize("sep", ("\t", "\n", "\f", " ", "/", ">", "="))
++    def test_xmlattr_key_invalid(self, env: Environment, sep: str) -> None:
++        with pytest.raises(ValueError, match="Invalid character"):
++            env.from_string("{{ {key: 'my_class'}|xmlattr }}").render(
++                key=f"class{sep}onclick=alert(1)"
++            )
+ 
+     def test_sort1(self, env):
+         tmpl = env.from_string("{{ [2, 3, 1]|sort }}|{{ [2, 3, 1]|sort(true) }}")
+-- 
+2.34.1
+

--- a/SPECS/python-jinja2/python-jinja2.spec
+++ b/SPECS/python-jinja2/python-jinja2.spec
@@ -1,7 +1,7 @@
 Summary:        A fast and easy to use template engine written in pure Python
 Name:           python-jinja2
 Version:        3.0.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          Development/Languages/Python
 URL:            https://jinja.pocoo.org/
 Source0:        https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-%{version}.tar.gz
 Patch0:         CVE-2024-22195.patch
+Patch1:         CVE-2024-34064.patch
 BuildArch:      noarch
 
 %description
@@ -54,6 +55,9 @@ tox -e py%{python3_version_nodots}
 %{python3_sitelib}/Jinja2-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Wed May 22 2024 Sudipta Pandit <sudpandit@microsoft.com> - 3.0.3-4
+- Backport CVE-2024-34064 from upstream (based on previous backport of CVE-2024-22195)
+
 * Wed Jan 24 2024 Tobias Brick <tobiasb@microsoft.com> - 3.0.3-3
 - Backport CVE-2024-22195 from upstream
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport CVE-2024-34064 from upstream (based on previous backport of CVE-2024-22195)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-34064

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [573827](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=573827&view=results)
