### PR TITLE
php: update to 8.1.29 to fix CVEs

### DIFF
--- a/SPECS/php/php.signatures.json
+++ b/SPECS/php/php.signatures.json
@@ -1,19 +1,19 @@
 {
-  "Signatures": {
-    "10-opcache.ini": "6065beb2ace54d6cb5a8cde751330ea358bd23692073c6e3d2c57f7c97bec869",
-    "20-ffi.ini": "f5e968fdd3eca54f3dab2399e243931cf16cd9da034f0364800aefab222271c0",
-    "macros.php": "917104496e8239e1ed1d4812871be772a5fa8b38cf80c4c59ec3e0c36d48310e",
-    "nginx-fpm.conf": "5a222ab2c3fc0145cb67a1c5125471bbf097de304e77c9858e7077a3b4fcad59",
-    "nginx-php.conf": "b3b3f744c4c122302fcb11f39cac78d01cef15ee6f8bd67e98b3438efcf8dc95",
-    "opcache-default.blacklist": "4eef0875e1a0c6a75b8a2bafd4ddc029b83be74dd336a6a99214b0c32808cb38",
-    "php-fpm-www.conf": "1cacdd4962c01a0a968933c38db503023940ad9105f021bdab85d6cdc46dcbb8",
-    "php-fpm.conf": "bb261d53b9b42bb163a7637bb373ffa18a20dddf27a3efe6cb5ed1b1cf5981a9",
-    "php-fpm.logrotate": "7d8279bebb9ffabc596a2699150e93d4ce4513245890b9b786d337288b19fa79",
-    "php-fpm.service": "574f50dec5a0edd60e60e44e7cc2d03575bc728bdc0b0cab021ce3c55abc0117",
-    "php-fpm.wants": "846297e91ba02bd0e29b6635eeddcca01a7ad4faf5a8f27113543804331d0328",
-    "php.conf": "e2388be032eccf7c0197d597ba72259a095bf8434438a184e6a640edb4b59de2",
-    "php.ini": "8fd5a4d891c19320c07010fbbbac982c886b422bc8d062acaeae49d70c136fc8",
-    "php.modconf": "dc7303ea584452d2f742d002a648abe74905025aabf240259c7e8bd01746d278",
-    "php-8.1.28.tar.xz": "95d0b2e9466108fd750dab5c30a09e5c67f5ad2cb3b1ffb3625a038a755ad080"
-  }
+ "Signatures": {
+  "10-opcache.ini": "6065beb2ace54d6cb5a8cde751330ea358bd23692073c6e3d2c57f7c97bec869",
+  "20-ffi.ini": "f5e968fdd3eca54f3dab2399e243931cf16cd9da034f0364800aefab222271c0",
+  "macros.php": "917104496e8239e1ed1d4812871be772a5fa8b38cf80c4c59ec3e0c36d48310e",
+  "nginx-fpm.conf": "5a222ab2c3fc0145cb67a1c5125471bbf097de304e77c9858e7077a3b4fcad59",
+  "nginx-php.conf": "b3b3f744c4c122302fcb11f39cac78d01cef15ee6f8bd67e98b3438efcf8dc95",
+  "opcache-default.blacklist": "4eef0875e1a0c6a75b8a2bafd4ddc029b83be74dd336a6a99214b0c32808cb38",
+  "php-8.1.29.tar.xz": "288884af60581d4284baba2ace9ca6d646f72facbd3e3c2dd2acc7fe6f903536",
+  "php-fpm-www.conf": "1cacdd4962c01a0a968933c38db503023940ad9105f021bdab85d6cdc46dcbb8",
+  "php-fpm.conf": "bb261d53b9b42bb163a7637bb373ffa18a20dddf27a3efe6cb5ed1b1cf5981a9",
+  "php-fpm.logrotate": "7d8279bebb9ffabc596a2699150e93d4ce4513245890b9b786d337288b19fa79",
+  "php-fpm.service": "574f50dec5a0edd60e60e44e7cc2d03575bc728bdc0b0cab021ce3c55abc0117",
+  "php-fpm.wants": "846297e91ba02bd0e29b6635eeddcca01a7ad4faf5a8f27113543804331d0328",
+  "php.conf": "e2388be032eccf7c0197d597ba72259a095bf8434438a184e6a640edb4b59de2",
+  "php.ini": "8fd5a4d891c19320c07010fbbbac982c886b422bc8d062acaeae49d70c136fc8",
+  "php.modconf": "dc7303ea584452d2f742d002a648abe74905025aabf240259c7e8bd01746d278"
+ }
 }

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -32,7 +32,7 @@
 %global with_qdbm     0
 Summary:        PHP scripting language for creating dynamic web sites
 Name:           php
-Version:        8.1.28
+Version:        8.1.29
 Release:        1%{?dist}
 # All files licensed under PHP version 3.01, except
 # Zend is licensed under Zend
@@ -1516,6 +1516,9 @@ systemctl try-restart php-fpm.service >/dev/null 2>&1 || :
 %dir %{_datadir}/php/preload
 
 %changelog
+* Mon Jun 10 2024 Neha Agarwal <nehaagawral@microsoft.com> - 8.1.29-1
+- Upgrade to 8.1.29 to fix CVE-2024-4577, CVE-2024-5585 and CVE-2024-5458
+
 * Fri May 03 2024 Gary Swalling <gaswal@microsoft.com> - 8.1.28-1
 - Upgrade to 8.1.28 to fix CVE-2024-2756, CVE-2024-3096
 - Update BuildRequires, libpq is now provided by postgresql

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21124,8 +21124,8 @@
         "type": "other",
         "other": {
           "name": "php",
-          "version": "8.1.28",
-          "downloadUrl": "https://www.php.net/distributions/php-8.1.28.tar.xz"
+          "version": "8.1.29",
+          "downloadUrl": "https://www.php.net/distributions/php-8.1.29.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade to 8.1.29 to fix CVE-2024-4577, CVE-2024-5585 and CVE-2024-5458

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade to v8.1.29 to fix CVE-2024-4577, CVE-2024-5585 and CVE-2024-5458

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-4577
- https://nvd.nist.gov/vuln/detail/CVE-2024-5585
- https://nvd.nist.gov/vuln/detail/CVE-2024-5458

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build successful: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=584120&view=results
- Local build successful