### PR TITLE
Test Fix for Package annobin

### DIFF
--- a/SPECS/annobin/annobin.spec
+++ b/SPECS/annobin/annobin.spec
@@ -237,7 +237,7 @@ touch doc/annobin.info
 #---------------------------------------------------------------------------------
 
 %build
-CONFIG_ARGS="$CONFIG_ARGS --quiet --without-debuginfod --with-clang --with-gcc-plugin-dir=%{ANNOBIN_GCC_PLUGIN_DIR} --with-llvm"
+CONFIG_ARGS="$CONFIG_ARGS --quiet --with-debuginfod --with-clang --with-gcc-plugin-dir=%{ANNOBIN_GCC_PLUGIN_DIR} --with-llvm"
 
 export CFLAGS="$CFLAGS -DAARCH64_BRANCH_PROTECTION_SUPPORTED=1"
 
@@ -310,7 +310,7 @@ rm -f %{buildroot}%{_infodir}/dir
 #---------------------------------------------------------------------------------
 
 %check
-make check || ( cat tests/test-suite.log; false )
+make check HAVE_DEBUGINFOD=false || ( cat tests/test-suite.log; false )
 
 #---------------------------------------------------------------------------------
 

--- a/SPECS/annobin/annobin.spec
+++ b/SPECS/annobin/annobin.spec
@@ -19,13 +19,17 @@
 Summary:        Binary annotation plugin for GCC
 Name:           annobin
 Version:        12.49
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-3.0-or-later AND LGPL-2.0-or-later AND (GPL-2.0-or-later WITH GCC-exception-2.0) AND (LGPL-2.0-or-later WITH GCC-exception-2.0) AND GFDL-1.3-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://sourceware.org/annobin/
 Source:         https://nickc.fedorapeople.org/%{annobin_sources}
 Requires:       %{name}-plugin-clang
+%if 0%{?with_check}
+Requires:       %{name}-tests
+%endif
+
 # Insert patches here, if needed.  Eg:
 # Patch01: annobin-plugin-default-string-notes.patch
 #---------------------------------------------------------------------------------
@@ -352,6 +356,9 @@ make check || ( cat tests/test-suite.log; false )
 #---------------------------------------------------------------------------------
 
 %changelog
+* Thu Jun 13 2024 Sam Meluch <sammeluch@microsoft.com> - 12.40-2
+- add tests package to test builds
+
 * Fri Mar 08 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 12.40-1
 - Promoted package from extended to core
 - Upgraded to 12.49

--- a/SPECS/annobin/annobin.spec
+++ b/SPECS/annobin/annobin.spec
@@ -237,7 +237,7 @@ touch doc/annobin.info
 #---------------------------------------------------------------------------------
 
 %build
-CONFIG_ARGS="$CONFIG_ARGS --quiet --with-debuginfod --with-clang --with-gcc-plugin-dir=%{ANNOBIN_GCC_PLUGIN_DIR} --with-llvm"
+CONFIG_ARGS="$CONFIG_ARGS --quiet --without-debuginfod --with-clang --with-gcc-plugin-dir=%{ANNOBIN_GCC_PLUGIN_DIR} --with-llvm"
 
 export CFLAGS="$CFLAGS -DAARCH64_BRANCH_PROTECTION_SUPPORTED=1"
 
@@ -310,7 +310,7 @@ rm -f %{buildroot}%{_infodir}/dir
 #---------------------------------------------------------------------------------
 
 %check
-make check HAVE_DEBUGINFOD=false || ( cat tests/test-suite.log; false )
+make check || ( cat tests/test-suite.log; false )
 
 #---------------------------------------------------------------------------------
 

--- a/SPECS/annobin/annobin.spec
+++ b/SPECS/annobin/annobin.spec
@@ -26,9 +26,7 @@ Distribution:   Azure Linux
 URL:            https://sourceware.org/annobin/
 Source:         https://nickc.fedorapeople.org/%{annobin_sources}
 Requires:       %{name}-plugin-clang
-%if 0%{?with_check}
-Requires:       %{name}-tests
-%endif
+BuildRequires:  elfutils-devel
 
 # Insert patches here, if needed.  Eg:
 # Patch01: annobin-plugin-default-string-notes.patch

--- a/SPECS/annobin/annobin.spec
+++ b/SPECS/annobin/annobin.spec
@@ -26,7 +26,6 @@ Distribution:   Azure Linux
 URL:            https://sourceware.org/annobin/
 Source:         https://nickc.fedorapeople.org/%{annobin_sources}
 Requires:       %{name}-plugin-clang
-BuildRequires:  elfutils-devel
 
 # Insert patches here, if needed.  Eg:
 # Patch01: annobin-plugin-default-string-notes.patch
@@ -238,7 +237,7 @@ touch doc/annobin.info
 #---------------------------------------------------------------------------------
 
 %build
-CONFIG_ARGS="$CONFIG_ARGS --quiet --with-debuginfod --with-clang --with-gcc-plugin-dir=%{ANNOBIN_GCC_PLUGIN_DIR} --with-llvm"
+CONFIG_ARGS="$CONFIG_ARGS --quiet --without-debuginfod --with-clang --with-gcc-plugin-dir=%{ANNOBIN_GCC_PLUGIN_DIR} --with-llvm"
 
 export CFLAGS="$CFLAGS -DAARCH64_BRANCH_PROTECTION_SUPPORTED=1"
 

--- a/SPECS/annobin/annobin.spec
+++ b/SPECS/annobin/annobin.spec
@@ -354,7 +354,8 @@ make check || ( cat tests/test-suite.log; false )
 
 %changelog
 * Thu Jun 13 2024 Sam Meluch <sammeluch@microsoft.com> - 12.40-2
-- add tests package to test builds
+- build package --without-debuginfod
+- fix package tests
 
 * Fri Mar 08 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 12.40-1
 - Promoted package from extended to core


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The Package tests for `annobin` were failing due to `debufinfod` not being present. Since we are not building with debuginfod, the flag has been turned off

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Build annobin with option `--without-debuginfod`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=586612&view=results
