### PR TITLE
Use local http server for unit tests

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -113,7 +113,7 @@ else
 # Rebuild the go tools as needed
 $(TOOL_BINS_DIR)/%: $(go_common_files)
 	cd $(TOOLS_DIR)/$* && \
-		go test -ldflags="$(go_ldflags)" -p 1 -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
+		go test -ldflags="$(go_ldflags)" -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
 		CGO_ENABLED=0 go build \
 			-ldflags="$(go_ldflags)" \
 			$(if $(filter y,$(BUILD_TOOLS_NONPROD)),,-tags prod) \
@@ -123,7 +123,7 @@ endif
 # Runs tests for common components
 $(BUILD_DIR)/tools/internal.test_coverage: $(go_internal_files) $(go_imagegen_files) $(STATUS_FLAGS_DIR)/got_go_deps.flag
 	cd $(TOOLS_DIR)/$* && \
-		go test -ldflags="$(go_ldflags)" -p 1 -test.short -covermode=atomic -coverprofile=$@ ./...
+		go test -ldflags="$(go_ldflags)" -test.short -covermode=atomic -coverprofile=$@ ./...
 
 # Downloads all the go dependencies without using sudo, so we don't break other go use cases for the user.
 # We can check if $SUDO_USER is set (the user who invoked sudo), and if so, use that user to run go get via sudo -u.
@@ -157,7 +157,7 @@ go-fmt-all:
 # Formats the test coverage for the tools
 .PHONY: $(BUILD_DIR)/tools/all_tools.coverage
 $(BUILD_DIR)/tools/all_tools.coverage: $(call shell_real_build_only, find $(TOOLS_DIR)/ -type f -name '*.go') $(STATUS_FLAGS_DIR)/got_go_deps.flag
-	cd $(TOOLS_DIR) && go test -ldflags="$(go_ldflags)" -p 1 -coverpkg=./... -test.short -covermode=atomic -coverprofile=$@ ./...
+	cd $(TOOLS_DIR) && go test -ldflags="$(go_ldflags)" -coverpkg=./... -test.short -covermode=atomic -coverprofile=$@ ./...
 $(test_coverage_report): $(BUILD_DIR)/tools/all_tools.coverage
 	cd $(TOOLS_DIR) && go tool cover -html=$(BUILD_DIR)/tools/all_tools.coverage -o $@
 ##help:target:go-test-coverage=Run and publish test coverage for all go tools.

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -113,7 +113,7 @@ else
 # Rebuild the go tools as needed
 $(TOOL_BINS_DIR)/%: $(go_common_files)
 	cd $(TOOLS_DIR)/$* && \
-		go test -ldflags="$(go_ldflags)" -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
+		go test -ldflags="$(go_ldflags)" -p 1 -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
 		CGO_ENABLED=0 go build \
 			-ldflags="$(go_ldflags)" \
 			$(if $(filter y,$(BUILD_TOOLS_NONPROD)),,-tags prod) \
@@ -123,7 +123,7 @@ endif
 # Runs tests for common components
 $(BUILD_DIR)/tools/internal.test_coverage: $(go_internal_files) $(go_imagegen_files) $(STATUS_FLAGS_DIR)/got_go_deps.flag
 	cd $(TOOLS_DIR)/$* && \
-		go test -ldflags="$(go_ldflags)" -test.short -covermode=atomic -coverprofile=$@ ./...
+		go test -ldflags="$(go_ldflags)" -p 1 -test.short -covermode=atomic -coverprofile=$@ ./...
 
 # Downloads all the go dependencies without using sudo, so we don't break other go use cases for the user.
 # We can check if $SUDO_USER is set (the user who invoked sudo), and if so, use that user to run go get via sudo -u.
@@ -157,7 +157,7 @@ go-fmt-all:
 # Formats the test coverage for the tools
 .PHONY: $(BUILD_DIR)/tools/all_tools.coverage
 $(BUILD_DIR)/tools/all_tools.coverage: $(call shell_real_build_only, find $(TOOLS_DIR)/ -type f -name '*.go') $(STATUS_FLAGS_DIR)/got_go_deps.flag
-	cd $(TOOLS_DIR) && go test -ldflags="$(go_ldflags)" -coverpkg=./... -test.short -covermode=atomic -coverprofile=$@ ./...
+	cd $(TOOLS_DIR) && go test -ldflags="$(go_ldflags)" -p 1 -coverpkg=./... -test.short -covermode=atomic -coverprofile=$@ ./...
 $(test_coverage_report): $(BUILD_DIR)/tools/all_tools.coverage
 	cd $(TOOLS_DIR) && go tool cover -html=$(BUILD_DIR)/tools/all_tools.coverage -o $@
 ##help:target:go-test-coverage=Run and publish test coverage for all go tools.

--- a/toolkit/tools/internal/network/network_test.go
+++ b/toolkit/tools/internal/network/network_test.go
@@ -80,7 +80,7 @@ func TestDownloadFile(t *testing.T) {
 			expectedTime:     noCancelDelay,
 		},
 		{
-			name: "TestDownloadWithCancel",
+			name: "TestDownloadWithContext",
 			args: args{
 				srcUrl:   validUrl,
 				dstFile:  validFile,
@@ -134,11 +134,9 @@ func TestDownloadFile(t *testing.T) {
 		{
 			name: "TestDownloadWithBadTimeout",
 			args: args{
-				srcUrl:   validUrl,
-				dstFile:  validFile,
-				caCerts:  nil,
-				tlsCerts: nil,
-				timeout:  -1,
+				srcUrl:  validUrl,
+				dstFile: validFile,
+				timeout: -1,
 			},
 			useCtx:           false,
 			wantWasCancelled: false,


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Some of the unit tests expect to validate against wall-clock time. I've noticed that on occasion the tests will stall, making these specific tests fail.

Use a local server instead of relying on github.com. This gives us much more reliable timing.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use a local http sever for network tests.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
