### PR TITLE
Remove locales from core images, add documentation on restoring locales

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -217,6 +217,10 @@ A specific locale string may also be set using:
 
 This may be any value compatible with the `%_install_langs` rpm macro.
 
+#### Restoring Documentation and Locales on an Installed System
+
+The `OverrideRpmLocales` and `DisableRpmDocs` settings are stored in `/usr/lib/rpm/macros.d/macros.installercustomizations_*` files on the final system. The files selected for install are based on the `rpm` macros at the time of transaction, so to restore these files on an installed system remove the associated macro definition and run  `tdnf -y reinstall $(rpm -qa)`. This will reinstall all packages and apply the new settings.
+
 ### Customization Scripts
 The tools offer the option of executing arbitrary shell scripts during various points of the image generation process. There are three points that scripts can be executed: `PreInstall`, `PostInstall`, and `ImageFinalize`.
 

--- a/toolkit/imageconfigs/core-efi.json
+++ b/toolkit/imageconfigs/core-efi.json
@@ -54,7 +54,8 @@
                 "default": "kernel"
             },
             "Hostname": "azurelinux",
-            "DisableRpmDocs": true
+            "DisableRpmDocs": true,
+            "OverrideRpmLocales": "NONE"
         }
     ]
 }

--- a/toolkit/imageconfigs/core-legacy.json
+++ b/toolkit/imageconfigs/core-legacy.json
@@ -51,7 +51,9 @@
             "KernelOptions": {
                 "default": "kernel"
             },
-            "Hostname": "azurelinux"
+            "Hostname": "azurelinux",
+            "DisableRpmDocs": true,
+            "OverrideRpmLocales": "NONE"
         }
     ]
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Roll out the locales removal for core images. This should remove `/usr/share/locale/*` from `core-efi` and `core-legacy` images.

Locales off (3.3MB):
![image](https://github.com/microsoft/azurelinux/assets/23200982/444d6bcd-086b-485c-95e6-52cbf9a36856)

Locales on, re-install with `tdnf -y reinstall $(rpm -qa)` (19MB):
![image](https://github.com/microsoft/azurelinux/assets/23200982/948d5181-a7ce-4479-a676-3c57665c5127)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Set `"DisableRpmDocs": true` and `"OverrideRpmLocales": "NONE"` for both `core-efi.json` and `core-legacy.json`.
- Add some documentation on restoring files

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local check of build images, checked size, re-enabled locales and re-installed all files
