### PR TITLE
Add patch for cloud init dhcp issue

### DIFF
--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        23.4.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,8 @@ Source0:        https://github.com/canonical/%{name}/archive/refs/tags/%{version
 Source1:        10-azure-kvp.cfg
 Patch0:         0001-Add-new-distro-azurelinux-for-Microsoft-Azure-Linux.patch
 Patch1:         Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
+# Patch no longer needed for cloud-init >= 24.1
+Patch2:         dhcp_support_dhclient-unknown-121.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus
@@ -144,7 +146,10 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
-* Thu May 9 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 23.4.3-2
+* Wed June 06 2024 Minghe Ren <mingheren@microsoft.com> - 23.4.3-3
+- Add patch for cloud-init to support dhclient's unknown-121 option
+
+* Thu May 09 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 23.4.3-2
 - Add patch to add network interface renaming support for CAPM3 Met.
 
 * Mon Feb 26 2024 Dan Streetman <ddstreet@microsoft.com> - 23.4.3-1

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -12,7 +12,7 @@ Source1:        10-azure-kvp.cfg
 Patch0:         0001-Add-new-distro-azurelinux-for-Microsoft-Azure-Linux.patch
 Patch1:         Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
 # Patch no longer needed for cloud-init >= 24.1
-Patch2:         dhcp_support_dhclient-unknown-121.patch
+Patch2:         dhcp_support_dhclient-unknown_121.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -12,7 +12,7 @@ Source1:        10-azure-kvp.cfg
 Patch0:         0001-Add-new-distro-azurelinux-for-Microsoft-Azure-Linux.patch
 Patch1:         Add-Network-Interface-Renaming-Support-for-CAPM3-Met.patch
 # Patch no longer needed for cloud-init >= 24.1
-Patch2:         dhcp_support_dhclient-unknown_121.patch
+Patch2:         dhcp_support_dhclient_unknown_121.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus

