### PR TITLE
Improve user/group creation in image build

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -501,6 +501,7 @@ The table below are the keys for the users.
 |PrimaryGroup       |string             |
 |SecondaryGroups    |array of strings   |
 |StartupCommand     |string             |
+|HomeDirectory      |string             |
 
 An example usage for users "root" and "basicUser" would look like:
 

--- a/toolkit/imageconfigs/packagelists/core-packages-image.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image.json
@@ -8,7 +8,8 @@
         "core-packages-base-image",
         "dracut-hostonly",
         "dracut-vrf",
-        "initramfs"
+        "initramfs",
+        "shadow-utils"
     ],
     "_comment": "Install 'initramfs' last to avoid unnecessary regeneration when other packages, such as 'kernel', are installed."
 }

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -177,7 +177,7 @@ func validatePackages(config configuration.Config) (err error) {
 		}
 		if len(systemConfig.Users) > 0 || len(systemConfig.Groups) > 0 {
 			if !foundUserAddPackage {
-				return fmt.Errorf("%s: add users require '%s' package that is not included in the package lists", validateError, userAddPkgName)
+				return fmt.Errorf("%s: the '%s' package must be included in the package lists when the image is configured to add users or groups", validateError, userAddPkgName)
 			}
 		}
 	}

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -85,11 +85,6 @@ func ValidateConfiguration(config configuration.Config) (err error) {
 		return
 	}
 
-	err = validateUsersGroups(config)
-	if err != nil {
-		return
-	}
-
 	err = validateKickStartInstall(config)
 	return
 }
@@ -183,42 +178,6 @@ func validatePackages(config configuration.Config) (err error) {
 		if len(systemConfig.Users) > 0 || len(systemConfig.Groups) > 0 {
 			if !foundUserAddPackage {
 				return fmt.Errorf("%s: add users require '%s' package that is not included in the package lists", validateError, userAddPkgName)
-			}
-		}
-	}
-
-	return
-}
-
-// Function to check if a user belongs to groups that are defined
-func userBelongsToGroup(user configuration.User, groups map[string]bool) bool {
-	if !groups[user.PrimaryGroup] {
-		return false
-	}
-
-	for _, group := range user.SecondaryGroups {
-		if !groups[group] {
-			return false
-		}
-	}
-
-	return true
-}
-
-func validateUsersGroups(config configuration.Config) (err error) {
-	timestamp.StartEvent("validate users groups", nil)
-	defer timestamp.StopEvent(nil)
-
-	for _, systemConfig := range config.SystemConfigs {
-		// Create a map of valid group IDs for quick lookup
-		groupMap := make(map[string]bool)
-		for _, group := range systemConfig.Groups {
-			groupMap[group.GID] = true
-		}
-		// Check each user
-		for _, user := range systemConfig.Users {
-			if !userBelongsToGroup(user, groupMap) {
-				fmt.Errorf("User %s (UID: %s) does not belong to any valid group\n", user.Name, user.UID)
 			}
 		}
 	}

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
@@ -301,3 +301,44 @@ func TestShouldSucceedSELinuxPackageDefinedInline(t *testing.T) {
 	}
 	assert.Fail(t, "Could not find "+targetPackage+" to test")
 }
