### PR TITLE
Image Customizer: Simplify container build script.

### DIFF
--- a/toolkit/tools/imagecustomizer/container/build-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-mic-container.sh
@@ -11,31 +11,15 @@ function showUsage() {
     echo "usage:"
     echo
     echo "build-mic-container.sh \\"
-    echo "    -r <container-registry> \\"
-    echo "    -n <container-name> \\"
     echo "    -t <container-tag>"
     echo
 }
 
 while getopts ":r:n:t:" OPTIONS; do
   case "${OPTIONS}" in
-    r ) containerRegistery=$OPTARG ;;
-    n ) containerName=$OPTARG ;;
     t ) containerTag=$OPTARG ;;
   esac
 done
-
-if [[ -z $containerRegistery ]]; then
-    echo "missing required argument '-r containerRegistry'"
-    showUsage
-    exit 1
-fi
-
-if [[ -z $containerName ]]; then
-    echo "missing required argument '-n containerName'"
-    showUsage
-    exit 1
-fi
 
 if [[ -z $containerTag ]]; then
     echo "missing required argument '-t containerTag'"
@@ -57,7 +41,6 @@ trap 'cleanUp' ERR
 micLocalFile=$enlistmentRoot/toolkit/out/tools/imagecustomizer
 micContainerFolder=/usr/bin
 
-containerFullPath=$containerRegistery/$containerName:$containerTag
 dockerFile=$enlistmentRoot/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
 
 # stage those files that need to be in the container
@@ -67,7 +50,7 @@ touch ${containerStagingFolder}/.mariner-toolkit-ignore-dockerenv
 
 # build the container
 pushd $containerStagingFolder
-docker build -f $dockerFile . -t $containerFullPath
+docker build -f $dockerFile . -t "$containerTag"
 popd
 
 # clean-up

--- a/toolkit/tools/imagecustomizer/container/run-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/run-mic-container.sh
@@ -7,8 +7,6 @@ function showUsage() {
     echo "usage:"
     echo
     echo "build-mic-container.sh \\"
-    echo "    -r <container-registry> \\"
-    echo "    -n <container-name> \\"
     echo "    -t <container-tag> \\"
     echo "    -i <input-image-path> \\"
     echo "    -c <input-config-path> \\"
@@ -20,8 +18,6 @@ function showUsage() {
 
 while getopts ":r:n:t:i:c:f:o:l:" OPTIONS; do
   case "${OPTIONS}" in
-    r ) containerRegistery=$OPTARG ;;
-    n ) containerName=$OPTARG ;;
     t ) containerTag=$OPTARG ;;
     i ) inputImage=$OPTARG ;;
     c ) inputConfig=$OPTARG ;;
@@ -30,18 +26,6 @@ while getopts ":r:n:t:i:c:f:o:l:" OPTIONS; do
     l ) logLevel=$OPTARG ;;
   esac
 done
-
-if [[ -z $containerRegistery ]]; then
-    echo "missing required argument '-r containerRegistry'"
-    showUsage
-    exit 1
-fi
-
-if [[ -z $containerName ]]; then
-    echo "missing required argument '-n containerName'"
-    showUsage
-    exit 1
-fi
 
 if [[ -z $containerTag ]]; then
     echo "missing required argument '-t containerTag'"
@@ -79,8 +63,6 @@ fi
 
 # ---- main ----
 
-containerFullPath=$containerRegistery/$containerName:$containerTag
-
 inputImageDir=$(dirname $inputImage)
 inputConfigDir=$(dirname $inputConfig)
 outputImageDir=$(dirname $outputImage)
@@ -109,7 +91,7 @@ docker run --rm \
    -v $inputConfigDir:$containerInputConfigDir:z \
    -v $outputImageDir:$containerOutputDir:z \
    -v /dev:/dev \
-   $containerFullPath \
+   "$containerTag" \
    imagecustomizer \
       --image-file $containerInputImage \
       --config-file $containerInputConfig \


### PR DESCRIPTION
Change the `build-mic-container.sh` script to take the full container tag as a single param instead of as individual components. This makes the script more flexible and easier to use.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually built and ran Image Customizer container.

