### PR TITLE
telegraf: patch CVE-2024-35255

### DIFF
--- a/SPECS/telegraf/CVE-2024-35255.patch
+++ b/SPECS/telegraf/CVE-2024-35255.patch
@@ -1,0 +1,203 @@
+From a6e3194c6cf3e2a683fe69db61cba50b6eabe754 Mon Sep 17 00:00:00 2001
+From: Saul Paredes <saulparedes@microsoft.com>
+Date: Tue, 18 Jun 2024 10:38:52 -0700
+Subject: [PATCH] fix CVE-2024-35255
+
+This patch is a combination of 50774cd9709905523136fb05e8c85a50e8984499
+and 48d39a82091b3aebe3df3505bd5372294b3461ed confirmed by the author
+that fix CVE-2024-35255. This was slighly adapted to be applied to
+current version (v1.4.0) This patch can be removed once azure-sdk-for-go
+vendored dependency version gets updated to >= v1.6.0
+
+Signed-off-by: Saul Paredes <saulparedes@microsoft.com>
+---
+ .../sdk/azidentity/managed_identity_client.go | 70 ++++++++++++++-----
+ 1 file changed, 51 insertions(+), 19 deletions(-)
+
+diff --git a/vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/managed_identity_client.go b/vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/managed_identity_client.go
+index fdc3c1f67..e5f24ffce 100644
+--- a/vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/managed_identity_client.go
++++ b/vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/managed_identity_client.go
+@@ -14,13 +14,15 @@ import (
+ 	"net/http"
+ 	"net/url"
+ 	"os"
++	"path/filepath"
++	"runtime"
+ 	"strconv"
+ 	"strings"
+ 	"time"
+ 
+ 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+ 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
++	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+ 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+ 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+ 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+@@ -55,12 +57,28 @@ const (
+ // managedIdentityClient provides the base for authenticating in managed identity environments
+ // This type includes an runtime.Pipeline and TokenCredentialOptions.
+ type managedIdentityClient struct {
+-	pipeline runtime.Pipeline
++	pipeline azruntime.Pipeline
+ 	msiType  msiType
+ 	endpoint string
+ 	id       ManagedIDKind
+ }
+ 
++// arcKeyDirectory returns the directory expected to contain Azure Arc keys
++var arcKeyDirectory = func() (string, error) {
++	switch runtime.GOOS {
++	case "linux":
++		return "/var/opt/azcmagent/tokens", nil
++	case "windows":
++		pd := os.Getenv("ProgramData")
++		if pd == "" {
++			return "", errors.New("environment variable ProgramData has no value")
++		}
++		return filepath.Join(pd, "AzureConnectedMachineAgent", "Tokens"), nil
++	default:
++		return "", fmt.Errorf("unsupported OS %q", runtime.GOOS)
++	}
++}
++
+ type wrappedNumber json.Number
+ 
+ func (n *wrappedNumber) UnmarshalJSON(b []byte) error {
+@@ -141,7 +159,7 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) (*manag
+ 	} else {
+ 		setIMDSRetryOptionDefaults(&cp.Retry)
+ 	}
+-	c.pipeline = runtime.NewPipeline(component, version, runtime.PipelineOptions{}, &cp)
++	c.pipeline = azruntime.NewPipeline(component, version, azruntime.PipelineOptions{}, &cp)
+ 
+ 	if log.Should(EventAuthentication) {
+ 		log.Writef(EventAuthentication, "Managed Identity Credential will use %s managed identity", env)
+@@ -173,7 +191,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
+ 		return azcore.AccessToken{}, newAuthenticationFailedError(credNameManagedIdentity, err.Error(), nil, err)
+ 	}
+ 
+-	if runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated) {
++	if azruntime.HasStatusCode(resp, http.StatusOK, http.StatusCreated) {
+ 		return c.createAccessToken(resp)
+ 	}
+ 
+@@ -184,14 +202,14 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
+ 				return azcore.AccessToken{}, newAuthenticationFailedError(credNameManagedIdentity, "the requested identity isn't assigned to this resource", resp, nil)
+ 			}
+ 			msg := "failed to authenticate a system assigned identity"
+-			if body, err := runtime.Payload(resp); err == nil && len(body) > 0 {
++			if body, err := azruntime.Payload(resp); err == nil && len(body) > 0 {
+ 				msg += fmt.Sprintf(". The endpoint responded with %s", body)
+ 			}
+ 			return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, msg)
+ 		case http.StatusForbidden:
+ 			// Docker Desktop runs a proxy that responds 403 to IMDS token requests. If we get that response,
+ 			// we return credentialUnavailableError so credential chains continue to their next credential
+-			body, err := runtime.Payload(resp)
++			body, err := azruntime.Payload(resp)
+ 			if err == nil && strings.Contains(string(body), "A socket operation was attempted to an unreachable network") {
+ 				return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, fmt.Sprintf("unexpected response %q", string(body)))
+ 			}
+@@ -209,7 +227,7 @@ func (c *managedIdentityClient) createAccessToken(res *http.Response) (azcore.Ac
+ 		ExpiresIn    wrappedNumber `json:"expires_in,omitempty"` // this field should always return the number of seconds for which a token is valid
+ 		ExpiresOn    interface{}   `json:"expires_on,omitempty"` // the value returned in this field varies between a number and a date string
+ 	}{}
+-	if err := runtime.UnmarshalAsJSON(res, &value); err != nil {
++	if err := azruntime.UnmarshalAsJSON(res, &value); err != nil {
+ 		return azcore.AccessToken{}, fmt.Errorf("internal AccessToken: %v", err)
+ 	}
+ 	if value.ExpiresIn != "" {
+@@ -257,7 +275,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, id Manage
+ }
+ 
+ func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, id ManagedIDKind, scopes []string) (*policy.Request, error) {
+-	request, err := runtime.NewRequest(ctx, http.MethodGet, c.endpoint)
++	request, err := azruntime.NewRequest(ctx, http.MethodGet, c.endpoint)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -277,7 +295,7 @@ func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, id Ma
+ }
+ 
+ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context, id ManagedIDKind, scopes []string) (*policy.Request, error) {
+-	request, err := runtime.NewRequest(ctx, http.MethodGet, c.endpoint)
++	request, err := azruntime.NewRequest(ctx, http.MethodGet, c.endpoint)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -297,7 +315,7 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
+ }
+ 
+ func (c *managedIdentityClient) createServiceFabricAuthRequest(ctx context.Context, id ManagedIDKind, scopes []string) (*policy.Request, error) {
+-	request, err := runtime.NewRequest(ctx, http.MethodGet, c.endpoint)
++	request, err := azruntime.NewRequest(ctx, http.MethodGet, c.endpoint)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -320,7 +338,7 @@ func (c *managedIdentityClient) createServiceFabricAuthRequest(ctx context.Conte
+ 
+ func (c *managedIdentityClient) getAzureArcSecretKey(ctx context.Context, resources []string) (string, error) {
+ 	// create the request to retreive the secret key challenge provided by the HIMDS service
+-	request, err := runtime.NewRequest(ctx, http.MethodGet, c.endpoint)
++	request, err := azruntime.NewRequest(ctx, http.MethodGet, c.endpoint)
+ 	if err != nil {
+ 		return "", err
+ 	}
+@@ -342,22 +360,36 @@ func (c *managedIdentityClient) getAzureArcSecretKey(ctx context.Context, resour
+ 	}
+ 	header := response.Header.Get("WWW-Authenticate")
+ 	if len(header) == 0 {
+-		return "", errors.New("did not receive a value from WWW-Authenticate header")
++		return "", newAuthenticationFailedError(credNameManagedIdentity, "HIMDS response has no WWW-Authenticate header", nil, nil)
+ 	}
+ 	// the WWW-Authenticate header is expected in the following format: Basic realm=/some/file/path.key
+-	pos := strings.LastIndex(header, "=")
+-	if pos == -1 {
+-		return "", fmt.Errorf("did not receive a correct value from WWW-Authenticate header: %s", header)
++	_, p, found := strings.Cut(header, "=")
++	if !found {
++		return "", newAuthenticationFailedError(credNameManagedIdentity, "unexpected WWW-Authenticate header from HIMDS: "+header, nil, nil)
++	}
++	expected, err := arcKeyDirectory()
++	if err != nil {
++		return "", err
++	}
++	if filepath.Dir(p) != expected || !strings.HasSuffix(p, ".key") {
++		return "", newAuthenticationFailedError(credNameManagedIdentity, "unexpected file path from HIMDS service: "+p, nil, nil)
++	}
++	f, err := os.Stat(p)
++	if err != nil {
++		return "", newAuthenticationFailedError(credNameManagedIdentity, fmt.Sprintf("could not stat %q: %v", p, err), nil, nil)
++	}
++	if s := f.Size(); s > 4096 {
++		return "", newAuthenticationFailedError(credNameManagedIdentity, fmt.Sprintf("key is too large (%d bytes)", s), nil, nil)
+ 	}
+-	key, err := os.ReadFile(header[pos+1:])
++	key, err := os.ReadFile(p)
+ 	if err != nil {
+-		return "", fmt.Errorf("could not read file (%s) contents: %v", header[pos+1:], err)
++		return "", newAuthenticationFailedError(credNameManagedIdentity, fmt.Sprintf("could not read %q: %v", p, err), nil, nil)
+ 	}
+ 	return string(key), nil
+ }
+ 
+ func (c *managedIdentityClient) createAzureArcAuthRequest(ctx context.Context, id ManagedIDKind, resources []string, key string) (*policy.Request, error) {
+-	request, err := runtime.NewRequest(ctx, http.MethodGet, c.endpoint)
++	request, err := azruntime.NewRequest(ctx, http.MethodGet, c.endpoint)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -379,7 +411,7 @@ func (c *managedIdentityClient) createAzureArcAuthRequest(ctx context.Context, i
+ }
+ 
+ func (c *managedIdentityClient) createCloudShellAuthRequest(ctx context.Context, id ManagedIDKind, scopes []string) (*policy.Request, error) {
+-	request, err := runtime.NewRequest(ctx, http.MethodPost, c.endpoint)
++	request, err := azruntime.NewRequest(ctx, http.MethodPost, c.endpoint)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-- 
+2.25.1
+

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.29.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,7 @@ Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2023-45288.patch
 Patch1:         CVE-2024-28110.patch
 Patch2:         CVE-2024-27289.patch
+Patch3:         CVE-2024-35255.patch
 BuildRequires:  golang
 BuildRequires:  iana-etc
 BuildRequires:  systemd-devel
@@ -83,6 +84,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Tue Jun 18 2024 Saul Paredes <saulparedes@microsoft.com> - 1.29.4-6
+- Patch CVE-2024-35255
+
 * Thu Jun 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.29.4-5
 - Bump release to rebuild with go 1.21.11
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

telegraf: patch CVE-2024-35255

How was this patch generated:
- Based on https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255, this CVE is fixed on versions >= 1.6.0
- There is no version of telegraf available yet that uses azure-sdk-for-go >= 1.6.0. So we need to patch
- Based on release notes in https://github.com/Azure/azure-sdk-for-go/releases/tag/sdk%2Fazidentity%2Fv1.6.0 , the fix for CVE seems to be https://github.com/Azure/azure-sdk-for-go/commit/50774cd9709905523136fb05e8c85a50e8984499 and https://github.com/Azure/azure-sdk-for-go/commit/48d39a82091b3aebe3df3505bd5372294b3461ed
- Confirmed with commit author this fixes the CVE
- Created combined patch out of them and slightly modified to cleanly apply to current version (v1.4.0)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- telegraf

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-35255

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=588647&view=results