+
+func TestShouldFailMissingShadowUtilsPackageWithUsers(t *testing.T) {
+	const (
+		configDirectory   = "../../imageconfigs/"
+		targetPackage     = "core-efi.json"
+		targetPackageList = "core-packages-image.json"
+	)
+	configFiles, err := os.ReadDir(configDirectory)
+	assert.NoError(t, err)
+
+	// Pick the core-efi config file, then add a user, then remove shadow-utils from the package list (via dropping core... its a bit hacky)
+	for _, file := range configFiles {
+		if !file.IsDir() && strings.Contains(file.Name(), targetPackage) {
+			configPath := filepath.Join(configDirectory, file.Name())
+
+			fmt.Println("Corrupting ", configPath)
+
+			config, err := configuration.LoadWithAbsolutePaths(configPath, configDirectory)
+			for i, list := range config.SystemConfigs[0].PackageLists {
+				// Delete the packagelist from the config
+				if strings.Contains(list, targetPackageList) {
+					config.SystemConfigs[0].PackageLists = append(config.SystemConfigs[0].PackageLists[:i], config.SystemConfigs[0].PackageLists[i+1:]...)
+				}
+			}
+			assert.NoError(t, err)
+
+			config.SystemConfigs[0].Users = []configuration.User{
+				{
+					Name: "testuser",
+				},
+			}
+
+			err = ValidateConfiguration(config)
+			assert.Error(t, err)
+			assert.Equal(t, "failed to validate package lists in config: add users require 'shadow-utils' package that is not included in the package lists", err.Error())
+
+			return
+		}
+	}
+	assert.Fail(t, "Could not find "+targetPackage+" to test")
+}

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
@@ -335,7 +335,7 @@ func TestShouldFailMissingShadowUtilsPackageWithUsers(t *testing.T) {
 
 			err = ValidateConfiguration(config)
 			assert.Error(t, err)
-			assert.Equal(t, "failed to validate package lists in config: add users require 'shadow-utils' package that is not included in the package lists", err.Error())
+			assert.Equal(t, "failed to validate package lists in config: the 'shadow-utils' package must be included in the package lists when the image is configured to add users or groups", err.Error())
 
 			return
 		}

