### PR TITLE
python-jsonschema: revert upgrade

### DIFF
--- a/SPECS/python-jsonschema/python-jsonschema.signatures.json
+++ b/SPECS/python-jsonschema/python-jsonschema.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "jsonschema-4.21.1.tar.gz": "85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
-  }
+ "Signatures": {
+  "jsonschema-2.6.0.tar.gz": "6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
+ }
 }

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -1,7 +1,7 @@
 Summary:        An implementation of JSON Schema validation for Python
 Name:           python-jsonschema
-Version:        4.21.1
-Release:        1%{?dist}
+Version:        2.6.0
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -16,66 +16,37 @@ http://tools.ietf.org/html/draft-zyp-json-schema-03
 
 %package -n     python3-jsonschema
 Summary:        An implementation of JSON Schema validation for Python
-BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel
-BuildRequires:  python3-hatchling
-BuildRequires:  python3-hatch-fancy-pypi-readme
-BuildRequires:  python3-hatch-vcs
-BuildRequires:  python3-packaging
-BuildRequires:  python3-pathspec
-BuildRequires:  python3-pip
-BuildRequires:  python3-pluggy
 BuildRequires:  python3-setuptools
-BuildRequires:  python3-setuptools_scm
-BuildRequires:  python3-trove-classifiers
 BuildRequires:  python3-vcversioner
-BuildRequires:  python3-wheel
 BuildRequires:  python3-xml
-%if %{with_check}
-BuildRequires:  python3-twisted
-BuildRequires:  python3-typing-extensions
-%endif
 Requires:       python3
 
 %description -n python3-jsonschema
 jsonschema is JSON Schema validator currently based on
 http://tools.ietf.org/html/draft-zyp-json-schema-03
 
-%pyproject_extras_subpkg -n python3-jsonschema format format-nongpl
-
 %prep
 %autosetup -n jsonschema-%{version}
 
-# Requires a checkout of the JSON-Schema-Test-Suite
-# https://github.com/json-schema-org/JSON-Schema-Test-Suite
-rm jsonschema/tests/test_jsonschema_test_suite.py
-
-%generate_buildrequires
-%pyproject_buildrequires
- 
 %build
-%pyproject_wheel
+%py3_build
 
 %install
-%pyproject_install
-%pyproject_save_files jsonschema
+%py3_install
+ln -s jsonschema %{buildroot}%{_bindir}/jsonschema3
 
-%if %{with_check}
 %check
-pip3 install jsonschema-specifications referencing
-PYTHONPATH=%{buildroot}%{python3_sitelib} trial3 jsonschema
-%endif
+%python3 setup test
 
-%files -n python3-jsonschema -f %{pyproject_files}
+%files -n python3-jsonschema
 %defattr(-,root,root)
-%license COPYING json/LICENSE
-%doc README.rst
+%license COPYING
+%{python3_sitelib}/*
 %{_bindir}/jsonschema
+%{_bindir}/jsonschema3
 
 %changelog
-* Mon Feb 26 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 4.21.1-1
-- Auto-upgrade to 4.21.1 - Azure Linux 3.0 - package upgrades
-
 * Wed Oct 20 2021 Thomas Crain <thcrain@microsoft.com> - 2.6.0-6
 - Remove python2 package
 - Lint spec

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22833,8 +22833,8 @@
         "type": "other",
         "other": {
           "name": "python-jsonschema",
-          "version": "4.21.1",
-          "downloadUrl": "https://pypi.python.org/packages/source/j/jsonschema/jsonschema-4.21.1.tar.gz"
+          "version": "2.6.0",
+          "downloadUrl": "https://pypi.python.org/packages/source/j/jsonschema/jsonschema-2.6.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The jsonschema package after upgrade does not work as expected, as was found by attempting to use it in azurelinux-sysinfo package. It is missing the following prerequisites:
attrs 23.2.0
jsonschema-specifications 2023.12.1
referencing 0.35.1
rpds-py 0.18.1

While we have the attrs package, we don't have the others in SPECS. 

In light of the upcoming GA and a desire for a stable release, this PR seeks to revert the upgrade so that we have a working version of jsonschema.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Revert upgrade for python-jsonschema

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/mariner-org/ECF/_workitems/edit/7801
- GA blocking bug: https://microsoft.visualstudio.com/OS/_workitems/edit/51858899

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=588674&view=results)
