### PR TITLE
moby-compose: Fix CVE-2024-24786, CVE-2024-23650, CVE-2023-2253

### DIFF
--- a/SPECS/moby-compose/CVE-2023-2253.patch
+++ b/SPECS/moby-compose/CVE-2023-2253.patch
@@ -1,0 +1,98 @@
+Backported from distribution/distribution upstream:
+https://github.com/distribution/distribution/commit/521ea3d973cb0c7089ebbcdd4ccadc34be941f54
+
+Modified to apply to vendored code by: corvus-callidus <108946721+corvus-callidus@users.noreply.github.com>
+ - Adjusted paths
+ - Removed references to files which are not present in the vendored code
+
+
+From 521ea3d973cb0c7089ebbcdd4ccadc34be941f54 Mon Sep 17 00:00:00 2001
+From: "Jose D. Gomez R" <jose.gomez@suse.com>
+Date: Mon, 24 Apr 2023 18:52:27 +0200
+Subject: [PATCH] Fix runaway allocation on /v2/_catalog
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Introduced a Catalog entry in the configuration struct. With it,
+it's possible to control the maximum amount of entries returned
+by /v2/catalog (`GetCatalog` in registry/handlers/catalog.go).
+
+It's set to a default value of 1000.
+
+`GetCatalog` returns 100 entries by default if no `n` is
+provided. When provided it will be validated to be between `0`
+and `MaxEntries` defined in Configuration. When `n` is outside
+the aforementioned boundary, ErrorCodePaginationNumberInvalid is
+returned.
+
+`GetCatalog` now handles `n=0` gracefully with an empty response
+as well.
+
+Signed-off-by: José D. Gómez R. <1josegomezr@gmail.com>
+Co-authored-by: Cory Snider <corhere@gmail.com>
+---
+ vendor/github.com/docker/distribution/registry/api/v2/descriptors.go      |  17 ++
+ vendor/github.com/docker/distribution/registry/api/v2/errors.go           |   9 +
+ 2 files changed, 26 insertions(+)
+
+diff --git a/vendor/github.com/docker/distribution/registry/api/v2/descriptors.go b/vendor/github.com/docker/distribution/registry/api/v2/descriptors.go
+index a9616c58ad..c3bf90f71d 100644
+--- a/vendor/github.com/docker/distribution/registry/api/v2/descriptors.go
++++ b/vendor/github.com/docker/distribution/registry/api/v2/descriptors.go
+@@ -134,6 +134,19 @@ var (
+ 		},
+ 	}
+
++	invalidPaginationResponseDescriptor = ResponseDescriptor{
++		Name:        "Invalid pagination number",
++		Description: "The received parameter n was invalid in some way, as described by the error code. The client should resolve the issue and retry the request.",
++		StatusCode:  http.StatusBadRequest,
++		Body: BodyDescriptor{
++			ContentType: "application/json",
++			Format:      errorsBody,
++		},
++		ErrorCodes: []errcode.ErrorCode{
++			ErrorCodePaginationNumberInvalid,
++		},
++	}
++
+ 	repositoryNotFoundResponseDescriptor = ResponseDescriptor{
+ 		Name:        "No Such Repository Error",
+ 		StatusCode:  http.StatusNotFound,
+@@ -490,6 +503,7 @@ var routeDescriptors = []RouteDescriptor{
+ 							},
+ 						},
+ 						Failures: []ResponseDescriptor{
++							invalidPaginationResponseDescriptor,
+ 							unauthorizedResponseDescriptor,
+ 							repositoryNotFoundResponseDescriptor,
+ 							deniedResponseDescriptor,
+@@ -1578,6 +1592,9 @@ var routeDescriptors = []RouteDescriptor{
+ 								},
+ 							},
+ 						},
++						Failures: []ResponseDescriptor{
++							invalidPaginationResponseDescriptor,
++						},
+ 					},
+ 				},
+ 			},
+diff --git a/vendor/github.com/docker/distribution/registry/api/v2/errors.go b/vendor/github.com/docker/distribution/registry/api/v2/errors.go
+index 97d6923aa0..87e9f3c14b 100644
+--- a/vendor/github.com/docker/distribution/registry/api/v2/errors.go
++++ b/vendor/github.com/docker/distribution/registry/api/v2/errors.go
+@@ -133,4 +133,13 @@ var (
+ 		longer proceed.`,
+ 		HTTPStatusCode: http.StatusNotFound,
+ 	})
++
++	ErrorCodePaginationNumberInvalid = errcode.Register(errGroup, errcode.ErrorDescriptor{
++		Value:   "PAGINATION_NUMBER_INVALID",
++		Message: "invalid number of results requested",
++		Description: `Returned when the "n" parameter (number of results
++		to return) is not an integer, "n" is negative or "n" is bigger than
++		the maximum allowed.`,
++		HTTPStatusCode: http.StatusBadRequest,
++	})
+ )

--- a/SPECS/moby-compose/CVE-2024-23650.patch
+++ b/SPECS/moby-compose/CVE-2024-23650.patch
@@ -1,0 +1,82 @@
+Backported from moby buildkit upstream:
+https://github.com/moby/buildkit/commit/1981eb123dc979fc71d097adeb5bbb84110aa9f4
+
+Modified to apply to vendored code by: corvus-callidus <108946721+corvus-callidus@users.noreply.github.com>
+ - Adjusted paths
+ - Removed reference to files not present in the vendored version
+
+From 8dfaf014d7f9721b501f99ab0aeb9f0ed957948d Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Sun, 17 Dec 2023 20:43:57 -0800
+Subject: [PATCH 3/5] exporter: add validation for platforms key value
+
+Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
+(cherry picked from commit 432ece72ae124ce8a29ced6854a08206f09f3a73)
+---
+vendor/github.com/moby/buildkit/exporter/containerimage/exptypes/parse.go |  14 +++
+ 1 files changed, 14 insertions(+)
+
+diff --git a/vendor/github.com/moby/buildkit/exporter/containerimage/exptypes/parse.go b/vendor/github.com/moby/buildkit/exporter/containerimage/exptypes/parse.go
+index 293a24ed0772..e8d9b7f0cb73 100644
+--- a/vendor/github.com/moby/buildkit/exporter/containerimage/exptypes/parse.go
++++ b/vendor/github.com/moby/buildkit/exporter/containerimage/exptypes/parse.go
+@@ -17,6 +17,18 @@ func ParsePlatforms(meta map[string][]byte) (Platforms, error) {
+ 				return Platforms{}, errors.Wrapf(err, "failed to parse platforms passed to provenance processor")
+ 			}
+ 		}
++		if len(ps.Platforms) == 0 {
++			return Platforms{}, errors.Errorf("invalid empty platforms index for exporter")
++		}
++		for i, p := range ps.Platforms {
++			if p.ID == "" {
++				return Platforms{}, errors.Errorf("invalid empty platform key for exporter")
++			}
++			if p.Platform.OS == "" || p.Platform.Architecture == "" {
++				return Platforms{}, errors.Errorf("invalid platform value %v for exporter", p.Platform)
++			}
++			ps.Platforms[i].Platform = platforms.Normalize(p.Platform)
++		}
+ 		return ps, nil
+ 	}
+
+@@ -36,6 +48,8 @@ func ParsePlatforms(meta map[string][]byte) (Platforms, error) {
+ 				OSFeatures:   img.OSFeatures,
+ 				Variant:      img.Variant,
+ 			}
++		} else if img.OS != "" || img.Architecture != "" {
++			return Platforms{}, errors.Errorf("invalid image config: os and architecture must be specified together")
+ 		}
+ 	}
+ 	p = platforms.Normalize(p)
+
+From 5d7d85f5a0388bb0faa0d9250f96b35814cff1f9 Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Sun, 17 Dec 2023 23:39:51 -0800
+Subject: [PATCH 5/5] pb: add extra validation to protobuf types
+
+Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
+(cherry picked from commit 838635998dcae34bbde59e3eab129ab85bd37bef)
+---
+vendor/github.com/moby/buildkit/frontend/gateway/client/attestation.go |  6 ++++++
+
+ 1 files changed, 6 insertions(+)
+
+diff --git a/vendor/github.com/moby/buildkit/frontend/gateway/client/attestation.go b/vendor/github.com/moby/buildkit/frontend/gateway/client/attestation.go
+index 5ffe67233c50..c5112db9db64 100644
+--- a/vendor/github.com/moby/buildkit/frontend/gateway/client/attestation.go
++++ b/vendor/github.com/moby/buildkit/frontend/gateway/client/attestation.go
+@@ -30,8 +30,14 @@ func AttestationToPB[T any](a *result.Attestation[T]) (*pb.Attestation, error) {
+ }
+
+ func AttestationFromPB[T any](a *pb.Attestation) (*result.Attestation[T], error) {
++	if a == nil {
++		return nil, errors.Errorf("invalid nil attestation")
++	}
+ 	subjects := make([]result.InTotoSubject, len(a.InTotoSubjects))
+ 	for i, subject := range a.InTotoSubjects {
++		if subject == nil {
++			return nil, errors.Errorf("invalid nil attestation subject")
++		}
+ 		subjects[i] = result.InTotoSubject{
+ 			Kind:   subject.Kind,
+ 			Name:   subject.Name,

--- a/SPECS/moby-compose/CVE-2024-24786.patch
+++ b/SPECS/moby-compose/CVE-2024-24786.patch
@@ -1,0 +1,83 @@
+Backported from protobuf upstream:
+https://go-review.googlesource.com/c/protobuf/+/569356
+
+Modified to apply to vendored code by: corvus-callidus <108946721+corvus-callidus@users.noreply.github.com>
+ - Adjusted paths
+ - Removed references to protobuf/encoding/protojson/decode_test.go and
+   protobuf/internal/encoding/json/decode_test.go which are not present in the vendored code
+ - Modified json.EOF check to apply to our older version of skipJSONValue
+
+
+From f01a588e5810b90996452eec4a28f22a0afae023 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Tue, 05 Mar 2024 08:54:24 -0800
+Subject: [PATCH] encoding/protojson, internal/encoding/json: handle missing object values
+
+In internal/encoding/json, report an error when encountering a }
+when we are expecting an object field value. For example, the input
+`{"":}` now correctly results in an error at the closing } token.
+
+In encoding/protojson, check for an unexpected EOF token in
+skipJSONValue. This is redundant with the check in internal/encoding/json,
+but adds a bit more defense against any other similar bugs that
+might exist.
+
+Fixes CVE-2024-24786
+
+Change-Id: I03d52512acb5091c8549e31ca74541d57e56c99d
+Reviewed-on: https://go-review.googlesource.com/c/protobuf/+/569356
+TryBot-Bypass: Damien Neil <dneil@google.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Commit-Queue: Damien Neil <dneil@google.com>
+---
+
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 25329b7..4b177c8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -328,6 +328,10 @@ func (d decoder) skipJSONValue() error {
+ 				if err := d.skipJSONValue(); err != nil {
+ 					return err
+ 				}
++			case json.EOF:
++				// This can only happen if there's a bug in Decoder.Read.
++				// Avoid an infinite loop if this does happen.
++				return errors.New("unexpected EOF")
+ 			}
+ 		}
+
+@@ -341,6 +345,10 @@ func (d decoder) skipJSONValue() error {
+ 			case json.ArrayClose:
+ 				d.Read()
+ 				return nil
++			case json.EOF:
++				// This can only happen if there's a bug in Decoder.Read.
++				// Avoid an infinite loop if this does happen.
++				return errors.New("unexpected EOF")
+ 			default:
+ 				// Skip array item.
+ 				if err := d.skipJSONValue(); err != nil {
+@@ -348,6 +356,10 @@ func (d decoder) skipJSONValue() error {
+ 				}
+ 			}
+ 		}
++	case json.EOF:
++		// This can only happen if there's a bug in Decoder.Read.
++		// Avoid an infinite loop if this does happen.
++		return errors.New("unexpected EOF")
+ 	}
+ 	return nil
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index d043a6e..d2b3ac0 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@
+
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}

--- a/SPECS/moby-compose/moby-compose.spec
+++ b/SPECS/moby-compose/moby-compose.spec
@@ -1,7 +1,7 @@
 Summary:        Define and run multi-container applications with Docker
 Name:           moby-compose
 Version:        2.17.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -19,15 +19,7 @@ Patch2:         Change-server-stream-context-handling.patch
 Patch3:         prohibit-more-than-MaxConcurrentStreams-handlers.patch
 Patch4:         CVE-2023-45288.patch
 Patch5:         CVE-2023-48795.patch
-
-# Leverage the `generate_source_tarball.sh` to create the vendor sources
-# NOTE: govendor-v1 format is for inplace CVE updates so that we do not have to overwrite in the blob-store.
-# After fixing any possible CVE for the vendored source, we must bump v1 -> v2
-Source1:        %{name}-%{version}-govendor-v1.tar.gz
-BuildRequires:  golang
-Requires:       moby-cli
-
-Patch10:        CVE-2024-24786.patch
+Patch6:         CVE-2024-24786.patch
 # Patch for CVE-2024-23650 (buildkit) must be redone if the package is updated and
 # the vendored code begins including any of the following modules:
 #    github.com/moby/buildkit/control (for control.go)
@@ -36,13 +28,20 @@ Patch10:        CVE-2024-24786.patch
 #    github.com/moby/buildkit/solver/llbsolver (for bridge.go and solver.go)
 #    github.com/moby/buildkit/sourcepolicy (for matcher.go)
 #    github.com/moby/buildkit/util/tracing/transform (for attribute.go and span.go)
-Patch11:        CVE-2024-23650.patch
-
+Patch7:         CVE-2024-23650.patch
 # Patch for CVE-2023-2253 (distribution/distribution) must be redone if the package is updated and
 # the vendored code begins including any of the following modules:
 #    github.com/docker/distribution/configuration (for configuration.go)
 #    github.com/docker/distribution/catalog (for catalog.go)
-Patch12:        CVE-2023-2253.patch
+Patch8:         CVE-2023-2253.patch
+
+
+# Leverage the `generate_source_tarball.sh` to create the vendor sources
+# NOTE: govendor-v1 format is for inplace CVE updates so that we do not have to overwrite in the blob-store.
+# After fixing any possible CVE for the vendored source, we must bump v1 -> v2
+Source1:        %{name}-%{version}-govendor-v1.tar.gz
+BuildRequires:  golang
+Requires:       moby-cli
 
 %description
 Compose is a tool for defining and running multi-container Docker applications.
@@ -73,6 +72,9 @@ install -D -m0755 bin/build/docker-compose %{buildroot}/%{_libexecdir}/docker/cl
 %{_libexecdir}/docker/cli-plugins/docker-compose
 
 %changelog
+* Tue May 28 2024 corvus-callidus <108946721+corvus-callidus@users.noreply.github.com> - 2.17.3-5
+- Fix for CVE-2024-24786, CVE-2024-23650, CVE-2023-2253
+
 * Tue May 28 2024 Bala <balakumaran.kannan@microsoft.com> - 2.17.3-4
 - Fix for CVE-2023-48795
 

--- a/SPECS/moby-compose/moby-compose.spec
+++ b/SPECS/moby-compose/moby-compose.spec
@@ -27,6 +27,22 @@ Source1:        %{name}-%{version}-govendor-v1.tar.gz
 BuildRequires:  golang
 Requires:       moby-cli
 
+Patch10:        CVE-2024-24786.patch
+# Patch for CVE-2024-23650 (buildkit) must be redone if the package is updated and
+# the vendored code begins including any of the following modules:
+#    github.com/moby/buildkit/control (for control.go)
+#    github.com/moby/buildkit/exporter/containerimage (for writer.go)
+#    github.com/moby/buildkit/frontend/gateway (for gateway.go)
+#    github.com/moby/buildkit/solver/llbsolver (for bridge.go and solver.go)
+#    github.com/moby/buildkit/sourcepolicy (for matcher.go)
+#    github.com/moby/buildkit/util/tracing/transform (for attribute.go and span.go)
+Patch11:        CVE-2024-23650.patch
+
+# Patch for CVE-2023-2253 (distribution/distribution) must be redone if the package is updated and
+# the vendored code begins including any of the following modules:
+#    github.com/docker/distribution/configuration (for configuration.go)
+#    github.com/docker/distribution/catalog (for catalog.go)
+Patch12:        CVE-2023-2253.patch
 
 %description
 Compose is a tool for defining and running multi-container Docker applications.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Addresses CVE-2024-24786, CVE-2024-23650, CVE-2023-2253 for moby-compose

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2024-24786
- CVE-2024-23650
- CVE-2023-2253

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-24786
- https://nvd.nist.gov/vuln/detail/CVE-2024-23650
- https://nvd.nist.gov/vuln/detail/CVE-2023-2253

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
- Pipeline build id: [577555](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=577555)
