### PR TITLE
Update conntrack-tools and dependency

### DIFF
--- a/SPECS/conntrack-tools/conntrack-tools.signatures.json
+++ b/SPECS/conntrack-tools/conntrack-tools.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "conntrack-tools-1.4.5.tar.bz2": "36c6d99c7684851d4d72e75bd07ff3f0ff1baaf4b6f069eb7244990cd1a9a462",
+  "conntrack-tools-1.4.8.tar.xz": "067677f4c5f6564819e78ed3a9d4a8980935ea9273f3abb22a420ea30ab5ded6",
   "conntrackd.conf": "dc7fa36293263d0674508cba4499c90d20df15eabea7a7d901f2050094ede38b",
   "conntrackd.service": "c18f00e7b76df6dce5b7b46e1bb35e6c34f5d1fe329892c1f0327c2712282778"
  }

--- a/SPECS/conntrack-tools/conntrack-tools.spec
+++ b/SPECS/conntrack-tools/conntrack-tools.spec
@@ -1,19 +1,19 @@
 Summary:        Manipulate netfilter connection tracking table and run High Availability
 Name:           conntrack-tools
-Version:        1.4.5
-Release:        8%{?dist}
+Version:        1.4.8
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://conntrack-tools.netfilter.org/
-Source0:        https://netfilter.org/projects/%{name}/files/%{name}-%{version}.tar.bz2
+Source0:        https://netfilter.org/projects/%{name}/files/%{name}-%{version}.tar.xz
 Source1:        conntrackd.service
 Source2:        conntrackd.conf
 BuildRequires:  bison
 BuildRequires:  flex
 BuildRequires:  gcc
 BuildRequires:  libmnl-devel >= 1.0.3
-BuildRequires:  libnetfilter_conntrack-devel >= 1.0.7
+BuildRequires:  libnetfilter_conntrack-devel >= 1.0.9
 BuildRequires:  libnetfilter_cthelper-devel >= 1.0.0
 BuildRequires:  libnetfilter_cttimeout-devel >= 1.0.0
 BuildRequires:  libnetfilter_queue-devel >= 1.0.2
@@ -96,6 +96,11 @@ echo "disable conntrackd.service" > %{buildroot}%{_libdir}/systemd/system-preset
 %systemd_postun conntrackd.service
 
 %changelog
+* Wed Jun 12 2024 corvus-callidus <108946721+corvus-callidus@users.noreply.github.com> - 1.4.8-1
+- Update to version 1.4.8
+- Updating source from tar.bz2 to tar.xz
+- Build requires libnetfilter_conntrack >= 1.0.9
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 1.4.5-8
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 
@@ -213,7 +218,7 @@ echo "disable conntrackd.service" > %{buildroot}%{_libdir}/systemd/system-preset
 - Updated to 1.0.1
 - Added daemon using systemd and configuration file
 - Removed legacy spec requirements
-- Patch for: parse.c:240:34: error: 'NULL' undeclared 
+- Patch for: parse.c:240:34: error: 'NULL' undeclared
 
 * Thu Jan 12 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.0.0-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild

--- a/SPECS/conntrack-tools/conntrack-tools.spec
+++ b/SPECS/conntrack-tools/conntrack-tools.spec
@@ -218,7 +218,7 @@ echo "disable conntrackd.service" > %{buildroot}%{_libdir}/systemd/system-preset
 - Updated to 1.0.1
 - Added daemon using systemd and configuration file
 - Removed legacy spec requirements
-- Patch for: parse.c:240:34: error: 'NULL' undeclared
+- Patch for: parse.c:240:34: error: 'NULL' undeclared 
 
 * Thu Jan 12 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.0.0-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild

--- a/SPECS/libnetfilter_conntrack/libnetfilter_conntrack.signatures.json
+++ b/SPECS/libnetfilter_conntrack/libnetfilter_conntrack.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libnetfilter_conntrack-1.0.8.tar.bz2": "0cd13be008923528687af6c6b860f35392d49251c04ee0648282d36b1faec1cf"
+  "libnetfilter_conntrack-1.0.9.tar.bz2": "67bd9df49fe34e8b82144f6dfb93b320f384a8ea59727e92ff8d18b5f4b579a8"
  }
 }

--- a/SPECS/libnetfilter_conntrack/libnetfilter_conntrack.spec
+++ b/SPECS/libnetfilter_conntrack/libnetfilter_conntrack.spec
@@ -1,6 +1,6 @@
 Summary:        Netfilter conntrack userspace library
 Name:           libnetfilter_conntrack
-Version:        1.0.8
+Version:        1.0.9
 Release:        1%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
@@ -51,6 +51,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/*.so
 
 %changelog
+* Wed Jun 12 2024 corvus-callidus <108946721+corvus-callidus@users.noreply.github.com> - 1.0.9-1
+- Update to version 1.0.9
+
 * Tue Jan 11 2022 Henry Li <lihl@microsoft.com> - 1.0.8-1
 - Upgrade to version 1.0.8
 - Verified License

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2027,8 +2027,8 @@
         "type": "other",
         "other": {
           "name": "conntrack-tools",
-          "version": "1.4.5",
-          "downloadUrl": "https://netfilter.org/projects/conntrack-tools/files/conntrack-tools-1.4.5.tar.bz2"
+          "version": "1.4.8",
+          "downloadUrl": "https://netfilter.org/projects/conntrack-tools/files/conntrack-tools-1.4.8.tar.xz"
         }
       }
     },
@@ -10251,8 +10251,8 @@
         "type": "other",
         "other": {
           "name": "libnetfilter_conntrack",
-          "version": "1.0.8",
-          "downloadUrl": "http://www.netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-1.0.8.tar.bz2"
+          "version": "1.0.9",
+          "downloadUrl": "http://www.netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-1.0.9.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update conntrack-tools to v1.4.8 which addresses situations where conntrack flush command exits with error code 1. To update conntrack-tools to v1.4.8, libnetfilter_conntrack dependency needs to also be updated.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

