### PR TITLE
Patch bash to load startup files when invoked with '-bash'

### DIFF
--- a/SPECS/bash/bash-2.03-profile.patch
+++ b/SPECS/bash/bash-2.03-profile.patch
@@ -1,0 +1,12 @@
+diff -up bash-3.2/config-top.h.profile bash-3.2/config-top.h
+--- bash-3.2/config-top.h.profile	2008-07-17 13:35:39.000000000 +0200
++++ bash-3.2/config-top.h	2008-07-17 13:42:18.000000000 +0200
+@@ -26,6 +26,8 @@
+    what POSIX.2 specifies. */
+ #define CONTINUE_AFTER_KILL_ERROR
+ 
++#define NON_INTERACTIVE_LOGIN_SHELLS
++
+ /* Define BREAK_COMPLAINS if you want the non-standard, but useful
+    error messages about `break' and `continue' out of context. */
+ #define BREAK_COMPLAINS

--- a/SPECS/bash/bash.spec
+++ b/SPECS/bash/bash.spec
@@ -332,7 +332,7 @@ fi
 %changelog
 * Mon Jun 17 2024 Daniel McIlvaney <damcilva@microsoft.com> - 5.2.15-2
 - When non-interactive shells are started with '-bash' load startup files. From
-  Fedora upstream: https://src.fedoraproject.org/rpms/bash/blob/f40/f/bash-2.03-profile.patch
+- Fedora upstream: https://src.fedoraproject.org/rpms/bash/blob/f40/f/bash-2.03-profile.patch
 
 * Tue Nov 21 2023 Andrew Phelps <anphel@microsoft.com> - 5.2.15-1
 - Upgrade to version 5.2.15

--- a/SPECS/bash/bash.spec
+++ b/SPECS/bash/bash.spec
@@ -1,7 +1,7 @@
 Summary:        Bourne-Again SHell
 Name:           bash
 Version:        5.2.15
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -10,6 +10,8 @@ URL:            https://www.gnu.org/software/bash/
 Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
 Source1:        bash_completion
 Patch0:         bash-5.1.patch
+# Non-interactive shells beginning with argv[0][0] == '-' should run the startup files when not in posix mode.
+Patch1:         bash-2.03-profile.patch
 BuildRequires:  readline
 Requires:       readline
 Requires(post): /bin/cp
@@ -328,6 +330,10 @@ fi
 %defattr(-,root,root)
 
 %changelog
+* Mon Jun 17 2024 Daniel McIlvaney <damcilva@microsoft.com> - 5.2.15-2
+- When non-interactive shells are started with '-bash' load startup files. From
+  Fedora upstream: https://src.fedoraproject.org/rpms/bash/blob/f40/f/bash-2.03-profile.patch
+
 * Tue Nov 21 2023 Andrew Phelps <anphel@microsoft.com> - 5.2.15-1
 - Upgrade to version 5.2.15
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -43,9 +43,9 @@ readline-8.2-1.azl3.aarch64.rpm
 readline-devel-8.2-1.azl3.aarch64.rpm
 coreutils-9.4-2.azl3.aarch64.rpm
 coreutils-lang-9.4-2.azl3.aarch64.rpm
-bash-5.2.15-1.azl3.aarch64.rpm
-bash-devel-5.2.15-1.azl3.aarch64.rpm
-bash-lang-5.2.15-1.azl3.aarch64.rpm
+bash-5.2.15-2.azl3.aarch64.rpm
+bash-devel-5.2.15-2.azl3.aarch64.rpm
+bash-lang-5.2.15-2.azl3.aarch64.rpm
 bzip2-1.0.8-1.azl3.aarch64.rpm
 bzip2-devel-1.0.8-1.azl3.aarch64.rpm
 bzip2-libs-1.0.8-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -43,9 +43,9 @@ readline-8.2-1.azl3.x86_64.rpm
 readline-devel-8.2-1.azl3.x86_64.rpm
 coreutils-9.4-2.azl3.x86_64.rpm
 coreutils-lang-9.4-2.azl3.x86_64.rpm