--- a/toolkit/tools/imagecustomizerapi/user.go
+++ b/toolkit/tools/imagecustomizerapi/user.go
@@ -19,6 +19,7 @@ type User struct {
 	PrimaryGroup        string    `yaml:"primaryGroup"`
 	SecondaryGroups     []string  `yaml:"secondaryGroups"`
 	StartupCommand      string    `yaml:"startupCommand"`
+	HomeDirectory       string    `yaml:"HomeDirectory"`
 }
 
 func (u *User) IsValid() error {

--- a/toolkit/tools/imagecustomizerapi/user.go
+++ b/toolkit/tools/imagecustomizerapi/user.go
@@ -19,7 +19,7 @@ type User struct {
 	PrimaryGroup        string    `yaml:"primaryGroup"`
 	SecondaryGroups     []string  `yaml:"secondaryGroups"`
 	StartupCommand      string    `yaml:"startupCommand"`
-	HomeDirectory       string    `yaml:"HomeDirectory"`
+	HomeDirectory       string    `yaml:"homeDirectory"`
 }
 
 func (u *User) IsValid() error {

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 )
 
 // SystemConfig defines how each system present on the image is supposed to be configured.
@@ -64,6 +65,34 @@ func (s *SystemConfig) IsRootFS() bool {
 // corresponding to a mount point.
 func (s *SystemConfig) GetMountpointPartitionSetting(mountPoint string) (partitionSetting *PartitionSetting) {
 	return FindMountpointPartitionSetting(s.PartitionSettings, mountPoint)
+}
+
+func (s *SystemConfig) validateUsersAndGroups() (err error) {
+	for _, user := range s.Users {
+		groupMatchFunc := func(groupName interface{}, groupObj interface{}) bool {
+			return groupName == groupObj.(Group).Name
+		}
+
+		if user.PrimaryGroup != "" {
+			if !sliceutils.Contains(s.Groups, user.PrimaryGroup, groupMatchFunc) {
+				// Unclear how to validate these while allowing users to be added to existing system groups. If we
+				// define a group in the config that already exists it will cause errors.
+				// Maybe we can scrape /etc/group and /etc/passwd from filesystem.sepc to validate these?
+				logger.Log.Warnf("Primary group (%s) for user (%s) not defined", user.PrimaryGroup, user.Name)
+			}
+		}
+
+		for _, group := range user.SecondaryGroups {
+			if !sliceutils.Contains(s.Groups, group, groupMatchFunc) {
+				// Unclear how to validate these while allowing users to be added to existing system groups. If we
+				// define a group in the config that already exists it will cause errors.
+				// Maybe we can scrape /etc/group and /etc/passwd from filesystem.sepc to validate these?
+				logger.Log.Warnf("secondary group (%s) for user (%s) not defined", group, user.Name)
+			}
+		}
+	}
+
+	return err
 }
 
 // IsValid returns an error if the SystemConfig is not valid
@@ -186,6 +215,11 @@ func (s *SystemConfig) IsValid() (err error) {
 		if err = b.IsValid(); err != nil {
 			return fmt.Errorf("invalid [User]: %w", err)
 		}
+	}
+	// Currently validateUsersAndGroups() is not able to return an error, it will only print warnings.
+	err = s.validateUsersAndGroups()
+	if err != nil {
+		return fmt.Errorf("invalid [Users]: %w", err)
 	}
 
 	//Validate Encryption

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -68,16 +68,18 @@ func (s *SystemConfig) GetMountpointPartitionSetting(mountPoint string) (partiti
 }
 
 func (s *SystemConfig) validateUsersAndGroups() (err error) {
+	groupMatchFunc := func(groupName interface{}, groupObj interface{}) bool {
+		return groupName == groupObj.(Group).Name
+	}
+
 	for _, user := range s.Users {
-		groupMatchFunc := func(groupName interface{}, groupObj interface{}) bool {
-			return groupName == groupObj.(Group).Name
-		}
 
 		if user.PrimaryGroup != "" {
 			if !sliceutils.Contains(s.Groups, user.PrimaryGroup, groupMatchFunc) {
-				// Unclear how to validate these while allowing users to be added to existing system groups. If we
-				// define a group in the config that already exists it will cause errors.
-				// Maybe we can scrape /etc/group and /etc/passwd from filesystem.sepc to validate these?
+				// Unclear how to validate that users and groups match together correctly while still allowing
+				// users to be added to existing system groups. If we define a group in the config that already
+				// exists it will cause errors, but we don't have insight into the default users/groups already in
+				// an image before we install the filesystem package.
 				logger.Log.Warnf("Primary group (%s) for user (%s) not defined", user.PrimaryGroup, user.Name)
 			}
 		}

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -80,7 +80,7 @@ func (s *SystemConfig) validateUsersAndGroups() (err error) {
 				// users to be added to existing system groups. If we define a group in the config that already
 				// exists it will cause errors, but we don't have insight into the default users/groups already in
 				// an image before we install the filesystem package.
-				logger.Log.Warnf("Primary group (%s) for user (%s) not defined", user.PrimaryGroup, user.Name)
+				logger.Log.Warnf("Primary group (%s) for user (%s) not defined in [SystemConfig.Groups], if this group is not present user creation may fail.", user.PrimaryGroup, user.Name)
 			}
 		}
 
@@ -89,7 +89,7 @@ func (s *SystemConfig) validateUsersAndGroups() (err error) {
 				// Unclear how to validate these while allowing users to be added to existing system groups. If we
 				// define a group in the config that already exists it will cause errors.
 				// Maybe we can scrape /etc/group and /etc/passwd from filesystem.sepc to validate these?
-				logger.Log.Warnf("secondary group (%s) for user (%s) not defined", group, user.Name)
+				logger.Log.Warnf("Secondary group (%s) for user (%s) not defined in [SystemConfig.Groups], if this group is not present user creation may fail.", group, user.Name)
 			}
 		}
 	}

--- a/toolkit/tools/imagegen/configuration/user.go
+++ b/toolkit/tools/imagegen/configuration/user.go
@@ -25,6 +25,7 @@ type User struct {
 	PrimaryGroup        string   `json:"PrimaryGroup"`
 	SecondaryGroups     []string `json:"SecondaryGroups"`
 	StartupCommand      string   `json:"StartupCommand"`
+	HomeDirectory       string   `json:"HomeDirectory"`
 }
 
 // UnmarshalJSON Unmarshals a User entry

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -508,7 +508,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 		}
 
 		// Remove shadow-utils from the list of packages to install
