### PR TITLE
Image Customizer: Partition UUID reset.

### DIFF
--- a/toolkit/tools/imagecustomizer/README.md
+++ b/toolkit/tools/imagecustomizer/README.md
@@ -46,7 +46,8 @@ Disadvantages:
 3. Install prerequisites: `qemu-img`, `rpm`, `dd`, `lsblk`, `losetup`, `sfdisk`,
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
    `genisoimage`, `parted`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
-   `e2fsck`, `xfs_repair`, `resize2fs`, `zstd`, `veritysetup`.
+   `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
+   `veritysetup`.
 
    - For Ubuntu 22.04 images, run:
 

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -6,6 +6,9 @@ The Azure Linux Image Customizer is configured using a YAML (or JSON) file.
 
 1. If partitions were specified in the config, customize the disk partitions.
 
+   Otherwise, if the [resetpartitionsuuidstype](#resetpartitionsuuidstype-string) value
+   is specified, then the partitions' UUIDs are changed.
+
 2. Override the `/etc/resolv.conf` file with the version from the host OS.
 
 3. Update packages:
@@ -131,6 +134,7 @@ os:
             - [idType](#idtype-string)
             - [options](#options-string)
             - [path](#mountpoint-path)
+  - [resetPartitionsUuidsType](#resetpartitionsuuidstype-string)
   - [iso](#iso-type)
     - [additionalFiles](#additionalfiles-mapstring-fileconfig)
       - [fileConfig type](#fileconfig-type)
@@ -257,6 +261,35 @@ os:
   resetBootLoaderType: hard-reset
 ```
 
