### PR TITLE
Image Customizer: Fix prereqs list + container fixes.

### DIFF
--- a/toolkit/tools/imagecustomizer/README.md
+++ b/toolkit/tools/imagecustomizer/README.md
@@ -45,15 +45,23 @@ Disadvantages:
 
 3. Install prerequisites: `qemu-img`, `rpm`, `dd`, `lsblk`, `losetup`, `sfdisk`,
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
-   `genisoimage`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`, `e2fsck`,
-   `xfs_repair`, `resize2fs`, `zstd`, `veritysetup`.
+   `genisoimage`, `parted`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
+   `e2fsck`, `xfs_repair`, `resize2fs`, `zstd`, `veritysetup`.
 
    - For Ubuntu 22.04 images, run:
 
      ```bash
      sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
-        sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools xfsprogs zstd \
-        cryptsetup-bin
+        sed createrepo-c squashfs-tools genisoimage parted e2fsprogs dosfstools \
+        xfsprogs zstd cryptsetup-bin
+     ```
+
+   - For Mariner 2.0, run:
+
+     ```bash
+     sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
+        sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
+        xfsprogs zstd veritysetup
      ```
 
 4. Run the Azure Linux Image Customizer tool.

--- a/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+++ b/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
@@ -1,4 +1,6 @@
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
-RUN tdnf update -y && tdnf install -y sudo qemu-img rpm coreutils util-linux systemd openssl sed squashfs-tools dosfstools \
-   genisoimage e2fsprogs xfsprogs zstd cryptsetup
+RUN tdnf update -y && \
+   tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
+      sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
+      xfsprogs zstd veritysetup
 COPY . /

--- a/toolkit/tools/imagecustomizer/container/build-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-mic-container.sh
@@ -49,15 +49,15 @@ containerStagingFolder=$(mktemp -d)
 
 function cleanUp() {
     local exit_code=$?
-    sudo rm -rf $containerStagingFolder
+    rm -rf $containerStagingFolder
     exit $exit_code
 }
 trap 'cleanUp' ERR
 
-micLocalFile=$enlistmentRoot/toolkit/tools/imagecustomizer/imagecustomizer
+micLocalFile=$enlistmentRoot/toolkit/out/tools/imagecustomizer
 micContainerFolder=/usr/bin
 
-containerFullPath=$containerRegistery/$containerName/$containerTag
+containerFullPath=$containerRegistery/$containerName:$containerTag
 dockerFile=$enlistmentRoot/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
 
 # stage those files that need to be in the container

--- a/toolkit/tools/imagecustomizer/container/run-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/run-mic-container.sh
@@ -79,14 +79,13 @@ fi
 
 # ---- main ----
 
-containerFullPath=$containerRegistery/$containerName/$containerTag
+containerFullPath=$containerRegistery/$containerName:$containerTag
 
 inputImageDir=$(dirname $inputImage)
-inputConfigDdir=$(dirname $inputConfig)
+inputConfigDir=$(dirname $inputConfig)
 outputImageDir=$(dirname $outputImage)
 
-sudo rm -rf $outputImageDir
-sudo mkdir -p $outputImageDir
+mkdir -p $outputImageDir
 
 # setup input image within the container
 containerInputImageDir=/mic/input
@@ -107,9 +106,9 @@ containerOutputImage=$containerOutputDir/$(basename $outputImage)
 docker run --rm \
   --privileged=true \
    -v $inputImageDir:$containerInputImageDir:z \
-   -v $inputConfigDdir:$containerInputConfigDir:z \
+   -v $inputConfigDir:$containerInputConfigDir:z \
    -v $outputImageDir:$containerOutputDir:z \
-   -v /dev:/dev:z \
+   -v /dev:/dev \
    $containerFullPath \
    imagecustomizer \
       --image-file $containerInputImage \


### PR DESCRIPTION
1. Add `parted` to the list of prerequisites.

2. Add list of Mariner 2.0 prerequisites to README.

3. Fix prereqs list in Dockerfile.

4. In `build-mic-container.sh`, use `imagecustomizer` binary location that is generated by running `make go-imagecustomizer REBUILD_TOOLS=y`.

5. Remove use of `sudo` from scripts.

6. Fix `imagecustomizer` container path so that version is treated as a tag and not a part of the path.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

