### PR TITLE
Upgrade kernel to 5.15.158.2

### DIFF
--- a/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
+++ b/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
+++ b/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
@@ -9,7 +9,7 @@
 %define uname_r %{version}-%{release}
 Summary:        Signed Linux Kernel for Azure
 Name:           kernel-azure-signed-%{buildarch}
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation

--- a/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
+++ b/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
@@ -4,7 +4,7 @@
 %define uname_r %{version}-%{release}
 Summary:        Signed Linux Kernel for HCI
 Name:           kernel-hci-signed-%{buildarch}
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -149,6 +149,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -9,7 +9,7 @@
 %define uname_r %{version}-%{release}
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/SPECS/hyperv-daemons/CVE-2024-35848.nopatch
+++ b/SPECS/hyperv-daemons/CVE-2024-35848.nopatch
@@ -1,3 +1,0 @@
-CVE-2024-35848 - in version 5.15.159.1
-upstream: f42c97027fb75776e2e9358d16bf4a99aeb04cf2 
-stable: 26d32bec4c6d255a03762f33c637bfa3718be15a

--- a/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
+++ b/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
@@ -7,6 +7,6 @@
     "hypervkvpd.service": "c1bb207cf9f388f8f3cf5b649abbf8cfe4c4fcf74538612946e68f350d1f265f",
     "hypervvss.rules": "94cead44245ef6553ab79c0bbac8419e3ff4b241f01bcec66e6f508098cbedd1",
     "hypervvssd.service": "22270d9f0f23af4ea7905f19c1d5d5495e40c1f782cbb87a99f8aec5a011078d",
-    "kernel-5.15.159.1.tar.gz": "2936521edcf244601b35cc6bbda543ea39a5b65d938789499d347832a3cdbd0a"
+    "kernel-5.15.158.2.tar.gz": "f1cd19f50f1f182f61cbaebfee52f344708b0a71bce03eabaf3772d4ecf05c8d"
   }
 }

