### PR TITLE
rubygem-rexml: fix CVE-2024-35176

### DIFF
--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -88,7 +88,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        %{ruby_version}
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -407,6 +407,9 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
+* Wed May 22 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.3.0-4
+- Bump release to build with new rubygem-rexml to fix CVE-2024-35176
+
 * Mon Apr 01 2024 Riken Maharjan <rmaharjan@microsoft.com> - 3.3.0-3
 - Change the 'gemspec_clear_signing' macro to delete gem.signature also.
 

--- a/SPECS/rubygem-rexml/add-support-for-old-strscan.patch
+++ b/SPECS/rubygem-rexml/add-support-for-old-strscan.patch
@@ -1,0 +1,129 @@
+From f1df7d13b3e57a5e059273d2f0870163c08d7420 Mon Sep 17 00:00:00 2001
+From: Sutou Kouhei <kou@clear-code.com>
+Date: Mon, 20 May 2024 12:17:27 +0900
+Subject: [PATCH] Add support for old strscan
+
+Fix GH-132
+
+If we support old strscan, users can also use strscan installed as a
+default gem.
+
+Reported by Adam. Thanks!!!
+---
+ .github/workflows/test.yml      | 32 ++++++++++++++++++++++----------
+ lib/rexml/parsers/baseparser.rb | 11 +++++++++++
+ rexml.gemspec                   |  2 +-
+ 3 files changed, 34 insertions(+), 11 deletions(-)
+
+diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml
+index fd26b9a..f977de6 100644
+--- a/.github/workflows/test.yml
++++ b/.github/workflows/test.yml
+@@ -3,14 +3,14 @@ on:
+   - push
+   - pull_request
+ jobs:
+-  ruby-versions:
++  ruby-versions-inplace:
+     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+     with:
+       engine: cruby-jruby
+       min_version: 2.5
+
+   inplace:
+-    needs: ruby-versions
++    needs: ruby-versions-inplace
+     name: "Inplace: ${{ matrix.ruby-version }} on ${{ matrix.runs-on }}"
+     runs-on: ${{ matrix.runs-on }}
+     strategy:
+@@ -20,7 +20,7 @@ jobs:
+           - ubuntu-latest
+           - macos-latest
+           - windows-latest
+-        ruby-version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
++        ruby-version: ${{ fromJson(needs.ruby-versions-inplace.outputs.versions) }}
+         exclude:
+           - {runs-on: macos-latest, ruby-version: 2.5}
+         # include:
+@@ -47,7 +47,14 @@ jobs:
+       - name: Test
+         run: bundle exec rake test RUBYOPT="--enable-frozen-string-literal"
+
++  ruby-versions-gem:
++    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
++    with:
++      engine: cruby-jruby
++      min_version: 3.0
++
+   gem:
++    needs: ruby-versions-gem
+     name: "Gem: ${{ matrix.ruby-version }} on ${{ matrix.runs-on }}"
+     runs-on: ${{ matrix.runs-on }}
+     strategy:
+@@ -57,21 +64,26 @@ jobs:
+           - ubuntu-latest
+           - macos-latest
+           - windows-latest
+-        ruby-version:
+-          - "3.0"
+-          - head
++        ruby-version: ${{ fromJson(needs.ruby-versions-gem.outputs.versions) }}
+     steps:
+       - uses: actions/checkout@v4
+       - uses: ruby/setup-ruby@v1
+         with:
+           ruby-version: ${{ matrix.ruby-version }}
+       - name: Install as gem
+-        env:
+-          BUNDLE_PATH__SYSTEM: "true"
+-          BUNDLE_WITHOUT: "benchmark:development"
+         run: |
+           rake install
+-          bundle install
++      - name: Install test dependencies on non-Windows
++        if: matrix.runs-on != 'windows-latest'
++        run: |
++          for gem in $(ruby -e 'puts ARGF.read[/^group :test do(.*)^end/m, 1].scan(/"(.+?)"/)' Gemfile); do
++            gem install ${gem}
++          done
++      - name: Install test dependencies on Windows
++        if: matrix.runs-on == 'windows-latest'
++        run: |
++          gem install test-unit
++          gem install test-unit-ruby-core
+       - name: Test
+         run: |
+           ruby -run -e mkdir -- tmp
+diff --git a/lib/rexml/parsers/baseparser.rb b/lib/rexml/parsers/baseparser.rb
+index d09237c..da051a7 100644
+--- a/lib/rexml/parsers/baseparser.rb
++++ b/lib/rexml/parsers/baseparser.rb
+@@ -7,6 +7,17 @@
+
+ module REXML
+   module Parsers
++    if StringScanner::Version < "3.0.8"
++      module StringScannerCaptures
++        refine StringScanner do
++          def captures
++            values_at(*(1...size))
++          end
++        end
++      end
++      using StringScannerCaptures
++    end
++
+     # = Using the Pull Parser
+     # <em>This API is experimental, and subject to change.</em>
+     #  parser = PullParser.new( "<a>text<b att='val'/>txet</a>" )
+diff --git a/rexml.gemspec b/rexml.gemspec
+index 97eac65..169e49d 100644
+--- a/rexml.gemspec
++++ b/rexml.gemspec
+@@ -55,5 +55,5 @@ Gem::Specification.new do |spec|
+
+   spec.required_ruby_version = '>= 2.5.0'
+
+-  spec.add_runtime_dependency("strscan", ">= 3.0.9")
++  spec.add_runtime_dependency("strscan")
+ end

