### PR TITLE
Image Customizer: Minor doc updates.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -66,8 +66,8 @@ The Azure Linux Image Customizer is configured using a YAML (or JSON) file.
 21. If ([verity](#verity-type)) is specified, then create the hash tree and update the
     grub config.
 
-22. if the output format is set to `iso`, copy additional iso media files.
-([iso](#iso-type))
+22. If the output format is set to `iso`, copy additional iso media files.
+    ([iso](#iso-type))
 
 ### /etc/resolv.conf
 
@@ -78,6 +78,10 @@ It is assumed there is a process that runs on boot that will write the
 For example, `systemd-resolved`.
 Hence, the `/etc/resolv.conf` file is simply deleted at the end instead of being
 restored to its original contents.
+
+If you want to explicitly set the `/etc/resolv.conf` file contents, you can do so within
+a [finalizeCustomization](#finalizecustomization-script) script, since those scripts run
+after the `/etc/resolv.conf` is deleted.
 
 ### Replacing packages
 
@@ -1032,7 +1036,7 @@ These scripts are run under a chroot of the customized OS.
 Example:
 
 ```yaml
-os:
+scripts:
   finalizeCustomization:
   - path: scripts/b.sh
 ```


### PR DESCRIPTION
1. Call out that you can set the `/etc/resolv.conf` file using a `finalizeCustomization` script.

2. Fix the example given for `finalizeCustomization` scripts.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- n/a