--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -8,7 +8,7 @@
 %global udev_prefix 70
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
@@ -219,6 +219,9 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/SPECS/kernel-azure/config
+++ b/SPECS/kernel-azure/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.15.159.1 Kernel Configuration
+# Linux/x86_64 5.15.158.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel-azure/config_aarch64
+++ b/SPECS/kernel-azure/config_aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.159.1 Kernel Configuration
+# Linux/arm64 5.15.158.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel-azure/kernel-azure.signatures.json
+++ b/SPECS/kernel-azure/kernel-azure.signatures.json
@@ -1,9 +1,9 @@
 {
   "Signatures": {
     "cbl-mariner-ca-20211013.pem": "5ef124b0924cb1047c111a0ecff1ae11e6ad7cac8d1d9b40f98f99334121f0b0",
-    "config": "77c866dee4e6ade4d24a525f66c839d6000164cc77022122bf7c799783f569da",
-    "config_aarch64": "82d3529ac9b6bba268991521d177cfc158f8b5d7dfe22016b5015935fcbb3b82",
+    "config": "7650bca555140f8b2c2e6b03709da0a8d730993215e9d28751068c799100c7bf",
+    "config_aarch64": "1c9733a974fa2aa7f38ae3c05887921cb7e94db0f2d5e37f85780da5824dab38",
     "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f",
-    "kernel-5.15.159.1.tar.gz": "2936521edcf244601b35cc6bbda543ea39a5b65d938789499d347832a3cdbd0a"
+    "kernel-5.15.158.2.tar.gz": "f1cd19f50f1f182f61cbaebfee52f344708b0a71bce03eabaf3772d4ecf05c8d"
   }
 }

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -27,7 +27,7 @@
 
 Summary:        Linux Kernel
 Name:           kernel-azure
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -420,6 +420,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/SPECS/kernel-hci/config
+++ b/SPECS/kernel-hci/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.15.159.1 Kernel Configuration
+# Linux/x86_64 5.15.158.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel-hci/kernel-hci.signatures.json
+++ b/SPECS/kernel-hci/kernel-hci.signatures.json
@@ -1,7 +1,7 @@
 {
   "Signatures": {
     "cbl-mariner-ca-20211013.pem": "5ef124b0924cb1047c111a0ecff1ae11e6ad7cac8d1d9b40f98f99334121f0b0",
-    "config": "a87f0f1b7b22e314f5570892020bc99928eb108c86f2612db1a5a30274f4e9c7",
-    "kernel-5.15.159.1.tar.gz": "2936521edcf244601b35cc6bbda543ea39a5b65d938789499d347832a3cdbd0a"
+    "config": "c8c6eb36480dc13723e2c29f8df52b2557c88c5fd2c6b28acedd763f90954855",
+    "kernel-5.15.158.2.tar.gz": "f1cd19f50f1f182f61cbaebfee52f344708b0a71bce03eabaf3772d4ecf05c8d"
   }
 }

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -17,7 +17,7 @@
 %define config_source %{SOURCE1}
 Summary:        Linux Kernel for HCI
 Name:           kernel-hci
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -547,6 +547,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/SPECS/kernel-headers/kernel-headers.signatures.json
+++ b/SPECS/kernel-headers/kernel-headers.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "kernel-5.15.159.1.tar.gz": "2936521edcf244601b35cc6bbda543ea39a5b65d938789499d347832a3cdbd0a"
+    "kernel-5.15.158.2.tar.gz": "f1cd19f50f1f182f61cbaebfee52f344708b0a71bce03eabaf3772d4ecf05c8d"
   }
 }

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -11,7 +11,7 @@
 
 Summary:        Linux API header files
 Name:           kernel-headers
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -73,6 +73,9 @@ done
 %endif
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/SPECS/kernel/CVE-2024-26900.nopatch
+++ b/SPECS/kernel/CVE-2024-26900.nopatch
@@ -1,3 +1,0 @@
-CVE-2024-26900 - in version 5.15.159.1
-upstream: 6cf350658736681b9d6b0b6e58c5c76b235bb4c4
-stable: f3a1787dc48213f6caea5ba7d47e0222e7fa34a9

--- a/SPECS/kernel/config
+++ b/SPECS/kernel/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.15.159.1 Kernel Configuration
+# Linux/x86_64 5.15.158.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel/config_aarch64
+++ b/SPECS/kernel/config_aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.159.1 Kernel Configuration
+# Linux/arm64 5.15.158.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -1,9 +1,9 @@
 {
   "Signatures": {
     "cbl-mariner-ca-20211013.pem": "5ef124b0924cb1047c111a0ecff1ae11e6ad7cac8d1d9b40f98f99334121f0b0",
-    "config": "06d85c7e3e286274d246f834eaf37258e13b0b391421376fa55f243230d728e9",
-    "config_aarch64": "9de72286da24a8e90052238d13f24621a48835a1b45a35740887ad27ef749448",
+    "config": "4c524dadcc8f306d8cd9e34ba5aa03cf1fb6b1f40fca0b811861ac09d916f4a8",
+    "config_aarch64": "764d801459dd24b7676b30a6fa05c68bf544ff8b577bd8085adbe01d56b8c697",
     "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f",
-    "kernel-5.15.159.1.tar.gz": "2936521edcf244601b35cc6bbda543ea39a5b65d938789499d347832a3cdbd0a"
+    "kernel-5.15.158.2.tar.gz": "f1cd19f50f1f182f61cbaebfee52f344708b0a71bce03eabaf3772d4ecf05c8d"
   }
 }

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -27,7 +27,7 @@
 
 Summary:        Linux Kernel
 Name:           kernel
