### PR TITLE
[grub] Disable code optimization for ip frame checksum calculation.

### DIFF
--- a/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
@@ -12,7 +12,7 @@
 Summary:        Signed GRand Unified Bootloader for %{buildarch} systems
 Name:           grub2-efi-binary-signed-%{buildarch}
 Version:        2.06
-Release:        18%{?dist}
+Release:        19%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -79,6 +79,9 @@ cp %{SOURCE3} %{buildroot}/boot/efi/EFI/BOOT/%{grubpxeefiname}
 /boot/efi/EFI/BOOT/%{grubpxeefiname}
 
 %changelog
+* Wed Jun 12 2024 George Mileka <gmileka@microsoft.com> - 2.06-19
+- disable code optimization for ip checksum calculation
+
 * Mon Apr 15 2024 Dan Streetman <ddstreet@microsoft.com> - 2.06-18
 - update grub to sbat 4
 

--- a/SPECS/grub2/disable-checksum-code-optimization.patch
+++ b/SPECS/grub2/disable-checksum-code-optimization.patch
@@ -1,0 +1,12 @@
+diff -ruN grub-2.06-ori/grub-core/net/ip.c grub-2.06/grub-core/net/ip.c
+--- grub-2.06-ori/grub-core/net/ip.c	2024-06-07 15:02:36.073464745 -0700
++++ grub-2.06/grub-core/net/ip.c	2024-06-12 19:02:51.293389116 -0700
+@@ -94,7 +94,7 @@
+ static struct reassemble *reassembles;
+ 
+ grub_uint16_t
+-grub_net_ip_chksum (void *ipv, grub_size_t len)
++__attribute__((optimize("O0"))) grub_net_ip_chksum (void *ipv, grub_size_t len)
+ {
+   grub_uint16_t *ip = (grub_uint16_t *) ipv;
+   grub_uint32_t sum = 0;

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -6,7 +6,7 @@
 Summary:        GRand Unified Bootloader
 Name:           grub2
 Version:        2.06
-Release:        18%{?dist}
+Release:        19%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -103,6 +103,10 @@ Patch:          sbat-4-0003-fs-ntfs-Fix-an-OOB-read-when-parsing-directory-entri
 Patch:          sbat-4-0004-fs-ntfs-Fix-an-OOB-read-when-parsing-bitmaps-for-ind.patch
 Patch:          sbat-4-0005-fs-ntfs-Fix-an-OOB-read-when-parsing-a-volume-label.patch
 Patch:          sbat-4-0006-fs-ntfs-Make-code-more-readable.patch
+# The Azure Linux team created this patch since the gcc version in use at the
+# time optimizes the code incorrectly, leading to network traffic getting
+# dropped in scenarios like PXE booting.
+Patch:          disable-checksum-code-optimization.patch
 BuildRequires:  autoconf
 BuildRequires:  device-mapper-devel
 BuildRequires:  python3
@@ -440,6 +444,9 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 %config(noreplace) %{_sysconfdir}/grub.d/41_custom
 
 %changelog
+* Wed Jun 12 2024 George Mileka <gmileka@microsoft.com> - 2.06-19
+- disable code optimization for ip checksum calculation
+
 * Mon Apr 15 2024 Dan Streetman <ddstreet@microsoft.com> - 2.06-18
 - update grub to sbat 4
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
With the current gcc version, the code optimization leads to incorrect checksums of packets in some cases. This, consequently, leads to those packets getting dropped by receiving client due to their incorrect checksums. This broke our PXE boot scenario.

The fix here is a work around where we disable code optimization for the function in question. Future versions of gcc might fix this issue - at which point, this fix can be reverted.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- [Disable code optimization for ip frame checksum calculation](https://github.com/microsoft/azurelinux/commit/80307229fcc7cfe5062018bde59a3a65d9f333c6)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [7849: [mic][iso][pxe] [commodore] 3.0 isos created by mic are failing to be pxe booted](https://dev.azure.com/mariner-org/ECF/_workitems/edit/7849)
- [51752056: Azl3 grub fails to PXE boot](https://microsoft.visualstudio.com/OS/_workitems/edit/51752056)

###### Links to CVEs  <!-- optional -->
- n/a

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of grub and its package with the patch.
- Local build of the baremetal vhdx.
- User MIC to create a PXE iso.
- Deploy the artifacts from the PXE ISO unto a PXE server on a private network.
- Launch a PXE client VM on the same private network and verify it boots.
