### PR TITLE
[mic][iso] Add support for Azure Linux 3.0 images

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -88,7 +88,7 @@ func (b *BootCustomizer) getSELinuxModeFromGrub() (imagecustomizerapi.SELinuxMod
 			return "", err
 		}
 	} else {
-		args, _, err = getLinuxCommandLineArgs(b.grubCfgContent)
+		args, _, err = getLinuxCommandLineArgs(b.grubCfgContent, true /*requireKernelOpts*/)
 		if err != nil {
 			return imagecustomizerapi.SELinuxModeDefault, err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
@@ -31,16 +31,30 @@ const (
 	selinuxConfigModeRegexSELinuxMode = 1
 )
 
-// Looks for a command with the provided name and ensures there is only 1 such command.
-// Returns the line of the found command.
-func findSingularGrubCommand(inputGrubCfgContent string, commandName string) (grub.Line, error) {
+// Looks for all occurences of a command with the provided name.
+// Returns the lines containing the command.
+func findGrubCommandAll(inputGrubCfgContent string, commandName string) ([]grub.Line, error) {
 	grubTokens, err := grub.TokenizeConfig(inputGrubCfgContent)
 	if err != nil {
-		return grub.Line{}, err
+		return nil, err
 	}
 
 	grubLines := grub.SplitTokensIntoLines(grubTokens)
 	lines := grub.FindCommandAll(grubLines, commandName)
+	if len(lines) < 1 {
+		return nil, fmt.Errorf("failed to find the '%s' command in grub config", commandName)
+	}
+
+	return lines, nil
+}
+
+// Looks for a command with the provided name and ensures there is only 1 such command.
+// Returns the line of the found command.
+func findSingularGrubCommand(inputGrubCfgContent string, commandName string) (grub.Line, error) {
+	lines, err := findGrubCommandAll(inputGrubCfgContent, commandName)
+	if err != nil {
+		return grub.Line{}, err
+	}
 	if len(lines) < 1 {
 		return grub.Line{}, fmt.Errorf("failed to find the '%s' command in grub config", commandName)
 	}
@@ -52,16 +66,22 @@ func findSingularGrubCommand(inputGrubCfgContent string, commandName string) (gr
 	return line, nil
 }
 
-// Finds the search command and replaces it.
-func replaceSearchCommand(inputGrubCfgContent string, searchCommand string) (outputGrubCfgContent string, err error) {
-	searchLine, err := findSingularGrubCommand(inputGrubCfgContent, "search")
+// Finds all search command occurences and replaces them.
+func replaceSearchCommandAll(inputGrubCfgContent string, newSearchCommand string) (outputGrubCfgContent string, err error) {
+	lines, err := findGrubCommandAll(inputGrubCfgContent, "search")
 	if err != nil {
 		return "", err
 	}
-
-	start := searchLine.Tokens[0].Loc.Start.Index
-	end := searchLine.Tokens[len(searchLine.Tokens)-1].Loc.Start.Index
-	outputGrubCfgContent = inputGrubCfgContent[:start] + searchCommand + inputGrubCfgContent[end:]
+	outputGrubCfgContent = inputGrubCfgContent
+	// loop from last to first so that the captured locations from
+	// findGrubCommandAll are not invalidated as reconstructing
+	// outputGrubCfgContent.
+	for i := len(lines); i > 0; i = i - 1 {
+		line := lines[i-1]
+		start := line.Tokens[0].Loc.Start.Index
+		end := line.EndToken.Loc.Start.Index
+		outputGrubCfgContent = outputGrubCfgContent[:start] + newSearchCommand + outputGrubCfgContent[end:]
+	}
 
 	return outputGrubCfgContent, nil
 }
@@ -95,18 +115,48 @@ func replaceToken(inputGrubCfgContent string, oldToken string, newToken string) 
 	return outputGrubCfgContent, nil
 }
 
+// Find all occurences of the linux command within the grub config file.
+func findLinuxLineAll(inputGrubCfgContent string) ([]grub.Line, error) {
+	lines, err := findGrubCommandAll(inputGrubCfgContent, "linux")
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(lines); i = i + 1 {
+		if len(lines[i].Tokens) < 2 {
+			return nil, fmt.Errorf("grub config 'linux' command is missing file path arg")
+		}
+	}
+	return lines, nil
+}
+
 // Find the linux command within the grub config file.
 func findLinuxLine(inputGrubCfgContent string) (grub.Line, error) {
-	linuxLine, err := findSingularGrubCommand(inputGrubCfgContent, "linux")
+	lines, err := findLinuxLineAll(inputGrubCfgContent)
 	if err != nil {
 		return grub.Line{}, err
 	}
+	if len(lines) < 1 {
+		return grub.Line{}, fmt.Errorf("failed to find the 'linux' command in grub config")
+	}
+	if len(lines) > 1 {
+		return grub.Line{}, fmt.Errorf("more than one 'linux' command in grub config")
+	}
+	return lines[0], nil
+}
 
-	if len(linuxLine.Tokens) < 2 {
-		return grub.Line{}, fmt.Errorf("grub config 'linux' command is missing file path arg")
+// Find all occurences of the initrd command within the grub config file.
+func findInitrdLineAll(inputGrubCfgContent string) ([]grub.Line, error) {
+	initrdLines, err := findGrubCommandAll(inputGrubCfgContent, "initrd")
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(initrdLines); i = i + 1 {
+		if len(initrdLines[i].Tokens) < 2 {
+			return nil, fmt.Errorf("grub config 'initrd' command is missing file path arg")
+		}
 	}
 
-	return linuxLine, nil
+	return initrdLines, nil
 }
 
 // Overrides the path of the kernel binary of the linux command within a grub config file.
@@ -126,6 +176,31 @@ func setLinuxPath(inputGrubCfgContent string, linuxPath string) (outputGrubCfgCo
 	outputGrubCfgContent = inputGrubCfgContent[:start] + quotedLinuxPath + inputGrubCfgContent[end:]
 
 	return outputGrubCfgContent, oldKernelPath, nil
+}
+
+// Overrides the path of the kernel binary of all the linux commands within a grub config file.
+func setLinuxPathAll(inputGrubCfgContent string, linuxPath string) (outputGrubCfgContent string, err error) {
+	quotedLinuxPath := grub.QuoteString(linuxPath)
+
+	lines, err := findLinuxLineAll(inputGrubCfgContent)
+	if err != nil {
+		return "", err
+	}
+
+	outputGrubCfgContent = inputGrubCfgContent
+	// loop from last to first so that the captured locations from
+	// findGrubCommandAll are not invalidated as reconstructing
+	// outputGrubCfgContent.
+	for i := len(lines); i > 0; i = i - 1 {
+		line := lines[i-1]
+		linuxFilePathToken := line.Tokens[1]
+		start := linuxFilePathToken.Loc.Start.Index
+		end := linuxFilePathToken.Loc.End.Index
+
+		outputGrubCfgContent = outputGrubCfgContent[:start] + quotedLinuxPath + outputGrubCfgContent[end:]
+	}
+
+	return outputGrubCfgContent, nil
 }
 
 // Overrides the path of the initramfs file of the initrd command within a grub config file.
@@ -151,6 +226,31 @@ func setInitrdPath(inputGrubCfgContent string, initrdPath string) (outputGrubCfg
 	return outputGrubCfgContent, oldInitrdPath, nil
 }
 
+// Overrides the path of the initramfs file of all the initrd commands within a grub config file.
+func setInitrdPathAll(inputGrubCfgContent string, initrdPath string) (outputGrubCfgContent string, err error) {
+	quotedInitrdPath := grub.QuoteString(initrdPath)
+
+	lines, err := findInitrdLineAll(inputGrubCfgContent)
+	if err != nil {
+		return "", err
+	}
+
+	outputGrubCfgContent = inputGrubCfgContent
+	// loop from last to first so that the captured locations from
+	// findGrubCommandAll are not invalidated as reconstructing
+	// outputGrubCfgContent.
+	for i := len(lines); i > 0; i = i - 1 {
+		line := lines[i-1]
+		initrdFilePathToken := line.Tokens[1]
+		start := initrdFilePathToken.Loc.Start.Index
+		end := initrdFilePathToken.Loc.End.Index
+
+		outputGrubCfgContent = outputGrubCfgContent[:start] + quotedInitrdPath + outputGrubCfgContent[end:]
+	}
+
+	return outputGrubCfgContent, nil
+}
+
 // Appends kernel command-line args to the linux command within a grub config file.
 func appendKernelCommandLineArgs(inputGrubCfgContent string, extraCommandLine string) (outputGrubCfgContent string, err error) {
 	_, insertAt, err := getLinuxCommandLineArgs(inputGrubCfgContent)
@@ -160,6 +260,38 @@ func appendKernelCommandLineArgs(inputGrubCfgContent string, extraCommandLine st
 
 	// Insert args at the end of the line.
 	outputGrubCfgContent = inputGrubCfgContent[:insertAt] + extraCommandLine + " " + inputGrubCfgContent[insertAt:]
+	return outputGrubCfgContent, nil
+}
+
+// Appends kernel command-line args to the linux command within a grub config file.
+// If $kernelopts is present, extraCommandLine is inserted before $kernelopts.
+// If $kernelopts is not present, extraCommandLine is appended at the end.
+func appendKernelCommandLineArgsAll(inputGrubCfgContent string, extraCommandLine string) (outputGrubCfgContent string, err error) {
+
+	lines, err := findLinuxLineAll(inputGrubCfgContent)
+	if err != nil {
+		return "", err
+	}
+
+	outputGrubCfgContent = inputGrubCfgContent
+	// loop from last to first so that the captured locations from
+	// findGrubCommandAll are not invalidated as reconstructing
+	// outputGrubCfgContent.
+	for i := len(lines); i > 0; i = i - 1 {
+		line := lines[i-1]
+
+		// Skip the "linux" command and the kernel binary path arg.
+		argTokens := line.Tokens[2:]
+
+		insertAt, err := findCommandLineInsertAt(argTokens, false /*requireKernelOpts*/)
+		if err != nil {
+			return "", err
+		}
+
+		// Insert args at the end of the line.
+		outputGrubCfgContent = outputGrubCfgContent[:insertAt] + extraCommandLine + " " + outputGrubCfgContent[insertAt:]
+	}
+
 	return outputGrubCfgContent, nil
 }
 
@@ -189,7 +321,7 @@ func getLinuxCommandLineArgs(grub2Config string) ([]grubConfigLinuxArg, int, err
 	// Skip the "linux" command and the kernel binary path arg.
 	argTokens := linuxLine.Tokens[2:]
 
-	insertAt, err := findCommandLineInsertAt(argTokens)
+	insertAt, err := findCommandLineInsertAt(argTokens, true /*requireKernelOpts*/)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -203,8 +335,11 @@ func getLinuxCommandLineArgs(grub2Config string) ([]grubConfigLinuxArg, int, err
 }
 
 // Takes a tokenized grub.cfg file and looks for an appropriate place to insert new args.
-// Specifically, it looks for the index of the $kernelopts args.
-func findCommandLineInsertAt(argTokens []grub.Token) (int, error) {
+// If $kernelopts is present, it returns its location for insertion.
+// If $kernelopts is absent,
+// - If requireKernelOpts is true, it fails (could not find required $kernelopts).
+// - If requireKernelOpts is false, it returns the location after the last token.
+func findCommandLineInsertAt(argTokens []grub.Token, requireKernelOpts bool) (int, error) {
 	insertAtTokens := []grub.Token(nil)
 	for i := range argTokens {
 		argToken := argTokens[i]
@@ -223,7 +358,13 @@ func findCommandLineInsertAt(argTokens []grub.Token) (int, error) {
 	}
 
 	if len(insertAtTokens) < 1 {
-		return 0, fmt.Errorf("failed to find $%s in linux command line", grubKernelOpts)
+		// Could not find the grubKernelOpts
+		if !requireKernelOpts && len(argTokens) > 0 {
+			// Try to insert at the very end as long as there are other tokens.
+			return argTokens[len(argTokens)-1].Loc.End.Index, nil
+		} else {
+			return 0, fmt.Errorf("failed to find $%s in linux command line", grubKernelOpts)
+		}
 	}
 	if len(insertAtTokens) > 1 {
 		return 0, fmt.Errorf("too many $%s tokens found in linux command line", grubKernelOpts)
@@ -357,6 +498,49 @@ func replaceKernelCommandLineArgValue(inputGrubCfgContent string, name string, v
 	return outputGrubCfgContent, oldValue, nil
 }
 
+func replaceKernelCommandLineArgValueAll(inputGrubCfgContent string, name string, value string,
+) (outputGrubCfgContent string, err error) {
+	newArg := fmt.Sprintf("%s=%s", name, value)
+	quotedNewArg := grub.QuoteString(newArg)
+
+	lines, err := findLinuxLineAll(inputGrubCfgContent)
+	if err != nil {
+		return "", err
+	}
+
+	outputGrubCfgContent = inputGrubCfgContent
+	// loop from last to first so that the captured locations from
+	// findGrubCommandAll are not invalidated as reconstructing
+	// outputGrubCfgContent.
+	for i := len(lines); i > 0; i = i - 1 {
+		line := lines[i-1]
+
+		// Skip the "linux" command and the kernel binary path arg.
+		argTokens := line.Tokens[2:]
+
+		args, err := parseCommandLineArgs(argTokens)
+		if err != nil {
+			return "", err
+		}
+
+		foundArgs := findMatchingCommandLineArgs(args, []string{name})
+		if len(foundArgs) < 1 {
+			return "", fmt.Errorf("failed to find kernel arg (%s)", name)
+		}
+		if len(foundArgs) > 1 {
+			return "", fmt.Errorf("too many instances of kernel arg found (%s)", name)
+		}
+
+		arg := foundArgs[0]
+		start := arg.Token.Loc.Start.Index
+		end := arg.Token.Loc.End.Index
+
+		outputGrubCfgContent = outputGrubCfgContent[:start] + quotedNewArg + outputGrubCfgContent[end:]
+	}
+
+	return outputGrubCfgContent, nil
+}
+
 // Finds all the kernel command-line args that match the provided names, then insert replacement arg(s).
 //
 // Params:
@@ -377,6 +561,39 @@ func updateKernelCommandLineArgs(grub2Config string, argsToRemove []string, newA
 		return "", err
 	}
 
+	return grub2Config, nil
+}
+
+func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, newArgs []string) (string, error) {
+	lines, err := findLinuxLineAll(grub2Config)
+	if err != nil {
+		return "", err
+	}
+
+	// loop from last to first so that the captured locations from
+	// findGrubCommandAll are not invalidated as reconstructing
+	// outputGrubCfgContent.
+	for i := len(lines); i > 0; i = i - 1 {
+		line := lines[i-1]
+
+		// Skip the "linux" command and the kernel binary path arg.
+		argTokens := line.Tokens[2:]
+
+		insertAtToken, err := findCommandLineInsertAt(argTokens, false /*requireKernelOpts*/)
+		if err != nil {
+			return "", err
+		}
+
+		args, err := parseCommandLineArgs(argTokens)
+		if err != nil {
+			return "", err
+		}
+
+		grub2Config, err = updateKernelCommandLineArgsHelper(grub2Config, args, insertAtToken, argsToRemove, newArgs)
+		if err != nil {
+			return "", err
+		}
+	}
 	return grub2Config, nil
 }
 
@@ -471,6 +688,20 @@ func updateSELinuxCommandLineHelper(grub2Config string, selinuxMode imagecustomi
 	return grub2Config, nil
 }
 
+func updateSELinuxCommandLineHelperAll(grub2Config string, selinuxMode imagecustomizerapi.SELinuxMode) (string, error) {
+	newSELinuxArgs, err := selinuxModeToArgs(selinuxMode)
+	if err != nil {
+		return "", err
+	}
+
+	grub2Config, err = updateKernelCommandLineArgsAll(grub2Config, selinuxArgNames, newSELinuxArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return grub2Config, nil
+}
+
 // Finds a set command that sets the variable with the provided name and then change the value that is set.
 func replaceSetCommandValue(grub2Config string, varName string, newValue string) (string, error) {
 	quotedNewValue := grub.QuoteString(newValue)
@@ -484,7 +715,7 @@ func replaceSetCommandValue(grub2Config string, varName string, newValue string)
 	setLines := grub.FindCommandAll(grubLines, "set")
 
 	// Search for all the set commands that set the variable.
-	setVarLines := [][]grub.Token(nil)
+	setVarLines := []grub.Line(nil)
 	for _, line := range setLines {
 		if len(line.Tokens) < 2 {
 			return "", fmt.Errorf("grub config has a set command that has zero args")
@@ -516,7 +747,7 @@ func replaceSetCommandValue(grub2Config string, varName string, newValue string)
 
 		// Check if the name matches.
 		if name == varName {
-			setVarLines = append(setVarLines, line.Tokens)
+			setVarLines = append(setVarLines, line)
 		}
 	}
 
@@ -531,7 +762,7 @@ func replaceSetCommandValue(grub2Config string, varName string, newValue string)
 	setVarLine := setVarLines[0]
 
 	// Override set command.
-	argToken := setVarLine[1]
+	argToken := setVarLine.Tokens[1]
 	start := argToken.Loc.Start.Index
 	end := argToken.Loc.End.Index
 	grub2Config = fmt.Sprintf("%s%s=%s%s", grub2Config[:start], varName, quotedNewValue, grub2Config[end:])

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
@@ -197,8 +197,13 @@ func appendKernelCommandLineArgsAll(inputGrubCfgContent string, extraCommandLine
 			return "", err
 		}
 
-		// Insert args at the end of the line.
-		outputGrubCfgContent = outputGrubCfgContent[:insertAt] + extraCommandLine + " " + outputGrubCfgContent[insertAt:]
+		leadingSpace := " "
+		if requireKernelOpts {
+			// When requireKernelOpts is true, we are inserting right before
+			// kernelOpts, and there is already an empty space.
+			leadingSpace = ""
+		}
+		outputGrubCfgContent = outputGrubCfgContent[:insertAt] + leadingSpace + extraCommandLine + " " + outputGrubCfgContent[insertAt:]
 	}
 
 	return outputGrubCfgContent, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -190,3 +190,13 @@ func callTdnf(tnfArgs []string, tdnfMessagePrefix string, imageChroot *safechroo
 			Execute()
 	})
 }
+
+func isPackageInstalled(imageChroot *safechroot.Chroot, packageName string) bool {
+	err := imageChroot.UnsafeRun(func() error {
+		return shell.ExecuteLive(true /*squashErrors*/, "rpm", "-qi", packageName)
+	})
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/defaultgrubutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/defaultgrubutils.go
@@ -164,7 +164,7 @@ func getDefaultGrubFileLinuxArgs(defaultGrubFileContent string, varName defaultG
 	if varName == defaultGrubFileVarNameCmdlineLinuxDefault {
 		// GRUB_CMDLINE_LINUX_DEFAULT variable has the $kernelopts arg.
 		// Any args inserted should be inserted before $kernelopts.
-		insertAt, err = findCommandLineInsertAt(grubTokens)
+		insertAt, err = findCommandLineInsertAt(grubTokens, true /*requireKernelOpts*/)
 		if err != nil {
 			err = fmt.Errorf("failed to parse %s's value args:\n%w", varName, err)
 			return defaultGrubFileVarAssign{}, nil, 0, err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -229,11 +229,6 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 		}
 	}()
 
-	err = updateConfig(imageCustomizerParameters)
-	if err != nil {
-		return err
-	}
-
 	// ensure build and output folders are created up front
 	err = os.MkdirAll(imageCustomizerParameters.buildDirAbs, os.ModePerm)
 	if err != nil {
@@ -307,20 +302,6 @@ func convertInputImageToWriteableFormat(ic *ImageCustomizerParameters) (*LiveOSI
 
 		return nil, nil
 	}
-}
-
-func updateConfig(ic *ImageCustomizerParameters) error {
-	// If we are converting vhd(x)/qcow to an iso, we need to make sure that
-	// the following packages are pre-installed for dracut live-os to work
-	// correctly.
-	if !ic.inputIsIso && ic.outputIsIso {
-		if ic.config.OS == nil {
-			ic.config.OS = &imagecustomizerapi.OS{}
-		}
-		ic.config.OS.Packages.Install =
-			append(ic.config.OS.Packages.Install, "squashfs-tools", "tar", "device-mapper")
-	}
-	return nil
 }
 
 func customizeOSContents(ic *ImageCustomizerParameters) error {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -229,6 +229,11 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 		}
 	}()
 
+	err = updateConfig(imageCustomizerParameters)
+	if err != nil {
+		return err
+	}
+
 	// ensure build and output folders are created up front
 	err = os.MkdirAll(imageCustomizerParameters.buildDirAbs, os.ModePerm)
 	if err != nil {
@@ -302,6 +307,20 @@ func convertInputImageToWriteableFormat(ic *ImageCustomizerParameters) (*LiveOSI
 
 		return nil, nil
 	}
+}
+
+func updateConfig(ic *ImageCustomizerParameters) error {
+	// If we are converting vhd(x)/qcow to an iso, we need to make sure that
+	// the following packages are pre-installed for dracut live-os to work
+	// correctly.
+	if !ic.inputIsIso && ic.outputIsIso {
+		if ic.config.OS == nil {
+			ic.config.OS = &imagecustomizerapi.OS{}
+		}
+		ic.config.OS.Packages.Install =
+			append(ic.config.OS.Packages.Install, "squashfs-tools", "tar", "device-mapper")
+	}
+	return nil
 }
 
 func customizeOSContents(ic *ImageCustomizerParameters) error {

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -315,7 +315,7 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigKernelArgsFilePath string, g
 		return fmt.Errorf("failed to update the root kernel argument in the iso grub.cfg:\n%w", err)
 	}
 
-	inputContentString, err = updateSELinuxCommandLineHelperAll(inputContentString, imagecustomizerapi.SELinuxModeDisabled)
+	inputContentString, err = updateSELinuxCommandLineHelperAll(inputContentString, imagecustomizerapi.SELinuxModeDisabled, true /*allowMultiple*/, false /*requireKernelOpts*/)
 	if err != nil {
 		return fmt.Errorf("failed to set SELinux mode:\n%w", err)
 	}
@@ -326,9 +326,9 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigKernelArgsFilePath string, g
 	}
 
 	liveosKernelArgs := fmt.Sprintf(kernelArgsLiveOSTemplate, liveOSDir, liveOSImage)
-	additionalKernelCommandline := " " + liveosKernelArgs + " " + mergedExtraCommandLine
+	additionalKernelCommandline := liveosKernelArgs + " " + mergedExtraCommandLine
 
-	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline, true /*allowMultiple*/)
+	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline, true /*allowMultiple*/, false /*requireKernelOpts*/)
 	if err != nil {
 		return fmt.Errorf("failed to update the kernel arguments with the LiveOS configuration and user configuration in the iso grub.cfg:\n%w", err)
 	}
@@ -707,7 +707,7 @@ func (b *LiveOSIsoBuilder) generateInitrdImage(rootfsSourceDir, artifactsSourceD
 	for _, requiredRpm := range requiredRpms {
 		logger.Log.Debugf("Checking if (%s) is installed", requiredRpm)
 		if !isPackageInstalled(chroot, requiredRpm) {
-			return fmt.Errorf("failed to find required package (%s). The following packages must be installed:%v", requiredRpm, requiredRpms)
+			return fmt.Errorf("package (%s) is not installed:\nthe following packages must be installed to generate an iso: %v", requiredRpm, requiredRpms)
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -315,7 +315,8 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigKernelArgsFilePath string, g
 		return fmt.Errorf("failed to update the root kernel argument in the iso grub.cfg:\n%w", err)
 	}
 
-	inputContentString, err = updateSELinuxCommandLineHelperAll(inputContentString, imagecustomizerapi.SELinuxModeDisabled, true /*allowMultiple*/, false /*requireKernelOpts*/)
+	inputContentString, err = updateSELinuxCommandLineHelperAll(inputContentString, imagecustomizerapi.SELinuxModeDisabled,
+		true /*allowMultiple*/, false /*requireKernelOpts*/)
 	if err != nil {
 		return fmt.Errorf("failed to set SELinux mode:\n%w", err)
 	}
@@ -328,7 +329,8 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigKernelArgsFilePath string, g
 	liveosKernelArgs := fmt.Sprintf(kernelArgsLiveOSTemplate, liveOSDir, liveOSImage)
 	additionalKernelCommandline := liveosKernelArgs + " " + mergedExtraCommandLine
 
-	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline, true /*allowMultiple*/, false /*requireKernelOpts*/)
+	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline,
+		true /*allowMultiple*/, false /*requireKernelOpts*/)
 	if err != nil {
 		return fmt.Errorf("failed to update the kernel arguments with the LiveOS configuration and user configuration in the iso grub.cfg:\n%w", err)
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change enables the generation of iso images from 3.0 Azure Linux images:
- Update dracut configuration
  - Explicitly set the no host-only configuration (new dmsquash-live requirement).
  - Include the `rd.live.overlay.overlayfs` kernel command line to create the overlay fs (new dmsquash-live requirement).
- Ensure pkgs required by dracut live os are installed
  -  dracut live os modules require the following pkgs: squashfs-tools, tar, "device-mapper. However, the 3.0 baremetal image does not have them pre-installed. The changes in this PR will check their presence, and if any is missing, the image build will stop and report and error.
- Update grub.cfg generation
  - The 3.0 grub.cfg has multiple menu entries, and each entry has a search/linux/initrd set of commands. This change updates our grub manipulation code to update all occurences.
  - In the past, we'd just store them in grub.cfg and re-use that grub.cfg for future customizations of the iso. We can no longer rely on grub.cfg because it gets regenerated with grub-mkconfig. To solve this problem, we're saving the user-provided iso kernel parameters to a file on the iso and re-using that saved copy when building a new iso from an existing one.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- [Add MIC ISO suport for Azure Linux 3.0 images.](https://github.com/microsoft/azurelinux/pull/9283/commits/60f86437f8f674f149a9e6053246796d7dd6f4cd)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- none

###### Links to CVEs  <!-- optional -->
- none

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Testing
  - Base Images {2.0, 3.0}
    - Phase 1: vhdx->iso { os and so, iso-only}
    - Phase 2: iso->iso { os and iso, iso-only}
  - 'os' means kernel arguments under the os configuration.
  - 'iso' means kernel arguments under the iso configuration.
