### PR TITLE
crash: add crash-target-arm64 binary

### DIFF
--- a/SPECS/crash/crash.spec
+++ b/SPECS/crash/crash.spec
@@ -36,6 +36,15 @@ The core analysis suite is a self-contained tool that can be used to investigate
 
 This package contains libraries and header files need for development.
 
+%ifarch x86_64
+%package target-arm64
+Summary:       Crash executable for analyzing arm64 crash dumps on x86_64 host machines
+Group:         Development/Libraries
+
+%description target-arm64
+This package contains the "crash-target-arm64" binary for analyzing arm64 crash dumps on x86_64 host machines.
+%endif
+
 %prep
 %autosetup -n %{name}-%{version}
 # make expect the gdb tarball to be named with its version only, gdb-[version].tar.gz, e.g.: gdb-10.2.tar.gz
@@ -72,9 +81,6 @@ cp -p defs.h %{buildroot}%{_includedir}/crash
 %defattr(-,root,root)
 %license COPYING3
 %{_bindir}/crash
-%ifarch x86_64
-%{_bindir}/crash-target-arm64
-%endif
 %{_mandir}/man8/crash.8.gz
 %doc COPYING3 README
 
@@ -82,6 +88,12 @@ cp -p defs.h %{buildroot}%{_includedir}/crash
 %defattr(-,root,root)
 %dir %{_includedir}/crash
 %{_includedir}/crash/*.h
+
+%ifarch x86_64
+%files target-arm64
+%defattr(-,root,root)
+%{_bindir}/crash-target-arm64
+%endif
 
 %changelog
 * Tue Jun 18 2024 Andrew Phelps <anphel@microsoft.com> - 8.0.4-3

--- a/SPECS/crash/crash.spec
+++ b/SPECS/crash/crash.spec
@@ -47,9 +47,13 @@ cp %{SOURCE1} ./gdb-%{gdb_version}.tar.gz
 # After creating the "crash-target-arm64" binary, clean everything and rebuild for native target
 make RPMPKG=%{version}-%{release} target=ARM64
 cp -v crash crash-target-arm64
+rm -rf ./gdb-%{gdb_version}
 make clean
-%endif
+# Need to specify target=X86_64 here, since this parameter is "sticky" from the previous build
+make RPMPKG=%{version}-%{release} target=X86_64
+%else
 make RPMPKG=%{version}-%{release}
+%endif
 
 %install
 mkdir -p %{buildroot}%{_bindir}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Support analyzing arm64 kernel dump files with crash on x86-64 host machines. I've added a new binary `/usr/bin/crash-target-arm64` in subpackage `crash-target-arm64` that supports this scenario. The existing `/usr/bin/crash` tool is unmodified, and continues to support analyzing crash dumps of the native architecture (x86-64 dumps on x86-64 machines, and arm64 dumps on arm64 machines).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Create crash-target-arm64.x86_64 subpackage to generate `crash-target-arm64`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Needed for 3.0 GA, dependency and tasks are:
- https://microsoft.visualstudio.com/OS/_workitems/edit/51621462
- https://microsoft.visualstudio.com/OS/_workitems/edit/50777684

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=590197&view=results
Tested on X86_64 AZL 3.0 VM.
Confirmed the new binary can analyze arm64 dump:
```
$ sudo tdnf install ./crash-target-arm64-8.0.4-3.azl3.x86_64.rpm
...
$ /usr/bin/crash-target-arm64 ../vmlinux-arm64.bin ../vmcore.arm64
crash-target-arm64 8.0.4-3.azl3
      KERNEL: ../vmlinux-arm64/.bin  [TAINTED]
    DUMPFILE: ../vmcore.arm64  [PARTIAL DUMP]
        CPUS: 16
     MACHINE: aarch64  (unknown Mhz)
    ...
crash-target-arm64>
```

Also confirmed the existing crash binary cannot analyze arm64 dumps, as expected:
```
$ /usr/bin/crash ../vmlinux-arm64.bin ../vmcore.arm64
crash 8.0.4-1.azl3
WARNING: machine type mismatch:
         crash utility: X86_64
         ../vmlinux-arm64.bin: ARM64
WARNING: machine type mismatch:
         crash utility: X86_64
         ../vmcore.arm64: ARM64
crash: ../vmcore.arm64: not a supported file format
```


