### PR TITLE
cryptsetup: fix package build error

### DIFF
--- a/SPECS/cryptsetup/cryptsetup.spec
+++ b/SPECS/cryptsetup/cryptsetup.spec
@@ -139,6 +139,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %files libs -f cryptsetup.lang
 %license COPYING COPYING.LGPL
 %{_libdir}/libcryptsetup.so.*
+%exclude %{_tmpfilesdir}/cryptsetup.conf
 %ghost %dir /run/cryptsetup
 
 %files ssh-token


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix package build error seen in 3.0-dev.
```
                time="2024-05-29T12:35:52Z" level=info msg="Failed SRPMs:" 
                time="2024-05-29T12:35:52Z" level=info msg="--> cryptsetup-2.4.3-6.azl3.src.rpm , error: exit status 2, for details see: /mnt/vss/_work/1/s/outDir/build/logs/pkggen/rpmbuilding/cryptsetup-2.4.3-6.azl3.src.rpm.log" 
                time="2024-05-29T12:35:52Z" level=info msg="--> perl-Net-SSLeay-1.92-3.azl3.src.rpm , error: exit status 2, for details see: /mnt/vss/_work/1/s/outDir/build/logs/pkggen/rpmbuilding/perl-Net-SSLeay-1.92-3.azl3.src.rpm.log" 
                time="2024-05-29T10:03:25Z" level=debug msg="RPM build errors:"
                time="2024-05-29T10:03:25Z" level=debug msg="error: Installed (but unpackaged) file(s) found:"
                time="2024-05-29T10:03:25Z" level=debug msg="   /usr/lib/tmpfiles.d/cryptsetup.conf"
```
Seems to be caused by #9172 
Not bumping release number since the package hasn't built yet

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change cryptsetup.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=578996&view=results
