### PR TITLE
Use urandom

### DIFF
--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -347,7 +347,7 @@ fi
 # Fix permissions on existing device files on upgrade
 %define chroot_fix_devices() \
 if [ $1 -gt 1 ]; then \
-  for DEV in "%{1}/dev"/{null,random,zero}; do \
+  for DEV in "%{1}/dev"/{null,random,urandom,zero}; do \
     if [ -e "$DEV" -a "$(/bin/stat --printf="%{G} %{a}" "$DEV")" = "root 644" ]; \
     then \
       /bin/chmod 0664 "$DEV" \

--- a/SPECS/dhcp/dhcp.spec
+++ b/SPECS/dhcp/dhcp.spec
@@ -58,6 +58,7 @@ CFLAGS="$CFLAGS \
     --with-cli-pid-file=%{_localstatedir}/run/dhclient.pid \
     --with-cli6-pid-file=%{_localstatedir}/run/dhclient6.pid \
     --with-relay-pid-file=%{_localstatedir}/run/dhcrelay.pid \
+    --with-randomdev=/dev/urandom \
     --enable-log-pid \
     --enable-paranoia --enable-early-chroot
 


### PR DESCRIPTION
This is a very minor suggestion PR.

The first change makes ISC DHCP use `/dev/urandom` instead of its default. It also adds `/dev/urandom` to a small helper function in the ISC BIND spec.

It doesn't look like the version of `bind9` being shipped in AL3 supports specifying the `randomdev` anymore, so I didn't make any changes there.

It's possible other packages shipped in AL2+ support configuring the PRNG in `configure`, but I don't have a readily available list of them. Some packages perform autodetection or otherwise have logic to detect the PRNG. The best way to determine it would be to profile package builds (assuming tests hit `/dev/random`) or production.

I have not built and tested the new DHCP package since I lack the test harness and infrastructure to test `dhclient`, but I'm leaving it here as a suggestion.