### PR TITLE
libkcapi: Package proper measurements & binary aliases in libkcapi for fips boot

### DIFF
--- a/SPECS/libkcapi/fipshmac-openssl.sh
+++ b/SPECS/libkcapi/fipshmac-openssl.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Mocks fipshmac using the openssl tool.
-# Only for use during RPM build.
-
-[ "$1" = '-d' ] || exit 1
-
-openssl sha256 -hmac orboDeJITITejsirpADONivirpUkvarP -hex "$3" | cut -f 2 -d ' ' \
-	>"$2/$(basename "$3").hmac"

--- a/SPECS/libkcapi/libkcapi.signatures.json
+++ b/SPECS/libkcapi/libkcapi.signatures.json
@@ -1,7 +1,5 @@
 {
  "Signatures": {
-  "fipshmac-openssl.sh": "78f6d74404fb60cc13ab36569a4077046de5a1b62271e4401801294f8eb05c3a",
-  "libkcapi-1.5.0.tar.xz": "15b550c14165a266fa233b485d029d54508da593dfa6d1731ec5d5a285c716e9",
-  "sha512hmac-openssl.sh": "e0b44bedb58b06547e13c48c8170333bb7f131b6c1f0056ae9486fee6f3cb435"
+  "libkcapi-1.5.0.tar.xz": "15b550c14165a266fa233b485d029d54508da593dfa6d1731ec5d5a285c716e9"
  }
 }

--- a/SPECS/libkcapi/libkcapi.spec
+++ b/SPECS/libkcapi/libkcapi.spec
@@ -22,8 +22,8 @@
 %global apps_hmaccalc sha1hmac sha224hmac sha256hmac sha384hmac sha512hmac sm3hmac
 %global apps_fipscheck sha1sum sha224sum sha256sum sha384sum sha512sum md5sum sm3sum fipscheck fipshmac
 # Use OpenSSL to perform hmac calculations
-%global sha512hmac bash %{_sourcedir}/sha512hmac-openssl.sh
-%global fipshmac   bash %{_sourcedir}/fipshmac-openssl.sh
+%global sha512hmac bin/kcapi-hasher -n sha512hmac
+%global fipshmac   bin/kcapi-hasher -n fipshmac
 # Add generation of HMAC checksums of the final stripped
 # binaries.  %%define with lazy globbing is used here
 # intentionally, because using %%global does not work.
@@ -47,6 +47,10 @@ done                                                             \
   "$lib_path"/libkcapi.so.%{version} || exit 1                   \
 ln -s libkcapi.so.%{version}.hmac                            \\\
   "$lib_path"/fipscheck/libkcapi.so.%{vmajor}.hmac               \
+{ %{sha512hmac} "$lib_path"/libkcapi.so.%{version} || exit 1; }      \\\
+    | cut -f 1 -d ' ' >"$lib_path"/hmaccalc/libkcapi.so.%{version}.hmac    \
+ln -s libkcapi.so.%{version}.hmac                            \\\
+  "$lib_path"/hmaccalc/libkcapi.so.%{vmajor}.hmac               \
 %{nil}
 %global fipscheck_next_evr     1.5.0-10%{?dist}
 %global hmaccalc_next_evr      0.9.14-11%{?dist}
@@ -61,14 +65,12 @@ ln -s libkcapi.so.%{version}.hmac                            \\\
 Summary:        User space interface to the Linux Kernel Crypto API
 Name:           libkcapi
 Version:        %{vmajor}.%{vminor}.%{vpatch}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD OR GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://www.chronox.de/%{name}.html
 Source0:        https://www.chronox.de/%{name}/releases/%{version}/%{name}-1.5.0.tar.xz
-Source1:        sha512hmac-openssl.sh
-Source2:        fipshmac-openssl.sh
 BuildRequires:  bash
 BuildRequires:  clang
 BuildRequires:  coreutils
@@ -209,6 +211,11 @@ rm -f                            \
   %{buildroot}%{_bindir}/sha*sum      \
   %{buildroot}%{_bindir}/sm*sum
 
+# Create hard-links to alias dracut-expected sha* bins to new kcapi-hasher bin.
+for app in %{apps_hmaccalc}; do
+  ln %{buildroot}%{_bindir}/kcapi-hasher %{buildroot}%{_bindir}/$app || exit 1;
+done
+
 # We don't ship autocrap dumplings.
 find %{buildroot} -type f -name "*.la" -delete -print
 
@@ -228,6 +235,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 /%{_lib}/%{name}.so.%{version}
 /%{_lib}/fipscheck/%{name}.so.%{vmajor}.hmac
 /%{_lib}/fipscheck/%{name}.so.%{version}.hmac
