### PR TITLE
Image Customizer: Add doc for building custom packages.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/building-packages.md
+++ b/toolkit/tools/imagecustomizer/docs/building-packages.md
@@ -1,0 +1,85 @@
+# Building custom packages
+
+This is a guide on how to build your own packages for Azure Linux.
+
+This guide uses an Azure Linux container to build the packages.
+This method is generally a lot easier than trying to use the Azure Linux toolkit, which
+is only really necessary when you need to build Azure Linux from scratch.
+
+## Quick start
+
+1. Create a file called `samplescript.sh` with the following contents:
+
+   ```bash
+   echo "Hello, World"
+   ```
+
+2. Create a file called `samplepackage.spec` with the following contents:
+
+   ```rpmspec
+   Summary:        A sample package
+   Name:           samplepackage
+   Version:        0.0.1
+   Release:        1%{?dist}
+   Vendor:         Contoso
+   License:        Proprietary
+
+   Source0:        samplescript.sh
+
+   %description
+   A very descriptive description for the sample package.
+
+   %install
+   install -D -m 755 %{SOURCE0} %{buildroot}%{_bindir}/samplescript.sh
+
+   %files
+   %{_bindir}/samplescript.sh
+   ```
+
+3. Create a file called `samplepackage.Dockerfile` with the following contents:
+
+   Azure Linux 2.0:
+
+   ```Dockerfile
+   FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+   RUN tdnf update -y
+   RUN tdnf install -y rpm-build
+
+   WORKDIR /work
+
+   COPY samplepackage.spec .
+   COPY samplescript.sh /usr/src/mariner/SOURCES/
+
+   RUN rpmbuild -bb --build-in-place samplepackage.spec
+   ```
+
+   Azure Linux 3.0:
+
+   ```Dockerfile
+   FROM mcr.microsoft.com/azurelinux/base/core:3.0
+
+   RUN tdnf update -y
+   RUN tdnf install -y rpm-build
+
+   WORKDIR /work
+
+   COPY samplepackage.spec .
+   COPY samplescript.sh /usr/src/azl/SOURCES/
+
+   RUN rpmbuild -bb --build-in-place samplepackage.spec
+   ```
+
+4. Build the rpm file using `docker`, by running:
+
+   ```bash
+   docker build -t samplepackage:latest -f samplepackage.Dockerfile .
+   ```
+
+5. Extract RPM file(s) from container:
+
+   ```bash
+   id=$(docker create samplepackage:latest)
+   docker cp $id:/usr/src/mariner/RPMS ./
+   docker rm -v $id
+   ```

--- a/toolkit/tools/imagecustomizer/docs/building-packages.md
+++ b/toolkit/tools/imagecustomizer/docs/building-packages.md
@@ -1,10 +1,12 @@
 # Building custom packages
 
-This is a guide on how to build your own packages for Azure Linux.
+This is a guide on how to build custom packages for Azure Linux.
+Once built, the RPM files can be provided to the Image Customizer tool using the
+[--rpm-source](cli.md#--rpm-sourcepath) command-line arg.
 
-This guide uses an Azure Linux container to build the packages.
-This method is generally a lot easier than trying to use the Azure Linux toolkit, which
-is only really necessary when you need to build Azure Linux from scratch.
+This guide uses an Azure Linux container and docker to build the packages.
+This avoids the complexity of using the Azure Linux toolkit (which has to be capable of
+building Azure Linux from scratch, including on other Linux distros).
 
 ## Quick start
 
@@ -17,17 +19,23 @@ is only really necessary when you need to build Azure Linux from scratch.
 2. Create a file called `samplepackage.spec` with the following contents:
 
    ```rpmspec
-   Summary:        A sample package
-   Name:           samplepackage
-   Version:        0.0.1
-   Release:        1%{?dist}
-   Vendor:         Contoso
-   License:        Proprietary
+   Summary:    A sample package
+   Name:       samplepackage
+   Version:    0.0.1
+   Release:    1%{?dist}
+   Vendor:     Contoso
+   License:    Proprietary
 
-   Source0:        samplescript.sh
+   Source0:    samplescript.sh
+
+   Requires:   bash
 
    %description
    A very descriptive description for the sample package.
+
+   %prep
+
+   %build
 
    %install
    install -D -m 755 %{SOURCE0} %{buildroot}%{_bindir}/samplescript.sh
@@ -70,16 +78,20 @@ is only really necessary when you need to build Azure Linux from scratch.
    RUN rpmbuild -bb --build-in-place samplepackage.spec
    ```
 
-4. Build the rpm file using `docker`, by running:
+4. Build the rpm file using docker:
 
    ```bash
    docker build -t samplepackage:latest -f samplepackage.Dockerfile .
    ```
 
-5. Extract RPM file(s) from container:
+5. Extract RPM file(s) from the container image:
 
    ```bash
    id=$(docker create samplepackage:latest)
    docker cp $id:/usr/src/mariner/RPMS ./
    docker rm -v $id
    ```
+
+## Helpful links
+
+- [Official documentation for RPM spec file format](https://rpm-software-management.github.io/rpm/manual/spec.html)

--- a/toolkit/tools/imagecustomizer/docs/cli.md
+++ b/toolkit/tools/imagecustomizer/docs/cli.md
@@ -91,6 +91,9 @@ RPM sources are specified in the order or priority from lowest to highest.
 If `--disable-base-image-rpm-repos` is not specified, then the in-built RPM repos are
 given the lowest priority.
 
+See, [Building custom packages](building-packages.md) for a guide on how to build your
+own packages for Azure Linux.
+
 ## --disable-base-image-rpm-repos
 
 Disable the base image's installed RPM repos as a source of RPMs during package


### PR DESCRIPTION
Add a quick guide for how to build custom packages for Azure Linux. This guide uses a normal Azure Linux core container and directly uses `rpmbuild`, instead of using the Azure Linux toolkit, since it is a lot simpler.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

n/a
