### PR TITLE
[WIP] Enable check section for glibc

### DIFF
--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -123,7 +123,7 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 %{_datadir}/%{name}/test
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.18.0-28
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.18.0-28
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.18.0-27

--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -21,7 +21,7 @@
 Summary:        A command line tool used for creating OCI Images
 Name:           buildah
 Version:        1.18.0
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -123,6 +123,9 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 %{_datadir}/%{name}/test
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.18.0-28
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.18.0-27
 - Bump to rebuild with updated glibc
 
@@ -1896,7 +1899,7 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 
 * Thu Feb 22 2018 Dan Walsh <dwalsh@redhat.com> 0.13-1
 - Vendor in latest containers/storage
-- This fixes a large SELinux bug.  
+- This fixes a large SELinux bug.
 - run: do not open /etc/hosts if not needed
 - Add the following flags to buildah bud and from
             --add-host
@@ -2024,7 +2027,7 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 - Bump for inclusion of OCI 1.0 Runtime and Image Spec
 
 * Tue Jul 18 2017 Dan Walsh <dwalsh@redhat.com> 0.2.0-1.gitac2aad6
-- buildah run: Add support for -- ending options parsing 
+- buildah run: Add support for -- ending options parsing
 - buildah Add/Copy support for glob syntax
 - buildah commit: Add flag to remove containers on commit
 - buildah push: Improve man page and help information

--- a/SPECS-EXTENDED/catatonit/catatonit.spec
+++ b/SPECS-EXTENDED/catatonit/catatonit.spec
@@ -3,7 +3,7 @@ Distribution:   Azure Linux
 
 Name: catatonit
 Version: 0.1.7
-Release: 15%{?dist}
+Release: 16%{?dist}
 Summary: A signal-forwarding process manager for containers
 License: GPLv3+
 URL: https://github.com/openSUSE/catatonit
@@ -61,6 +61,9 @@ ln -s %{_libexecdir}/%{name}/%{name} %{buildroot}%{_libexecdir}/podman/%{name}
 %{_libexecdir}/podman/%{name}
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.1.7-16
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 0.1.7-15
 - Bump to rebuild with updated glibc
 
@@ -105,7 +108,7 @@ ln -s %{_libexecdir}/%{name}/%{name} %{buildroot}%{_libexecdir}/podman/%{name}
 - autobuilt v0.1.5
 
 * Wed Apr 29 2020 Lokesh Mandvekar <lsm5@fedoraproject.org> - 0.1.5-2
-- complain if not statically linked, patch from Jindrich Novy <jnovy@redhat.com> 
+- complain if not statically linked, patch from Jindrich Novy <jnovy@redhat.com>
 
 * Wed Apr 29 2020 Lokesh Mandvekar <lsm5@fedoraproject.org> - 0.1.5-1
 - bump to v0.1.5

--- a/SPECS-EXTENDED/catatonit/catatonit.spec
+++ b/SPECS-EXTENDED/catatonit/catatonit.spec
@@ -61,7 +61,7 @@ ln -s %{_libexecdir}/%{name}/%{name} %{buildroot}%{_libexecdir}/podman/%{name}
 %{_libexecdir}/podman/%{name}
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.1.7-16
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.1.7-16
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 0.1.7-15