-Version:        5.15.159.1
+Version:        5.15.158.2
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -426,6 +426,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Fri Jun 07 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.15.158.2-1
+- Revert to 5.15.158.2
+
 * Wed May 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.159.1-1
 - Auto-upgrade to 5.15.159.1
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6560,8 +6560,8 @@
         "type": "other",
         "other": {
           "name": "hyperv-daemons",
-          "version": "5.15.159.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.159.1.tar.gz"
+          "version": "5.15.158.2",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.158.2.tar.gz"
         }
       }
     },
@@ -8151,8 +8151,8 @@
         "type": "other",
         "other": {
           "name": "kernel",
-          "version": "5.15.159.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.159.1.tar.gz"
+          "version": "5.15.158.2",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.158.2.tar.gz"
         }
       }
     },
@@ -8161,8 +8161,8 @@
         "type": "other",
         "other": {
           "name": "kernel-azure",
-          "version": "5.15.159.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.159.1.tar.gz"
+          "version": "5.15.158.2",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.158.2.tar.gz"
         }
       }
     },
@@ -8171,8 +8171,8 @@
         "type": "other",
         "other": {
           "name": "kernel-hci",
-          "version": "5.15.159.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.159.1.tar.gz"
+          "version": "5.15.158.2",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.158.2.tar.gz"
         }
       }
     },
@@ -8181,8 +8181,8 @@
         "type": "other",
         "other": {
           "name": "kernel-headers",
-          "version": "5.15.159.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.159.1.tar.gz"
+          "version": "5.15.158.2",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.158.2.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-20.cm2.aarch64.rpm
-kernel-headers-5.15.159.1-1.cm2.noarch.rpm
+kernel-headers-5.15.158.2-1.cm2.noarch.rpm
 glibc-2.35-7.cm2.aarch64.rpm
 glibc-devel-2.35-7.cm2.aarch64.rpm
 glibc-i18n-2.35-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-20.cm2.x86_64.rpm
-kernel-headers-5.15.159.1-1.cm2.noarch.rpm
+kernel-headers-5.15.158.2-1.cm2.noarch.rpm
 glibc-2.35-7.cm2.x86_64.rpm
 glibc-devel-2.35-7.cm2.x86_64.rpm
 glibc-i18n-2.35-7.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -136,7 +136,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.159.1-1.cm2.noarch.rpm
+kernel-headers-5.15.158.2-1.cm2.noarch.rpm
 kmod-29-2.cm2.aarch64.rpm
 kmod-debuginfo-29-2.cm2.aarch64.rpm
 kmod-devel-29-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -141,8 +141,8 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-cross-headers-5.15.159.1-1.cm2.noarch.rpm
-kernel-headers-5.15.159.1-1.cm2.noarch.rpm
+kernel-cross-headers-5.15.158.2-1.cm2.noarch.rpm
+kernel-headers-5.15.158.2-1.cm2.noarch.rpm
 kmod-29-2.cm2.x86_64.rpm
 kmod-debuginfo-29-2.cm2.x86_64.rpm
 kmod-devel-29-2.cm2.x86_64.rpm


### PR DESCRIPTION
5.15.157.1 introduced a failure with network hairpinning on AKS. Upgrade to 5.15.158.2 which has the commit [dceb683] reverted.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
5.15.157.1 introduced a failure with network hairpinning on AKS. Upgrade to 5.15.158.2 which has the commit [dceb683] https://github.com/microsoft/CBL-Mariner-Linux-Kernel/commit/dceb683ab87ca3666a9bb5c0158528b646faedc4 reverted.

Revert commit: https://github.com/microsoft/CBL-Mariner-Linux-Kernel/commit/20e00f82783e6ba78214d49a9c266bcb6e18a2f1

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade kernel to 5.15.158.2

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/51540596

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=582922&view=results
- toolchain build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=582925&view=results

<img width="392" alt="image" src="https://github.com/microsoft/azurelinux/assets/10325590/61eb2c2c-926c-4b35-ab4f-30552d7b01e2">

