### PR TITLE
dracut: Remove reference to zlib in dracut-fips module

### DIFF
--- a/SPECS/dracut/0011-Remove-reference-to-kernel-module-zlib-in-fips-module.patch
+++ b/SPECS/dracut/0011-Remove-reference-to-kernel-module-zlib-in-fips-module.patch
@@ -1,0 +1,27 @@
+From 7cb87bb5b37b570b9316281864fe1619ea4eab70 Mon Sep 17 00:00:00 2001
+From: Cameron Baird <cameronbaird@microsoft.com>
+Date: Wed, 29 May 2024 22:16:41 +0000
+Subject: [PATCH] Remove reference to kernel module zlib in fips module
+
+Remove reference to kernel module zlib (deprecated in kernel v4.6+) since the 
+pedantic dracut behavior causes initramfs generation to fail otherwise.
+---
+ modules.d/01fips/module-setup.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules.d/01fips/module-setup.sh b/modules.d/01fips/module-setup.sh
+index a3e56020..48509077 100755
+--- a/modules.d/01fips/module-setup.sh
++++ b/modules.d/01fips/module-setup.sh
+@@ -30,7 +30,7 @@ installkernel() {
+         _fipsmodules+="ecb cbc ctr xts gcm ccm authenc hmac cmac ofb cts "
+ 
+         # Compression algs:
+-        _fipsmodules+="deflate lzo zlib "
++        _fipsmodules+="deflate lzo "
+ 
+         # PRNG algs:
+         _fipsmodules+="ansi_cprng "
+-- 
+2.34.1
+

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        059
-Release:        17%{?dist}
+Release:        18%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -132,6 +132,10 @@ mkdir -p %{buildroot}/boot/%{name} \
 install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-fips.conf
 > %{buildroot}%{_sysconfdir}/system-fips
 
+# Remove reference to kernel module zlib (deprecated in kernel v4.6+) since the 
+# pedantic dracut behavior causes initramfs generation to fail otherwise.
+sed -i 's/zlib//g' %{buildroot}%{dracutlibdir}/modules.d/01fips/module-setup.sh
+
 install -m 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/dracut.conf.d/50-megaraid.conf
 install -m 0644 %{SOURCE6} %{buildroot}%{_sysconfdir}/dracut.conf.d/00-defaults.conf
 
@@ -217,6 +221,10 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Tue May 28 2024 Cameron Baird <cameronbaird@microsoft.com> - 059-18
+- Remove reference to zlib from dracut-fips module setup to address
+    pedantic initramfs regeneration behavior
+
 * Thu May 03 2024 Rachel Menge <rachelmenge@microsoft.com> - 059-17
 - Patch microcode output check based on CONFIG_MICROCODE_AMD/INTEL
 

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -33,6 +33,7 @@ Patch:          0007-feat-dracut.sh-support-multiple-config-dirs.patch
 Patch:          0008-fix-dracut-systemd-rootfs-generator-cannot-write-out.patch
 Patch:          0009-install-systemd-executor.patch
 Patch:          0010-fix-remove-microcode-check-based-on-CONFIG_MICROCODE_AMD-INTEL.patch
+Patch:          0011-Remove-reference-to-kernel-module-zlib-in-fips-module.patch
 
 BuildRequires:  bash
 BuildRequires:  kmod-devel
@@ -131,10 +132,6 @@ mkdir -p %{buildroot}/boot/%{name} \
 
 install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-fips.conf
 > %{buildroot}%{_sysconfdir}/system-fips
-
-# Remove reference to kernel module zlib (deprecated in kernel v4.6+) since the 
-# pedantic dracut behavior causes initramfs generation to fail otherwise.
-sed -i 's/zlib//g' %{buildroot}%{dracutlibdir}/modules.d/01fips/module-setup.sh
 
 install -m 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/dracut.conf.d/50-megaraid.conf
 install -m 0644 %{SOURCE6} %{buildroot}%{_sysconfdir}/dracut.conf.d/00-defaults.conf


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
In 3.0-dev, Dracut will fail early during initramfs regeneration in the case that a kernel module is not found. This presents a problem as the dracut-fips module is still searching for zlib, which has long since been deprecated as a buildable module in kernel since v4.6. 

Remove reference to zlib from dracut-fips module setup to address pedantic initramfs regeneration behavior.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove reference to zlib from dracut-fips module

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- See that initramfs is successfully built with this version of dracut in fips images (core-fips.json)