--- a/SPECS-EXTENDED/dyninst/dyninst.spec
+++ b/SPECS-EXTENDED/dyninst/dyninst.spec
@@ -194,7 +194,7 @@ echo "%{_libdir}/dyninst" > %{buildroot}/etc/ld.so.conf.d/%{name}-%{_arch}.conf
 %attr(644,root,root) %{_libdir}/dyninst/testsuite/*.a
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 10.1.0-18
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 10.1.0-18
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 10.1.0-17

--- a/SPECS-EXTENDED/dyninst/dyninst.spec
+++ b/SPECS-EXTENDED/dyninst/dyninst.spec
@@ -1,7 +1,7 @@
 Summary: An API for Run-time Code Generation
 License: LGPLv2+
 Name: dyninst
-Release: 17%{?dist}
+Release: 18%{?dist}
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL: http://www.dyninst.org
@@ -194,6 +194,9 @@ echo "%{_libdir}/dyninst" > %{buildroot}/etc/ld.so.conf.d/%{name}-%{_arch}.conf
 %attr(644,root,root) %{_libdir}/dyninst/testsuite/*.a
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 10.1.0-18
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 10.1.0-17
 - Bump to rebuild with updated glibc
 
@@ -236,7 +239,7 @@ echo "%{_libdir}/dyninst" > %{buildroot}/etc/ld.so.conf.d/%{name}-%{_arch}.conf
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
 
 * Fri Nov 15 2019 Stan Cox <scox@redhat.com> - 10.1.0-4
-- Fix rhbz963475 dyninst must be ported to aarch64 
+- Fix rhbz963475 dyninst must be ported to aarch64
 
 * Wed Jul 24 2019 Fedora Release Engineering <releng@fedoraproject.org> - 10.1.0-3
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -386,7 +386,7 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 4.1.1-26
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 4.1.1-26
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 4.1.1-25

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -35,7 +35,7 @@
 
 Name:           podman
 Version:        4.1.1
-Release:        25%{?dist}
+Release:        26%{?dist}
 License:        ASL 2.0 and BSD and ISC and MIT and MPLv2.0
 Summary:        Manage Pods, Containers and Container Images
 Vendor:         Microsoft Corporation
@@ -386,6 +386,9 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 4.1.1-26
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 4.1.1-25
 - Bump to rebuild with updated glibc
 

--- a/SPECS/busybox/busybox.spec
+++ b/SPECS/busybox/busybox.spec
@@ -103,7 +103,7 @@ SKIP_KNOWN_BUGS=1 ./runtest
 %{_mandir}/man1/busybox.petitboot.1.gz
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.36.1-8
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.36.1-8
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.36.1-7

--- a/SPECS/busybox/busybox.spec
+++ b/SPECS/busybox/busybox.spec
@@ -1,7 +1,7 @@
 Summary:        Statically linked binary providing simplified versions of system commands
 Name:           busybox
 Version:        1.36.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -103,6 +103,9 @@ SKIP_KNOWN_BUGS=1 ./runtest
 %{_mandir}/man1/busybox.petitboot.1.gz
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.36.1-8
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.36.1-7
 - Bump to rebuild with updated glibc
 

--- a/SPECS/flannel/flannel.spec
+++ b/SPECS/flannel/flannel.spec
@@ -50,7 +50,7 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./dist/flanneld
 %{_bindir}/flanneld
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.24.2-7
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.24.2-7
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 0.24.2-6

--- a/SPECS/flannel/flannel.spec
+++ b/SPECS/flannel/flannel.spec
@@ -3,7 +3,7 @@
 Summary:        Simple and easy way to configure a layer 3 network fabric designed for Kubernetes
 Name:           flannel
 Version:        0.24.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -50,6 +50,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./dist/flanneld
 %{_bindir}/flanneld
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.24.2-7
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 0.24.2-6
 - Bump to rebuild with updated glibc
 

--- a/SPECS/glibc/0001-Remove-Wno-format-cflag-from-tests.patch
+++ b/SPECS/glibc/0001-Remove-Wno-format-cflag-from-tests.patch
@@ -1,0 +1,52 @@
+From 8768893dbd2b055f71c719e5135d9b8720731d81 Mon Sep 17 00:00:00 2001
+From: Rachel Menge <rachelmenge@microsoft.com>
+Date: Fri, 7 Jun 2024 21:17:37 +0000
+Subject: [PATCH] Remove -Wno-format cflag from tests
+
+This flag prevents the error
+"c1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]"
+The error occurs when glibc is compiled with -Wformat-security which
+requires -Wformat and thus conflicts with tests which use -Wno-format
+---
+ debug/Makefile | 4 ++--
+ time/Makefile  | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/debug/Makefile b/debug/Makefile
+index 434e52f7..05363c26 100644
+--- a/debug/Makefile
++++ b/debug/Makefile
+@@ -192,7 +192,7 @@ tests-cc-def-chk =
+ tests-c-time64-chk =
+ tests-cc-time64-chk =
+ 
+-CFLAGS-tst-fortify.c += -Wno-format -Wno-deprecated-declarations -Wno-error
++CFLAGS-tst-fortify.c += -Wno-deprecated-declarations
+ 
+ # No additional flags for the default tests.
+ define cflags-default
+@@ -215,7 +215,7 @@ src-chk-nongnu = \#undef _GNU_SOURCE
+ # cannot be disabled via pragmas, so require -Wno-error to be used.
+ define gen-chk-test
+ tests-$(1)-$(4)-chk += tst-fortify-$(1)-$(2)-$(3)-$(4)
+-CFLAGS-tst-fortify-$(1)-$(2)-$(3)-$(4).$(1) += $(no-fortify-source),-D_FORTIFY_SOURCE=$(3) -Wno-format \
++CFLAGS-tst-fortify-$(1)-$(2)-$(3)-$(4).$(1) += $(no-fortify-source),-D_FORTIFY_SOURCE=$(3) \
+ 					  -Wno-deprecated-declarations \
+ 					  -Wno-error
+ $(eval $(call cflags-$(2),$(1),$(3),$(4)))
+diff --git a/time/Makefile b/time/Makefile
+index 1d2e667c..8b878bcc 100644
+--- a/time/Makefile
++++ b/time/Makefile
+@@ -102,7 +102,7 @@ CFLAGS-nanosleep.c += -fexceptions -fasynchronous-unwind-tables
+ CFLAGS-mktime.c += $(config-cflags-wno-ignored-attributes)
+ 
+ # Don't warn about Y2k problem in strftime format string.
+-CFLAGS-test_time.c += -Wno-format
++CFLAGS-test_time.c += -Wformat
+ 
+ test_time-ARGS= EST5EDT CST
+ 
+-- 
+2.34.1
+

--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -251,14 +251,19 @@ ls -1 %{buildroot}%{_libdir}/*.a | grep -v -e "$static_libs_in_devel_pattern" | 
 %check
 cd %{_builddir}/glibc-build
 
-# Should have around the following results:
+# Should have the following results:
 # Summary of test results:
-#      2 FAIL : nptl/tst-cancel1, io/tst-lchmod
-#   5041 PASS
+#      3 FAIL : nptl/tst-cancel1, io/tst-lchmod, nptl/tst-mutex10
+#   5040 PASS
 #    152 UNSUPPORTED
 #     12 XFAIL
 #      8 XPASS
-make %{?_smp_mflags} check
+make %{?_smp_mflags} check ||:
+n=0
+grep "^FAIL: nptl/tst-cancel1" tests.sum >/dev/null && n=$((n+1)) ||:
+grep "^FAIL: io/tst-lchmod" tests.sum >/dev/null && n=$((n+1)) ||:
+grep "^FAIL: nptl/tst-mutex10" tests.sum >/dev/null && n=$((n+1)) ||:
+[ `grep ^FAIL tests.sum | wc -l` -ne $n ] && exit 1 ||:
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig

--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -345,7 +345,7 @@ make %{?_smp_mflags} check
 %exclude %{_libdir}/locale/C.utf8
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 2.38-7
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 2.38-8
 - Enable check section for glibc
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 2.38-7

--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -35,6 +35,8 @@ Patch7:         CVE-2023-5156.patch
 Patch8:         CVE-2023-6246.patch
 Patch9:         CVE-2023-6779.patch
 Patch10:        CVE-2023-6780.patch
+# Patches for testing
+Patch100:       0001-Remove-Wno-format-cflag-from-tests.patch
 
 BuildRequires:  bison
 BuildRequires:  gawk
@@ -248,26 +250,15 @@ ls -1 %{buildroot}%{_libdir}/*.a | grep -v -e "$static_libs_in_devel_pattern" | 
 
 %check
 cd %{_builddir}/glibc-build
-make %{?_smp_mflags} check ||:
-# These 2 persistant false positives are OK
-# XPASS for: elf/tst-protected1a and elf/tst-protected1b
-[ `grep ^XPASS tests.sum | wc -l` -ne 2 -a `grep "^XPASS: elf/tst-protected1[ab]" tests.sum | wc -l` -ne 2 ] && exit 1 ||:
 
-# FAIL (intermittent) in chroot but PASS in container:
-# posix/tst-spawn3 and stdio-common/test-vfprintf
-n=0
-grep "^FAIL: posix/tst-spawn3" tests.sum >/dev/null && n=$((n+1)) ||:
-grep "^FAIL: stdio-common/test-vfprintf" tests.sum >/dev/null && n=$((n+1)) ||:
-# FAIL always on overlayfs/aufs (in container)
-grep "^FAIL: posix/tst-dir" tests.sum >/dev/null && n=$((n+1)) ||:
-
-#https://sourceware.org/glibc/wiki/Testing/Testsuite
-grep "^FAIL: nptl/tst-eintr1" tests.sum >/dev/null && n=$((n+1)) ||:
-#This happens because the kernel fails to reap exiting threads fast enough,
-#eventually resulting an EAGAIN when pthread_create is called within the test.
-
-# check for exact 'n' failures
-[ `grep ^FAIL tests.sum | wc -l` -ne $n ] && exit 1 ||:
+# Should have around the following results:
+# Summary of test results:
+#      2 FAIL : nptl/tst-cancel1, io/tst-lchmod
+#   5041 PASS
+#    152 UNSUPPORTED
+#     12 XFAIL
+#      8 XPASS
+make %{?_smp_mflags} check
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
@@ -354,6 +345,9 @@ grep "^FAIL: nptl/tst-eintr1" tests.sum >/dev/null && n=$((n+1)) ||:
 %exclude %{_libdir}/locale/C.utf8
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 2.38-7
+- Enable check section for glibc
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 2.38-7
 - Fix syslog failing to print issue
 

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -269,7 +269,7 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.30.1-3
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.30.1-3
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.30.1-2

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.30.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -269,6 +269,9 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.30.1-3
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.30.1-2
 - Bump to rebuild with updated glibc
 
@@ -465,5 +468,3 @@ fi
 
 * Wed Dec 02 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 1.19.1-1
 - Original version for CBL-Mariner
-
-

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -269,7 +269,7 @@ install -p -m 0644 cmd/virt-launcher/qemu.conf %{buildroot}%{_datadir}/kube-virt
 %{_bindir}/virt-tests
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.2.0-6
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.2.0-6
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.2.0-5

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -20,7 +20,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        1.2.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -269,6 +269,9 @@ install -p -m 0644 cmd/virt-launcher/qemu.conf %{buildroot}%{_datadir}/kube-virt
 %{_bindir}/virt-tests
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.2.0-6
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.2.0-5
 - Bump to rebuild with updated glibc
 
@@ -320,10 +323,10 @@ install -p -m 0644 cmd/virt-launcher/qemu.conf %{buildroot}%{_datadir}/kube-virt
 - Bump release to rebuild with go 1.19.10
 
 * Fri May 12 2023 Kanika Nema <kanikanema@microsoft.com> - 0.59.0-2
-- Patch 0.59.0 with Operator Nexus patches 
+- Patch 0.59.0 with Operator Nexus patches
 
 * Fri May 05 2023 Kanika Nema <kanikanema@microsoft.com> - 0.59.0-1
-- Upgrade to v0.59.0 
+- Upgrade to v0.59.0
 
 * Wed Apr 05 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.58.0-7
 - Bump release to rebuild with go 1.19.8

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -1147,7 +1147,7 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.52.0-9
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.52.0-9
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.52.0-8

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -25,7 +25,7 @@
 Summary:        Access and modify virtual machine disk images
 Name:           libguestfs
 Version:        1.52.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -1147,6 +1147,9 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.52.0-9
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.52.0-8
 - Bump to rebuild with updated glibc
 

--- a/SPECS/mdadm/mdadm.spec
+++ b/SPECS/mdadm/mdadm.spec
@@ -2,7 +2,7 @@
 
 Name:        mdadm
 Version:     4.2
-Release:     5%{?dist}
+Release:     6%{?dist}
 Summary:     The mdadm program controls Linux md devices (software RAID arrays)
 URL:         http://www.kernel.org/pub/linux/utils/raid/mdadm/
 License:     GPLv2+
@@ -146,9 +146,9 @@ Patch199:    disable-Werror.patch
 
 BuildRequires: make
 BuildRequires: glibc-static >= 2.38-7%{?dist}
-BuildRequires: systemd-rpm-macros 
-BuildRequires: binutils-devel 
-BuildRequires: gcc 
+BuildRequires: systemd-rpm-macros
+BuildRequires: binutils-devel
+BuildRequires: gcc
 BuildRequires: systemd-devel
 %if %{with libreport}
 Requires:       libreport-filesystem
@@ -157,7 +157,7 @@ Requires(post): systemd coreutils
 Requires(preun): systemd
 Requires(postun): systemd coreutils
 
-%description 
+%description
 The mdadm program is used to create, manage, and monitor Linux MD (software
 RAID) devices.  As such, it provides similar functionality to the raidtools
 package.  However, mdadm is a single program, and it can perform
@@ -219,6 +219,9 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 %{_datadir}/mdadm/mdcheck
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 4.2-6
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 4.2-5
 - Bump to rebuild with updated glibc
 
@@ -326,7 +329,7 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
 
 * Thu Jan 12 2017 Xiao Ni <xni@redhat.com> - 4.0-1
-- Upgrade to mdadm-4.0 
+- Upgrade to mdadm-4.0
 - Resolves bz1411555
 
 * Mon Aug 15 2016 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.4-3
@@ -423,7 +426,7 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 
 * Wed Oct 9 2013 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.3-3
 - Check for DM_UDEV_DISABLE_OTHER_RULES_FLAG instead of
-  DM_UDEV_DISABLE_DISK_RULES_FLAG in 65-md-incremental.rules 
+  DM_UDEV_DISABLE_DISK_RULES_FLAG in 65-md-incremental.rules
 - Resolves bz1015521
 
 * Tue Oct 8 2013 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.3-2
@@ -444,7 +447,7 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 
 * Wed Apr 24 2013 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.2.6-19
 - Fix problem where  rebuild of IMSM RAID5 volume started in OROM,
-  does not proceed in OS 
+  does not proceed in OS
 - Resolves bz956021 (f18), bz956026 (f17), bz956031 (f19)
 
 * Tue Apr 23 2013 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.2.6-18
@@ -557,7 +560,7 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 
 * Wed Jul 18 2012 Karsten Hopp <karsten@redhat.com> 3.2.5-5
 - include <linux/types.h> in some to avoid type clashes.
-  same problem as rhbz #840902  
+  same problem as rhbz #840902
 
 * Mon Jul 16 2012 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.2.5-4
 - Move /etc/tmpfiles.d/mdadm.conf to /lib/tmpfiles.d/ to comply with
@@ -632,7 +635,7 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 * Thu Feb 16 2012 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.2.3-5
 - Fix issue with devices failing to be added to a raid using bitmaps,
   due to trying to write the bitmap with mis-aligned buffers using
-  O_DIRECT 
+  O_DIRECT
 - Resolves: bz789898 (f16) bz791189 (f15)
 
 * Mon Jan 30 2012 Jes Sorensen <Jes.Sorensen@redhat.com> - 3.2.3-4
@@ -932,7 +935,7 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 - Modify mdadm to put its mapfile in /dev/md instead of /var/run/mdadm
   since at startup /var/run/mdadm is read-only by default and this
   breaks incremental assembly
-- Change how mdadm decides to assemble incremental devices using their 
+- Change how mdadm decides to assemble incremental devices using their
   preferred name or a random name to avoid possible conflicts when plugging
   a foreign array into a host
 

--- a/SPECS/mdadm/mdadm.spec
+++ b/SPECS/mdadm/mdadm.spec
@@ -219,7 +219,7 @@ install -m644 %{SOURCE5} %{buildroot}/etc/libreport/events.d
 %{_datadir}/mdadm/mdcheck
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 4.2-6
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 4.2-6
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 4.2-5

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -3421,7 +3421,7 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 8.2.0-11
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 8.2.0-11
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 8.2.0-10

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -428,7 +428,7 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 8.2.0
-Release: 10%{?dist}
+Release: 11%{?dist}
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -3421,6 +3421,9 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 8.2.0-11
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 8.2.0-10
 - Bump to rebuild with updated glibc
 

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -172,7 +172,7 @@ rm %{buildroot}%{_bindir}/*.old
 %{_mandir}/man1/*
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.75.0-11
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.75.0-11
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.75.0-10

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -9,7 +9,7 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.75.0
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -172,6 +172,9 @@ rm %{buildroot}%{_bindir}/*.old
 %{_mandir}/man1/*
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.75.0-11
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 1.75.0-10
 - Bump to rebuild with updated glibc
 

--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -21,7 +21,7 @@
 Summary:        Tool for creating supermin appliances
 Name:           supermin
 Version:        5.3.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -129,6 +129,9 @@ make check || {
 %{_rpmconfigdir}/supermin-find-requires
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.3.4-3
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 5.3.4-2
 - Bump to rebuild with updated glibc
 

--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -129,7 +129,7 @@ make check || {
 %{_rpmconfigdir}/supermin-find-requires
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.3.4-3
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 5.3.4-3
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 5.3.4-2

--- a/SPECS/tini/tini.spec
+++ b/SPECS/tini/tini.spec
@@ -66,7 +66,7 @@ ln -s %{_bindir}/tini-static %{buildroot}%{_bindir}/docker-init
 %{_bindir}/docker-init
 
 %changelog
-* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.19.0-18
+* Mon Aug 26 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.19.0-18
 - Update to build dep latest glibc-static version
 
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 0.19.0-17

--- a/SPECS/tini/tini.spec
+++ b/SPECS/tini/tini.spec
@@ -1,7 +1,7 @@
 Summary:        A tiny but valid init for containers
 Name:           tini
 Version:        0.19.0
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -66,6 +66,9 @@ ln -s %{_bindir}/tini-static %{buildroot}%{_bindir}/docker-init
 %{_bindir}/docker-init
 
 %changelog
+* Fri Jun 21 2024 Rachel Menge <rachelmenge@microsoft.com> - 0.19.0-18
+- Update to build dep latest glibc-static version
+
 * Wed Aug 21 2024 Chris Co <chrco@microsoft.com> - 0.19.0-17
 - Bump to rebuild with updated glibc
 

--- a/toolkit/resources/manifests/package/macros.override
+++ b/toolkit/resources/manifests/package/macros.override
@@ -13,7 +13,6 @@
 %skip_check_socat 1
 
 # Check hangs
-%skip_check_glibc 1
 %skip_check_gtk_doc 1
 %skip_check_tdnf 1
 %skip_check_vim 1


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Previously, the glibc check section caused major failures for the builds. However, these no longer exisit. To enable these tests, address conflicting gcc flags and turn off the macro which prevents check section for glibc.

The patch prevents the error
`c1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]`
The error occurs when glibc is compiled with -Wformat-security which requires -Wformat and thus conflicts with tests which use -Wno-format

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enable glibc check section

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=591181&view=results
- BuddyBuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=591178&view=results