-		packagesToInstall = sliceutils.FindMatches(packagesToInstall, func(pkg string) bool { return pkg != "shadow-utils" })
+		packagesToInstall = sliceutils.FindMatches(packagesToInstall, func(pkg string) bool { return pkg != shadowUtilsPkg })
 	}
 
 	hostname := config.Hostname

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -498,7 +498,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	// imageconfigvalidator should have ensured that we intend to install shadow-utils, so we can go ahead and do that here.
 	if len(config.Users) > 0 || len(config.Groups) > 0 {
 		if !sliceutils.ContainsValue(packagesToInstall, "shadow-utils") {
-			err = fmt.Errorf("shadow-utils package is required when setting users or groups")
+			err = fmt.Errorf("shadow-utils package must be added to the image's package lists when setting users or groups")
 			return
 		}
 
@@ -1399,7 +1399,7 @@ func addGroups(installChroot *safechroot.Chroot, groups []configuration.Group) (
 			return shell.ExecuteLive(squashErrors, "groupadd", args...)
 		})
 		if err != nil {
-			return fmt.Errorf("failed to add group: %w", err)
+			return fmt.Errorf("failed to add group (%s):\n%w",  group.Name, err)
 		}
 	}
 

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1398,6 +1398,9 @@ func addGroups(installChroot *safechroot.Chroot, groups []configuration.Group) (
 		err = installChroot.UnsafeRun(func() error {
 			return shell.ExecuteLive(squashErrors, "groupadd", args...)
 		})
+		if err != nil {
+			return fmt.Errorf("failed to add group: %w", err)
+		}
 	}
 
 	return

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -442,7 +442,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	defer timestamp.StopEvent(nil)
 
 	const (
-		filesystemPkg = "filesystem"
+		filesystemPkg  = "filesystem"
 		shadowUtilsPkg = "shadow-utils"
 	)
 

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -76,13 +76,19 @@ func UserExists(username string, installChroot safechroot.ChrootInterface) (bool
 	return userExists, nil
 }
 
-func AddUser(username string, hashedPassword string, uid string, installChroot safechroot.ChrootInterface) error {
+func AddUser(username string, homeDir string, primaryGroup string, hashedPassword string, uid string, installChroot *safechroot.Chroot) error {
 	var args = []string{username, "-m"}
 	if hashedPassword != "" {
 		args = append(args, "-p", hashedPassword)
 	}
 	if uid != "" {
 		args = append(args, "-u", uid)
+	}
+	if homeDir != "" {
+		args = append(args, "-d", homeDir)
+	}
+	if primaryGroup != "" {
+		args = append(args, "-g", primaryGroup)
 	}
 
 	err := installChroot.UnsafeRun(func() error {

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -76,7 +76,7 @@ func UserExists(username string, installChroot safechroot.ChrootInterface) (bool
 	return userExists, nil
 }
 
-func AddUser(username string, homeDir string, primaryGroup string, hashedPassword string, uid string, installChroot *safechroot.Chroot) error {
+func AddUser(username string, homeDir string, primaryGroup string, hashedPassword string, uid string, installChroot safechroot.ChrootInterface) error {
 	var args = []string{username, "-m"}
 	if hashedPassword != "" {
 		args = append(args, "-p", hashedPassword)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -315,7 +315,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 		}
 
 		// Add the user.
-		err = userutils.AddUser(user.Name, hashedPassword, uidStr, imageChroot)
+		err = userutils.AddUser(user.Name, user.HomeDirectory, user.PrimaryGroup, hashedPassword, uidStr, imageChroot.(*safechroot.Chroot))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR is a combination of the following changes that's been in review process once:
1- https://github.com/microsoft/azurelinux/pull/6957
2- https://github.com/microsoft/azurelinux/pull/6876

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR accomplishes the following goals:
1- Add support to specify home directory and primary group when creating users. We needed this to overwrite those defaults for some of the service's users that are predefined in an Azure Linux derivative image. Also, added a validation step in imageconfigvalidator to ensure "shadow-utils" package is added to the packages list. 
2- Add support to define a list of users and groups when building a rootFS image type and do it earlier in the image build stage. The reason for shifting users/groups creation to an earlier time is that some of the upstream packages also define their own users or groups, and the chances are some of the users/groups get defined by installing packages in the build chroot and later on addUsers/addGroups will fail because some of the users/groups are already defined. Also, added a validation step in imageconfigvalidator to enforce each user can only belong to the groups that are defined in the config.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Tested locally to build an image with a list of users with predefined home directory and primary group

