### PR TITLE
Fix CVE-2024-3154 in package cri-o

### DIFF
--- a/SPECS/cri-o/CVE-2024-3154.patch
+++ b/SPECS/cri-o/CVE-2024-3154.patch
@@ -1,0 +1,38 @@
+From 976ab1f4c916099fc1f2e6569f13e45df2f26b4f Mon Sep 17 00:00:00 2001
+From: Peter Hunt <pehunt@redhat.com>
+Date: Tue, 26 Mar 2024 12:07:17 -0400
+Subject: [PATCH] annotations: add OCI runtime specific annotations to the
+ AllowedAnnotations
+
+meaning an admin would have to opt-into allowing them to be used
+
+Signed-off-by: Peter Hunt <pehunt@redhat.com>
+---
+ pkg/annotations/annotations.go | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/pkg/annotations/annotations.go b/pkg/annotations/annotations.go
+index 51920eb..e517f18 100644
+--- a/pkg/annotations/annotations.go
++++ b/pkg/annotations/annotations.go
+@@ -48,4 +48,17 @@ var AllAllowedAnnotations = []string{
+ 	OCISeccompBPFHookAnnotation,
+ 	rdt.RdtContainerAnnotation,
+ 	TrySkipVolumeSELinuxLabelAnnotation,
++	// Keep in sync with
++	// https://github.com/opencontainers/runc/blob/3db0871f1cf25c7025861ba0d51d25794cb21623/features.go#L67
++	// Once runc 1.2 is released, we can use the `runc features` command to get this programatically,
++	// but we should hardcode these for now to prevent misuse.
++	"bundle",
++	"org.systemd.property.",
++	"org.criu.config",
++
++	// Simiarly, keep in sync with
++	// https://github.com/containers/crun/blob/475a3fd0be/src/libcrun/container.c#L362-L366
++	"module.wasm.image/variant",
++	"io.kubernetes.cri.container-type",
++	"run.oci.",
+ }
+-- 
+2.33.8
+

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -1792,4 +1792,4 @@ mkdir -p /opt/cni/bin
 - Add cri-o package: CRI-O is meant to provide an integration path between OCI
   conformant runtimes and the kubelet. Specifically, it implements the Kubelet
   Container Runtime Interface (CRI) using OCI conformant runtimes. The scope of
-
+  CRI-O is tied to the scope of the CRI.

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.22.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -63,6 +63,7 @@ Patch7:         CVE-2022-21698.patch
 Patch8:         CVE-2023-44487.patch
 Patch9:         CVE-2024-28180.patch
 Patch10:        CVE-2024-21626.patch
+Patch11:        CVE-2024-3154.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  fdupes
@@ -215,6 +216,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Mon Jun 03 2024 Bala <balakumaran.kannan@microsoft.com> - 1.22.3-2
+- Patch CVE-2024-3154
+
 * Thu May 21 2024 Henry Li <lihl@microsoft.com> - 1.22.3-1
 - Upgrade to 1.22.3 to resolve regressed CVE-2022-0811
 - Updated vendor source tar
@@ -1788,4 +1792,4 @@ mkdir -p /opt/cni/bin
 - Add cri-o package: CRI-O is meant to provide an integration path between OCI
   conformant runtimes and the kubelet. Specifically, it implements the Kubelet
   Container Runtime Interface (CRI) using OCI conformant runtimes. The scope of
-  CRI-O is tied to the scope of the CRI.
+


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix CVE-2024-3154 in package cri-o

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2024-3154 for cri-o

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-3154

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=580253&view=results


Arbitrary sytemd pod annotations can be copied to the OCI. So, it may affect the host. So, explicitly hard-code the systemd annotations to AllAllowedAnnotations file.

Ref: [[annotations: add OCI runtime specific annotations to the AllowedAnnot… · haircommander/cri-o@976ab1f (github.com)](https://github.com/haircommander/cri-o/commit/976ab1f4c916099fc1f2e6569f13e45df2f26b4f)](https://github.com/haircommander/cri-o/commit/976ab1f4c916099fc1f2e6569f13e45df2f26b4f)

**Explanation:** ValidateRuntimeAllowedAnnotations function in pkg/config/config.go uses the following logic to validate the annotations.

1. add all annotations in AllAllowedAnnotations to a temporary disallowedAnnotations
2. loop through the allowed annotations, if it is in disallowedAnnotations, remove it from disallowedAnnotations.
3. If it is not there, return error as not an expected Annotations
4. The leftover disallowedAnnotations were added to the global DisallowedAnnotations list

If an unknown annotation is there, it is filtered in the step-3. So, it looks like an unknown annotation is flagged by the ValidateRuntimeAllowedAnnotations function. But it is not explicitly added to the DisallowedAnnotations variable. So, if the caller doesn’t honor the response of ValidateRuntimeAllowedAnnotations and just rely on DisallowedAnnotations, this patch is worth adding. But it looks like that is not possible, because upon an unknown annotations, the DisallowedAnnotations also will be partial.

Anyway adding the patch as it is not causing any harm.

*Note: If you can’t find the function grep for `AllAllowedAnnotations` in the entire repo.*

**Not patching the vendor packages:**

Below is the actual patch mentioned in the CVE websites.

[[features: implement returning potentiallyUnsafeConfigAnnotations list by AkihiroSuda · Pull Request #4217 · opencontainers/runc (github.com)](https://github.com/opencontainers/runc/pull/4217/commits/eefc6ae2544a6819da9f92c5aa8e65d356da4c96)](https://github.com/opencontainers/runc/pull/4217/commits/eefc6ae2544a6819da9f92c5aa8e65d356da4c96)

But it is not applicable to us. Because the file getting patched is features.go. But this file is not in the vendor package. Instead only the `libcontainer` directory was cloned into the `vendor/github.com/opencntainers/runc` directory. Also, it is not mentioned by the CVE tools as well. So, patching this not relevant to cri-o
