### PR TITLE
Check if gpgconf is in chroot, not host env, when cleaning up chroot

### DIFF
--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -732,7 +732,6 @@ func (c *Chroot) stopGPGComponents() (err error) {
 		if chrootErr != nil {
 			return chrootErr
 		}
-		
 		if !found {
 			logger.Log.Debugf("gpgconf is not installed, so gpg-agent is not running: %s", err)
 			return nil

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -731,7 +731,9 @@ func (c *Chroot) stopGPGComponents() (err error) {
 		found, chrootErr := file.CommandExists("gpgconf")
 		if chrootErr != nil {
 			return chrootErr
-		} else if !found {
+		}
+		
+		if !found {
 			logger.Log.Debugf("gpgconf is not installed, so gpg-agent is not running: %s", err)
 			return nil
 		}

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -728,16 +727,18 @@ func (c *Chroot) stopGPGComponents() (err error) {
 		return
 	}
 
-	_, err = exec.LookPath("gpgconf")
-	if err != nil {
-		logger.Log.Debugf("gpgconf is not installed, so gpg-agent is not running: %s", err)
-		return nil
-	}
-
 	err = c.UnsafeRun(func() (err error) {
-		components, err := listGPGComponents()
-		if err != nil {
-			return err
+		found, chrootErr := file.CommandExists("gpgconf")
+		if chrootErr != nil {
+			return chrootErr
+		} else if !found {
+			logger.Log.Debugf("gpgconf is not installed, so gpg-agent is not running: %s", err)
+			return nil
+		}
+
+		components, chrootErr := listGPGComponents()
+		if chrootErr != nil {
+			return chrootErr
 		}
 		// List of components to kill. The names must be verbatim identical to the name tag that is used by `gpgconf`
 		componentsToKill := []string{"gpg-agent", "keyboxd"}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We have logic to kill several `gpgconf` agents inside our chroots. They hold open the `/dev` mount point and block graceful cleanup. 

This logic was failing for the ISO installer:
```
...
WARN[0063][liveinstaller] DEBU[0063][imager] Calling unmount on path(/installroot/dev/pts) with flags (0)
WARN[0064][liveinstaller] DEBU[0064][imager] Unmounting (/installroot/run)
WARN[0064][liveinstaller] DEBU[0064][imager] Calling unmount on path(/installroot/run) with flags (0)
WARN[0064][liveinstaller] DEBU[0064][imager] Unmounting (/installroot/sys)
WARN[0064][liveinstaller] DEBU[0064][imager] Calling unmount on path(/installroot/sys) with flags (0)
WARN[0064][liveinstaller] DEBU[0064][imager] Unmounting (/installroot/proc)
WARN[0064][liveinstaller] DEBU[0064][imager] Calling unmount on path(/installroot/proc) with flags (0)
WARN[0064][liveinstaller] DEBU[0064][imager] Unmounting (/installroot/dev)
WARN[0064][liveinstaller] DEBU[0064][imager] Calling unmount on path(/installroot/dev) with flags (0)
WARN[0065][liveinstaller] DEBU[0065][imager] Calling unmount on path(/installroot/dev) with flags (0)
WARN[0067][liveinstaller] DEBU[0067][imager] Calling unmount on path(/installroot/dev) with flags (0)
WARN[0067][liveinstaller] WARN[0067][imager] Chroot cleanup failed, will retry with lazy unmount. Error: failed to unmount (/installroot/dev):
WARN[0067][liveinstaller] device or resource busy
...
```

The logic that checks if we need to stop these agents was looking one layer up from the chroot when it should have been checking in the chroot.

i.e., `.../setuproot/installroot` are our two nested chroots for offline package build. The existing logic checks for the presence of `.../setuproot/usr/bin/gpgconf`, and if it finds it then `.../setuproot/installroot/usr/bin/gpgconf` is killed. 

This coincidentally works in most environments since the worker chroot does have `gpgconf` in it. However, the ISO installer initrd does NOT have `gpgconf` (In the liveinstaller case `/setuproot` is actually `/`). So, since we don't have `gpgconf` in the initrd, we do not run the cleanup logic to kill `gpg-agent` and `keyboxd` in the ISO's equivalent of `.../installroot`.

Move the check for `gpgconf` into the chroot that we are trying to clean up so we accurately detect if we need to do anything.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move the check for `gpgconf` into the chroot when running `stopGPGComponents()`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/51569571

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of full.json ISO, failure was seen in `/var/log/imager.log` prior to fix, now it exits cleanly.
