### PR TITLE
CVE-2022-34169: docbook-style-xsl - upgrade embedded xalan jar from 2.7.2 to 2.7.3

### DIFF
--- a/SPECS/docbook-style-xsl/docbook-style-xsl.signatures.json
+++ b/SPECS/docbook-style-xsl/docbook-style-xsl.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
-  "docbook-xsl-1.79.1.tar.bz2": "725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968"
+  "docbook-xsl-1.79.1.tar.bz2": "725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968",
+  "xalan-j_2_7_3-bin.tar.gz": "c3a36e027f91acbec3f2139343a4798a943f8b2957aab1cfb2eb57f4aeadccbc"  
  }
 }

--- a/SPECS/docbook-style-xsl/docbook-style-xsl.spec
+++ b/SPECS/docbook-style-xsl/docbook-style-xsl.spec
@@ -1,13 +1,15 @@
 Summary:        Docbook-xsl-1.79.1
 Name:           docbook-style-xsl
 Version:        1.79.1
-Release:        13%{?dist}
-License:        ASL 2.0
+Release:        14%{?dist}
+License:        DMIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://www.docbook.org
 Source0:        http://downloads.sourceforge.net/docbook/docbook-xsl-%{version}.tar.bz2
+# CVE-2022-34169: xalan 2.7.2 has security issue that is solved in 2.7.3
+Source1:        https://dlcdn.apache.org/xalan/xalan-j/binaries/xalan-j_2_7_3-bin.tar.gz
 BuildRequires:  libxml2
 BuildRequires:  zip
 Requires:       docbook-dtd-xml
@@ -24,6 +26,12 @@ allowing you to utilize transformations already written for that standard.
 
 %prep
 %setup -q -n docbook-xsl-%{version}
+# CVE-2022-34169: xalan 2.7.2 has security issue that is solved by 2.7.3,
+# so replace the embedded jar files in docbook-xsl release before continuing
+mkdir ./CVE-2022-34169
+tar -xf %{SOURCE1} -C ./CVE-2022-34169
+mv ./CVE-2022-34169/xalan-j_2_7_3/*.jar ./tools/lib/.
+rm -rf ./CVE-2022-34169
 
 %build
 zip -d tools/lib/jython.jar Lib/distutils/command/wininst-6.exe
@@ -102,6 +110,10 @@ fi
 %{_docdir}/*
 
 %changelog
+* Mon Jun 03 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 1.79.1-14
+- Fix CVE-2022-34169 by using newer release of xalan
+- License should be DMIT. License verified
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.79.1-10
 - Added %%license line automatically
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -197,7 +197,7 @@ createrepo_c-0.17.5-1.cm2.aarch64.rpm
 libxml2-2.10.4-3.cm2.aarch64.rpm
 libxml2-devel-2.10.4-3.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
-docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
+docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm
 glib-2.71.0-2.cm2.aarch64.rpm
 libltdl-2.4.6-8.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -197,7 +197,7 @@ createrepo_c-0.17.5-1.cm2.x86_64.rpm
 libxml2-2.10.4-3.cm2.x86_64.rpm
 libxml2-devel-2.10.4-3.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
-docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
+docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm
 glib-2.71.0-2.cm2.x86_64.rpm
 libltdl-2.4.6-8.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -56,7 +56,7 @@ debugedit-debuginfo-5.0-2.cm2.aarch64.rpm
 diffutils-3.8-2.cm2.aarch64.rpm
 diffutils-debuginfo-3.8-2.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
-docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
+docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 dwz-0.14-2.cm2.aarch64.rpm
 dwz-debuginfo-0.14-2.cm2.aarch64.rpm
 e2fsprogs-1.46.5-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -59,7 +59,7 @@ debugedit-debuginfo-5.0-2.cm2.x86_64.rpm
 diffutils-3.8-2.cm2.x86_64.rpm
 diffutils-debuginfo-3.8-2.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
-docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
+docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 dwz-0.14-2.cm2.x86_64.rpm
 dwz-debuginfo-0.14-2.cm2.x86_64.rpm
 e2fsprogs-1.46.5-3.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix for CVE-2022-34169 : embedded xalan jar 2.7.2 contains issue that is solved in 2.7.3.  Replace embedded jar.

###### Change Log  <!-- REQUIRED -->
- Uploaded xalan 2.7.3 release tarball containing new jars
- Updated SPEC file to download and overwrite existing 2.7.2 jar files
- Update SPEC license to DMIT

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://portal.microsofticm.com/imp/v3/incidents/incident/508269189/summary

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- BUDDY BUILD: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=580433&view=results
- REBUILD TOOLCHAIN and RPMS: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=580450&view=results 

Rebase 6/4
- BUDDY BUILD: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=581019&view=results
- REBUILD TOOLCHAIN and RPMS: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=581016&view=results
