### PR TITLE
Fixing toolchain rebuilds for delta builds. (CP: #8680)

### DIFF
--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -266,15 +266,28 @@ build_rpm_in_chroot_no_install () {
     rpmMacros=("${SHARED_RPM_MACROS[@]}" -D "_sourcedir $specDir")
     builtRpms="$(rpmspec -q $specPath --builtrpms "${rpmMacros[@]}" --queryformat="%{nvra}.rpm\n")"
 
-    # Find all the associated RPMs for the SRPM and check if they are in the chroot RPM directory
-    foundAllRPMs="false"
-    if [ "$INCREMENTAL_TOOLCHAIN" = "y" ]; then
-        foundAllRPMs="true"
+    builtEarlier=false
+    if grep -qP "^$1\$" $TEMP_BUILT_SPECS_LIST; then
+        builtEarlier=true
+    fi
+
+    # If a package was built earlier and we try to build it again,
+    # it means the earlier builds happened while only a subset of its build-time dependencies were available.
+    # Later builds are expected to have more/all dependencies available, so we rebuild the package.
+    #
+    # If the incremental build skipped the first build, it means the final version of the package
+    # was present from the beginning, so we skip further build attempts as well.
+    skipBuild=false
+    if $builtEarlier; then
+        echo "Package '$1' was built earlier. Skipping incremental toolchain check and building again."
+    elif [ "$INCREMENTAL_TOOLCHAIN" = "y" ]; then
+        # Find all the associated RPMs for the SRPM and check if they are in the chroot RPM directory.
+        skipBuild=true
         for rpm in $builtRpms; do
             rpmPath=$(find $CHROOT_RPMS_DIR -name "$rpm" -print -quit)
             if [ -z "$rpmPath" ]; then
                 echo "Did not find incremental toolchain rpm '$rpm' in '$CHROOT_RPMS_DIR', must rebuild."
-                foundAllRPMs="false"
+                skipBuild=false
                 break
             else
                 cp $rpmPath $FINISHED_RPM_DIR
@@ -282,7 +295,7 @@ build_rpm_in_chroot_no_install () {
         done
     fi
 
-    if [ "$foundAllRPMs" = "false" ]; then
+    if ! $skipBuild; then
         echo only building RPM $1 within the chroot
         srpmName=$(rpmspec -q $specPath --srpm "${rpmMacros[@]}" --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm)
         srpmPath=$MARINER_INPUT_SRPMS_DIR/$srpmName


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

### Cherry pick of #8680.

Our delta toolchain builds were skipping a rebuild of a spec, which needed to build more than once in the toolchain phase (for example `pam` or `selinux`). Building more than once is required, if we couldn't provide the package with all of its required build-time dependencies, because these dependencies required that package to build them. Later builds are expected to run with more/all build-time dependencies where the final build should have all of them.

During the delta toolchain build, we would build the spec for the first time but later attempts would be skipped, because we'd check for the presence of the RPM files produced by the built spec. Since they were all present from the first build, all future ones were skipped.

The fix checks, if a spec was already built once. If so, we assume future build request for the same spec are necessary and skip the incremental toolchain build check and go straight to building.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Full dev delta build for 2.0](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=542661&view=results).