-bash-5.2.15-1.azl3.x86_64.rpm
-bash-devel-5.2.15-1.azl3.x86_64.rpm
-bash-lang-5.2.15-1.azl3.x86_64.rpm
+bash-5.2.15-2.azl3.x86_64.rpm
+bash-devel-5.2.15-2.azl3.x86_64.rpm
+bash-lang-5.2.15-2.azl3.x86_64.rpm
 bzip2-1.0.8-1.azl3.x86_64.rpm
 bzip2-devel-1.0.8-1.azl3.x86_64.rpm
 bzip2-libs-1.0.8-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -20,10 +20,10 @@ azurelinux-repos-ms-oss-preview-3.0-2.azl3.noarch.rpm
 azurelinux-repos-preview-3.0-2.azl3.noarch.rpm
 azurelinux-repos-shared-3.0-2.azl3.noarch.rpm
 azurelinux-rpm-macros-3.0-5.azl3.noarch.rpm
-bash-5.2.15-1.azl3.aarch64.rpm
-bash-debuginfo-5.2.15-1.azl3.aarch64.rpm
-bash-devel-5.2.15-1.azl3.aarch64.rpm
-bash-lang-5.2.15-1.azl3.aarch64.rpm
+bash-5.2.15-2.azl3.aarch64.rpm
+bash-debuginfo-5.2.15-2.azl3.aarch64.rpm
+bash-devel-5.2.15-2.azl3.aarch64.rpm
+bash-lang-5.2.15-2.azl3.aarch64.rpm
 binutils-2.41-2.azl3.aarch64.rpm
 binutils-debuginfo-2.41-2.azl3.aarch64.rpm
 binutils-devel-2.41-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -20,10 +20,10 @@ azurelinux-repos-ms-oss-preview-3.0-2.azl3.noarch.rpm
 azurelinux-repos-preview-3.0-2.azl3.noarch.rpm
 azurelinux-repos-shared-3.0-2.azl3.noarch.rpm
 azurelinux-rpm-macros-3.0-5.azl3.noarch.rpm
-bash-5.2.15-1.azl3.x86_64.rpm
-bash-debuginfo-5.2.15-1.azl3.x86_64.rpm
-bash-devel-5.2.15-1.azl3.x86_64.rpm
-bash-lang-5.2.15-1.azl3.x86_64.rpm
+bash-5.2.15-2.azl3.x86_64.rpm
+bash-debuginfo-5.2.15-2.azl3.x86_64.rpm
+bash-devel-5.2.15-2.azl3.x86_64.rpm
+bash-lang-5.2.15-2.azl3.x86_64.rpm
 binutils-2.41-2.azl3.x86_64.rpm
 binutils-aarch64-linux-gnu-2.41-2.azl3.x86_64.rpm
 binutils-debuginfo-2.41-2.azl3.x86_64.rpm


### PR DESCRIPTION
i.e., when invoked via 'su - <user> -c ...'. This is done by Fedora and Ubuntu (and other distros).

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Bash loads startup scripts when it runs, based on some logic to detect if it is a login/normal prompt, and interactive/non-interactive. (profile, bashrc, etc..., depending on those modes).

Tools like `su` in `util-linux` can explicitly request login/non-login mode (`su - other_user ...` (`-` == `-l` == `--login`). It informs bash of this choice by  prepending a '-' to `argv[0]` (i.e., `-bash`). By default `bash` ignores this, but can be [configured to respect it via a "hidden" define](https://git.savannah.gnu.org/cgit/bash.git/tree/config-top.h#n105) `NON_INTERACTIVE_LOGIN_SHELLS`. Most distros set this flag, so lets add it.

In containers:
```bash
tdnf -y install util-linux shadow-utils # 'dnf -y install util-linux' on fedora, ubuntu works out of box
useradd -m test
echo "export test=test" >> /etc/profile
su test -c 'echo $test' # Expected to be ""
su - test -c 'echo $test' # SHOULD BE "TEST", this works on ubuntu/fedora!
```
![image](https://github.com/microsoft/azurelinux/assets/23200982/bac362de-5d22-42c3-b8ae-709c3101c98a)


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enable `NON_INTERACTIVE_LOGIN_SHELLS` for bash package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46864804

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build/test in vm & container
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=588741&view=results (uninstall test fails since removing bash from the env. breaks the test).
