### PR TITLE
Fix CVE-2024-3727 in cri-o by patching vendored github.com/containers/image

### DIFF
--- a/SPECS/cri-o/CVE-2024-3727.patch
+++ b/SPECS/cri-o/CVE-2024-3727.patch
@@ -1,0 +1,638 @@
+From: Francisco Huelsz Prince <frhuelsz@microsoft.com>
+Date: Tue, 19 Jun 2024 01:15:36 +0000
+Subject: [PATCH] apply CVE-2024-3727 fix to v5.15.2
+
+This is a backport of https://github.com/containers/image/pull/2403 to v5.15.2.
+
+diff --git a/vendor/github.com/containers/image/v5/directory/directory_dest.go b/vendor/github.com/containers/image/v5/directory/directory_dest.go
+index e3280aa2..3c443b54 100644
+--- a/vendor/github.com/containers/image/v5/directory/directory_dest.go
++++ b/vendor/github.com/containers/image/v5/directory/directory_dest.go
+@@ -189,7 +189,10 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
+ 		}
+ 	}
+ 
+-	blobPath := d.ref.layerPath(computedDigest)
++	blobPath, err := d.ref.layerPath(computedDigest)
++	if err != nil {
++		return types.BlobInfo{}, err
++	}
+ 	// need to explicitly close the file, since a rename won't otherwise not work on Windows
+ 	blobFile.Close()
+ 	explicitClosed = true
+@@ -213,7 +216,10 @@ func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.Blo
+ 	if info.Digest == "" {
+ 		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
+ 	}
+-	blobPath := d.ref.layerPath(info.Digest)
++	blobPath, err := d.ref.layerPath(info.Digest)
++	if err != nil {
++		return false, types.BlobInfo{}, err
++	}
+ 	finfo, err := os.Stat(blobPath)
+ 	if err != nil && os.IsNotExist(err) {
+ 		return false, types.BlobInfo{}, nil
+@@ -233,7 +239,11 @@ func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.Blo
+ // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+ // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
+ func (d *dirImageDestination) PutManifest(ctx context.Context, manifest []byte, instanceDigest *digest.Digest) error {
+-	return ioutil.WriteFile(d.ref.manifestPath(instanceDigest), manifest, 0644)
++	path, err := d.ref.manifestPath(instanceDigest)
++	if err != nil {
++		return err
++	}
++	return ioutil.WriteFile(path, manifest, 0644)
+ }
+ 
+ // PutSignatures writes a set of signatures to the destination.
+@@ -241,7 +251,11 @@ func (d *dirImageDestination) PutManifest(ctx context.Context, manifest []byte,
+ // (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
+ func (d *dirImageDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
+ 	for i, sig := range signatures {
+-		if err := ioutil.WriteFile(d.ref.signaturePath(i, instanceDigest), sig, 0644); err != nil {
++		path, err := d.ref.signaturePath(i, instanceDigest)
++		if err != nil {
++			return err
++		}
++		if err := ioutil.WriteFile(path, sig, 0644); err != nil {
+ 			return err
+ 		}
+ 	}
+diff --git a/vendor/github.com/containers/image/v5/directory/directory_src.go b/vendor/github.com/containers/image/v5/directory/directory_src.go
+index ad9129d4..420cee2f 100644
+--- a/vendor/github.com/containers/image/v5/directory/directory_src.go
++++ b/vendor/github.com/containers/image/v5/directory/directory_src.go
+@@ -37,7 +37,11 @@ func (s *dirImageSource) Close() error {
+ // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+ // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+ func (s *dirImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+-	m, err := ioutil.ReadFile(s.ref.manifestPath(instanceDigest))
++	path, err := s.ref.manifestPath(instanceDigest)
++	if err != nil {
++		return nil, "", err
++	}
++	m, err := ioutil.ReadFile(path)
+ 	if err != nil {
+ 		return nil, "", err
+ 	}
+@@ -53,7 +57,11 @@ func (s *dirImageSource) HasThreadSafeGetBlob() bool {
+ // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+ // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+ func (s *dirImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+-	r, err := os.Open(s.ref.layerPath(info.Digest))
++	path, err := s.ref.layerPath(info.Digest)
++	if err != nil {
++		return nil, -1, err
++	}
++	r, err := os.Open(path)
+ 	if err != nil {
+ 		return nil, -1, err
+ 	}
+@@ -71,7 +79,11 @@ func (s *dirImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache
+ func (s *dirImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+ 	signatures := [][]byte{}
+ 	for i := 0; ; i++ {
+-		signature, err := ioutil.ReadFile(s.ref.signaturePath(i, instanceDigest))
++		path, err := s.ref.signaturePath(i, instanceDigest)
++		if err != nil {
++			return nil, err
++		}
++		signature, err := ioutil.ReadFile(path)
+ 		if err != nil {
+ 			if os.IsNotExist(err) {
+ 				break
+diff --git a/vendor/github.com/containers/image/v5/directory/directory_transport.go b/vendor/github.com/containers/image/v5/directory/directory_transport.go
+index e542d888..ea280707 100644
+--- a/vendor/github.com/containers/image/v5/directory/directory_transport.go
++++ b/vendor/github.com/containers/image/v5/directory/directory_transport.go
+@@ -162,25 +162,34 @@ func (ref dirReference) DeleteImage(ctx context.Context, sys *types.SystemContex
+ }
+ 
+ // manifestPath returns a path for the manifest within a directory using our conventions.
+-func (ref dirReference) manifestPath(instanceDigest *digest.Digest) string {
++func (ref dirReference) manifestPath(instanceDigest *digest.Digest) (string, error) {
+ 	if instanceDigest != nil {
+-		return filepath.Join(ref.path, instanceDigest.Encoded()+".manifest.json")
++		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
++			return "", err
++		}
++		return filepath.Join(ref.path, instanceDigest.Encoded()+".manifest.json"), nil
+ 	}
+-	return filepath.Join(ref.path, "manifest.json")
++	return filepath.Join(ref.path, "manifest.json"), nil
+ }
+ 
+ // layerPath returns a path for a layer tarball within a directory using our conventions.
+-func (ref dirReference) layerPath(digest digest.Digest) string {
++func (ref dirReference) layerPath(digest digest.Digest) (string, error) {
++	if err := digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
++		return "", err
++	}
+ 	// FIXME: Should we keep the digest identification?
+-	return filepath.Join(ref.path, digest.Encoded())
++	return filepath.Join(ref.path, digest.Encoded()), nil
+ }
+ 
+ // signaturePath returns a path for a signature within a directory using our conventions.
+-func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) string {
++func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) (string, error) {
+ 	if instanceDigest != nil {
+-		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1))
++		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
++			return "", err
++		}
++		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1)), nil
+ 	}
+-	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1))
++	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1)), nil
+ }
+ 
+ // versionPath returns a path for the version file within a directory using our conventions.
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_client.go b/vendor/github.com/containers/image/v5/docker/docker_client.go
+index 3fe9a11d..ea15c9f7 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_client.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_client.go
+@@ -796,6 +796,9 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
+ // getExtensionsSignatures returns signatures from the X-Registry-Supports-Signatures API extension,
+ // using the original data structures.
+ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerReference, manifestDigest digest.Digest) (*extensionSignatureList, error) {
++	if err := manifestDigest.Validate(); err != nil { // Make sure manifestDigest.String() does not contain any unexpected characters
++		return nil, err
++	}
+ 	path := fmt.Sprintf(extensionsSignaturePath, reference.Path(ref.ref), manifestDigest)
+ 	res, err := c.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
+ 	if err != nil {
+@@ -818,3 +821,19 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
+ 	}
+ 	return &parsedBody, nil
+ }
++
++// sigstoreAttachmentTag returns a sigstore attachment tag for the specified digest.
++func sigstoreAttachmentTag(d digest.Digest) (string, error) {
++	if err := d.Validate(); err != nil { // Make sure d.String() doesn’t contain any unexpected characters
++		return "", err
++	}
++	return strings.Replace(d.String(), ":", "-", 1) + ".sig", nil
++}
++
++// Close removes resources associated with an initialized dockerClient, if any.
++func (c *dockerClient) Close() error {
++	if c.client != nil {
++		c.client.CloseIdleConnections()
++	}
++	return nil
++}
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_image.go b/vendor/github.com/containers/image/v5/docker/docker_image.go
+index c84bb37d..284b39f5 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_image.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_image.go
+@@ -83,7 +83,12 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
+ 		if err = json.NewDecoder(res.Body).Decode(&tagsHolder); err != nil {
+ 			return nil, err
+ 		}
+-		tags = append(tags, tagsHolder.Tags...)
++		for _, tag := range tagsHolder.Tags {
++			if _, err := reference.WithTag(dr.ref, tag); err != nil { // Ensure the tag does not contain unexpected values
++				return nil, fmt.Errorf("registry returned invalid tag %q: %w", tag, err)
++			}
++			tags = append(tags, tag)
++		}
+ 
+ 		link := res.Header.Get("Link")
+ 		if link == "" {
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
+index 360a7122..77ef1490 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
+@@ -213,6 +213,9 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader,
+ // If the destination does not contain the blob, or it is unknown, blobExists ordinarily returns (false, -1, nil);
+ // it returns a non-nil error only on an unexpected failure.
+ func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.Named, digest digest.Digest, extraScope *authScope) (bool, int64, error) {
++	if err := digest.Validate(); err != nil { // Make sure digest.String() does not contain any unexpected characters
++		return false, -1, err
++	}
+ 	checkPath := fmt.Sprintf(blobsPath, reference.Path(repo), digest.String())
+ 	logrus.Debugf("Checking %s", checkPath)
+ 	res, err := d.c.makeRequest(ctx, http.MethodHead, checkPath, nil, nil, v2Auth, extraScope)
+@@ -390,6 +393,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
+ 		// particular instance.
+ 		refTail = instanceDigest.String()
+ 		// Double-check that the manifest we've been given matches the digest we've been given.
++		// This also validates the format of instanceDigest.
+ 		matches, err := manifest.MatchesDigest(m, *instanceDigest)
+ 		if err != nil {
+ 			return errors.Wrapf(err, "digesting manifest in PutManifest")
+@@ -518,11 +522,17 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, m
+ 
+ 	// NOTE: Keep this in sync with docs/signature-protocols.md!
+ 	for i, signature := range signatures {
+-		url := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
+-		err := d.putOneSignature(url, signature)
++		url, err := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return err
++		}
++		err = d.putOneSignature(url, signature)
+ 		if err != nil {
+ 			return err
+ 		}
++		if err := d.putOneSignature(url, signature); err != nil {
++			return err
++		}
+ 	}
+ 	// Remove any other signatures, if present.
+ 	// We stop at the first missing signature; if a previous deleting loop aborted
+@@ -530,7 +540,10 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, m
+ 	// is enough for dockerImageSource to stop looking for other signatures, so that
+ 	// is sufficient.
+ 	for i := len(signatures); ; i++ {
+-		url := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
++		url, err := signatureStorageURL(d.c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return err
++		}
+ 		missing, err := d.c.deleteOneSignature(url)
+ 		if err != nil {
+ 			return err
+@@ -639,6 +652,7 @@ sigExists:
+ 			return err
+ 		}
+ 
++		// manifestDigest is known to be valid because it was not rejected by getExtensionsSignatures above.
+ 		path := fmt.Sprintf(extensionsSignaturePath, reference.Path(d.ref.ref), manifestDigest.String())
+ 		res, err := d.c.makeRequest(ctx, http.MethodPut, path, nil, bytes.NewReader(body), v2Auth, nil)
+ 		if err != nil {
+diff --git a/vendor/github.com/containers/image/v5/docker/docker_image_src.go b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
+index 5dc8e7b1..cf353b43 100644
+--- a/vendor/github.com/containers/image/v5/docker/docker_image_src.go
++++ b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
+@@ -178,6 +178,9 @@ func simplifyContentType(contentType string) string {
+ // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+ func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+ 	if instanceDigest != nil {
++		if err := instanceDigest.Validate(); err != nil { // Make sure instanceDigest.String() does not contain any unexpected characters
++			return nil, "", err
++		}
+ 		return s.fetchManifest(ctx, instanceDigest.String())
+ 	}
+ 	err := s.ensureManifestIsLoaded(ctx)
+@@ -187,6 +190,8 @@ func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *dig
+ 	return s.cachedManifest, s.cachedManifestMIMEType, nil
+ }
+ 
++// fetchManifest fetches a manifest for tagOrDigest.
++// The caller is responsible for ensuring tagOrDigest uses the expected format.
+ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest string) ([]byte, string, error) {
+ 	path := fmt.Sprintf(manifestPath, reference.Path(s.physicalRef.ref), tagOrDigest)
+ 	headers := map[string][]string{
+@@ -293,6 +298,9 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo,
+ 		return nil, nil, fmt.Errorf("external URLs not supported with GetBlobAt")
+ 	}
+ 
++	if err := info.Digest.Validate(); err != nil { // Make sure info.Digest.String() does not contain any unexpected characters
++		return nil, nil, err
++	}
+ 	path := fmt.Sprintf(blobsPath, reference.Path(s.physicalRef.ref), info.Digest.String())
+ 	logrus.Debugf("Downloading %s", path)
+ 	res, err := s.c.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
+@@ -423,7 +431,10 @@ func (s *dockerImageSource) getSignaturesFromLookaside(ctx context.Context, inst
+ 	// NOTE: Keep this in sync with docs/signature-protocols.md!
+ 	signatures := [][]byte{}
+ 	for i := 0; ; i++ {
+-		url := signatureStorageURL(s.c.signatureBase, manifestDigest, i)
++		url, err := signatureStorageURL(s.c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return nil, err
++		}
+ 		signature, missing, err := s.getOneSignature(ctx, url)
+ 		if err != nil {
+ 			return nil, err
+@@ -564,7 +575,10 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
+ 	}
+ 
+ 	for i := 0; ; i++ {
+-		url := signatureStorageURL(c.signatureBase, manifestDigest, i)
++		url, err := signatureStorageURL(c.signatureBase, manifestDigest, i)
++		if err != nil {
++			return err
++		}
+ 		missing, err := c.deleteOneSignature(url)
+ 		if err != nil {
+ 			return err
+diff --git a/vendor/github.com/containers/image/v5/docker/internal/tarfile/dest.go b/vendor/github.com/containers/image/v5/docker/internal/tarfile/dest.go
+index a558657b..2bb63a36 100644
+--- a/vendor/github.com/containers/image/v5/docker/internal/tarfile/dest.go
++++ b/vendor/github.com/containers/image/v5/docker/internal/tarfile/dest.go
+@@ -143,11 +143,19 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
+ 			return types.BlobInfo{}, errors.Wrap(err, "reading Config file stream")
+ 		}
+ 		d.config = buf
+-		if err := d.archive.sendFileLocked(d.archive.configPath(inputInfo.Digest), inputInfo.Size, bytes.NewReader(buf)); err != nil {
++		configPath, err := d.archive.configPath(inputInfo.Digest)
++		if err != nil {
++			return types.BlobInfo{}, err
++		}
++		if err := d.archive.sendFileLocked(configPath, inputInfo.Size, bytes.NewReader(buf)); err != nil {
+ 			return types.BlobInfo{}, errors.Wrap(err, "writing Config file")
+ 		}
+ 	} else {
+-		if err := d.archive.sendFileLocked(d.archive.physicalLayerPath(inputInfo.Digest), inputInfo.Size, stream); err != nil {
++		layerPath, err := d.archive.physicalLayerPath(inputInfo.Digest)
++		if err != nil {
++			return types.BlobInfo{}, err
++		}
++		if err := d.archive.sendFileLocked(layerPath, inputInfo.Size, stream); err != nil {
+ 			return types.BlobInfo{}, err
+ 		}
+ 	}
+diff --git a/vendor/github.com/containers/image/v5/docker/internal/tarfile/writer.go b/vendor/github.com/containers/image/v5/docker/internal/tarfile/writer.go
+index 255f0d35..742f977c 100644
+--- a/vendor/github.com/containers/image/v5/docker/internal/tarfile/writer.go
++++ b/vendor/github.com/containers/image/v5/docker/internal/tarfile/writer.go
+@@ -92,7 +92,10 @@ func (w *Writer) ensureSingleLegacyLayerLocked(layerID string, layerDigest diges
+ 	if _, ok := w.legacyLayers[layerID]; !ok {
+ 		// Create a symlink for the legacy format, where there is one subdirectory per layer ("image").
+ 		// See also the comment in physicalLayerPath.
+-		physicalLayerPath := w.physicalLayerPath(layerDigest)
++		physicalLayerPath, err := w.physicalLayerPath(layerDigest)
++		if err != nil {
++			return err
++		}
+ 		if err := w.sendSymlinkLocked(filepath.Join(layerID, legacyLayerFileName), filepath.Join("..", physicalLayerPath)); err != nil {
+ 			return errors.Wrap(err, "creating layer symbolic link")
+ 		}
+@@ -136,6 +139,9 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
+ 		}
+ 
+ 		// This chainID value matches the computation in docker/docker/layer.CreateChainID …
++		if err := l.Digest.Validate(); err != nil { // This should never fail on this code path, still: make sure the chainID computation is unambiguous.
++			return err
++		}
+ 		if chainID == "" {
+ 			chainID = l.Digest
+ 		} else {
+@@ -206,12 +212,20 @@ func checkManifestItemsMatch(a, b *ManifestItem) error {
+ func (w *Writer) ensureManifestItemLocked(layerDescriptors []manifest.Schema2Descriptor, configDigest digest.Digest, repoTags []reference.NamedTagged) error {
+ 	layerPaths := []string{}
+ 	for _, l := range layerDescriptors {
+-		layerPaths = append(layerPaths, w.physicalLayerPath(l.Digest))
++		p, err := w.physicalLayerPath(l.Digest)
++		if err != nil {
++			return err
++		}
++		layerPaths = append(layerPaths, p)
+ 	}
+ 
+ 	var item *ManifestItem
++	configPath, err := w.configPath(configDigest)
++	if err != nil {
++		return err
++	}
+ 	newItem := ManifestItem{
+-		Config:       w.configPath(configDigest),
++		Config:       configPath,
+ 		RepoTags:     []string{},
+ 		Layers:       layerPaths,
+ 		Parent:       "", // We don’t have this information
+@@ -296,21 +310,27 @@ func (w *Writer) Close() error {
+ // configPath returns a path we choose for storing a config with the specified digest.
+ // NOTE: This is an internal implementation detail, not a format property, and can change
+ // any time.
+-func (w *Writer) configPath(configDigest digest.Digest) string {
+-	return configDigest.Hex() + ".json"
++func (w *Writer) configPath(configDigest digest.Digest) (string, error) {
++	if err := configDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in unexpected paths, so validate explicitly.
++		return "", err
++	}
++	return configDigest.Hex() + ".json", nil
+ }
+ 
+ // physicalLayerPath returns a path we choose for storing a layer with the specified digest
+ // (the actual path, i.e. a regular file, not a symlink that may be used in the legacy format).
+ // NOTE: This is an internal implementation detail, not a format property, and can change
+ // any time.
+-func (w *Writer) physicalLayerPath(layerDigest digest.Digest) string {
++func (w *Writer) physicalLayerPath(layerDigest digest.Digest) (string, error) {
++	if err := layerDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in unexpected paths, so validate explicitly.
++		return "", err
++	}
+ 	// Note that this can't be e.g. filepath.Join(l.Digest.Hex(), legacyLayerFileName); due to the way
+ 	// writeLegacyMetadata constructs layer IDs differently from inputinfo.Digest values (as described
+ 	// inside it), most of the layers would end up in subdirectories alone without any metadata; (docker load)
+ 	// tries to load every subdirectory as an image and fails if the config is missing.  So, keep the layers
+ 	// in the root of the tarball.
+-	return layerDigest.Hex() + ".tar"
++	return layerDigest.Hex() + ".tar", nil
+ }
+ 
+ type tarFI struct {
+diff --git a/vendor/github.com/containers/image/v5/docker/lookaside.go b/vendor/github.com/containers/image/v5/docker/lookaside.go
+index 515e5932..2e400c09 100644
+--- a/vendor/github.com/containers/image/v5/docker/lookaside.go
++++ b/vendor/github.com/containers/image/v5/docker/lookaside.go
+@@ -229,8 +229,11 @@ func (ns registryNamespace) signatureTopLevel(write bool) string {
+ // signatureStorageURL returns an URL usable for accessing signature index in base with known manifestDigest.
+ // base is not nil from the caller
+ // NOTE: Keep this in sync with docs/signature-protocols.md!
+-func signatureStorageURL(base signatureStorageBase, manifestDigest digest.Digest, index int) *url.URL {
++func signatureStorageURL(base signatureStorageBase, manifestDigest digest.Digest, index int) (*url.URL, error) {
++	if err := manifestDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in a path with ../, so validate explicitly.
++		return nil, err
++	}
+ 	url := *base
+ 	url.Path = fmt.Sprintf("%s@%s=%s/signature-%d", url.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
+-	return &url
++	return &url, nil
+ }
+diff --git a/vendor/github.com/containers/image/v5/ostree/ostree_dest.go b/vendor/github.com/containers/image/v5/ostree/ostree_dest.go
+index c91a49c5..54ea740e 100644
+--- a/vendor/github.com/containers/image/v5/ostree/ostree_dest.go
++++ b/vendor/github.com/containers/image/v5/ostree/ostree_dest.go
+@@ -352,6 +352,10 @@ func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.
+ 		}
+ 		d.repo = repo
+ 	}
++
++	if err := info.Digest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, so validate explicitly.
++		return false, private.ReusedBlob{}, err
++	}
+ 	branch := fmt.Sprintf("ociimage/%s", info.Digest.Hex())
+ 
+ 	found, data, err := readMetadata(d.repo, branch, "docker.uncompressed_digest")
+@@ -472,12 +476,18 @@ func (d *ostreeImageDestination) Commit(context.Context, types.UnparsedImage) er
+ 		return nil
+ 	}
+ 	for _, layer := range d.schema.LayersDescriptors {
++		if err := layer.Digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
++			return err
++		}
+ 		hash := layer.Digest.Hex()
+ 		if err = checkLayer(hash); err != nil {
+ 			return err
+ 		}
+ 	}
+ 	for _, layer := range d.schema.FSLayers {
++		if err := layer.BlobSum.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
++			return err
++		}
+ 		hash := layer.BlobSum.Hex()
+ 		if err = checkLayer(hash); err != nil {
+ 			return err
+diff --git a/vendor/github.com/containers/image/v5/ostree/ostree_src.go b/vendor/github.com/containers/image/v5/ostree/ostree_src.go
+index 4948ec66..9c4b5396 100644
+--- a/vendor/github.com/containers/image/v5/ostree/ostree_src.go
++++ b/vendor/github.com/containers/image/v5/ostree/ostree_src.go
+@@ -272,7 +272,9 @@ func (s *ostreeImageSource) HasThreadSafeGetBlob() bool {
+ // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+ // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+ func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+-
++	if err := info.Digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
++		return nil, -1, err
++	}
+ 	blob := info.Digest.Hex()
+ 
+ 	// Ensure s.compressed is initialized.  It is build by LayerInfosForCopy.
+diff --git a/vendor/github.com/containers/image/v5/storage/storage_image.go b/vendor/github.com/containers/image/v5/storage/storage_image.go
+index 6b0fea61..8164e3a2 100644
+--- a/vendor/github.com/containers/image/v5/storage/storage_image.go
++++ b/vendor/github.com/containers/image/v5/storage/storage_image.go
+@@ -1,3 +1,4 @@
++//go:build !containers_image_storage_stub
+ // +build !containers_image_storage_stub
+ 
+ package storage
+@@ -23,7 +24,7 @@ import (
+ 	"github.com/containers/image/v5/pkg/blobinfocache/none"
+ 	"github.com/containers/image/v5/types"
+ 	"github.com/containers/storage"
+-	"github.com/containers/storage/drivers"
++	graphdriver "github.com/containers/storage/drivers"
+ 	"github.com/containers/storage/pkg/archive"
+ 	"github.com/containers/storage/pkg/chunked"
+ 	"github.com/containers/storage/pkg/ioutils"
+@@ -96,14 +97,20 @@ type storageImageCloser struct {
+ // manifestBigDataKey returns a key suitable for recording a manifest with the specified digest using storage.Store.ImageBigData and related functions.
+ // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
+ // for compatibility, if a manifest is not available under this key, check also storage.ImageDigestBigDataKey
+-func manifestBigDataKey(digest digest.Digest) string {
+-	return storage.ImageDigestManifestBigDataNamePrefix + "-" + digest.String()
++func manifestBigDataKey(digest digest.Digest) (string, error) {
++	if err := digest.Validate(); err != nil { // Make sure info.Digest.String() uses the expected format and does not collide with other BigData keys.
++		return "", err
++	}
++	return storage.ImageDigestManifestBigDataNamePrefix + "-" + digest.String(), nil
+ }
+ 
+ // signatureBigDataKey returns a key suitable for recording the signatures associated with the manifest with the specified digest using storage.Store.ImageBigData and related functions.
+ // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
+-func signatureBigDataKey(digest digest.Digest) string {
+-	return "signature-" + digest.Encoded()
++func signatureBigDataKey(digest digest.Digest) (string, error) {
++	if err := digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
++		return "", err
++	}
++	return "signature-" + digest.Encoded(), nil
+ }
+ 
+ // newImageSource sets up an image for reading.
+@@ -240,7 +247,10 @@ func (s *storageImageSource) getBlobAndLayerID(info types.BlobInfo) (rc io.ReadC
+ // GetManifest() reads the image's manifest.
+ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) (manifestBlob []byte, MIMEType string, err error) {
+ 	if instanceDigest != nil {
+-		key := manifestBigDataKey(*instanceDigest)
++		key, err := manifestBigDataKey(*instanceDigest)
++		if err != nil {
++			return nil, "", err
++		}
+ 		blob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
+ 		if err != nil {
+ 			return nil, "", errors.Wrapf(err, "reading manifest for image instance %q", *instanceDigest)
+@@ -252,7 +262,10 @@ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *di
+ 		// Prefer the manifest corresponding to the user-specified digest, if available.
+ 		if s.imageRef.named != nil {
+ 			if digested, ok := s.imageRef.named.(reference.Digested); ok {
+-				key := manifestBigDataKey(digested.Digest())
++				key, err := manifestBigDataKey(digested.Digest())
++				if err != nil {
++					return nil, "", err
++				}
+ 				blob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
+ 				if err != nil && !os.IsNotExist(err) { // os.IsNotExist is true if the image exists but there is no data corresponding to key
+ 					return nil, "", err
+@@ -365,7 +378,10 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
+ 	instance := "default instance"
+ 	if instanceDigest != nil {
+ 		signatureSizes = s.SignaturesSizes[*instanceDigest]
+-		key = signatureBigDataKey(*instanceDigest)
++		key, err = signatureBigDataKey(*instanceDigest)
++		if err != nil {
++			return nil, err
++		}
+ 		instance = instanceDigest.Encoded()
+ 	}
+ 	if len(signatureSizes) > 0 {
+@@ -1140,7 +1156,10 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
+ 		if err != nil {
+ 			return errors.Wrapf(err, "digesting top-level manifest")
+ 		}
+-		key := manifestBigDataKey(manifestDigest)
++		key, err := manifestBigDataKey(manifestDigest)
++		if err != nil {
++			return err
++		}
+ 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, toplevelManifest, manifest.Digest); err != nil {
+ 			logrus.Debugf("error saving top-level manifest for image %q: %v", img.ID, err)
+ 			return errors.Wrapf(err, "saving top-level manifest for image %q", img.ID)
+@@ -1149,7 +1168,10 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
+ 	// Save the image's manifest.  Allow looking it up by digest by using the key convention defined by the Store.
+ 	// Record the manifest twice: using a digest-specific key to allow references to that specific digest instance,
+ 	// and using storage.ImageDigestBigDataKey for future users that don’t specify any digest and for compatibility with older readers.
+-	key := manifestBigDataKey(s.manifestDigest)
++	key, err := manifestBigDataKey(s.manifestDigest)
++	if err != nil {
++		return err
++	}
+ 	if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, s.manifest, manifest.Digest); err != nil {
+ 		logrus.Debugf("error saving manifest for image %q: %v", img.ID, err)
+ 		return errors.Wrapf(err, "saving manifest for image %q", img.ID)
+@@ -1167,7 +1189,10 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
+ 		}
+ 	}
+ 	for instanceDigest, signatures := range s.signatureses {
+-		key := signatureBigDataKey(instanceDigest)
++		key, err := signatureBigDataKey(instanceDigest)
++		if err != nil {
++			return err
++		}
+ 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, signatures, manifest.Digest); err != nil {
+ 			logrus.Debugf("error saving signatures for image %q: %v", img.ID, err)
+ 			return errors.Wrapf(err, "saving signatures for image %q", img.ID)
+diff --git a/vendor/github.com/containers/image/v5/storage/storage_reference.go b/vendor/github.com/containers/image/v5/storage/storage_reference.go
+index 1aafe906..ea484634 100644
+--- a/vendor/github.com/containers/image/v5/storage/storage_reference.go
++++ b/vendor/github.com/containers/image/v5/storage/storage_reference.go
+@@ -72,7 +72,10 @@ func multiArchImageMatchesSystemContext(store storage.Store, img *storage.Image,
+ 	// We don't need to care about storage.ImageDigestBigDataKey because
+ 	// manifests lists are only stored into storage by c/image versions
+ 	// that know about manifestBigDataKey, and only using that key.
+-	key := manifestBigDataKey(manifestDigest)
++	key, err := manifestBigDataKey(manifestDigest)
++	if err != nil {
++		return false // This should never happen, manifestDigest comes from a reference.Digested, and that validates the format.
++	}
+ 	manifestBytes, err := store.ImageBigData(img.ID, key)
+ 	if err != nil {
+ 		return false
+@@ -94,7 +97,10 @@ func multiArchImageMatchesSystemContext(store storage.Store, img *storage.Image,
+ 	if err != nil {
+ 		return false
+ 	}
+-	key = manifestBigDataKey(chosenInstance)
++	key, err = manifestBigDataKey(chosenInstance)
++	if err != nil {
++		return false
++	}
+ 	_, err = store.ImageBigData(img.ID, key)
+ 	return err == nil // true if img.ID is based on chosenInstance.
+ }

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.22.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -64,6 +64,7 @@ Patch8:         CVE-2023-44487.patch
 Patch9:         CVE-2024-28180.patch
 Patch10:        CVE-2024-21626.patch
 Patch11:        CVE-2024-3154.patch
+Patch12:        CVE-2024-3727.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  fdupes
@@ -216,6 +217,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Tue Jun 18 2024 Francisco Huelsz Prince <frhuelsz@microsoft.com> - 1.22.3-3
+- Patch CVE-2024-3727 in vendored github.com/containers/image.
+
 * Mon Jun 03 2024 Bala <balakumaran.kannan@microsoft.com> - 1.22.3-2
 - Patch CVE-2024-3154
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Address https://github.com/advisories/GHSA-6wvf-f2vw-3425 by patching vendored github.com/containers/image.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Cherry pick commits in https://github.com/containers/image/pull/2403
- Prune to only the relevant sections.
- Adjustments to backport the fix. 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-3727

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->

- github.com/containers/image w/ patch built locally.
- github.com/containers/image w/ and w/o patch produce same results for `make test`.
- Built specfile with patch locally in 2.0 container.
- PR checks succeeded below.
