### PR TITLE
Image Customizer: Fix cloud-init ISO examples.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/iso.md
+++ b/toolkit/tools/imagecustomizer/docs/iso.md
@@ -76,28 +76,42 @@ cloud-init data files).
 If cloud-init data is to be placed directly within the iso file system:
 
 ```yaml
+scripts:
+  postCustomization:
+  - content: |
+      set -e
+      mkdir -p /var/lib/cloud/seed/
+      ln -s -T /run/initramfs/live/cloud-init-data /var/lib/cloud/seed/nocloud 
+
 iso:
   additionalFiles:
     cloud-init-data/user-data: /cloud-init-data/user-data
     cloud-init-data/network-config: /cloud-init-data/network-config
     cloud-init-data/meta-data: /cloud-init-data/meta-data
+
   kernelCommandLine:
-    ExtraCommandLine: "'ds=nocloud;s=file://run/initramfs/live/cloud-init-data'"
+    extraCommandLine: "ds=nocloud"
 ```
+
+Note: It is tempting to specify
+`extraCommandLine: "'ds=nocloud;seedfrom=file://run/initramfs/live/cloud-init-data'"`,
+instead of using a symbolic link.
+But cloud-init ignores the `network-config` file when you use `seedfrom`.
+See, cloud-init issue [#3307](https://github.com/canonical/cloud-init/issues/3307).
 
 #### Example 2
 
 If cloud-init data is to be placed within the LiveOS root file system:
 
 ```yaml
-iso:
-  kernelCommandLine:
-    extraCommandLine: "'ds=nocloud;s=file://cloud-init-data'"
 os:
+  kernelCommandLine:
+    extraCommandLine: "ds=nocloud"
+
   additionalFiles:
-    cloud-init-data/user-data: /cloud-init-data/user-data
-    cloud-init-data/network-config: /cloud-init-data/network-config
-    cloud-init-data/meta-data: /cloud-init-data/meta-data
+    cloud-init-data/user-data: /var/lib/cloud/seed/nocloud/user-data
+    cloud-init-data/network-config: /var/lib/cloud/seed/nocloud/network-config
+    cloud-init-data/meta-data: /var/lib/cloud/seed/nocloud/meta-data
 ```
 
 ## Input Image Layout Assumptions

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/cloud-init-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/cloud-init-config.yaml
@@ -1,0 +1,8 @@
+os:
+  additionalFiles:
+    files/cloud-init/user-data: /var/lib/cloud/seed/nocloud/user-data
+    files/cloud-init/network-config: /var/lib/cloud/seed/nocloud/network-config
+    files/cloud-init/meta-data: /var/lib/cloud/seed/nocloud/meta-data
+
+  kernelCommandLine:
+    extraCommandLine: "ds=nocloud"

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/cloud-init-iso-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/cloud-init-iso-config.yaml
@@ -1,0 +1,15 @@
+scripts:
+  postCustomization:
+  - content: |
+      set -e
+      mkdir -p /var/lib/cloud/seed/
+      ln -s -T /run/initramfs/live/cloud-init-data /var/lib/cloud/seed/nocloud 
+
+iso:
+  additionalFiles:
+    files/cloud-init/user-data: /cloud-init-data/user-data
+    files/cloud-init/network-config: /cloud-init-data/network-config
+    files/cloud-init/meta-data: /cloud-init-data/meta-data
+
+  kernelCommandLine:
+    extraCommandLine: "ds=nocloud"

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/files/cloud-init/meta-data
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/files/cloud-init/meta-data
@@ -1,0 +1,1 @@
+local-hostname: testmachine

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/files/cloud-init/network-config
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/files/cloud-init/network-config
@@ -1,0 +1,3 @@
+network:
+  version: 2
+  ethernets: {}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/files/cloud-init/user-data
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/files/cloud-init/user-data
@@ -1,0 +1,9 @@
+#cloud-config
+users:
+- name: test
+  shell: /bin/bash
+  sudo:
+  - "ALL=(ALL) NOPASSWD:ALL"
+  groups:
+  - sudo
+  - docker


### PR DESCRIPTION
There is a behavior in cloud-init where if you use the `seedfrom` arg on the kernel command-line, then the `network-config` file is ignored. So, change the example ISO configs that embed cloud-init configs to a solution that doesn't ignore the `network-config` file.

Also, add a couple of test ISO config files.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

n/a
