### PR TITLE
setuplkgtoolchain: use uname -m instead of uname -p to get processor

### DIFF
--- a/toolkit/scripts/setuplkgtoolchain.sh
+++ b/toolkit/scripts/setuplkgtoolchain.sh
@@ -6,14 +6,14 @@ set -e
 
 ROOT_FOLDER=$(git rev-parse --show-toplevel)
 LKG_FILENAME="lkg-3.0-dev.json"
-PROCESSOR=$(uname -m)
+ARCHITECTURE=$(uname -m)
 
 trap cleanup EXIT
 
 usage() {
     echo "./setuplkgtoolchain.sh"
     echo " Syncs toolchain manifests to match LKG build"
-    echo " WARNING: can overwrite local changes to 'toolkit/resources/manifests/package/pkggen_core_${PROCESSOR}.txt' or 'toolchain_${PROCESSOR}.txt'"
+    echo " WARNING: can overwrite local changes to 'toolkit/resources/manifests/package/pkggen_core_${ARCHITECTURE}.txt' or 'toolchain_${ARCHITECTURE}.txt'"
     exit 1
 }
 
@@ -24,16 +24,16 @@ get_lkg() {
 }
 
 check_for_modified_manifests() {
-    if git status --porcelain | grep -qP "(pkggen_core|toolchain)_${PROCESSOR}.txt"; then
-        echo "Local modifications to 'pkggen_core_${PROCESSOR}.txt' or 'toolchain_${PROCESSOR}.txt' detected."
+    if git status --porcelain | grep -qP "(pkggen_core|toolchain)_${ARCHITECTURE}.txt"; then
+        echo "Local modifications to 'pkggen_core_${ARCHITECTURE}.txt' or 'toolchain_${ARCHITECTURE}.txt' detected."
         echo -e "\nNOTE: Changes to manifests were detected, and these will be overwritten. Hit Ctrl+C within 10 seconds to cancel...\n"
         sleep 10s
     fi
 }
 
 update_manifests() {
-    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/toolchain_${PROCESSOR}.txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/toolchain_${PROCESSOR}.txt
-    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/pkggen_core_${PROCESSOR}.txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/pkggen_core_${PROCESSOR}.txt
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/toolchain_${ARCHITECTURE}.txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/toolchain_${ARCHITECTURE}.txt
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/pkggen_core_${ARCHITECTURE}.txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/pkggen_core_${ARCHITECTURE}.txt
 }
 
 cleanup() {

--- a/toolkit/scripts/setuplkgtoolchain.sh
+++ b/toolkit/scripts/setuplkgtoolchain.sh
@@ -6,13 +6,14 @@ set -e
 
 ROOT_FOLDER=$(git rev-parse --show-toplevel)
 LKG_FILENAME="lkg-3.0-dev.json"
+PROCESSOR=$(uname -m)
 
 trap cleanup EXIT
 
 usage() {
     echo "./setuplkgtoolchain.sh"
     echo " Syncs toolchain manifests to match LKG build"
-    echo " WARNING: can overwrite local changes to 'toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt'"
+    echo " WARNING: can overwrite local changes to 'toolkit/resources/manifests/package/pkggen_core_${PROCESSOR}.txt' or 'toolchain_${PROCESSOR}.txt'"
     exit 1
 }
 
@@ -23,16 +24,16 @@ get_lkg() {
 }
 
 check_for_modified_manifests() {
-    if git status --porcelain | grep -qP "(pkggen_core|toolchain)_$(uname -p).txt"; then
-        echo "Local modifications to 'pkggen_core_$(uname -p).txt' or 'toolchain_$(uname -p).txt' detected."
+    if git status --porcelain | grep -qP "(pkggen_core|toolchain)_${PROCESSOR}.txt"; then
+        echo "Local modifications to 'pkggen_core_${PROCESSOR}.txt' or 'toolchain_${PROCESSOR}.txt' detected."
         echo -e "\nNOTE: Changes to manifests were detected, and these will be overwritten. Hit Ctrl+C within 10 seconds to cancel...\n"
         sleep 10s
     fi
 }
 
 update_manifests() {
-    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/toolchain_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/toolchain_$(uname -p).txt
-    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/pkggen_core_$(uname -p).txt
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/toolchain_${PROCESSOR}.txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/toolchain_${PROCESSOR}.txt
+    wget -nv https://raw.githubusercontent.com/microsoft/CBL-Mariner/$GIT_COMMIT/toolkit/resources/manifests/package/pkggen_core_${PROCESSOR}.txt -O $ROOT_FOLDER/toolkit/resources/manifests/package/pkggen_core_${PROCESSOR}.txt
 }
 
 cleanup() {


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Our `setuplkgtoolchain.sh` script uses `uname -p` which is non-portable and does not work in `azl3`. This change updates it to use `uname -m` which is the portable way to get the same information.

###### Change Log  <!-- REQUIRED -->
- Update to use `uname -m`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Locally tested that this works properly on `azl3` and `azl2`.