+
 %if %{with_sysctl_tweak}
 %{_sysctldir}/%{sysctl_prio}-%{name}-optmem_max.conf
 %endif
@@ -239,6 +247,13 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/%{name}.pc
 
 %files hmaccalc
+%{_bindir}/kcapi-hasher
+%{_bindir}/sha*hmac
+%{_bindir}/sm*hmac
+/%{_lib}/hmaccalc/%{name}.so.%{vmajor}.hmac
+/%{_lib}/hmaccalc/%{name}.so.%{version}.hmac
+/%{_lib}/hmaccalc/sha*hmac.hmac
+/%{_lib}/hmaccalc/sm*hmac.hmac
 %{_libexecdir}/%{name}/sha*hmac
 %{_libexecdir}/%{name}/sm*hmac
 
@@ -249,14 +264,26 @@ find %{buildroot} -type f -name "*.la" -delete -print
 /%{_lib}/%{name}.a
 
 %files tools
-%{_bindir}/kcapi*
+%{_bindir}/kcapi
+%{_bindir}/kcapi-convenience
+%{_bindir}/kcapi-dgst
+%{_bindir}/kcapi-enc-test-large
+%{_bindir}/kcapi-rng
+%{_bindir}/kcapi-speed
 %{_mandir}/man1/kcapi*.1.*
 
 %files tests
 %{_libexecdir}/%{name}/*
 
 %changelog
-* Tue Feb 13 2024 Mitch Zhu <mitchzhu@microsoft.com> - 1.4.0-1
+* Tue May 28 2024 Cameron Baird <cameronbaird@microsoft.com> - 1.5.0-2
+- Install hard links from apps_hmaccalc to kcapi-hasher to
+    resolve incompatibility with dracut.
+- Install sha512hmac measurement of libkcapi.so.ver in /lib/hmaccalc dir
+    to satisfy kcapi-hasher self-check during initramfs fips check.
+- Drop openssl helper scripts since we rely on kcapi-hasher instead.
+
+* Tue Feb 13 2024 Mitch Zhu <mitchzhu@microsoft.com> - 1.5.0-1
 - Upgrade to version 1.5.0
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 1.3.1-3

--- a/SPECS/libkcapi/libkcapi.spec
+++ b/SPECS/libkcapi/libkcapi.spec
@@ -235,7 +235,6 @@ find %{buildroot} -type f -name "*.la" -delete -print
 /%{_lib}/%{name}.so.%{version}
 /%{_lib}/fipscheck/%{name}.so.%{vmajor}.hmac
 /%{_lib}/fipscheck/%{name}.so.%{version}.hmac
-
 %if %{with_sysctl_tweak}
 %{_sysctldir}/%{sysctl_prio}-%{name}-optmem_max.conf
 %endif

--- a/SPECS/libkcapi/sha512hmac-openssl.sh
+++ b/SPECS/libkcapi/sha512hmac-openssl.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Mocks sha512hmac using the openssl tool.
-# Only for use during RPM build.
-
-openssl sha512 -hmac FIPS-FTW-RHT2009 -hex "$1" | cut -f 2 -d ' '


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

libkcapi v1.5.0 comes with a breaking change with regards to dracut, fips boot. https://www.chronox.de/libkcapi/releases/1.5.0/index.html

> move all sha* applications to the libexec directory to allow them to coexist with other packages sha* applications - the caller is expected to make a symlink to them

I also observe in the build that, instead of producing sha*hmac bins, all functionality is now put in libkapi-hasher.

These changes cause sha512hmac to go missing from the perspective of Dracut, who expects to find it in the PATH. Furthermore, due to how our spec file was written for 1.3.1, the soft links 1.5.0 produces in libexec break due to the libkapi-hasher binary (the actual bin) being installed across package boundaries. Fix this by installing hard links in /usr/bin aliasing libkapi-hasher to sha512hmac and the other old bin names. Package libkapi-hasher in libkcapi-hmaccalc since it is required for integrity check. 

It seems that libkapi-hasher itself can be used to generate the hmac calculations. This is preferred to using the mock openssl hashers as it removes the need for openssl, openssl measurements in the initramfs. Instead, just add measurements for libkapi.so.1 which are needed anyways for libkapi-hasher. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Install hard links from apps_hmaccalc to kcapi-hasher to
    resolve incompatibility with dracut.
- Install sha512hmac measurement of libkcapi.so.ver in /lib/hmaccalc dir
    to satisfy kcapi-hasher self-check during initramfs fips check.
- Drop openssl helper scripts since we rely on kcapi-hasher instead.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with fips packages installed, enable fips=1, boot. Verify fips integrity was enforced. 
