### PR TITLE
[WIP] enable uname -i/-p patch for coreutils 9.4

### DIFF
--- a/SPECS/coreutils/coreutils-9.4-uname-1.patch
+++ b/SPECS/coreutils/coreutils-9.4-uname-1.patch
@@ -1,0 +1,70 @@
+From e92876a5257bc762eb61c2f12f0338be493ab939 Mon Sep 17 00:00:00 2001
+From: Rachel Menge <rachelmenge@microsoft.com>
+Date: Wed, 29 May 2024 22:27:32 +0000
+Subject: [PATCH] coreutils-9.4 uname patch for -i and -p
+
+Original commit info:
+
+Submitted by: William Immendorf <will.immendorf@gmail.com>
+Date: 2010-05-08
+Inital Package Version: 8.5
+Origin: http://cvs.fedoraproject.org/viewvc/devel/coreutils/coreutils-8.2-uname-processortype.patch
+Upstream Status: Rejected
+Description: Fixes the output of uname's -i and -p parameters
+---
+ src/uname.c | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/src/uname.c b/src/uname.c
+index 883b9a4..78641bf 100644
+--- a/src/uname.c
++++ b/src/uname.c
+@@ -313,7 +313,7 @@ main (int argc, char **argv)
+ 
+   if (toprint & PRINT_PROCESSOR)
+     {
+-      char const *element = unknown;
++      char *element = unknown;
+ #ifdef __APPLE__
+ # if defined __arm__ || defined __arm64__
+       element = "arm";
+@@ -330,6 +330,12 @@ main (int argc, char **argv)
+           if (0 <= sysinfo (SI_ARCHITECTURE, processor, sizeof processor))
+             element = processor;
+         }
++#else
++      {
++	struct utsname u;
++	uname(&u);
++	element = u.machine;
++      }
+ #endif
+ #ifdef UNAME_PROCESSOR
+       if (element == unknown)
+@@ -347,7 +353,7 @@ main (int argc, char **argv)
+ 
+   if (toprint & PRINT_HARDWARE_PLATFORM)
+     {
+-      char const *element = unknown;
++      char *element = unknown;
+ #if HAVE_SYSINFO && defined SI_PLATFORM
+       {
+         static char hardware_platform[257];
+@@ -355,6 +361,14 @@ main (int argc, char **argv)
+                           hardware_platform, sizeof hardware_platform))
+           element = hardware_platform;
+       }
++#else
++      {
++	struct utsname u;
++	uname(&u);
++	element = u.machine;
++	if(strlen(element)==4 && element[0]=='i' && element[2]=='8' && element[3]=='6')
++		element[1]='3';
++      }
+ #endif
+ #ifdef UNAME_HARDWARE_PLATFORM
+       if (element == unknown)
+-- 
+2.34.1
+

--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:        Basic system utilities
 Name:           coreutils
 Version:        9.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,7 @@ Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.xz
 # make this package to own serial console profile since it utilizes stty tool
 Source1:        serial-console.sh
 Patch0:         coreutils-9.4-i18n-1.patch
+Patch1:         coreutils-9.4-uname-1.patch
 BuildRequires:  libselinux-devel
 BuildRequires:  libselinux-utils
 Requires:       gmp
@@ -91,6 +92,9 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
+* Wed May 29 2024 Rachel Menge <rachelmenge@microsoft.com> - 9.4-3
+- Add patch to support the -i and -p uname flags
+
 * Wed Mar 20 2024 Dan Streetman <ddstreet@microsoft.com> - 9.4-2
 - fix serial-console.sh
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -41,8 +41,8 @@ ncurses-libs-6.4-2.azl3.aarch64.rpm
 ncurses-term-6.4-2.azl3.aarch64.rpm
 readline-8.2-1.azl3.aarch64.rpm
 readline-devel-8.2-1.azl3.aarch64.rpm
-coreutils-9.4-2.azl3.aarch64.rpm
-coreutils-lang-9.4-2.azl3.aarch64.rpm
+coreutils-9.4-3.azl3.aarch64.rpm
+coreutils-lang-9.4-3.azl3.aarch64.rpm
 bash-5.2.15-1.azl3.aarch64.rpm
 bash-devel-5.2.15-1.azl3.aarch64.rpm
 bash-lang-5.2.15-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -41,8 +41,8 @@ ncurses-libs-6.4-2.azl3.x86_64.rpm
 ncurses-term-6.4-2.azl3.x86_64.rpm
 readline-8.2-1.azl3.x86_64.rpm
 readline-devel-8.2-1.azl3.x86_64.rpm
-coreutils-9.4-2.azl3.x86_64.rpm
-coreutils-lang-9.4-2.azl3.x86_64.rpm
+coreutils-9.4-3.azl3.x86_64.rpm
+coreutils-lang-9.4-3.azl3.x86_64.rpm
 bash-5.2.15-1.azl3.x86_64.rpm
 bash-devel-5.2.15-1.azl3.x86_64.rpm
 bash-lang-5.2.15-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -47,9 +47,9 @@ chkconfig-debuginfo-1.25-1.azl3.aarch64.rpm
 chkconfig-lang-1.25-1.azl3.aarch64.rpm
 cmake-3.28.2-5.azl3.aarch64.rpm
 cmake-debuginfo-3.28.2-5.azl3.aarch64.rpm
-coreutils-9.4-2.azl3.aarch64.rpm
-coreutils-debuginfo-9.4-2.azl3.aarch64.rpm
-coreutils-lang-9.4-2.azl3.aarch64.rpm
+coreutils-9.4-3.azl3.aarch64.rpm
+coreutils-debuginfo-9.4-3.azl3.aarch64.rpm
+coreutils-lang-9.4-3.azl3.aarch64.rpm
 cpio-2.14-1.azl3.aarch64.rpm
 cpio-debuginfo-2.14-1.azl3.aarch64.rpm
 cpio-lang-2.14-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -48,9 +48,9 @@ chkconfig-debuginfo-1.25-1.azl3.x86_64.rpm
 chkconfig-lang-1.25-1.azl3.x86_64.rpm
 cmake-3.28.2-5.azl3.x86_64.rpm
 cmake-debuginfo-3.28.2-5.azl3.x86_64.rpm
-coreutils-9.4-2.azl3.x86_64.rpm
-coreutils-debuginfo-9.4-2.azl3.x86_64.rpm
-coreutils-lang-9.4-2.azl3.x86_64.rpm
+coreutils-9.4-3.azl3.x86_64.rpm
+coreutils-debuginfo-9.4-3.azl3.x86_64.rpm
+coreutils-lang-9.4-3.azl3.x86_64.rpm
 cpio-2.14-1.azl3.x86_64.rpm
 cpio-debuginfo-2.14-1.azl3.x86_64.rpm
 cpio-lang-2.14-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Support a non-upstream patch which enables the -i/-p options for uname. This patch was originally created by Fedora who
has since [removed the patch](https://src.fedoraproject.org/rpms/coreutils/c/cd953e11dd78cada371f0389171cea671949141b?branch=rawhide) on their side.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/50070147 

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=578372&view=results
