### PR TITLE
Cherry-pick Patch CVE-2024-26147 for cert-manager into fasttrack

### DIFF
--- a/SPECS/cert-manager/CVE-2024-26147.patch
+++ b/SPECS/cert-manager/CVE-2024-26147.patch
@@ -1,0 +1,43 @@
+From d02be38fc6c54828d5eec15efe058c61f3df4a60 Mon Sep 17 00:00:00 2001
+From: Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com>
+Date: Thu, 30 May 2024 16:33:17 -0700
+Subject: [PATCH] backport patch CVE-2024-26147. Based off commit https://github.com/helm/helm/commit/bb4cc9125503a923afb7988f3eb478722a8580af
+
+---
+ vendor/helm.sh/helm/v3/pkg/plugin/plugin.go | 4 ++++
+ vendor/helm.sh/helm/v3/pkg/repo/index.go    | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/vendor/helm.sh/helm/v3/pkg/plugin/plugin.go b/vendor/helm.sh/helm/v3/pkg/plugin/plugin.go
+index 1399b71..df580db 100644
+--- a/vendor/helm.sh/helm/v3/pkg/plugin/plugin.go
++++ b/vendor/helm.sh/helm/v3/pkg/plugin/plugin.go
+@@ -173,6 +173,10 @@ var validPluginName = regexp.MustCompile("^[A-Za-z0-9_-]+$")
+ 
+ // validatePluginData validates a plugin's YAML data.
+ func validatePluginData(plug *Plugin, filepath string) error {
++	// When metadata section missing, initialize with no data
++	if plug.Metadata == nil {
++		plug.Metadata = &Metadata{}
++	}
+ 	if !validPluginName.MatchString(plug.Metadata.Name) {
+ 		return fmt.Errorf("invalid plugin name at %q", filepath)
+ 	}
+diff --git a/vendor/helm.sh/helm/v3/pkg/repo/index.go b/vendor/helm.sh/helm/v3/pkg/repo/index.go
+index 60cfe58..94852bb 100644
+--- a/vendor/helm.sh/helm/v3/pkg/repo/index.go
++++ b/vendor/helm.sh/helm/v3/pkg/repo/index.go
+@@ -347,6 +347,10 @@ func loadIndex(data []byte, source string) (*IndexFile, error) {
+ 				log.Printf("skipping loading invalid entry for chart %q from %s: empty entry", name, source)
+ 				continue
+ 			}
++			// When metadata section missing, initialize with no data
++			if cvs[idx].Metadata == nil {
++				cvs[idx].Metadata = &chart.Metadata{}
++			}
+ 			if cvs[idx].APIVersion == "" {
+ 				cvs[idx].APIVersion = chart.APIVersionV1
+ 			}
+-- 
+2.34.1
+

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -1,7 +1,7 @@
 Summary:        Automatically provision and manage TLS certificates in Kubernetes
 Name:           cert-manager
 Version:        1.11.2
-Release:        8%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -20,6 +20,8 @@ Source0:        https://github.com/jetstack/%{name}/archive/refs/tags/v%{version
 #           -cf %%{name}-%%{version}-govendor.tar.gz vendor
 Source1:        %{name}-%{version}-govendor.tar.gz
 Patch0:         CVE-2023-48795.patch
+Patch1:         CVE-2023-45288.patch
+Patch2:         CVE-2024-26147.patch
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
 Requires:       %{name}-cainjector
@@ -112,6 +114,12 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %{_bindir}/webhook
 
 %changelog
+* Thu May 30 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 1.11.2-10
+- Patch for CVE-2024-26147
+
+* Thu Apr 18 2024 Chris Gunn <chrisgun@microsoft.com> - 1.11.2-9
+- Fix for CVE-2023-45288
+
 * Fri Feb 02 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.11.2-8
 - Bump release to rebuild with go 1.21.6
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR is to sync `cert-manager` high CVE patch for CVE-2024-26147 from `main` branch into fasttrack/2.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- cherry-picked patch for CVE-2024-26147 from main into fasttrack

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-26147

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
