### PR TITLE
Image Customizer: Add tests for API package.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/bootloaderresettype_test.go
+++ b/toolkit/tools/imagecustomizerapi/bootloaderresettype_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResetBootLoaderTypeIsValidValid(t *testing.T) {
+	err := ResetBootLoaderTypeHard.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestResetBootLoaderTypeIsValidInvalid(t *testing.T) {
+	err := ResetBootLoaderType("aaa").IsValid()
+	assert.ErrorContains(t, err, "invalid resetBootLoaderType value (aaa)")
+}

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -26,7 +26,7 @@ func (c *Config) IsValid() (err error) {
 	if c.Iso != nil {
 		err = c.Iso.IsValid()
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid 'iso' field:\n%w", err)
 		}
 	}
 
@@ -34,7 +34,7 @@ func (c *Config) IsValid() (err error) {
 	if c.OS != nil {
 		err = c.OS.IsValid()
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid 'os' field:\n%w", err)
 		}
 		hasResetBootLoader = c.OS.ResetBootLoaderType != ResetBootLoaderTypeDefault
 	}

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -162,7 +162,7 @@ func TestConfigIsValidMultipleDisks(t *testing.T) {
 
 	err := config.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "multiple disks is not currently supported")
+	assert.ErrorContains(t, err, "defining multiple disks is not currently supported")
 }
 
 func TestConfigIsValidZeroDisks(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/dirconfig.go
+++ b/toolkit/tools/imagecustomizerapi/dirconfig.go
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//
-
 package imagecustomizerapi
 
 import (
@@ -47,29 +45,29 @@ func (l *DirConfigList) IsValid() (err error) {
 func (d *DirConfig) IsValid() (err error) {
 	// Paths
 	if d.SourcePath == "" {
-		return fmt.Errorf("invalid [sourcePath] value: empty string")
+		return fmt.Errorf("invalid sourcePath value: empty string")
 	}
 	if d.DestinationPath == "" {
-		return fmt.Errorf("invalid [destinationPath] value: empty string")
+		return fmt.Errorf("invalid destinationPath value: empty string")
 	}
 
 	// Permissions
 	if d.NewDirPermissions != nil {
 		err = d.NewDirPermissions.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid [newDirPermissions] value:\n%w", err)
+			return fmt.Errorf("invalid newDirPermissions value:\n%w", err)
 		}
 	}
 	if d.MergedDirPermissions != nil {
 		err = d.MergedDirPermissions.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid [mergedDirPermissions] value:\n%w", err)
+			return fmt.Errorf("invalid mergedDirPermissions value:\n%w", err)
 		}
 	}
 	if d.ChildFilePermissions != nil {
 		err = d.ChildFilePermissions.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid [childFilePermissions] value:\n%w", err)
+			return fmt.Errorf("invalid childFilePermissions value:\n%w", err)
 		}
 	}
 

--- a/toolkit/tools/imagecustomizerapi/dirconfig_test.go
+++ b/toolkit/tools/imagecustomizerapi/dirconfig_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirConfigListIsValidEmpty(t *testing.T) {
+	list := DirConfigList{}
+	err := list.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestDirConfigListIsValidValidItem(t *testing.T) {
+	list := DirConfigList{
+		DirConfig{
+			SourcePath:      "a.txt",
+			DestinationPath: "/a.txt",
+		},
+	}
+	err := list.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestDirConfigListIsValidValidItemWithPermissions(t *testing.T) {
+	list := DirConfigList{
+		DirConfig{
+			SourcePath:           "a.txt",
+			DestinationPath:      "/a.txt",
+			NewDirPermissions:    ptrutils.PtrTo(FilePermissions(0o777)),
+			MergedDirPermissions: ptrutils.PtrTo(FilePermissions(0o777)),
+			ChildFilePermissions: ptrutils.PtrTo(FilePermissions(0o777)),
+		},
+	}
+	err := list.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestDirConfigListIsValidEmptySource(t *testing.T) {
+	list := DirConfigList{
+		DirConfig{
+			SourcePath:      "",
+			DestinationPath: "/a.txt",
+		},
+	}
+	err := list.IsValid()
+	assert.ErrorContains(t, err, "invalid value at index 0")
+	assert.ErrorContains(t, err, "invalid sourcePath value: empty string")
+}
+
+func TestDirConfigListIsValidEmptyDestination(t *testing.T) {
+	list := DirConfigList{
+		DirConfig{
+			SourcePath:      "a.txt",
+			DestinationPath: "",
+		},
+	}
+	err := list.IsValid()
+	assert.ErrorContains(t, err, "invalid value at index 0")
+	assert.ErrorContains(t, err, "invalid destinationPath value: empty string")
+}
+
+func TestDirConfigListIsValidInvalidNewDirPermissions(t *testing.T) {
+	list := DirConfigList{
+		DirConfig{
+			SourcePath:        "a.txt",
+			DestinationPath:   "/a.txt",
+			NewDirPermissions: ptrutils.PtrTo(FilePermissions(0o1000)),
+		},
+	}
+	err := list.IsValid()
+	assert.ErrorContains(t, err, "invalid value at index 0")
+	assert.ErrorContains(t, err, "invalid newDirPermissions value")
+	assert.ErrorContains(t, err, "0o1000 contains non-permission bits")
+}
+
+func TestDirConfigListIsValidInvalidMergedDirPermissions(t *testing.T) {
+	list := DirConfigList{
+		DirConfig{
+			SourcePath:           "a.txt",
+			DestinationPath:      "/a.txt",
+			MergedDirPermissions: ptrutils.PtrTo(FilePermissions(0o1000)),
+		},
+	}
+	err := list.IsValid()
+	assert.ErrorContains(t, err, "invalid value at index 0")
+	assert.ErrorContains(t, err, "invalid mergedDirPermissions value")
+	assert.ErrorContains(t, err, "0o1000 contains non-permission bits")
+}
+
+func TestDirConfigListIsValidInvalidChildFilePermissions(t *testing.T) {
+	list := DirConfigList{
+		DirConfig{
+			SourcePath:           "a.txt",
+			DestinationPath:      "/a.txt",
+			ChildFilePermissions: ptrutils.PtrTo(FilePermissions(0o1000)),
+		},
+	}
+	err := list.IsValid()
+	assert.ErrorContains(t, err, "invalid value at index 0")
+	assert.ErrorContains(t, err, "invalid childFilePermissions value")
+	assert.ErrorContains(t, err, "0o1000 contains non-permission bits")
+}

--- a/toolkit/tools/imagecustomizerapi/disksize_test.go
+++ b/toolkit/tools/imagecustomizerapi/disksize_test.go
@@ -16,6 +16,12 @@ func TestDiskSizeNum(t *testing.T) {
 	assert.ErrorContains(t, err, "must have a unit suffix (K, M, G, or T)")
 }
 
+func TestDiskSizeNumTooLarge(t *testing.T) {
+	var diskSize DiskSize
+	err := UnmarshalYaml([]byte("18446744073709551616M"), &diskSize)
+	assert.ErrorContains(t, err, "value out of range")
+}
+
 func TestDiskSizeKiB(t *testing.T) {
 	var diskSize DiskSize
 	err := UnmarshalYaml([]byte("1024K"), &diskSize)

--- a/toolkit/tools/imagecustomizerapi/identifiedpartition.go
+++ b/toolkit/tools/imagecustomizerapi/identifiedpartition.go
@@ -18,7 +18,7 @@ var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F
 func (i *IdentifiedPartition) IsValid() error {
 	// Check if IdType is valid
 	if err := i.IdType.IsValid(); err != nil {
-		return fmt.Errorf("invalid IdType: %v", err)
+		return fmt.Errorf("invalid idType:\n%w", err)
 	}
 
 	// Check if Id is not empty
@@ -31,12 +31,12 @@ func (i *IdentifiedPartition) IsValid() error {
 	case IdTypePartLabel:
 		// Validate using isGPTNameValid function for IdTypePartLabel
 		if err := isGPTNameValid(i.Id); err != nil {
-			return fmt.Errorf("invalid id for idTypePartLabel: %v", err)
+			return fmt.Errorf("invalid id format for %s:\n%w", IdTypePartLabel, err)
 		}
 	case IdTypeUuid, IdTypePartUuid:
 		// UUID validation (standard format)
 		if !uuidRegex.MatchString(i.Id) {
-			return fmt.Errorf("invalid id format for %s: %s", i.IdType, i.Id)
+			return fmt.Errorf("invalid id format for %s (%s)", i.IdType, i.Id)
 		}
 	}
 

--- a/toolkit/tools/imagecustomizerapi/identifiedpartition_test.go
+++ b/toolkit/tools/imagecustomizerapi/identifiedpartition_test.go
@@ -29,7 +29,7 @@ func TestIdentifiedPartitionIsValidValidPartLabel(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestIdentifiedPartitionIsValidInvalidPartLabel(t *testing.T) {
+func TestIdentifiedPartitionIsValidEmptyPartLabel(t *testing.T) {
 	invalidPartition := IdentifiedPartition{
 		IdType: "part-label",
 		Id:     "",
@@ -60,4 +60,28 @@ func TestIdentifiedPartitionIsValidInvalidPartUuidFormat(t *testing.T) {
 	err := incorrectUuidPartition.IsValid()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "invalid id format")
+}
+
+func TestIdentifiedPartitionIsValidInvalidIdType(t *testing.T) {
+	incorrectUuidPartition := IdentifiedPartition{
+		IdType: "cat",
+		Id:     "incorrect-uuid-format",
+	}
+
+	err := incorrectUuidPartition.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid idType")
+	assert.ErrorContains(t, err, "invalid idType value (cat)")
+}
+
+func TestIdentifiedPartitionIsValidInvalidPartLabel(t *testing.T) {
+	incorrectUuidPartition := IdentifiedPartition{
+		IdType: IdTypePartLabel,
+		Id:     "i ❤️ cats",
+	}
+
+	err := incorrectUuidPartition.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid id format for part-label")
+	assert.ErrorContains(t, err, "partition name (i ❤️ cats) contains a non-ASCII character (❤)")
 }

--- a/toolkit/tools/imagecustomizerapi/iso.go
+++ b/toolkit/tools/imagecustomizerapi/iso.go
@@ -14,9 +14,7 @@ type Iso struct {
 }
 
 func (i *Iso) IsValid() error {
-	var err error
-
-	err = i.KernelCommandLine.IsValid()
+	err := i.KernelCommandLine.IsValid()
 	if err != nil {
 		return fmt.Errorf("invalid kernelCommandLine: %w", err)
 	}

--- a/toolkit/tools/imagecustomizerapi/iso_test.go
+++ b/toolkit/tools/imagecustomizerapi/iso_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsoIsValid(t *testing.T) {
+	iso := Iso{
+		KernelCommandLine: KernelCommandLine{
+			ExtraCommandLine: "'",
+		},
+	}
+
+	err := iso.IsValid()
+	assert.ErrorContains(t, err, "invalid kernelCommandLine")
+}

--- a/toolkit/tools/imagecustomizerapi/main_test.go
+++ b/toolkit/tools/imagecustomizerapi/main_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+)
+
+var (
+	workingDir string
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	logger.InitStderrLog()
+
+	workingDir, err = os.Getwd()
+	if err != nil {
+		logger.Log.Panicf("Failed to get working directory, error: %s", err)
+	}
+
+	retVal := m.Run()
+
+	os.Exit(retVal)
+}

--- a/toolkit/tools/imagecustomizerapi/module.go
+++ b/toolkit/tools/imagecustomizerapi/module.go
@@ -20,22 +20,22 @@ func (m *Module) IsValid() error {
 	}
 
 	if err := m.LoadMode.IsValid(); err != nil {
-		return err
+		return fmt.Errorf("invalid module (%s):\n%w", m.Name, err)
 	}
 
 	for optionKey, optionValue := range m.Options {
 		if optionKey == "" {
-			return fmt.Errorf("option key cannot be empty for module %s", m.Name)
+			return fmt.Errorf("invalid module (%s):\noption key cannot be empty", m.Name)
 		}
 		if optionValue == "" {
-			return fmt.Errorf("option value cannot be empty for module %s", m.Name)
+			return fmt.Errorf("invalid module (%s):\noption value cannot be empty", m.Name)
 		}
 
 		if strings.ContainsAny(optionKey, " \n") {
-			return fmt.Errorf("option key cannot contain spaces or newline characters for module %s", m.Name)
+			return fmt.Errorf("invalid module (%s):\noption key (%s) cannot contain spaces or newline characters", m.Name, optionKey)
 		}
 		if strings.ContainsAny(optionValue, " \n") {
-			return fmt.Errorf("option value cannot contain spaces or newline characters for module %s", m.Name)
+			return fmt.Errorf("invalid module (%s):\noption value (%s) cannot contain spaces or newline characters", m.Name, optionValue)
 		}
 	}
 	return nil
@@ -46,7 +46,7 @@ func validateModuleName(moduleName string) error {
 		return fmt.Errorf("module name cannot be empty")
 	}
 	if strings.ContainsAny(moduleName, " \n") {
-		return fmt.Errorf("module name cannot contain spaces or newline characters")
+		return fmt.Errorf("module name (%s) cannot contain spaces or newline characters", moduleName)
 	}
 	return nil
 }

--- a/toolkit/tools/imagecustomizerapi/moduleLoadMode.go
+++ b/toolkit/tools/imagecustomizerapi/moduleLoadMode.go
@@ -24,6 +24,6 @@ func (loadmode ModuleLoadMode) IsValid() error {
 		return nil
 
 	default:
-		return fmt.Errorf("invalid module load mode value (%v), it can only be 'always', 'auto', 'disable', 'inherit' or ''", loadmode)
+		return fmt.Errorf("invalid module load mode value (%s):\nvalid values: 'always', 'auto', 'disable', 'inherit', or ''", loadmode)
 	}
 }

--- a/toolkit/tools/imagecustomizerapi/module_test.go
+++ b/toolkit/tools/imagecustomizerapi/module_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModuleIsValidValidValue(t *testing.T) {
+	module := Module{
+		Name:     "nbd",
+		LoadMode: ModuleLoadModeAlways,
+	}
+	err := module.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestModuleIsValidEmptyName(t *testing.T) {
+	module := Module{
+		Name: "",
+	}
+	err := module.IsValid()
+	assert.ErrorContains(t, err, "module name cannot be empty")
+}
+
+func TestModuleIsValidInvalidName(t *testing.T) {
+	module := Module{
+		Name: "cat and dogs",
+	}
+	err := module.IsValid()
+	assert.ErrorContains(t, err, "module name (cat and dogs) cannot contain spaces or newline characters")
+}
+
+func TestModuleIsValidInvalidLoadMode(t *testing.T) {
+	module := Module{
+		Name:     "nbd",
+		LoadMode: "dog",
+	}
+	err := module.IsValid()
+	assert.ErrorContains(t, err, "invalid module load mode value (dog)")
+}
+
+func TestModuleIsValidValidOptions(t *testing.T) {
+	module := Module{
+		Name: "nbd",
+		Options: map[string]string{
+			"nbds_max": "8",
+		},
+	}
+	err := module.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestModuleIsValidValidEmptyOptionName(t *testing.T) {
+	module := Module{
+		Name: "nbd",
+		Options: map[string]string{
+			"": "8",
+		},
+	}
+	err := module.IsValid()
+	assert.ErrorContains(t, err, "invalid module (nbd)")
+	assert.ErrorContains(t, err, "option key cannot be empty")
+}
+
+func TestModuleIsValidValidInvalidOptionName(t *testing.T) {
+	module := Module{
+		Name: "nbd",
+		Options: map[string]string{
+			" ": "8",
+		},
+	}
+	err := module.IsValid()
+	assert.ErrorContains(t, err, "invalid module (nbd)")
+	assert.ErrorContains(t, err, "option key ( ) cannot contain spaces or newline characters")
+}
+
+func TestModuleIsValidValidEmptyOptionValue(t *testing.T) {
+	module := Module{
+		Name: "nbd",
+		Options: map[string]string{
+			"nbds_max": "",
+		},
+	}
+	err := module.IsValid()
+	assert.ErrorContains(t, err, "invalid module (nbd)")
+	assert.ErrorContains(t, err, "option value cannot be empty")
+}
+
+func TestModuleIsValidValidInvalidOptionValue(t *testing.T) {
+	module := Module{
+		Name: "nbd",
+		Options: map[string]string{
+			"nbds_max": " ",
+		},
+	}
+	err := module.IsValid()
+	assert.ErrorContains(t, err, "invalid module (nbd)")
+	assert.ErrorContains(t, err, "option value ( ) cannot contain spaces or newline characters")
+}

--- a/toolkit/tools/imagecustomizerapi/mountpoint.go
+++ b/toolkit/tools/imagecustomizerapi/mountpoint.go
@@ -26,7 +26,7 @@ func (p *MountPoint) IsValid() error {
 	}
 
 	if p.Path == "" {
-		return fmt.Errorf("invalid path (%s): must not be empty", p.Path)
+		return fmt.Errorf("invalid path: must not be empty")
 	}
 
 	if !path.IsAbs(p.Path) {

--- a/toolkit/tools/imagecustomizerapi/mountpoint_test.go
+++ b/toolkit/tools/imagecustomizerapi/mountpoint_test.go
@@ -16,7 +16,16 @@ func TestMountPointIsValidInvalidIdType(t *testing.T) {
 	}
 
 	err := mountPoint.IsValid()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "invalid")
-	assert.ErrorContains(t, err, "idType")
+	assert.ErrorContains(t, err, "invalid idType value")
+	assert.ErrorContains(t, err, "invalid value (bad)")
+}
+
+func TestMountPointIsValidInvalidPath(t *testing.T) {
+	mountPoint := MountPoint{
+		IdType: MountIdentifierTypeDefault,
+		Path:   "",
+	}
+
+	err := mountPoint.IsValid()
+	assert.ErrorContains(t, err, "invalid path: must not be empty")
 }

--- a/toolkit/tools/imagecustomizerapi/os.go
+++ b/toolkit/tools/imagecustomizerapi/os.go
@@ -35,7 +35,7 @@ func (s *OS) IsValid() error {
 
 	if s.Hostname != "" {
 		if !govalidator.IsDNSName(s.Hostname) || strings.Contains(s.Hostname, "_") {
-			return fmt.Errorf("invalid hostname: %s", s.Hostname)
+			return fmt.Errorf("invalid hostname (%s)", s.Hostname)
 		}
 	}
 
@@ -46,23 +46,23 @@ func (s *OS) IsValid() error {
 
 	err = s.KernelCommandLine.IsValid()
 	if err != nil {
-		return fmt.Errorf("invalid kernelCommandLine: %w", err)
+		return fmt.Errorf("invalid kernelCommandLine:\n%w", err)
 	}
 
 	err = s.AdditionalFiles.IsValid()
 	if err != nil {
-		return fmt.Errorf("invalid additionalFiles: %w", err)
+		return fmt.Errorf("invalid additionalFiles:\n%w", err)
 	}
 
 	err = s.AdditionalDirs.IsValid()
 	if err != nil {
-		return fmt.Errorf("invalid additionalDirs: %w", err)
+		return fmt.Errorf("invalid additionalDirs:\n%w", err)
 	}
 
 	for i, user := range s.Users {
 		err = user.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid users item at index %d: %w", i, err)
+			return fmt.Errorf("invalid users item at index %d:\n%w", i, err)
 		}
 	}
 
@@ -79,14 +79,14 @@ func (s *OS) IsValid() error {
 		moduleMap[module.Name] = i
 		err = module.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid Modules item at index %d:\n%w", i, err)
+			return fmt.Errorf("invalid modules item at index %d:\n%w", i, err)
 		}
 	}
 
 	if s.Verity != nil {
 		err = s.Verity.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid verity: %w", err)
+			return fmt.Errorf("invalid verity:\n%w", err)
 		}
 	}
 
@@ -98,18 +98,18 @@ func (s *OS) IsValid() error {
 			// Validate the overlay itself
 			err := overlay.IsValid()
 			if err != nil {
-				return fmt.Errorf("invalid overlay (lowerDir: '%s') at index %d: %w", overlay.LowerDir, i, err)
+				return fmt.Errorf("invalid overlay at index %d:\n%w", i, err)
 			}
 
 			// Check for unique UpperDir
 			if _, exists := upperDirs[overlay.UpperDir]; exists {
-				return fmt.Errorf("duplicate upperDir '%s' found in overlay (lowerDir: '%s') at index %d", overlay.UpperDir, overlay.LowerDir, i)
+				return fmt.Errorf("duplicate upperDir (%s) found in overlay at index %d", overlay.UpperDir, i)
 			}
 			upperDirs[overlay.UpperDir] = true
 
 			// Check for unique WorkDir
 			if _, exists := workDirs[overlay.WorkDir]; exists {
-				return fmt.Errorf("duplicate workDir '%s' found in overlay (lowerDir: '%s') at index %d", overlay.WorkDir, overlay.LowerDir, i)
+				return fmt.Errorf("duplicate workDir (%s) found in overlay at index %d", overlay.WorkDir, i)
 			}
 			workDirs[overlay.WorkDir] = true
 		}

--- a/toolkit/tools/imagecustomizerapi/os_test.go
+++ b/toolkit/tools/imagecustomizerapi/os_test.go
@@ -18,11 +18,38 @@ func TestOSValidHostname(t *testing.T) {
 }
 
 func TestOSInvalidHostname(t *testing.T) {
-	testInvalidYamlValue[*OS](t, "{ \"hostname\": \"invalid_hostname\" }")
+	os := OS{
+		Hostname: "invalid_hostname",
+	}
+	err := os.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid hostname")
 }
 
 func TestOSInvalidAdditionalFiles(t *testing.T) {
-	testInvalidYamlValue[*OS](t, "{ \"additionalFiles\": { \"a.txt\": [] } }")
+	os := OS{
+		AdditionalFiles: AdditionalFilesMap{
+			"a.txt": FileConfigList{},
+		},
+	}
+	err := os.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid additionalFiles:\ninvalid file configs for (a.txt):\nlist is empty")
+}
+
+func TestOSIsValidInvalidAdditionalFilesEmptySourcePath(t *testing.T) {
+	os := OS{
+		AdditionalFiles: AdditionalFilesMap{
+			"": FileConfigList{
+				{
+					Path: "/a.txt",
+				},
+			},
+		},
+	}
+	err := os.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid additionalFiles:\ninvalid source path: cannot be empty")
 }
 
 func TestOSIsValidVerityInValidPartUuid(t *testing.T) {
@@ -44,14 +71,160 @@ func TestOSIsValidVerityInValidPartUuid(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid id format")
 }
 
-func TestOSIsValidOverlayInvalidLowerDir(t *testing.T) {
-	overlayWithInvalidLowerDir := Overlay{
-		LowerDir: "",
-		UpperDir: "/upper",
-		WorkDir:  "/work",
+func TestOSIsValidInvalidResetBootLoaderType(t *testing.T) {
+	os := OS{
+		ResetBootLoaderType: "bad",
 	}
 
-	err := overlayWithInvalidLowerDir.IsValid()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "path cannot be empty")
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid resetBootLoaderType value (bad)")
+}
+
+func TestOSIsValidInvalidSELinux(t *testing.T) {
+	os := OS{
+		SELinux: SELinux{
+			Mode: "bad",
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid selinux")
+	assert.ErrorContains(t, err, "invalid mode")
+	assert.ErrorContains(t, err, "invalid selinux value (bad)")
+}
+
+func TestOSIsValidInvalidAdditionalDirs(t *testing.T) {
+	os := OS{
+		AdditionalDirs: DirConfigList{
+			{
+				SourcePath:      "",
+				DestinationPath: "/a",
+			},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid additionalDirs")
+	assert.ErrorContains(t, err, "invalid value at index 0")
+	assert.ErrorContains(t, err, "invalid sourcePath value: empty string")
+}
+
+func TestOSIsValidInvalidUser(t *testing.T) {
+	os := OS{
+		Users: []User{
+			{
+				Name: "",
+			},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid users item at index 0")
+	assert.ErrorContains(t, err, "user () is invalid")
+}
+
+func TestOSIsValidInvalidServices(t *testing.T) {
+	os := OS{
+		Services: Services{
+			Enable: []string{
+				"",
+			},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid service enable at index (0)")
+	assert.ErrorContains(t, err, "name of service may not be empty")
+}
+
+func TestOSIsValidInvalidModule(t *testing.T) {
+	os := OS{
+		Modules: []Module{
+			{
+				Name: "",
+			},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid modules item at index 0")
+	assert.ErrorContains(t, err, "module name cannot be empty")
+}
+
+func TestOSIsValidModuleDuplicateName(t *testing.T) {
+	os := OS{
+		Modules: []Module{
+			{
+				Name: "nbd",
+			},
+			{
+				Name: "nbd",
+			},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "duplicate module found: nbd at index 1")
+}
+
+func TestOSIsValidInvalidOverlay(t *testing.T) {
+	os := OS{
+		Overlays: &[]Overlay{
+			{},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid overlay at index 0")
+}
+
+func TestOSIsValidOverlayDuplicateUpperDir(t *testing.T) {
+	os := OS{
+		Overlays: &[]Overlay{
+			{
+				LowerDir: "/",
+				UpperDir: "/upper_root",
+				WorkDir:  "/work_root",
+			},
+			{
+				LowerDir: "/var",
+				UpperDir: "/upper_root",
+				WorkDir:  "/work_var",
+			},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "duplicate upperDir (/upper_root) found in overlay at index 1")
+}
+
+func TestOSIsValidOverlayDuplicateWorkDir(t *testing.T) {
+	os := OS{
+		Overlays: &[]Overlay{
+			{
+				LowerDir: "/",
+				UpperDir: "/upper_root",
+				WorkDir:  "/work_root",
+			},
+			{
+				LowerDir: "/",
+				UpperDir: "/upper_var",
+				WorkDir:  "/work_root",
+			},
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "duplicate workDir (/work_root) found in overlay at index 1")
+}
+
+func TestOSIsValidInvalidKernelCommandLine(t *testing.T) {
+	os := OS{
+		KernelCommandLine: KernelCommandLine{
+			ExtraCommandLine: "\"",
+		},
+	}
+
+	err := os.IsValid()
+	assert.ErrorContains(t, err, "invalid kernelCommandLine")
 }

--- a/toolkit/tools/imagecustomizerapi/overlay.go
+++ b/toolkit/tools/imagecustomizerapi/overlay.go
@@ -18,13 +18,13 @@ type Overlay struct {
 func (o *Overlay) IsValid() error {
 	// Validate paths for UpperDir, WorkDir, and LowerDir
 	if err := validatePath(o.UpperDir); err != nil {
-		return fmt.Errorf("upperDir '%s': %w", o.UpperDir, err)
+		return fmt.Errorf("invalid upperDir (%s):\n%w", o.UpperDir, err)
 	}
 	if err := validatePath(o.WorkDir); err != nil {
-		return fmt.Errorf("workDir '%s': %w", o.WorkDir, err)
+		return fmt.Errorf("invalid workDir (%s):\n%w", o.WorkDir, err)
 	}
 	if err := validatePath(o.LowerDir); err != nil {
-		return fmt.Errorf("lowerDir '%s': %w", o.LowerDir, err)
+		return fmt.Errorf("invalid lowerDir (%s):\n%w", o.LowerDir, err)
 	}
 
 	// Check if UpperDir and WorkDir are identical
@@ -34,15 +34,15 @@ func (o *Overlay) IsValid() error {
 
 	// Check if UpperDir is a subdirectory of WorkDir or vice versa
 	if isSubDirString(o.UpperDir, o.WorkDir) {
-		return fmt.Errorf("upperDir '%s' should not be a subdirectory of workDir '%s'", o.UpperDir, o.WorkDir)
+		return fmt.Errorf("upperDir (%s) should not be a subdirectory of workDir (%s)", o.UpperDir, o.WorkDir)
 	}
 	if isSubDirString(o.WorkDir, o.UpperDir) {
-		return fmt.Errorf("workDir '%s' should not be a subdirectory of upperDir '%s'", o.WorkDir, o.UpperDir)
+		return fmt.Errorf("workDir (%s) should not be a subdirectory of upperDir (%s)", o.WorkDir, o.UpperDir)
 	}
 
 	if o.Partition != nil {
 		if err := o.Partition.IsValid(); err != nil {
-			return fmt.Errorf("invalid partition in upperDir '%s', workDir '%s', lowerDir '%s': %w", o.UpperDir, o.WorkDir, o.LowerDir, err)
+			return fmt.Errorf("invalid partition:\n%w", err)
 		}
 	}
 
@@ -57,7 +57,7 @@ func validatePath(path string) error {
 
 	// Check if the path contains spaces
 	if strings.Contains(path, " ") {
-		return fmt.Errorf("path '%s' contains spaces and is invalid", path)
+		return fmt.Errorf("path (%s) contains spaces and is invalid", path)
 	}
 
 	return nil

--- a/toolkit/tools/imagecustomizerapi/overlay_test.go
+++ b/toolkit/tools/imagecustomizerapi/overlay_test.go
@@ -32,8 +32,20 @@ func TestOverlayInvalidEmptyLowerDir(t *testing.T) {
 	}
 
 	err := overlay.IsValid()
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid lowerDir ()")
 	assert.ErrorContains(t, err, "path cannot be empty")
+}
+
+func TestOverlayInvalidInvalidWorkDir(t *testing.T) {
+	overlay := Overlay{
+		LowerDir: "/lower",
+		UpperDir: "/upper",
+		WorkDir:  " ",
+	}
+
+	err := overlay.IsValid()
+	assert.ErrorContains(t, err, "invalid workDir ( )")
+	assert.ErrorContains(t, err, "path ( ) contains spaces and is invalid")
 }
 
 func TestOverlayInvalidSameUpperAndWorkDir(t *testing.T) {
@@ -46,4 +58,40 @@ func TestOverlayInvalidSameUpperAndWorkDir(t *testing.T) {
 	err := overlay.IsValid()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "upperDir and workDir must be distinct")
+}
+
+func TestOverlayInvalidWorkDirSubsUpperDir(t *testing.T) {
+	overlay := Overlay{
+		LowerDir: "/lower",
+		UpperDir: "/invalid",
+		WorkDir:  "/invalid/same",
+	}
+
+	err := overlay.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "upperDir (/invalid) should not be a subdirectory of workDir (/invalid/same)")
+}
+
+func TestOverlayInvalidUpperDirSubsWorkDir(t *testing.T) {
+	overlay := Overlay{
+		LowerDir: "/lower",
+		UpperDir: "/invalid/same",
+		WorkDir:  "/invalid",
+	}
+
+	err := overlay.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "workDir (/invalid) should not be a subdirectory of upperDir (/invalid/same)")
+}
+
+func TestOverlayInvalidPartition(t *testing.T) {
+	overlay := Overlay{
+		LowerDir:  "/lower",
+		UpperDir:  "/upper",
+		WorkDir:   "/work",
+		Partition: &IdentifiedPartition{},
+	}
+
+	err := overlay.IsValid()
+	assert.ErrorContains(t, err, "invalid partition")
 }

--- a/toolkit/tools/imagecustomizerapi/partitionsize_test.go
+++ b/toolkit/tools/imagecustomizerapi/partitionsize_test.go
@@ -22,3 +22,15 @@ func TestParitionSizeMiB(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, PartitionSize{PartitionSizeTypeExplicit, 1 * diskutils.MiB}, size)
 }
+
+func TestParitionInvalidNotString(t *testing.T) {
+	var size PartitionSize
+	err := UnmarshalYaml([]byte("[]"), &size)
+	assert.ErrorContains(t, err, "failed to parse partition size")
+}
+
+func TestParitionInvalidValue(t *testing.T) {
+	var size PartitionSize
+	err := UnmarshalYaml([]byte("cat"), &size)
+	assert.ErrorContains(t, err, "(cat) has incorrect format")
+}

--- a/toolkit/tools/imagecustomizerapi/password_test.go
+++ b/toolkit/tools/imagecustomizerapi/password_test.go
@@ -36,3 +36,13 @@ func TestPasswordInvalidType(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "invalid password type (hello)")
 }
+
+func TestPasswordEmptyValue(t *testing.T) {
+	password := Password{
+		Type:  PasswordTypePlainText,
+		Value: "",
+	}
+	err := password.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "password value can't be empty with type (plain-text)")
+}

--- a/toolkit/tools/imagecustomizerapi/script_test.go
+++ b/toolkit/tools/imagecustomizerapi/script_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScriptIsValid(t *testing.T) {
+	script := Script{
+		Path: "a.sh",
+	}
+	err := script.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestScriptIsValidBothPathAndContent(t *testing.T) {
+	script := Script{
+		Path:    "a.sh",
+		Content: "echo hello",
+	}
+	err := script.IsValid()
+	assert.ErrorContains(t, err, "path and content may not both have a value")
+}

--- a/toolkit/tools/imagecustomizerapi/scripts_test.go
+++ b/toolkit/tools/imagecustomizerapi/scripts_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScriptsIsValid(t *testing.T) {
+	scripts := Scripts{
+		PostCustomization: []Script{
+			{
+				Path: "a.sh",
+			},
+		},
+		FinalizeCustomization: []Script{
+			{
+				Content: "echo hello",
+			},
+		},
+	}
+	err := scripts.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestScriptsInvalidPostCustomization(t *testing.T) {
+	scripts := Scripts{
+		PostCustomization: []Script{
+			{},
+		},
+	}
+	err := scripts.IsValid()
+	assert.ErrorContains(t, err, "invalid postCustomization script at index 0")
+	assert.ErrorContains(t, err, "either path or content must have a value")
+}
+
+func TestScriptsInvalidFinalizeCustomization(t *testing.T) {
+	scripts := Scripts{
+		FinalizeCustomization: []Script{
+			{
+				Path:    "a.sh",
+				Content: "echo hello",
+			},
+		},
+	}
+	err := scripts.IsValid()
+	assert.ErrorContains(t, err, "invalid finalizeCustomization script at index 0")
+	assert.ErrorContains(t, err, "path and content may not both have a value")
+}

--- a/toolkit/tools/imagecustomizerapi/service.go
+++ b/toolkit/tools/imagecustomizerapi/service.go
@@ -23,13 +23,13 @@ type Services struct {
 func (s *Services) IsValid() error {
 	for i, service := range s.Enable {
 		if err := serviceNameIsValid(service); err != nil {
-			return fmt.Errorf("invalid service (%s) in service.enable at index (%d): %w", service, i, err)
+			return fmt.Errorf("invalid service enable at index (%d):\n%w", i, err)
 		}
 	}
 
 	for i, service := range s.Disable {
 		if err := serviceNameIsValid(service); err != nil {
-			return fmt.Errorf("invalid service (%s) in service.disable at index (%d): %w", service, i, err)
+			return fmt.Errorf("invalid service disable at index (%d):\n%w", i, err)
 		}
 	}
 

--- a/toolkit/tools/imagecustomizerapi/service_test.go
+++ b/toolkit/tools/imagecustomizerapi/service_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServicesIsValid(t *testing.T) {
+	services := Services{
+		Enable: []string{
+			"nbd",
+		},
+	}
+
+	err := services.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestServicesIsValidInvalidName(t *testing.T) {
+	services := Services{
+		Disable: []string{
+			"",
+		},
+	}
+
+	err := services.IsValid()
+	assert.ErrorContains(t, err, "invalid service disable at index (0)")
+	assert.ErrorContains(t, err, "name of service may not be empty")
+}

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -27,7 +27,7 @@ func (s *Storage) IsValid() error {
 		return fmt.Errorf("at least 1 disk must be specified")
 	}
 	if len(s.Disks) > 1 {
-		return fmt.Errorf("multiple disks is not currently supported")
+		return fmt.Errorf("defining multiple disks is not currently supported")
 	}
 
 	for i, disk := range s.Disks {

--- a/toolkit/tools/imagecustomizerapi/user_test.go
+++ b/toolkit/tools/imagecustomizerapi/user_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserIsValid(t *testing.T) {
+	user := User{
+		Name: "test",
+		UID:  ptrutils.PtrTo(1000),
+		Password: &Password{
+			Type:  "plain-text",
+			Value: "hello",
+		},
+		PasswordExpiresDays: ptrutils.PtrTo(int64(10)),
+		SSHPublicKeyPaths: []string{
+			"/home/test/.ssh/id_ed25519.pub",
+		},
+		PrimaryGroup: "test",
+		SecondaryGroups: []string{
+			"sudo", "docker",
+		},
+		StartupCommand: "/bin/bash",
+	}
+
+	err := user.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestUserIsValidBadUid(t *testing.T) {
+	user := User{
+		Name: "test",
+		UID:  ptrutils.PtrTo(-1),
+	}
+
+	err := user.IsValid()
+	assert.ErrorContains(t, err, "user (test) is invalid")
+	assert.ErrorContains(t, err, "invalid value for UID (-1), not within [0, 60000]")
+}
+
+func TestUserIsValidBadPassword(t *testing.T) {
+	user := User{
+		Name: "test",
+		Password: &Password{
+			Type:  "cat",
+			Value: "dog",
+		},
+	}
+
+	err := user.IsValid()
+	assert.ErrorContains(t, err, "user (test) is invalid")
+	assert.ErrorContains(t, err, "invalid password type (cat)")
+}
+
+func TestUserIsValidBadPasswordExpiry(t *testing.T) {
+	user := User{
+		Name:                "test",
+		PasswordExpiresDays: ptrutils.PtrTo(int64(-2)),
+	}
+
+	err := user.IsValid()
+	assert.ErrorContains(t, err, "user (test) is invalid")
+	assert.ErrorContains(t, err, "invalid value for PasswordExpiresDays (-2), not within [-1, 99999]")
+}

--- a/toolkit/tools/imagecustomizerapi/utils_test.go
+++ b/toolkit/tools/imagecustomizerapi/utils_test.go
@@ -4,11 +4,33 @@
 package imagecustomizerapi
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalYamlFile(t *testing.T) {
+	var config Config
+	err := UnmarshalYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/nochange-config.yaml"),
+		&config)
+	assert.NoError(t, err)
+}
+
+func TestUnmarshalYamlFileDoesNotExist(t *testing.T) {
+	var config Config
+	err := UnmarshalYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/no-such-file.yaml"),
+		&config)
+	assert.ErrorContains(t, err, "no such file or directory")
+}
+
+func TestUnmarshalYamlInvalidFile(t *testing.T) {
+	var config Config
+	err := UnmarshalYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/lists/dracut-fips.yaml"),
+		&config)
+	assert.ErrorContains(t, err, "yaml: unmarshal errors")
+}
 
 func testValidYamlValue[DataType HasIsValid](t *testing.T, yamlString string, expectedValue DataType) {
 	value := makeValue[DataType]()


### PR DESCRIPTION
This change adds tests for the image customizer API package, so that the vast majority of lines have test coverage. The only lines remaining are related to validity checking for kernel command-line args, since these will very likely be changed/remove in the future (when the API is changed from a string to a list of strings).

In addition, some of the error messages were cleaned up / made more consistent.

---

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran new UTs.

