### PR TITLE
Address CVE-2024-3727 by patching vendored github.com/containers/image

### DIFF
--- a/SPECS/containerized-data-importer/CVE-2024-3727.patch
+++ b/SPECS/containerized-data-importer/CVE-2024-3727.patch
@@ -1,0 +1,163 @@
+From b64f84fa97b494ec754d3ba2b174011f4847095b Mon Sep 17 00:00:00 2001
+From: Brian Fjeldstad <bfjelds@microsoft.com>
+Date: Thu, 6 Jun 2024 20:11:41 +0000
+Subject: [PATCH] apply CVE-2024-3727 fix to v5.19.1
+
+---
+ vendor/github.com/containers/image/v5/docker/docker_client.go     |  3 +++
+ vendor/github.com/containers/image/v5/docker/docker_image.go      |  8 ++++++--
+ vendor/github.com/containers/image/v5/docker/docker_image_dest.go | 13 +++++++++++--
+ vendor/github.com/containers/image/v5/docker/docker_image_src.go  | 19 +++++++++++++++++--
+ vendor/github.com/containers/image/v5/docker/lookaside.go         |  7 +++++--
+ 5 files changed, 42 insertions(+), 8 deletions(-)
+
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_client.go b/vendor/github.com/containers/image/v5/docker/docker_client.go
+index 833323b4..99bde923 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_client.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_client.go
+@@ -796,6 +796,9 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
+ // getExtensionsSignatures returns signatures from the X-Registry-Supports-Signatures API extension,
+ // using the original data structures.
+ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerReference, manifestDigest digest.Digest) (*extensionSignatureList, error) {
++	if err := manifestDigest.Validate(); err != nil { // Make sure manifestDigest.String() does not contain any unexpected characters
++		return nil, err
++	}
+ 	path := fmt.Sprintf(extensionsSignaturePath, reference.Path(ref.ref), manifestDigest)
+ 	res, err := c.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
+ 	if err != nil {
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_image.go b/vendor/github.com/containers/image/v5/docker/docker_image.go
+index c84bb37d..0076d229 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_image.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_image.go
+@@ -83,8 +83,12 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
+ 		if err = json.NewDecoder(res.Body).Decode(&tagsHolder); err != nil {
+ 			return nil, err
+ 		}
+-		tags = append(tags, tagsHolder.Tags...)
+-
++		for _, tag := range tagsHolder.Tags {
++			if _, err := reference.WithTag(dr.ref, tag); err != nil { // Ensure the tag does not contain unexpected values
++				return nil, fmt.Errorf("registry returned invalid tag %q: %w", tag, err)
++			}
++			tags = append(tags, tag)
++		}
+ 		link := res.Header.Get("Link")
+ 		if link == "" {
+ 			break
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
+index e7af8f93..8117ad4e 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
+@@ -226,6 +226,9 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader,
+ // If the destination does not contain the blob, or it is unknown, blobExists ordinarily returns (false, -1, nil);
+ // it returns a non-nil error only on an unexpected failure.
+ func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.Named, digest digest.Digest, extraScope *authScope) (bool, int64, error) {
++	if err := digest.Validate(); err != nil { // Make sure digest.String() does not contain any unexpected characters
++		return false, -1, err
++	}
+ 	checkPath := fmt.Sprintf(blobsPath, reference.Path(repo), digest.String())
+ 	logrus.Debugf("Checking %s", checkPath)
+ 	res, err := d.c.makeRequest(ctx, http.MethodHead, checkPath, nil, nil, v2Auth, extraScope)
+@@ -558,7 +561,10 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, m
+ 
+ 	// NOTE: Keep this in sync with docs/signature-protocols.md!
+ 	for i, signature := range signatures {
+-		url := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
++		url, err := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return err
++		}
+ 		err := d.putOneSignature(url, signature)
+ 		if err != nil {
+ 			return err
+@@ -570,7 +576,10 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, m
+ 	// is enough for dockerImageSource to stop looking for other signatures, so that
+ 	// is sufficient.
+ 	for i := len(signatures); ; i++ {
+-		url := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
++		url, err := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return err
++		}
+ 		missing, err := d.c.deleteOneSignature(url)
+ 		if err != nil {
+ 			return err
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_image_src.go b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
+index 314e9b39..5432f320 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_image_src.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
+@@ -178,6 +178,9 @@ func simplifyContentType(contentType string) string {
+ // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+ func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+ 	if instanceDigest != nil {
++		if err := instanceDigest.Validate(); err != nil { // Make sure instanceDigest.String() does not contain any unexpected characters
++			return nil, "", err
++		}
+ 		return s.fetchManifest(ctx, instanceDigest.String())
+ 	}
+ 	err := s.ensureManifestIsLoaded(ctx)
+@@ -373,6 +376,9 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo,
+ 		return nil, nil, fmt.Errorf("external URLs not supported with GetBlobAt")
+ 	}
+ 
++	if err := info.Digest.Validate(); err != nil { // Make sure info.Digest.String() does not contain any unexpected characters
++		return nil, nil, err
++	}
+ 	path := fmt.Sprintf(blobsPath, reference.Path(s.physicalRef.ref), info.Digest.String())
+ 	logrus.Debugf("Downloading %s", path)
+ 	res, err := s.c.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
+@@ -425,6 +431,9 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
+ 		}
+ 	}
+ 
++	if err := info.Digest.Validate(); err != nil { // Make sure info.Digest.String() does not contain any unexpected characters
++		return nil, 0, err
++	}
+ 	path := fmt.Sprintf(blobsPath, reference.Path(s.physicalRef.ref), info.Digest.String())
+ 	logrus.Debugf("Downloading %s", path)
+ 	res, err := s.c.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
+@@ -486,7 +495,10 @@ func (s *dockerImageSource) getSignaturesFromLookaside(ctx context.Context, inst
+ 	// NOTE: Keep this in sync with docs/signature-protocols.md!
+ 	signatures := [][]byte{}
+ 	for i := 0; ; i++ {
+-		url := signatureStorageURL(s.c.signatureBase, manifestDigest, i)
++		url, err := signatureStorageURL(s.c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return err
++		}
+ 		signature, missing, err := s.getOneSignature(ctx, url)
+ 		if err != nil {
+ 			return nil, err
+@@ -627,7 +639,10 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
+ 	}
+ 
+ 	for i := 0; ; i++ {
+-		url := signatureStorageURL(c.signatureBase, manifestDigest, i)
++		url, err := signatureStorageURL(c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return err
++		}
+ 		missing, err := c.deleteOneSignature(url)
+ 		if err != nil {
+ 			return err
+diff --git a/vendor/github.com/containers/image/v5/docker/lookaside.go b/vendor/github.com/containers/image/v5/docker/lookaside.go
+index 515e5932..2e400c09 100644
+--- a/vendor/github.com/containers/image/v5/docker/lookaside.go
++++ b/vendor/github.com/containers/image/v5/docker/lookaside.go
+@@ -229,8 +229,11 @@ func (ns registryNamespace) signatureTopLevel(write bool) string {
+ // signatureStorageURL returns an URL usable for accessing signature index in base with known manifestDigest.
+ // base is not nil from the caller
+ // NOTE: Keep this in sync with docs/signature-protocols.md!
+-func signatureStorageURL(base signatureStorageBase, manifestDigest digest.Digest, index int) *url.URL {
++func signatureStorageURL(base signatureStorageBase, manifestDigest digest.Digest, index int) (*url.URL, error) {
++	if err := manifestDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in a path with ../, so validate explicitly.
++		return nil, err
++	}
+ 	url := *base
+ 	url.Path = fmt.Sprintf("%s@%s=%s/signature-%d", url.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
+-	return &url
++	return &url, nil
+ }
+-- 
+2.34.1
+

--- a/SPECS/containerized-data-importer/CVE-2024-3727.patch
+++ b/SPECS/containerized-data-importer/CVE-2024-3727.patch
@@ -1,15 +1,15 @@
-From b64f84fa97b494ec754d3ba2b174011f4847095b Mon Sep 17 00:00:00 2001
+From ea14d57b98cc37decad0c39ccbafb27994274b47 Mon Sep 17 00:00:00 2001
 From: Brian Fjeldstad <bfjelds@microsoft.com>
-Date: Thu, 6 Jun 2024 20:11:41 +0000
+Date: Thu, 6 Jun 2024 21:13:36 +0000
 Subject: [PATCH] apply CVE-2024-3727 fix to v5.19.1
 
 ---
  vendor/github.com/containers/image/v5/docker/docker_client.go     |  3 +++
  vendor/github.com/containers/image/v5/docker/docker_image.go      |  8 ++++++--
- vendor/github.com/containers/image/v5/docker/docker_image_dest.go | 13 +++++++++++--
+ vendor/github.com/containers/image/v5/docker/docker_image_dest.go | 15 ++++++++++++---
  vendor/github.com/containers/image/v5/docker/docker_image_src.go  | 19 +++++++++++++++++--
  vendor/github.com/containers/image/v5/docker/lookaside.go         |  7 +++++--
- 5 files changed, 42 insertions(+), 8 deletions(-)
+ 5 files changed, 43 insertions(+), 9 deletions(-)
 
 diff --git a/vendor/github.com/containers/image/v5/docker/docker_client.go b/vendor/github.com/containers/image/v5/docker/docker_client.go
 index 833323b4..99bde923 100644
@@ -45,7 +45,7 @@ index c84bb37d..0076d229 100644
  		if link == "" {
  			break
 diff --git a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
-index e7af8f93..8117ad4e 100644
+index e7af8f93..1096c56f 100644
 --- a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
 +++ b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
 @@ -226,6 +226,9 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader,
@@ -58,18 +58,20 @@ index e7af8f93..8117ad4e 100644
  	checkPath := fmt.Sprintf(blobsPath, reference.Path(repo), digest.String())
  	logrus.Debugf("Checking %s", checkPath)
  	res, err := d.c.makeRequest(ctx, http.MethodHead, checkPath, nil, nil, v2Auth, extraScope)
-@@ -558,7 +561,10 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, m
+@@ -558,8 +561,11 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, m
  
  	// NOTE: Keep this in sync with docs/signature-protocols.md!
  	for i, signature := range signatures {
 -		url := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
+-		err := d.putOneSignature(url, signature)
 +		url, err := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
 +		if err != nil {
 +			return err
 +		}
- 		err := d.putOneSignature(url, signature)
++		err = d.putOneSignature(url, signature)
  		if err != nil {
  			return err
+ 		}
 @@ -570,7 +576,10 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, m
  	// is enough for dockerImageSource to stop looking for other signatures, so that
  	// is sufficient.
@@ -83,7 +85,7 @@ index e7af8f93..8117ad4e 100644
  		if err != nil {
  			return err
 diff --git a/vendor/github.com/containers/image/v5/docker/docker_image_src.go b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
-index 314e9b39..5432f320 100644
+index 314e9b39..43ca0c4f 100644
 --- a/vendor/github.com/containers/image/v5/docker/docker_image_src.go
 +++ b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
 @@ -178,6 +178,9 @@ func simplifyContentType(contentType string) string {
@@ -123,7 +125,7 @@ index 314e9b39..5432f320 100644
 -		url := signatureStorageURL(s.c.signatureBase, manifestDigest, i)
 +		url, err := signatureStorageURL(s.c.signatureBase, manifestDigest, i)
 +		if err != nil {
-+			return err
++			return nil, err
 +		}
  		signature, missing, err := s.getOneSignature(ctx, url)
  		if err != nil {

--- a/SPECS/containerized-data-importer/containerized-data-importer.spec
+++ b/SPECS/containerized-data-importer/containerized-data-importer.spec
@@ -18,13 +18,14 @@
 Summary:        Container native virtualization
 Name:           containerized-data-importer
 Version:        1.57.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System/Packages
 URL:            https://github.com/kubevirt/containerized-data-importer
 Source0:        https://github.com/kubevirt/containerized-data-importer/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-3727.patch
 BuildRequires:  golang
 BuildRequires:  golang-packaging
 BuildRequires:  libnbd-devel
@@ -108,6 +109,7 @@ kubernetes installation with kubectl apply.
 # to be 'physically' placed into the proper location.
 %setup -q -n go/src/kubevirt.io/%{name} -c -T
 tar --strip-components=1 -xf %{SOURCE0}
+%autopatch -p1
 
 %build
 
@@ -198,6 +200,9 @@ install -m 0644 _out/manifests/release/cdi-cr.yaml %{buildroot}%{_datadir}/cdi/m
 %{_datadir}/cdi/manifests
 
 %changelog
+* Thu Jun 06 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 1.57.0-2
+- Address CVE-2024-3727 by patching vendored github.com/containers/image
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.57.0-1
 - Auto-upgrade to 1.57.0 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2024-3727 by patching vendored github.com/containers/image.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Create patch from PR: https://[patch-diff.githubusercontent.com/raw/containers/image/pull/2403.patch](https://patch-diff.githubusercontent.com/raw/containers/image/pull/2403.patch)
- Adjust patch for containers/image version and vendored files (only docker folder is vendored)
- Adjust patch paths to reflect vendored paths

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-3727

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=582455&view=results
- validated golden containers (built with: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=582648&view=results) using kubevirt live migration test pipeline: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=582963&view=results
