### PR TITLE
Enable KNI module in DPDK build

### DIFF
--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -3,7 +3,7 @@
 # Define variables for kernel version and source directory
 %global KVERSION %(/bin/rpm -q --queryformat '%{RPMTAG_VERSION}-%{RPMTAG_RELEASE}' $(/bin/rpm -q --whatprovides kernel-headers))
 %global K_SRC %{_libdir}/modules/%{KVERSION}/build
-%global moddestdir %{buildroot}%{_libdir}/modules/%{KVERSION}/kernel/
+%global moddestdir %{_libdir}/modules/%{KVERSION}/kernel/drivers/net
 
 # Add option to build without examples
 %define target %{machine_arch}-%{machine_tmpl}-linuxapp-gcc
@@ -139,7 +139,8 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 %meson_install
 
 # Install the kernel modules to the specified directory
-install -D -m 755 %{buildroot}%{_libdir}/dpdk-pmds/*.ko %{moddestdir}
+mkdir -p %{buildroot}%{moddestdir}
+find %{_builddir}/dpdk-stable-%{version} -name rte_kni.ko -exec install -D -m 755 '{}' %{buildroot}%{moddestdir} \\;
 
 %files
 # BSD

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -114,7 +114,7 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
        -Ddrivers_install_subdir=dpdk-pmds \
        -Denable_docs=true \
        -Dmachine=default \
-       -Dkni=true \
+       -Denable_kmods=true \
 %if %{with examples}
        -Dexamples=all \
 %endif

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -180,7 +180,7 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 %endif
 
 %changelog
-* Wed Aug 22 2024 Dinesh Kumar Ramasamy <dramasamy@microsoft.com> - 21.11.2-3
+* Wed May 22 2024 Dinesh Kumar Ramasamy <dramasamy@microsoft.com> - 21.11.2-3
 - Enable KNI module in DPDK build
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 21.11.2-2

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -3,7 +3,7 @@
 # Define variables for kernel version and source directory
 %global KVERSION %(/bin/rpm -q --queryformat '%{RPMTAG_VERSION}-%{RPMTAG_RELEASE}' $(/bin/rpm -q --whatprovides kernel-headers))
 %global K_SRC %{_libdir}/modules/%{KVERSION}/build
-%global moddestdir %{_libdir}/modules/%{KVERSION}/kernel/drivers/net/kni
+%global moddestdir /lib/modules/%{KVERSION}/kernel/drivers/net/kni
 
 # Add option to build without examples
 %define target %{machine_arch}-%{machine_tmpl}-linuxapp-gcc
@@ -156,6 +156,7 @@ chmod +x install_kni.sh
 %{_bindir}/dpdk-proc-info
 %{_libdir}/*.so.*
 %{pmddir}/*.so.*
+%{moddestdir}/rte_kni.ko
 
 %files devel
 #BSD

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -30,7 +30,7 @@
 Summary:        Set of libraries and drivers for fast packet processing
 Name:           dpdk
 Version:        21.11.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD AND LGPLv2 AND GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -114,6 +114,7 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
        -Ddrivers_install_subdir=dpdk-pmds \
        -Denable_docs=true \
        -Dmachine=default \
+       -Dkni=true \
 %if %{with examples}
        -Dexamples=all \
 %endif
@@ -179,6 +180,9 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 %endif
 
 %changelog
+* Wed Aug 22 2024 Dinesh Kumar Ramasamy <dramasamy@microsoft.com> - 21.11.2-3
+- Enable KNI module in DPDK build
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 21.11.2-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -3,7 +3,7 @@
 # Define variables for kernel version and source directory
 %global KVERSION %(/bin/rpm -q --queryformat '%{RPMTAG_VERSION}-%{RPMTAG_RELEASE}' $(/bin/rpm -q --whatprovides kernel-headers))
 %global K_SRC %{_libdir}/modules/%{KVERSION}/build
-%global moddestdir %{_libdir}/modules/%{KVERSION}/kernel/drivers/net
+%global moddestdir %{_libdir}/modules/%{KVERSION}/kernel/drivers/net/kni
 
 # Add option to build without examples
 %define target %{machine_arch}-%{machine_tmpl}-linuxapp-gcc
@@ -140,7 +140,9 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 
 # Install the kernel modules to the specified directory
 mkdir -p %{buildroot}%{moddestdir}
-find %{_builddir}/dpdk-stable-%{version} -name rte_kni.ko -exec install -D -m 755 '{}' %{buildroot}%{moddestdir} \\;
+echo "find %{_builddir}/dpdk-stable-%{version} -name rte_kni.ko -exec install -D -m 755 '{}' %{buildroot}%{moddestdir} \;" > install_kni.sh
+chmod +x install_kni.sh
+./install_kni.sh
 
 %files
 # BSD

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -1,4 +1,10 @@
 %define _unpackaged_files_terminate_build 0
+
+# Define variables for kernel version and source directory
+%global KVERSION %(/bin/rpm -q --queryformat '%{RPMTAG_VERSION}-%{RPMTAG_RELEASE}' $(/bin/rpm -q --whatprovides kernel-headers))
+%global K_SRC %{_libdir}/modules/%{KVERSION}/build
+%global moddestdir %{buildroot}%{_libdir}/modules/%{KVERSION}/kernel/
+
 # Add option to build without examples
 %define target %{machine_arch}-%{machine_tmpl}-linuxapp-gcc
 # machine_arch maps between rpm and dpdk arch name, often same as _target_cpu
@@ -27,6 +33,7 @@
 # Add option to build with examples, tools subpackages
 %bcond_with examples
 %bcond_without tools
+
 Summary:        Set of libraries and drivers for fast packet processing
 Name:           dpdk
 Version:        21.11.2
@@ -47,6 +54,7 @@ BuildRequires:  meson
 BuildRequires:  python3-pyelftools
 BuildRequires:  python3-sphinx
 BuildRequires:  zlib-devel
+BuildRequires:  kernel-devel
 #
 # The DPDK is designed to optimize througput of network traffic using, among
 # other techniques, carefully crafted assembly instructions.  As such it
@@ -115,6 +123,7 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
        -Denable_docs=true \
        -Dmachine=default \
        -Denable_kmods=true \
+       -Dkernel_dir=%{K_SRC} \
 %if %{with examples}
        -Dexamples=all \
 %endif
@@ -128,6 +137,9 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 
 %install
 %meson_install
+
+# Install the kernel modules to the specified directory
+install -D -m 755 %{buildroot}%{_libdir}/dpdk-pmds/*.ko %{moddestdir}
 
 %files
 # BSD
@@ -182,6 +194,8 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 %changelog
 * Wed May 22 2024 Dinesh Kumar Ramasamy <dramasamy@microsoft.com> - 21.11.2-3
 - Enable KNI module in DPDK build
+- Update spec file to set kernel source directory using KVERSION and K_SRC variables.
+- Ensure correct installation directory for kernel modules using moddestdir variable.
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 21.11.2-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)


### PR DESCRIPTION
- Add `-Denable_kmods=true` to the meson build configuration to enable the Kernel Network Interface (KNI) module.
- Ensure the KNI module is built as part of the DPDK package without automatically loading it.

This change ensures that the KNI module is available for use when needed, without being loaded by default.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
This pull request enables the Kernel Network Interface (KNI) module in the DPDK build process. The KNI module is a key component for packet processing in user space, and enabling it as part of the build ensures it is available for use when needed. Enabling the KNI module provides flexibility for network applications that require fast packet processing. By building the KNI module but not loading it automatically, users can control when and how the module is loaded, enhancing system stability and customization.

###### Change Log  <!-- REQUIRED -->
- Added -Denable_kmods=true to the meson build configuration to enable the KNI module.
- Ensured the KNI module is built but not loaded by default, preventing it from being automatically loaded after installation.