+### resetPartitionsUuidsType [string]
+
+Specifies that the partition UUIDs and filesystem UUIDs should be reset.
+
+Value is optional.
+
+This value cannot be specified if [storage](#storage-storage) is specified (since
+customizing the partition layout resets all the UUIDs anyway).
+
+If this value is specified, then [os.resetBootLoaderType](#resetbootloadertype-string)
+must also be specified.
+
+Supported options:
+
+- `reset-all`: Resets the partition UUIDs and filesystem UUIDs for all the partitions.
+
+Example:
+
+```yaml
+resetPartitionsUuidsType: reset-all
+
+os:
+  resetBootLoaderType: hard-reset
+```
+
+### iso [[iso](#iso-type)]
+
+Specifies the configuration for the generated ISO media.
+
 ### os [[os](#os-type)]
 
 Contains the configuration options for the OS.
@@ -267,6 +300,10 @@ Example:
 os:
   hostname: example-image
 ```
+
+### scripts [[scripts](#scripts-type)]
+
+Specifies custom scripts to run during the customization process.
 
 ## disk type
 
@@ -1000,6 +1037,8 @@ scripts:
 
 ## scripts type
 
+Specifies custom scripts to run during the customization process.
+
 Note: Script files must be in the same directory or a child directory of the directory
 that contains the config file.
 
@@ -1090,8 +1129,6 @@ Supported options:
 - `hard-reset`: Fully reset the boot-loader and its configuration.
   This includes removing any customized kernel command-line arguments that were added to
   base image.
-
-This field can only be specified if [Disks](#disks-disk) is also specified.
 
 ### hostname [string]
 

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -6,14 +6,14 @@ package imagecustomizerapi
 import "fmt"
 
 type Config struct {
-	Storage *Storage `yaml:"storage"`
-	Iso     *Iso     `yaml:"iso"`
-	OS      *OS      `yaml:"os"`
-	Scripts *Scripts `yaml:"scripts"`
+	Storage                  *Storage                 `yaml:"storage"`
+	ResetPartitionsUuidsType ResetPartitionsUuidsType `yaml:"resetPartitionsUuidsType"`
+	Iso                      *Iso                     `yaml:"iso"`
+	OS                       *OS                      `yaml:"os"`
+	Scripts                  *Scripts                 `yaml:"scripts"`
 }
 
 func (c *Config) IsValid() (err error) {
-
 	hasStorage := false
 	if c.Storage != nil {
 		err = c.Storage.IsValid()
@@ -22,6 +22,12 @@ func (c *Config) IsValid() (err error) {
 		}
 		hasStorage = true
 	}
+
+	err = c.ResetPartitionsUuidsType.IsValid()
+	if err != nil {
+		return err
+	}
+	hasResetPartitionsUuids := c.ResetPartitionsUuidsType != ResetPartitionsUuidsTypeDefault
 
 	if c.Iso != nil {
 		err = c.Iso.IsValid()
@@ -46,8 +52,16 @@ func (c *Config) IsValid() (err error) {
 		}
 	}
 
-	if hasStorage != hasResetBootLoader {
-		return fmt.Errorf("os.resetBootLoaderType and storage must be specified together")
+	if hasStorage && hasResetPartitionsUuids {
+		return fmt.Errorf("storage and resetPartitionsUuidsType cannot be specified together")
+	}
+
+	if hasStorage && !hasResetBootLoader {
+		return fmt.Errorf("os.resetBootLoaderType must be specified if storage is specified")
+	}
+
+	if hasResetPartitionsUuids && !hasResetBootLoader {
+		return fmt.Errorf("os.resetBootLoaderType must be specified if resetPartitionsUuidsType is specified")
 	}
 
 	return nil

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -136,7 +136,7 @@ func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 
 	err := config.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "os.resetBootLoaderType and storage must be specified together")
+	assert.ErrorContains(t, err, "os.resetBootLoaderType must be specified if storage is specified")
 }
 
 func TestConfigIsValidMultipleDisks(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/resetpartitionuuidtype.go
+++ b/toolkit/tools/imagecustomizerapi/resetpartitionuuidtype.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type ResetPartitionsUuidsType string
+
+const (
+	ResetPartitionsUuidsTypeDefault ResetPartitionsUuidsType = ""
+	ResetPartitionsUuidsTypeAll     ResetPartitionsUuidsType = "reset-all"
+)
+
+func (t ResetPartitionsUuidsType) IsValid() error {
+	switch t {
+	case ResetPartitionsUuidsTypeDefault, ResetPartitionsUuidsTypeAll:
+		// All good.
+		return nil
+
+	default:
+		return fmt.Errorf("invalid resetPartitionUuidType value (%v)", t)
+	}
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,48 +66,20 @@ func TestCustomizeImagePartitions(t *testing.T) {
 	defer imageConnection.Close()
 
 	// Check for key files/directories on the partitions.
-	fstabPath := filepath.Join(imageConnection.Chroot().RootDir(), "/etc/fstab")
-	_, err = os.Stat(fstabPath)
-	assert.NoError(t, err, "check for /etc/fstab")
-
 	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/usr/bin/bash"))
 	assert.NoError(t, err, "check for /usr/bin/bash")
-
-	grubCfgFilePath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/grub2/grub.cfg")
-	_, err = os.Stat(grubCfgFilePath)
-	assert.NoError(t, err, "check for /boot/grub2/grub2.cfg")
-
-	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi/boot/grub2/grub.cfg"))
-	assert.NoError(t, err, "check for /boot/efi/boot/grub2/grub2.cfg")
 
 	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/var/log"))
 	assert.NoError(t, err, "check for /var/log")
 
-	// Check that the fstab entries are correct.
-	fstabEntries, err := diskutils.ReadFstabFile(fstabPath)
-	assert.NoError(t, err, "read /etc/fstab")
-
 	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	assert.NoError(t, err, "get disk partitions")
 
-	assert.Equal(t, len(mountPoints), len(fstabEntries), "/etc/fstab entries count")
-
-	for i := range mountPoints {
-		mountPoint := mountPoints[i]
-		fstabEntry := fstabEntries[i]
-		partition := partitions[mountPoint.PartitionNum]
-
-		assert.Equalf(t, mountPoint.FileSystemType, fstabEntry.FsType, "fstab [%d]: file system type", i)
-		assert.Equalf(t, mountPoint.Path, fstabEntry.Target, "fstab [%d]: target path", i)
-
-		expectedSource := fmt.Sprintf("PARTUUID=%s", partition.PartUuid)
-		assert.Equalf(t, expectedSource, fstabEntry.Source, "fstab [%d]: source", i)
-	}
-
-	// Check that the extraCommandLine was added to the grub.cfg file.
-	grubCfgContents, err := file.Read(grubCfgFilePath)
-	assert.NoError(t, err, "read grub.cfg file")
-	assert.Regexp(t, "linux.* console=tty0 console=ttyS0 ", grubCfgContents)
+	// Check that the fstab entries are correct.
+	verifyFstabEntries(t, imageConnection, mountPoints, partitions)
+	verifyBootloaderConfig(t, imageConnection, "console=tty0 console=ttyS0",
+		partitions[mountPoints[1].PartitionNum].Uuid,
+		partitions[mountPoints[0].PartitionNum].PartUuid)
 }
 
 func TestCustomizeImageKernelCommandLine(t *testing.T) {
@@ -134,4 +109,145 @@ func TestCustomizeImageKernelCommandLine(t *testing.T) {
 	grubCfgContents, err := file.Read(grubCfgFilePath)
 	assert.NoError(t, err, "read grub.cfg file")
 	assert.Regexp(t, "linux.* console=tty0 console=ttyS0 ", grubCfgContents)
+}
+
+func TestCustomizeImageNewUUIDs(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageCopyFiles")
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "newpartitionsuuids-config.yaml")
+	tempRawBaseImage := filepath.Join(testTmpDir, "baseImage.raw")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	err := os.MkdirAll(buildDir, os.ModePerm)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Get the partitions from the base image.
+	err = shell.ExecuteLiveWithErr(1, "qemu-img", "convert", "-O", "raw", baseImage, tempRawBaseImage)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	baseImageLoopback, err := safeloopback.NewLoopback(tempRawBaseImage)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer baseImageLoopback.Close()
+
+	baseImagePartitions, err := diskutils.GetDiskPartitions(baseImageLoopback.DevicePath())
+	if !assert.NoError(t, err, "get base image partitions") {
+		return
+	}
+
+	err = baseImageLoopback.CleanClose()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	os.Remove(tempRawBaseImage)
+
+	// Customize image.
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imageConnection, err := connectToCoreEfiImage(buildDir, outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	newImagePartitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
+	if !assert.NoError(t, err, "get customized image partitions") {
+		return
+	}
+
+	// Ensure the partition UUIDs have been changed.
+	if assert.Equal(t, len(baseImagePartitions), len(newImagePartitions)) {
+		for i := range baseImagePartitions {
+			baseImagePartition := baseImagePartitions[i]
+			newImagePartition := newImagePartitions[i]
+
+			if baseImagePartition.Type != "part" {
+				continue
+			}
+
+			assert.Equalf(t, baseImagePartition.FileSystemType, newImagePartition.FileSystemType, "[%d] filesystem type didn't change", i)
+			assert.NotEqualf(t, baseImagePartition.PartUuid, newImagePartition.PartUuid, "[%d] partition UUID did change", i)
+			assert.NotEqual(t, baseImagePartition.Uuid, newImagePartition.Uuid, "[%d] filesystem UUID did change", i)
+		}
+	}
+
+	// Check that the fstab entries are correct.
+	verifyFstabEntries(t, imageConnection, coreEfiMountPoints, newImagePartitions)
+	verifyBootloaderConfig(t, imageConnection, "",
+		newImagePartitions[coreEfiMountPoints[0].PartitionNum].Uuid,
+		newImagePartitions[coreEfiMountPoints[0].PartitionNum].PartUuid)
+}
+
+func verifyFstabEntries(t *testing.T, imageConnection *ImageConnection, mountPoints []mountPoint,
+	partitions []diskutils.PartitionInfo,
+) {
+	fstabPath := filepath.Join(imageConnection.Chroot().RootDir(), "/etc/fstab")
+	fstabEntries, err := diskutils.ReadFstabFile(fstabPath)
+	if !assert.NoError(t, err, "read /etc/fstab") {
+		return
+	}
+
+	filteredFstabEntries := filterOutSpecialPartitions(fstabEntries)
+
+	if !assert.Equalf(t, len(mountPoints), len(filteredFstabEntries), "/etc/fstab entries count: %v", filteredFstabEntries) {
+		return
+	}
+
+	for i := range mountPoints {
+		mountPoint := mountPoints[i]
+		fstabEntry := filteredFstabEntries[i]
+		partition := partitions[mountPoint.PartitionNum]
+
+		assert.Equalf(t, mountPoint.FileSystemType, fstabEntry.FsType, "fstab [%d]: file system type", i)
+		assert.Equalf(t, mountPoint.Path, fstabEntry.Target, "fstab [%d]: target path", i)
+
+		expectedSource := fmt.Sprintf("PARTUUID=%s", partition.PartUuid)
+		assert.Equalf(t, expectedSource, fstabEntry.Source, "fstab [%d]: source", i)
+	}
+}
+
+func verifyBootloaderConfig(t *testing.T, imageConnection *ImageConnection, extraCommandLineArgs string,
+	bootUuid string, rootfsPartUuid string,
+) {
+	verifyEspGrubCfg(t, imageConnection, bootUuid)
+	verifyBootGrubCfg(t, imageConnection, extraCommandLineArgs, bootUuid, rootfsPartUuid)
+}
+
+func verifyEspGrubCfg(t *testing.T, imageConnection *ImageConnection, bootUuid string) {
+	grubCfgFilePath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi/boot/grub2/grub.cfg")
+	grubCfgContents, err := file.Read(grubCfgFilePath)
+	if !assert.NoError(t, err, "read ESP grub.cfg file") {
+		return
+	}
+
+	assert.Regexp(t, fmt.Sprintf("(?m)^search -n -u %s -s$", regexp.QuoteMeta(bootUuid)), grubCfgContents)
+}
+
+func verifyBootGrubCfg(t *testing.T, imageConnection *ImageConnection, extraCommandLineArgs string, bootUuid string,
+	rootfsPartUuid string,
+) {
+	grubCfgFilePath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/grub2/grub.cfg")
+	grubCfgContents, err := file.Read(grubCfgFilePath)
+	if !assert.NoError(t, err, "read boot grub.cfg file") {
+		return
+	}
+
+	assert.Regexp(t, fmt.Sprintf("(?m)^search -n -u %s -s$", regexp.QuoteMeta(bootUuid)), grubCfgContents)
+	assert.Regexp(t, fmt.Sprintf("(?m)^set rootdevice=PARTUUID=%s$", regexp.QuoteMeta(rootfsPartUuid)), grubCfgContents)
+
+	if extraCommandLineArgs != "" {
+		assert.Regexp(t, fmt.Sprintf("linux.* %s ", regexp.QuoteMeta(extraCommandLineArgs)), grubCfgContents)
+	}
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+)
+
+func resetPartitionsUuids(buildImageFile string, buildDir string) error {
+	logger.Log.Infof("Resetting partition UUIDs")
+
+	loopback, err := safeloopback.NewLoopback(buildImageFile)
+	if err != nil {
+		return err
+	}
+	defer loopback.Close()
+
+	partitions, err := diskutils.GetDiskPartitions(loopback.DevicePath())
+	if err != nil {
+		return err
+	}
+
+	// Update the UUIDs.
+	newUuids := make([]string, len(partitions))
+	for i, partition := range partitions {
+		if partition.Type != "part" {
+			continue
+		}
+
+		newUuid, err := resetFileSystemUuid(partition)
+		if err != nil {
+			return fmt.Errorf("failed to reset partition's (%s) filesystem (%s) UUID:\n%w", partition.Path,
+				partition.FileSystemType, err)
+		}
+
+		newUuids[i] = newUuid
+	}
+
+	// Update the PARTUUIDs.
+	newPartUuids := make([]string, len(partitions))
+	for i, partition := range partitions {
+		if partition.Type != "part" {
+			continue
+		}
+
+		newPartUuid, err := resetPartitionUuid(loopback.DevicePath(), i)
+		if err != nil {
+			return fmt.Errorf("failed to update partition (%s) UUID:\n%w", partition.Path, err)
+		}
+
+		newPartUuids[i] = newPartUuid
+	}
+
+	// Fix /etc/fstab file.
+	err = fixPartitionUuidsInFstabFile(partitions, newUuids, newPartUuids, buildDir)
+	if err != nil {
+		return err
+	}
+
+	err = loopback.CleanClose()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resetFileSystemUuid(partition diskutils.PartitionInfo) (string, error) {
+	newUuid := ""
+	switch partition.FileSystemType {
+	case "ext2", "ext3", "ext4":
+		// tune2fs requires you to run 'e2fsck -f' first.
+		err := shell.ExecuteLive(true /*squashErrors*/, "e2fsck", "-fy", partition.Path)
+		if err != nil {
+			return "", fmt.Errorf("failed to check %s with e2fsck:\n%w", partition.Path, err)
+		}
+
+		newUuid = uuid.NewString()
+		err = shell.ExecuteLive(true /*squashErrors*/, "tune2fs", "-U", newUuid, partition.Path)
+		if err != nil {
+			return "", err
+		}
+
+	case "xfs":
+		newUuid = uuid.NewString()
+		err := shell.ExecuteLive(true /*squashErrors*/, "xfs_admin", "-U", newUuid, partition.Path)
+		if err != nil {
+			return "", err
+		}
+
+	case "vfat":
+		newUuidBytes := make([]byte, 4)
+		_, err := rand.Read(newUuidBytes)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate new random ID for vfat partition:\n%w", err)
+		}
+
+		newUuid = hex.EncodeToString(newUuidBytes)
+		err = shell.ExecuteLive(true /*squashErrors*/, "fatlabel", "--volume-id", partition.Path, newUuid)
+		if err != nil {
+			return "", err
+		}
+
+		// Change the UUID string format to match what is expected by fstab.
+		newUuid = strings.ToUpper(newUuid)
+		newUuid = newUuid[:4] + "-" + newUuid[4:]
+
+	default:
+		return "", fmt.Errorf("unsupported filesystem type (%s)", partition.FileSystemType)
+	}
+
+	return newUuid, nil
+}
+
+func resetPartitionUuid(device string, partNum int) (string, error) {
+	newUuid := uuid.NewString()
+	err := shell.ExecuteLive(true /*squashErrors*/, "sfdisk", "--part-uuid", device, strconv.Itoa(partNum), newUuid)
+	if err != nil {
+		return "", err
+	}
+
+	return newUuid, nil
+}
+
+func fixPartitionUuidsInFstabFile(partitions []diskutils.PartitionInfo, newUuids []string, newPartUuids []string,
+	buildDir string,
+) error {
+	rootfsPartition, err := findRootfsPartition(partitions, buildDir)
+	if err != nil {
+		return err
+	}
+
+	// Mount the rootfs partition.
+	tmpDir := filepath.Join(buildDir, tmpParitionDirName)
+	partitionMount, err := safemount.NewMount(rootfsPartition.Path, tmpDir, rootfsPartition.FileSystemType, 0, "", true)
+	if err != nil {
+		return err
+	}
+	defer partitionMount.Close()
+
+	// Read the existing fstab file.
+	fsTabFilePath := filepath.Join(partitionMount.Target(), "/etc/fstab")
+	fstabEntries, err := diskutils.ReadFstabFile(fsTabFilePath)
+	if err != nil {
+		return err
+	}
+
+	// Fix the fstab entries.
+	for i, fstabEntry := range fstabEntries {
+		// Ignore special partitions.
+		if isSpecialPartition(fstabEntry) {
+			continue
+		}
+
+		// Find the partition.
+		// Note: The 'partitions' list was collected before all the changes were made. So, the fstab entires will still
+		// match the values in the `partitions` list.
+		mountIdType, _, partitionIndex, err := findSourcePartitionHelper(fstabEntry.Source, partitions)
+		if err != nil {
+			return err
+		}
+
+		// Create a new value for the source.
+		newSource := fstabEntry.Source
+		switch mountIdType {
+		case imagecustomizerapi.MountIdentifierTypeUuid:
+			newSource = fmt.Sprintf("UUID=%s", newUuids[partitionIndex])
+
+		case imagecustomizerapi.MountIdentifierTypePartUuid:
+			newSource = fmt.Sprintf("PARTUUID=%s", newPartUuids[partitionIndex])
+		}
+
+		logger.Log.Debugf("Fix fstab: (%s) to (%s)", fstabEntry.Source, newSource)
+		fstabEntries[i].Source = newSource
+	}
+
+	// Write the updated fstab entries back to the fstab file.
+	err = diskutils.WriteFstabFile(fstabEntries, fsTabFilePath)
+	if err != nil {
+		return err
+	}
+
+	err = partitionMount.CleanClose()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -498,10 +498,6 @@ func validateConfig(baseConfigPath string, config *imagecustomizerapi.Config, rp
 	return nil
 }
 
-func hasPartitionCustomizations(config *imagecustomizerapi.Config) bool {
-	return config.Storage != nil
-}
-
 func validateAdditionalFiles(baseConfigPath string, additionalFiles imagecustomizerapi.AdditionalFilesMap) error {
 	var aggregateErr error
 	for sourceFile := range additionalFiles {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -22,6 +22,21 @@ const (
 	testImageRootDirName = "testimageroot"
 )
 
+var (
+	coreEfiMountPoints = []mountPoint{
+		{
+			PartitionNum:   2,
+			Path:           "/",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   1,
+			Path:           "/boot/efi",
+			FileSystemType: "vfat",
+		},
+	}
+)
+
 func TestCustomizeImageEmptyConfig(t *testing.T) {
 	var err error
 
@@ -73,18 +88,7 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 }
 
 func connectToCoreEfiImage(buildDir string, imageFilePath string) (*ImageConnection, error) {
-	return connectToImage(buildDir, imageFilePath, []mountPoint{
-		{
-			PartitionNum:   2,
-			Path:           "/",
-			FileSystemType: "ext4",
-		},
-		{
-			PartitionNum:   1,
-			Path:           "/boot/efi",
-			FileSystemType: "vfat",
-		},
-	})
+	return connectToImage(buildDir, imageFilePath, coreEfiMountPoints)
 }
 
 type mountPoint struct {

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -119,7 +119,7 @@ func createNewImageHelper(imageConnection *ImageConnection, filename string, dis
 	return nil
 }
 
-func configureDiskBootLoader(imageConnection *ImageConnection, fileSystems []imagecustomizerapi.FileSystem,
+func configureDiskBootLoader(imageConnection *ImageConnection, rootMountIdType imagecustomizerapi.MountIdentifierType,
 	bootType imagecustomizerapi.BootType, selinuxConfig imagecustomizerapi.SELinux,
 	kernelCommandLine imagecustomizerapi.KernelCommandLine, currentSELinuxMode imagecustomizerapi.SELinuxMode,
 ) error {
@@ -133,7 +133,7 @@ func configureDiskBootLoader(imageConnection *ImageConnection, fileSystems []ima
 		return err
 	}
 
-	imagerPartitionSettings, err := partitionSettingsToImager(fileSystems)
+	imagerRootMountIdType, err := mountIdentifierTypeToImager(rootMountIdType)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func configureDiskBootLoader(imageConnection *ImageConnection, fileSystems []ima
 	}
 
 	// Configure the boot loader.
-	err = installutils.ConfigureDiskBootloader(imagerBootType, false, false, imagerPartitionSettings,
+	err = installutils.ConfigureDiskBootloaderWithRootMountIdType(imagerBootType, false, false, imagerRootMountIdType,
 		imagerKernelCommandLine, imageConnection.Chroot(), imageConnection.Loopback().DevicePath(),
 		mountPointMap, diskutils.EncryptedRootDevice{}, diskutils.VerityDevice{}, grubMkconfigEnabled,
 		!grubMkconfigEnabled)

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/newpartitionsuuids-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/newpartitionsuuids-config.yaml
@@ -1,0 +1,4 @@
+resetPartitionsUuidsType: reset-all
+
+os:
+  resetBootLoaderType: hard-reset


### PR DESCRIPTION
Add support for resetting the partition and filesystem UUIDs without needing to customize the partition layout.

In addition, this change has necessitated adding support for resetting the bootloader configuration even when the partition layout isn't customized.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added UTs.

