### PR TITLE
Fix shadow-utils to reenable user groups

### DIFF
--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.14.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -99,9 +99,6 @@ mv -v %{buildroot}%{_bindir}/passwd %{buildroot}/bin
 chmod ug-s %{buildroot}/bin/passwd
 install -vm644 %{SOURCE12} %{buildroot}%{_sysconfdir}/default/useradd
 install -vm644 %{SOURCE13} %{buildroot}%{_sysconfdir}/login.defs
-# Disable usergroups. Use "users" group by default (see /usr/sbin/useradd)
-# for all nonroot users.
-sed -i 's/USERGROUPS_ENAB.*/USERGROUPS_ENAB no/' %{buildroot}%{_sysconfdir}/login.defs
 ln -s useradd %{buildroot}%{_sbindir}/adduser
 cp etc/{limits,login.access} %{buildroot}%{_sysconfdir}
 for FUNCTION in FAIL_DELAY               \
@@ -184,6 +181,9 @@ rm -rf %{buildroot}/*
 %{_libdir}/libsubid.so
 
 %changelog
+* Mon Jun 10 2024 Tobias Brick <tobiasb@microsoft.com> - 4.14.3-2
+- Enable user groups for useradd
+
 * Fri Feb 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 4.14.3-1
 - Auto-upgrade to 4.14.3 - 3.0 Upgrade
 - Remove obsolete patches and fix configure command


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Change #7761 upgraded `shadow-utils` and took part of a [change from upstream](https://github.com/vmware/photon/commit/96763cf667979d81003ee084b8d33a96fe5a2d46) that modifies `/etc/login.defs` so that `USERGROUPS_ENAB` is set to `no`. This makes all users be created in the same group (in our case `users`) rather than created with their own group.

This change undoes that, so users will once again be created with their own group with the same name as the user.

###### Change Log  <!-- REQUIRED -->
- Removed code in `shadow-utils.spec` that changed the setting.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Built locally and verified change to `/etc/login.defs`
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=583292&view=results
- Full Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=583291&view=results
- Used built RPM to upgrade `shadow-utils` and created a user -- it had the correct group.
