### PR TITLE
Enable protobuf ptest

### DIFF
--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -13,6 +13,7 @@ BuildRequires:  libstdc++
 BuildRequires:  cmake
 BuildRequires:  unzip
 BuildRequires:  abseil-cpp-devel
+BuildRequires:  gtest-devel
 Provides:       %{name}-compiler = %{version}-%{release}
 Provides:       %{name}-lite = %{version}-%{release}
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -1,7 +1,7 @@
 Summary:        Google's data interchange format
 Name:           protobuf
 Version:        25.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -115,6 +115,9 @@ popd
 %{python3_sitelib}/*
 
 %changelog
+* Mon Jun 03 2024 Sindhu Karri <lakarri@microsoft.com> - 25.3-3
+- Enable ptest using system gtest package
+
 * Wed Mar 20 2024 Betty Lakes <bettylakes@microsoft.com> - 25.3-2
 - Set new abseil-cpp version
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -14,6 +14,7 @@ BuildRequires:  cmake
 BuildRequires:  unzip
 BuildRequires:  abseil-cpp-devel
 BuildRequires:  gtest-devel
+BuildRequires:  gmock-devel
 Provides:       %{name}-compiler = %{version}-%{release}
 Provides:       %{name}-lite = %{version}-%{release}
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -66,6 +66,7 @@ This contains protobuf python3 libraries.
     -Dprotobuf_ABSL_PROVIDER=package \
     -Dprotobuf_ABSL_MIN=20240116.0 \
     -Dprotobuf_BUILD_SHARED_LIBS=ON \
+    -Dprotobuf_USE_EXTERNAL_GTEST=ON \
     -DCMAKE_INSTALL_LIBDIR=%{_libdir}
 
 %{cmake_build}

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -13,8 +13,10 @@ BuildRequires:  libstdc++
 BuildRequires:  cmake
 BuildRequires:  unzip
 BuildRequires:  abseil-cpp-devel
+%if 0%{?with_check}
 BuildRequires:  gtest-devel
 BuildRequires:  gmock-devel
+%endif
 Provides:       %{name}-compiler = %{version}-%{release}
 Provides:       %{name}-lite = %{version}-%{release}
 
@@ -64,11 +66,15 @@ This contains protobuf python3 libraries.
 
 %build
 %{cmake} \
-    -Dprotobuf_BUILD_TESTS=ON \
     -Dprotobuf_ABSL_PROVIDER=package \
     -Dprotobuf_ABSL_MIN=20240116.0 \
     -Dprotobuf_BUILD_SHARED_LIBS=ON \
+%if 0%{?with_check}
+    -Dprotobuf_BUILD_TESTS=ON \
     -Dprotobuf_USE_EXTERNAL_GTEST=ON \
+%else
+   -Dprotobuf_BUILD_TESTS=OFF \
+%endif
     -DCMAKE_INSTALL_LIBDIR=%{_libdir}
 
 %{cmake_build}

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -85,6 +85,10 @@ pushd python
 %{py3_install}
 popd
 
+%check
+# run C++ unit tests
+%make_build check
+
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -62,7 +62,7 @@ This contains protobuf python3 libraries.
 
 %build
 %{cmake} \
-    -Dprotobuf_BUILD_TESTS=OFF \
+    -Dprotobuf_BUILD_TESTS=ON \
     -Dprotobuf_ABSL_PROVIDER=package \
     -Dprotobuf_ABSL_MIN=20240116.0 \
     -Dprotobuf_BUILD_SHARED_LIBS=ON \

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -87,7 +87,7 @@ popd
 
 %check
 # run C++ unit tests
-%make_build check
+%ctest
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Protobuf ptests are dropped during the package upgrade to 3.0 as the build system changed from make to cmake.
This PR brings back the ptests. Protobuf is now built with tests. The tests are enabled and passing. (refer [buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=580291&view=results))

Fixes the work item https://microsoft.visualstudio.com/OS/_workitems/edit/49669184

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enable ptest using system gtest package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=580291&view=results
- Latest Buddy builds:
- With test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=581688&view=results
- Without test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=581689&view=results