--- a/SPECS/rubygem-rexml/rubygem-rexml.signatures.json
+++ b/SPECS/rubygem-rexml/rubygem-rexml.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "rexml-3.2.6.tar.gz": "38239d0b3068549d4efd0d8f32ca650be76af83223caeacaa536b69f81011113"
-  }
+ "Signatures": {
+  "rexml-3.2.8.tar.gz": "44c1d11af52fba515380867980ff1e30b3a3d303cb90a7ca89659563969f3444"
+ }
 }

--- a/SPECS/rubygem-rexml/rubygem-rexml.spec
+++ b/SPECS/rubygem-rexml/rubygem-rexml.spec
@@ -10,6 +10,7 @@ Distribution:   Azure Linux
 Group:          Development/Languages
 URL:            https://github.com/ruby/rexml
 Source0:        https://github.com/ruby/rexml/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
+Patch0:         add-support-for-old-strscan.patch
 BuildRequires:  git
 BuildRequires:  ruby
 Requires:       ruby(release)
@@ -20,7 +21,7 @@ REXML was inspired by the Electric XML library for Java, which features an easy-
 REXML supports both tree and stream document parsing. Stream parsing is faster (about 1.5 times as fast). However, with stream parsing, you don't get access to features such as XPath.
 
 %prep
-%setup -q -n %{gem_name}-%{version}
+%autosetup -n %{gem_name}-%{version} -p1
 
 %build
 gem build %{gem_name}
@@ -30,12 +31,13 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 
 %files
 %defattr(-,root,root,-)
-%license %{gemdir}/gems/%{gem_name}-%{version}/LICENSE.txt
+%license LICENSE.txt
 %{gemdir}
 
 %changelog
 * Wed May 22 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.2.8-1
 - Upgrade to v3.2.8 to fix CVE-2024-35176
+- Add patch to support old strscan
 
 * Fri Nov 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.2.6-1
 - Auto-upgrade to 3.2.6 - Azure Linux 3.0 - package upgrades

--- a/SPECS/rubygem-rexml/rubygem-rexml.spec
+++ b/SPECS/rubygem-rexml/rubygem-rexml.spec
@@ -2,7 +2,7 @@
 %global gem_name rexml
 Summary:        REXML is an XML toolkit for Ruby
 Name:           rubygem-%{gem_name}
-Version:        3.2.6
+Version:        3.2.8
 Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
@@ -30,10 +30,13 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 
 %files
 %defattr(-,root,root,-)
-%doc %{gemdir}/gems/%{gem_name}-%{version}/LICENSE.txt
+%license %{gemdir}/gems/%{gem_name}-%{version}/LICENSE.txt
 %{gemdir}
 
 %changelog
+* Wed May 22 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.2.8-1
+- Upgrade to v3.2.8 to fix CVE-2024-35176
+
 * Fri Nov 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.2.6-1
 - Auto-upgrade to 3.2.6 - Azure Linux 3.0 - package upgrades
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -26604,8 +26604,8 @@
         "type": "other",
         "other": {
           "name": "rubygem-rexml",
-          "version": "3.2.6",
-          "downloadUrl": "https://github.com/ruby/rexml/archive/refs/tags/v3.2.6.tar.gz"
+          "version": "3.2.8",
+          "downloadUrl": "https://github.com/ruby/rexml/archive/refs/tags/v3.2.8.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
rubygem-rexml: fix CVE-2024-35176

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- rubygem-rexml: fix CVE-2024-35176

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-35176

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Successful buddy build, error unrelated to the change: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=574806&view=results