### PR TITLE
Image Customizer: Modify /etc/selinux/config on SELinux disable.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -64,10 +64,10 @@ const (
 	// SELinuxConfigEnforcing is the string value to set SELinux to enforcing in the /etc/selinux/config file.
 	SELinuxConfigEnforcing = "enforcing"
 
-	// SELinuxConfigEnforcing is the string value to set SELinux to permissive in the /etc/selinux/config file.
+	// SELinuxConfigPermissive is the string value to set SELinux to permissive in the /etc/selinux/config file.
 	SELinuxConfigPermissive = "permissive"
 
-	// SELinuxConfigEnforcing is the string value to set SELinux to disabled in the /etc/selinux/config file.
+	// SELinuxConfigDisabled is the string value to set SELinux to disabled in the /etc/selinux/config file.
 	SELinuxConfigDisabled = "disabled"
 
 	// GrubCfgFile is the filepath of the grub config file.

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1812,6 +1812,8 @@ func SELinuxUpdateConfig(selinuxMode configuration.SELinux, installChroot *safec
 		mode = SELinuxConfigEnforcing
 	case configuration.SELinuxPermissive:
 		mode = SELinuxConfigPermissive
+	case configuration.SELinuxOff:
+		mode = SELinuxConfigDisabled
 	}
 
 	selinuxConfigPath := filepath.Join(installChroot.RootDir(), SELinuxConfigFile)


### PR DESCRIPTION
Currently, when the image customizer disables SELinux in an image it doesn't bother modifying the `/etc/selinux/config` file and instead only modifies the kernel command-line args. While this is technically fine, it is confusing for the user. So, this change fixes this so that `/etc/selinux/config` is kept in sync with the kernel command-line args.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

