### PR TITLE
Changes to kubevirt, multus to build container images on 3.0

### DIFF
--- a/.pipelines/containerSourceData/kubevirt/Dockerfile-kubevirt-virt-launcher
+++ b/.pipelines/containerSourceData/kubevirt/Dockerfile-kubevirt-virt-launcher
@@ -7,11 +7,6 @@ FROM $BASE_IMAGE
 
 @INCLUDE_MAIN_RUN_INSTRUCTION@
 
-# XXX Once edk2 is moved to SPECS this will not be needed
-RUN tdnf -y install azurelinux-repos-extended.noarch \
-  && tdnf -y install edk2-ovmf \
-  && tdnf clean all
-
 # Setup permissions and capabilities for non-root VMIs. KubeVirt sets
 # XDG_* directories to /var/run.
 RUN  cd /var && rm -rf run && ln -s ../run . \

--- a/.pipelines/containerSourceData/kubevirt/virt-launcher.pkg
+++ b/.pipelines/containerSourceData/kubevirt/virt-launcher.pkg
@@ -1,5 +1,6 @@
 augeas
 ca-certificates
+edk2-ovmf
 iptables
 kubevirt-container-disk
 kubevirt-virt-launcher

--- a/.pipelines/containerSourceData/multus/Dockerfile-Multus
+++ b/.pipelines/containerSourceData/multus/Dockerfile-Multus
@@ -11,7 +11,6 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN mkdir -p /usr/src/multus-cni/bin \ 
   && cp /usr/bin/multus /usr/src/multus-cni/bin/ \ 
-  && cp /usr/bin/install_multus /install_multus \ 
-  && cp /usr/bin/thin_entrypoint /thin_entrypoint 
+  && cp /usr/bin/multus-entrypoint /multus-entrypoint 
 
-ENTRYPOINT [ "/thin_entrypoint" ]
+ENTRYPOINT [ "/multus-entrypoint" ]


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removing edk2-ovmf package from virt-launcher dockerfile
- Adding edk2-ovmf to virt-launcher.pkg
- Changing name for multus entrypoint to get it to work with 3.0 golden container image build

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=586092&view=results