--- a/SPECS/cloud-init/dhcp_support_dhclient_unknown_121.patch
+++ b/SPECS/cloud-init/dhcp_support_dhclient_unknown_121.patch
@@ -1,0 +1,130 @@
+From 5cf6f3aee2a8af335b36cf573abf48642b94aa65 Mon Sep 17 00:00:00 2001
+From: Chris Patterson <cpatterson@microsoft.com>
+Date: Thu, 4 Apr 2024 12:16:06 -0400
+Subject: [PATCH] dhcp: support configuring static routes for dhclient's
+ unknown-121 option
+
+Cloud-init does not configure rfc3442-classless-static-routes if dhclient isn't
+patched to support them or it is not configured with:
+
+```
+option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
+```
+
+Example lease with option configured (typical):
+
+lease {
+  interface "eth0";
+  <...cut...>
+  option rfc3442-classless-static-routes 0,10,0,0,1,32,168,63,129,16,10,0,0,1,32,169,254,169,254,10,0,0,1;
+  <...cut...>
+}
+
+Example lease without option, where it is presented as "unknown-121":
+
+lease {
+  interface "eth0";
+  <...cut...>
+  option unknown-121 0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1;
+  <...cut...>
+}
+
+The primary difference is that dhclient outputs the bytes in a
+hex-encoded format and with `:` delimiter. Extend existing
+parsing to support this format.
+
+With a couple added INFO logs, here is a sample DHCP on Azure with
+static routes being parsed from unknown-121 option with this patch:
+
+```
+2024-04-04 16:12:01,677 - ephemeral.py[DEBUG]: Received dhcp lease on eth0 for 10.0.0.11/255.255.255.0
+2024-04-04 16:12:01,677 - dhcp.py[INFO]: Parsing: '0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1'
+2024-04-04 16:12:01,677 - dhcp.py[INFO]: Tokens: ['0', '10', '0', '0', '1', '32', '168', '63', '129', '16', '10', '0', '0', '1', '32', '169', '254', '169', '254', '10', '0', '0', '1']
+2024-04-04 16:12:01,677 - ephemeral.py[DEBUG]: Attempting setup of ephemeral network on eth0 with 10.0.0.11/24 brd 10.0.0.255
+2024-04-04 16:12:01,677 - subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'addr', 'add', '10.0.0.11/24', 'broadcast', '10.0.0.255', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
+2024-04-04 16:12:01,679 - subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'link', 'set', 'dev', 'eth0', 'up'] with allowed return codes [0] (shell=False, capture=True)
+2024-04-04 16:12:01,681 - subp.py[DEBUG]: Running command ['ip', '-4', 'route', 'append', '0.0.0.0/0', 'via', '10.0.0.1', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
+2024-04-04 16:12:01,683 - subp.py[DEBUG]: Running command ['ip', '-4', 'route', 'append', '168.63.129.16/32', 'via', '10.0.0.1', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
+2024-04-04 16:12:01,684 - subp.py[DEBUG]: Running command ['ip', '-4', 'route', 'append', '169.254.169.254/32', 'via', '10.0.0.1', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
+2024-04-04 16:12:01,686 - handlers.py[DEBUG]: start: azure-ds/_check_if_primary: _check_if_primary
+2024-04-04 16:12:01,686 - handlers.py[DEBUG]: finish: azure-ds/_check_if_primary: SUCCESS: _check_if_primary
+2024-04-04 16:12:01,687 - azure.py[DEBUG]: Obtained DHCP lease on interface 'eth0' (primary=True driver='hv_netvsc' router='10.0.0.1' routes=[('0.0.0.0/0', '10.0.0.1'), ('168.63.129.16/32', '10.0.0.1'), ('169.254.169.254/32', '10.0.0.1')] lease={'inter
+face': 'eth0', 'fixed-address': '10.0.0.11', 'server-name': 'BL24A1071918060SOC', 'subnet-mask': '255.255.255.0', 'dhcp-lease-time': '4294967295', 'routers': '10.0.0.1', 'dhcp-message-type': '5', 'domain-name-servers': '168.63.129.16', 'dhcp-server-ide
+ntifier': '168.63.129.16', 'dhcp-renewal-time': '4294967295', 'unknown-121': '0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1', 'dhcp-rebinding-time': '4294967295', 'unknown-245': 'a8:3f:81:10', 'domain-name': 'fyoqc4gghleevjxtq4h4pjbded.bx.int
+ernal.cloudapp.net', 'renew': '0 2160/05/11 22:40:16', 'rebind': '0 2160/05/11 22:40:16', 'expire': '0 2160/05/11 22:40:16'} imds_routed=True wireserver_routed=True)
+```
+
+Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
+---
+ cloudinit/net/dhcp.py            | 15 ++++++++++++++-
+ cloudinit/net/ephemeral.py       |  1 +
+ tests/unittests/net/test_dhcp.py | 11 +++++++++++
+ 3 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/cloudinit/net/dhcp.py b/cloudinit/net/dhcp.py
+index 07c1339..ce1402a 100644
+--- a/cloudinit/net/dhcp.py
++++ b/cloudinit/net/dhcp.py
+@@ -388,14 +388,27 @@ class IscDhclient(DhcpClient):
+         ("0.0.0.0/0", "192.168.128.1")
+         ]
+
++        # unknown-121 option format
++        sr3 = parse_static_routes(\
++        "0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1")
++        sr3 = [
++            ("0.0.0.0/0", "10.0.0.1"),
++            ("168.63.129.16/32", "10.0.0.1"),
++            ("169.254.169.254/32", "10.0.0.1"),
++        ]
++
+         Python version of isc-dhclient's hooks:
+            /etc/dhcp/dhclient-exit-hooks.d/rfc3442-classless-routes
+         """
+         # raw strings from dhcp lease may end in semi-colon
+         rfc3442 = rfc3442.rstrip(";")
+-        tokens = [tok for tok in re.split(r"[, .]", rfc3442) if tok]
++        tokens = [tok for tok in re.split(r"[, . :]", rfc3442) if tok]
+         static_routes = []
+
++        # Handle unknown-121 format by converting hex to base 10.
++        if ":" in rfc3442:
++            tokens = [str(int(tok, 16)) for tok in tokens]
++
+         def _trunc_error(cidr, required, remain):
+             msg = (
+                 "RFC3442 string malformed.  Current route has CIDR of %s "
+diff --git a/cloudinit/net/ephemeral.py b/cloudinit/net/ephemeral.py
+index 28c851c..d4a1095 100644
+--- a/cloudinit/net/ephemeral.py
++++ b/cloudinit/net/ephemeral.py
+@@ -305,6 +305,7 @@ class EphemeralDHCPv4:
+             "static_routes": [
+                 "rfc3442-classless-static-routes",
+                 "classless-static-routes",
++                "unknown-121",
+             ],
+             "router": "routers",
+         }
+diff --git a/tests/unittests/net/test_dhcp.py b/tests/unittests/net/test_dhcp.py
+index a7b6231..b75bb40 100644
+--- a/tests/unittests/net/test_dhcp.py
++++ b/tests/unittests/net/test_dhcp.py
+@@ -262,6 +262,17 @@ class TestDHCPParseStaticRoutes(CiTestCase):
+             IscDhclient.parse_static_routes(rfc3442),
+         )
+
++    def test_unknown_121(self):
++        for unknown121 in [
++            "0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1",
++            "0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1;",
++        ]:
++            assert IscDhclient.parse_static_routes(unknown121) == [
++                ("0.0.0.0/0", "10.0.0.1"),
++                ("168.63.129.16/32", "10.0.0.1"),
++                ("169.254.169.254/32", "10.0.0.1"),
++            ]
++
+     def test_parse_static_routes_default_route(self):
+         rfc3442 = "0,130,56,240,1"
+         self.assertEqual(


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Cloud-init does not configure rfc3442-classless-static-routes if dhclient not patched to support them or it is not configured with. Currently, our dhclient package does not support rfc3442-classless-static-routes. So add an upstream up to resolve this. This change will resolve this and remove an DHCP error in cloud-init.log due to this.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add [upstream patch](https://github.com/canonical/cloud-init/pull/5146) for this issue

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 51407171](https://microsoft.visualstudio.com/OS/_workitems/edit/51407171): [Core][3.0] cloud-init in Azure Linux 3.0 needs to be updated to 24.2


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with RUN_CHECK=y
- Azure VM Provisioning test. Verify dhcp error gone