### PR TITLE
xlsxwriter build issue

### DIFF
--- a/SPECS/python-xlsxwriter/python-xlsxwriter.spec
+++ b/SPECS/python-xlsxwriter/python-xlsxwriter.spec
@@ -3,9 +3,10 @@
 
 Name:		python-%{pypi_name}
 Version:	3.2.0
-Release:	2%{?dist}
+Release:	3%{?dist}
 Summary:	Python module for writing files in the Excel 2007+ XLSX file format
 License:	BSD
+Vendor:         Microsoft Corporation
 URL:		https://pypi.python.org/pypi/XlsxWriter
 Source0:	https://github.com/jmcnamara/XlsxWriter/archive/refs/tags/RELEASE_3.2.0.tar.gz#/%{name}-%{version}.tar.gz
 BuildArch:	noarch
@@ -48,7 +49,7 @@ BuildRequires:	python3-devel
 %{common_desc}
 
 %prep
-%setup -q -n %{src_name}-%{version}
+%setup -q -n %{src_name}-RELEASE_%{version}
 # Remove bundled egg-info
 rm -rf %{src_name}.egg-info
 
@@ -66,6 +67,9 @@ rm -rf %{src_name}.egg-info
 %{_bindir}/vba_extract.py
 
 %changelog
+* Fri Jun 14 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 3.2.0-3
+- Build step correction
+
 * Wed Jun 12 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 3.2.0-2
 - Initial Azure Linux import from Fedora 40 (license: MIT).
 - License verified.


### PR DESCRIPTION
Fix build issue
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fix build issue

###### Change Log  <!-- REQUIRED -->
modified:   python-xlsxwriter.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
[- Pipeline build id: xxxx](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=586727&view=results)
