### PR TITLE
CVE-2023-6349 mozjs embedded libvpx issue

### DIFF
--- a/SPECS/mozjs/CVE-2023-6349-0001-VP8-disallow-thread-count-changes.patch
+++ b/SPECS/mozjs/CVE-2023-6349-0001-VP8-disallow-thread-count-changes.patch
@@ -1,0 +1,50 @@
+From baed1218776fba096c05c1c683564ba4523d17e5 Mon Sep 17 00:00:00 2001
+From: James Zern <jzern@google.com>
+Date: Mon, 25 Sep 2023 18:55:59 -0700
+Subject: [PATCH 1/5] VP8: disallow thread count changes
+
+Currently allocations are done at encoder creation time. Going from
+threaded to non-threaded would cause a crash.
+
+Bug: chromium:1486441
+Change-Id: Ie301c2a70847dff2f0daae408fbef1e4d42e73d4
+(cherry picked from commit 3fbd1dca6a4d2dad332a2110d646e4ffef36d590)
+---
+ test/encode_api_test.cc | 4 ----
+ vp8/encoder/onyx_if.c   | 5 +++++
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/media/libvpx/libvpx/test/encode_api_test.cc b/media/libvpx/libvpx/test/encode_api_test.cc
+index 02aedc057..e0e793b15 100644
+--- a/media/libvpx/libvpx/test/encode_api_test.cc
++++ b/media/libvpx/libvpx/test/encode_api_test.cc
+@@ -366,10 +366,6 @@ TEST(EncodeAPI, ConfigResizeChangeThreadCount) {
+ 
+   for (const auto *iface : kCodecIfaces) {
+     SCOPED_TRACE(vpx_codec_iface_name(iface));
+-    if (!IsVP9(iface)) {
+-      GTEST_SKIP() << "TODO(https://crbug.com/1486441) remove this condition "
+-                      "after VP8 is fixed.";
+-    }
+     for (int i = 0; i < (IsVP9(iface) ? 2 : 1); ++i) {
+       vpx_codec_enc_cfg_t cfg = {};
+       struct Encoder {
+diff --git a/media/libvpx/libvpx/vp8/encoder/onyx_if.c b/media/libvpx/libvpx/vp8/encoder/onyx_if.c
+index 4bbeadef0..148a16cc4 100644
+--- a/media/libvpx/libvpx/vp8/encoder/onyx_if.c
++++ b/media/libvpx/libvpx/vp8/encoder/onyx_if.c
+@@ -1443,6 +1443,11 @@ void vp8_change_config(VP8_COMP *cpi, VP8_CONFIG *oxcf) {
+   last_h = cpi->oxcf.Height;
+   prev_number_of_layers = cpi->oxcf.number_of_layers;
+ 
++  if (cpi->initial_width) {
++    // TODO(https://crbug.com/1486441): Allow changing thread counts; the
++    // allocation is done once in vp8_create_compressor().
++    oxcf->multi_threaded = cpi->oxcf.multi_threaded;
++  }
+   cpi->oxcf = *oxcf;
+ 
+   switch (cpi->oxcf.Mode) {
+-- 
+2.34.1
+

--- a/SPECS/mozjs/CVE-2023-6349-0001-VP8-disallow-thread-count-changes.patch
+++ b/SPECS/mozjs/CVE-2023-6349-0001-VP8-disallow-thread-count-changes.patch
@@ -14,21 +14,6 @@ Change-Id: Ie301c2a70847dff2f0daae408fbef1e4d42e73d4
  vp8/encoder/onyx_if.c   | 5 +++++
  2 files changed, 5 insertions(+), 4 deletions(-)
 
-diff --git a/media/libvpx/libvpx/test/encode_api_test.cc b/media/libvpx/libvpx/test/encode_api_test.cc
-index 02aedc057..e0e793b15 100644
---- a/media/libvpx/libvpx/test/encode_api_test.cc
-+++ b/media/libvpx/libvpx/test/encode_api_test.cc
-@@ -366,10 +366,6 @@ TEST(EncodeAPI, ConfigResizeChangeThreadCount) {
- 
-   for (const auto *iface : kCodecIfaces) {
-     SCOPED_TRACE(vpx_codec_iface_name(iface));
--    if (!IsVP9(iface)) {
--      GTEST_SKIP() << "TODO(https://crbug.com/1486441) remove this condition "
--                      "after VP8 is fixed.";
--    }
-     for (int i = 0; i < (IsVP9(iface) ? 2 : 1); ++i) {
-       vpx_codec_enc_cfg_t cfg = {};
-       struct Encoder {
 diff --git a/media/libvpx/libvpx/vp8/encoder/onyx_if.c b/media/libvpx/libvpx/vp8/encoder/onyx_if.c
 index 4bbeadef0..148a16cc4 100644
 --- a/media/libvpx/libvpx/vp8/encoder/onyx_if.c

--- a/SPECS/mozjs/CVE-2023-6349-0002-vp9_alloccommon-clear-allocation-sizes-on-free.patch
+++ b/SPECS/mozjs/CVE-2023-6349-0002-vp9_alloccommon-clear-allocation-sizes-on-free.patch
@@ -1,0 +1,42 @@
+From a53700e4a3820ad929e2b8c79d10e46abef62575 Mon Sep 17 00:00:00 2001
+From: James Zern <jzern@google.com>
+Date: Mon, 26 Jun 2023 19:06:51 -0700
+Subject: [PATCH 2/5] vp9_alloccommon: clear allocation sizes on free
+
+This fixes reallocations (and avoids potential crashes) if any
+allocations fails and the application continues to call
+vpx_codec_decode().
+
+Found with vpx_dec_fuzzer_vp9 & Nallocfuzz
+(https://github.com/catenacyber/nallocfuzz).
+
+Bug: webm:1807
+Change-Id: If5dc96b73c02efc94ec84c25eb50d10ad6b645a6
+(cherry picked from commit 02ab555e992c191e5c509ed87b3cc48ed915b447)
+---
+ vp9/common/vp9_alloccommon.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c b/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c
+index faad657a0..e53883f62 100644
+--- a/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c
++++ b/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c
+@@ -65,6 +65,7 @@ static void free_seg_map(VP9_COMMON *cm) {
+     vpx_free(cm->seg_map_array[i]);
+     cm->seg_map_array[i] = NULL;
+   }
++  cm->seg_map_alloc_size = 0;
+ 
+   cm->current_frame_seg_map = NULL;
+   cm->last_frame_seg_map = NULL;
+@@ -108,6 +109,7 @@ void vp9_free_context_buffers(VP9_COMMON *cm) {
+   cm->above_context = NULL;
+   vpx_free(cm->above_seg_context);
+   cm->above_seg_context = NULL;
++  cm->above_context_alloc_cols = 0;
+   vpx_free(cm->lf.lfm);
+   cm->lf.lfm = NULL;
+ }
+-- 
+2.34.1
+

--- a/SPECS/mozjs/CVE-2023-6349-0003-Fix-bug-with-smaller-width-bigger-size.patch
+++ b/SPECS/mozjs/CVE-2023-6349-0003-Fix-bug-with-smaller-width-bigger-size.patch
@@ -16,35 +16,6 @@ Change-Id: If0e08e72abd2e042efe4dcfac21e4cc51afdfdb9
  vp9/encoder/vp9_encoder.c    | 27 +++++++++++++++++++++++++--
  3 files changed, 34 insertions(+), 17 deletions(-)
 
-diff --git a/media/libvpx/libvpx/test/resize_test.cc b/media/libvpx/libvpx/test/resize_test.cc
-index 715bb9d70..d9420a454 100644
---- a/media/libvpx/libvpx/test/resize_test.cc
-+++ b/media/libvpx/libvpx/test/resize_test.cc
-@@ -102,11 +102,8 @@ void ScaleForFrameNumber(unsigned int frame, unsigned int initial_w,
-     if (frame < 30) {
-       return;
-     }
--    if (frame < 100) {
--      *w = initial_w * 7 / 10;
--      *h = initial_h * 16 / 10;
--      return;
--    }
-+    *w = initial_w * 7 / 10;
-+    *h = initial_h * 16 / 10;
-     return;
-   }
-   if (frame < 10) {
-@@ -559,9 +556,7 @@ TEST_P(ResizeRealtimeTest, TestExternalResizeWorks) {
-   }
- }
- 
--// TODO(https://crbug.com/webm/1642): This causes a segfault in
--// init_encode_frame_mb_context().
--TEST_P(ResizeRealtimeTest, DISABLED_TestExternalResizeSmallerWidthBiggerSize) {
-+TEST_P(ResizeRealtimeTest, TestExternalResizeSmallerWidthBiggerSize) {
-   ResizingVideoSource video;
-   video.flag_codec_ = true;
-   video.smaller_width_larger_size_ = true;
 diff --git a/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c b/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c
 index e53883f62..9e73e40ea 100644
 --- a/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c

--- a/SPECS/mozjs/CVE-2023-6349-0003-Fix-bug-with-smaller-width-bigger-size.patch
+++ b/SPECS/mozjs/CVE-2023-6349-0003-Fix-bug-with-smaller-width-bigger-size.patch
@@ -1,0 +1,133 @@
+From df9fd9d5b7325060b2b921558a1eb20ca7880937 Mon Sep 17 00:00:00 2001
+From: Jerome Jiang <jianj@google.com>
+Date: Thu, 30 Jun 2022 13:48:56 -0400
+Subject: [PATCH 3/5] Fix bug with smaller width bigger size
+
+Fixed previous patch that clusterfuzz failed on.
+
+Local fuzzing passing overnight.
+
+Bug: webm:1642
+Change-Id: If0e08e72abd2e042efe4dcfac21e4cc51afdfdb9
+(cherry picked from commit 263682c9a29395055f3b3afe2d97be1828a6223f)
+---
+ test/resize_test.cc          | 11 +++--------
+ vp9/common/vp9_alloccommon.c | 13 ++++++-------
+ vp9/encoder/vp9_encoder.c    | 27 +++++++++++++++++++++++++--
+ 3 files changed, 34 insertions(+), 17 deletions(-)
+
+diff --git a/media/libvpx/libvpx/test/resize_test.cc b/media/libvpx/libvpx/test/resize_test.cc
+index 715bb9d70..d9420a454 100644
+--- a/media/libvpx/libvpx/test/resize_test.cc
++++ b/media/libvpx/libvpx/test/resize_test.cc
+@@ -102,11 +102,8 @@ void ScaleForFrameNumber(unsigned int frame, unsigned int initial_w,
+     if (frame < 30) {
+       return;
+     }
+-    if (frame < 100) {
+-      *w = initial_w * 7 / 10;
+-      *h = initial_h * 16 / 10;
+-      return;
+-    }
++    *w = initial_w * 7 / 10;
++    *h = initial_h * 16 / 10;
+     return;
+   }
+   if (frame < 10) {
+@@ -559,9 +556,7 @@ TEST_P(ResizeRealtimeTest, TestExternalResizeWorks) {
+   }
+ }
+ 
+-// TODO(https://crbug.com/webm/1642): This causes a segfault in
+-// init_encode_frame_mb_context().
+-TEST_P(ResizeRealtimeTest, DISABLED_TestExternalResizeSmallerWidthBiggerSize) {
++TEST_P(ResizeRealtimeTest, TestExternalResizeSmallerWidthBiggerSize) {
+   ResizingVideoSource video;
+   video.flag_codec_ = true;
+   video.smaller_width_larger_size_ = true;
+diff --git a/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c b/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c
+index e53883f62..9e73e40ea 100644
+--- a/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c
++++ b/media/libvpx/libvpx/vp9/common/vp9_alloccommon.c
+@@ -135,13 +135,6 @@ int vp9_alloc_context_buffers(VP9_COMMON *cm, int width, int height) {
+     cm->free_mi(cm);
+     if (cm->alloc_mi(cm, new_mi_size)) goto fail;
+   }
+-
+-  if (cm->seg_map_alloc_size < cm->mi_rows * cm->mi_cols) {
+-    // Create the segmentation map structure and set to 0.
+-    free_seg_map(cm);
+-    if (alloc_seg_map(cm, cm->mi_rows * cm->mi_cols)) goto fail;
+-  }
+-
+   if (cm->above_context_alloc_cols < cm->mi_cols) {
+     vpx_free(cm->above_context);
+     cm->above_context = (ENTROPY_CONTEXT *)vpx_calloc(
+@@ -156,6 +149,12 @@ int vp9_alloc_context_buffers(VP9_COMMON *cm, int width, int height) {
+     cm->above_context_alloc_cols = cm->mi_cols;
+   }
+ 
++  if (cm->seg_map_alloc_size < cm->mi_rows * cm->mi_cols) {
++    // Create the segmentation map structure and set to 0.
++    free_seg_map(cm);
++    if (alloc_seg_map(cm, cm->mi_rows * cm->mi_cols)) goto fail;
++  }
++
+   if (vp9_alloc_loop_filter(cm)) goto fail;
+ 
+   return 0;
+diff --git a/media/libvpx/libvpx/vp9/encoder/vp9_encoder.c b/media/libvpx/libvpx/vp9/encoder/vp9_encoder.c
+index b66fdc0bc..e38507754 100644
+--- a/media/libvpx/libvpx/vp9/encoder/vp9_encoder.c
++++ b/media/libvpx/libvpx/vp9/encoder/vp9_encoder.c
+@@ -1973,6 +1973,17 @@ static void alloc_copy_partition_data(VP9_COMP *cpi) {
+   }
+ }
+ 
++static void free_copy_partition_data(VP9_COMP *cpi) {
++  vpx_free(cpi->prev_partition);
++  cpi->prev_partition = NULL;
++  vpx_free(cpi->prev_segment_id);
++  cpi->prev_segment_id = NULL;
++  vpx_free(cpi->prev_variance_low);
++  cpi->prev_variance_low = NULL;
++  vpx_free(cpi->copied_frame_cnt);
++  cpi->copied_frame_cnt = NULL;
++}
++
+ void vp9_change_config(struct VP9_COMP *cpi, const VP9EncoderConfig *oxcf) {
+   VP9_COMMON *const cm = &cpi->common;
+   RATE_CONTROL *const rc = &cpi->rc;
+@@ -2052,6 +2063,8 @@ void vp9_change_config(struct VP9_COMP *cpi, const VP9EncoderConfig *oxcf) {
+     new_mi_size = cm->mi_stride * calc_mi_size(cm->mi_rows);
+     if (cm->mi_alloc_size < new_mi_size) {
+       vp9_free_context_buffers(cm);
++      vp9_free_pc_tree(&cpi->td);
++      vpx_free(cpi->mbmi_ext_base);
+       alloc_compressor_data(cpi);
+       realloc_segmentation_maps(cpi);
+       cpi->initial_width = cpi->initial_height = 0;
+@@ -2070,8 +2083,18 @@ void vp9_change_config(struct VP9_COMP *cpi, const VP9EncoderConfig *oxcf) {
+     update_frame_size(cpi);
+ 
+   if (last_w != cpi->oxcf.width || last_h != cpi->oxcf.height) {
+-    memset(cpi->consec_zero_mv, 0,
+-           cm->mi_rows * cm->mi_cols * sizeof(*cpi->consec_zero_mv));
++    vpx_free(cpi->consec_zero_mv);
++    CHECK_MEM_ERROR(
++        cm, cpi->consec_zero_mv,
++        vpx_calloc(cm->mi_rows * cm->mi_cols, sizeof(*cpi->consec_zero_mv)));
++
++    vpx_free(cpi->skin_map);
++    CHECK_MEM_ERROR(
++        cm, cpi->skin_map,
++        vpx_calloc(cm->mi_rows * cm->mi_cols, sizeof(cpi->skin_map[0])));
++
++    free_copy_partition_data(cpi);
++    alloc_copy_partition_data(cpi);
+     if (cpi->oxcf.aq_mode == CYCLIC_REFRESH_AQ)
+       vp9_cyclic_refresh_reset_resize(cpi);
+     rc->rc_1_frame = 0;
+-- 
+2.34.1
+

--- a/SPECS/mozjs/mozjs.spec
+++ b/SPECS/mozjs/mozjs.spec
@@ -68,6 +68,12 @@ Patch21:        0001-Skip-failing-tests-on-ppc64-and-s390x.patch
 # AzLinux CVE patches
 Patch30:       CVE-2022-48285.patch
 
+# libvpx CVE patches created by finding commits included in v1.13.1 after v1.13.0
+# and modifying paths to match embedded mozjs paths
+Patch40:       CVE-2023-6349-0001-VP8-disallow-thread-count-changes.patch
+Patch41:       CVE-2023-6349-0002-vp9_alloccommon-clear-allocation-sizes-on-free.patch
+Patch42:       CVE-2023-6349-0003-Fix-bug-with-smaller-width-bigger-size.patch
+
 # AzLinux packages cargo and rustfmt in the rust package
 %if !0%{?azl}
 BuildRequires:  cargo

--- a/SPECS/mozjs/mozjs.spec
+++ b/SPECS/mozjs/mozjs.spec
@@ -22,7 +22,7 @@
 
 Name:           mozjs
 Version:        102.15.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        SpiderMonkey JavaScript library
 
 Vendor:         Microsoft Corporation
@@ -68,8 +68,8 @@ Patch21:        0001-Skip-failing-tests-on-ppc64-and-s390x.patch
 # AzLinux CVE patches
 Patch30:       CVE-2022-48285.patch
 
-# libvpx CVE patches created by finding commits included in v1.13.1 after v1.13.0
-# and modifying paths to match embedded mozjs paths
+# libvpx CVE patches created by finding commits included in v1.13.1 after v1.13.0,
+# removing test code and modifying paths to match embedded mozjs paths
 Patch40:       CVE-2023-6349-0001-VP8-disallow-thread-count-changes.patch
 Patch41:       CVE-2023-6349-0002-vp9_alloccommon-clear-allocation-sizes-on-free.patch
 Patch42:       CVE-2023-6349-0003-Fix-bug-with-smaller-width-bigger-size.patch
@@ -270,6 +270,9 @@ $tests_ok
 %{_includedir}/mozjs-%{major}/
 
 %changelog
+* Tue Jun 04 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 102.15.1-2
+- Fix CVE-2023-6349.
+
 * Tue Mar 12 2024 corvus-callidus <108946721+corvus-callidus@users.noreply.github.com> - 102.15.1-1
 - Initial Azure Linux import from Fedora 39 (license: MIT).
 - License verified


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
CVE-2023-6349: mozjs embeds libvpx v1.11.0 which has a security issue solved in v1.13.1.  Capture v1.13.1 CVE changes in patch files, modify paths to match mozjs paths, and remove test code.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Create libvpx patch files capturing CVE changes from v1.13.1
- Modify patch paths to match mozjs paths
- Remove patch test code

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://cvedashboard.azurewebsites.net/#/cves/CVE-2023-6349

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Pipeline build id: xxxx](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=581084&view=results)
