### PR TITLE
Upgrade babel to Version 2.15.0 to Fix Package Tests

### DIFF
--- a/SPECS/babel/babel.signatures.json
+++ b/SPECS/babel/babel.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "Babel-2.15.0.tar.gz": "8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413"
+    "babel-2.15.0.tar.gz": "8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413"
   }
 }

--- a/SPECS/babel/babel.signatures.json
+++ b/SPECS/babel/babel.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "Babel-2.12.1.tar.gz": "cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455"
+    "Babel-2.15.0.tar.gz": "8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413"
   }
 }

--- a/SPECS/babel/babel.spec
+++ b/SPECS/babel/babel.spec
@@ -1,7 +1,7 @@
 Summary:        An integrated collection of utilities that assist in internationalizing and localizing Python applications
 Name:           babel
 Version:        2.12.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -19,6 +19,8 @@ BuildRequires:  openssl-devel
 BuildRequires:  python3-attrs
 BuildRequires:  python3-pip
 BuildRequires:  python3-six
+BuildRequires:  python3-pytest
+BuildRequires:  python3-pluggy
 %endif
 Requires:       python3
 Requires:       python3-pytz
@@ -44,8 +46,8 @@ The functionality Babel provides for internationalization (I18n) and localizatio
 ln -sfv pybabel %{buildroot}/%{_bindir}/pybabel3
 
 %check
-pip3 install pytest freezegun funcsigs pathlib2 pluggy utils
-%{python3} setup.py test
+pip3 install freezegun funcsigs pathlib2 utils
+%pytest
 
 %files
 %defattr(-,root,root,-)
@@ -55,6 +57,9 @@ pip3 install pytest freezegun funcsigs pathlib2 pluggy utils
 %{python3_sitelib}/*
 
 %changelog
+* Fri Jun 14 2024 Sam Meluch <sammeluch@microsoft.com> - 2.12.1-2
+- fix package tests
+
 * Thu Nov 02 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.12.1-1
 - Auto-upgrade to 2.12.1 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/babel/babel.spec
+++ b/SPECS/babel/babel.spec
@@ -1,13 +1,13 @@
 Summary:        An integrated collection of utilities that assist in internationalizing and localizing Python applications
 Name:           babel
-Version:        2.12.1
-Release:        2%{?dist}
+Version:        2.15.0
+Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Development/Languages/Python
 URL:            https://babel.pocoo.org
-Source0:        https://files.pythonhosted.org/packages/ba/42/54426ba5d7aeebde9f4aaba9884596eb2fe02b413ad77d62ef0b0422e205/Babel-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/15/d2/9671b93d623300f0aef82cde40e25357f11330bdde91743891b22a555bed/%{babel}-%{version}.tar.gz
 BuildRequires:  python3-devel
 BuildRequires:  python3-pytest
 BuildRequires:  python3-pytz
@@ -57,8 +57,9 @@ pip3 install freezegun funcsigs pathlib2 utils iniconfig
 %{python3_sitelib}/*
 
 %changelog
-* Fri Jun 14 2024 Sam Meluch <sammeluch@microsoft.com> - 2.12.1-2
+* Fri Jun 14 2024 Sam Meluch <sammeluch@microsoft.com> - 2.15.0-1
 - fix package tests
+- upgrade to 2.15.0 for python 3.12 support
 
 * Thu Nov 02 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.12.1-1
 - Auto-upgrade to 2.12.1 - Azure Linux 3.0 - package upgrades

--- a/SPECS/babel/babel.spec
+++ b/SPECS/babel/babel.spec
@@ -7,7 +7,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Development/Languages/Python
 URL:            https://babel.pocoo.org
-Source0:        https://files.pythonhosted.org/packages/15/d2/9671b93d623300f0aef82cde40e25357f11330bdde91743891b22a555bed/%{babel}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/15/d2/9671b93d623300f0aef82cde40e25357f11330bdde91743891b22a555bed/%{name}-%{version}.tar.gz
 BuildRequires:  python3-devel
 BuildRequires:  python3-pytest
 BuildRequires:  python3-pytz
@@ -36,7 +36,7 @@ The functionality Babel provides for internationalization (I18n) and localizatio
 2.A Python interface to the CLDR (Common Locale Data Repository), providing access to various locale display names, localized number and date formatting, etc.
 
 %prep
-%autosetup -n Babel-%{version}
+%autosetup -n babel-%{version}
 
 %build
 %py3_build

--- a/SPECS/babel/babel.spec
+++ b/SPECS/babel/babel.spec
@@ -46,7 +46,7 @@ The functionality Babel provides for internationalization (I18n) and localizatio
 ln -sfv pybabel %{buildroot}/%{_bindir}/pybabel3
 
 %check
-pip3 install freezegun funcsigs pathlib2 utils
+pip3 install freezegun funcsigs pathlib2 utils iniconfig
 %pytest
 
 %files

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -895,8 +895,8 @@
         "type": "other",
         "other": {
           "name": "babel",
-          "version": "2.12.1",
-          "downloadUrl": "https://files.pythonhosted.org/packages/ba/42/54426ba5d7aeebde9f4aaba9884596eb2fe02b413ad77d62ef0b0422e205/Babel-2.12.1.tar.gz"
+          "version": "2.15.0",
+          "downloadUrl": "https://files.pythonhosted.org/packages/15/d2/9671b93d623300f0aef82cde40e25357f11330bdde91743891b22a555bed/babel-2.15.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Package tests for babel are failing. This PR upgrades the package to support python3.12 (the default version for azure linux 3.0) and take a few fixes to support python3.12 f-string parsing.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade babel to version 2.15.0
- use pytest instead of setup.py for testing
- favor azure linux packages over pip install for stability

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=586673&view=results
