### PR TITLE
R: patch CVE-2024-27322

### DIFF
--- a/SPECS/R/CVE-2024-27322.patch
+++ b/SPECS/R/CVE-2024-27322.patch
@@ -1,0 +1,49 @@
+From f7c46500f455eb4edfc3656c3fa20af61b16abb7 Mon Sep 17 00:00:00 2001
+From: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Sun, 31 Mar 2024 19:35:58 +0000
+Subject: [PATCH] readRDS() and unserialize() now signal an errorr instead of
+ returning a PROMSXP.
+
+git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/main/serialize.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f713116..a190fbf8f3c 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);

--- a/SPECS/R/R.spec
+++ b/SPECS/R/R.spec
@@ -2,7 +2,7 @@
 Summary:        A language for data analysis and graphics
 Name:           R
 Version:        4.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,7 @@ Source0:        https://cran.r-project.org/src/base/R-4/R-%{version}.tar.gz
 # in 2018. Given curl 8.0.0 is not an actual breaking change, this patch should be fine.
 # We should drop this when R eventually gets official support for build with curl >= 8.0.0
 Patch0:         0001-configure-fix-compilation-with-curl-8.0.0.patch
+Patch1:         CVE-2024-27322.patch
 BuildRequires:  build-essential
 BuildRequires:  bzip2-devel
 BuildRequires:  curl-devel
@@ -121,6 +122,9 @@ TZ="Europe/Paris" make check -k -i
 %endif
 
 %changelog
+* Wed Jun 19 2024 Saul Paredes <saulparedes@microsoft.com> - 4.1.0-5
+- Patch CVE-2024-27322
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 4.1.0-4
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

R: patch CVE-2024-27322

Interesting to note: 
- Post claiming the vulnerability still hasn't been fixed: https://rud.is/b/2024/05/03/cve-2024-27322-should-never-have-been-assigned-and-r-data-files-are-still-super-risky-even-in-r-4-4-0/
- Rebuttal from upstream maintainers claiming it is indeed fixed: https://blog.r-project.org/2024/05/10/statement-on-cve-2024-27322/index.html
- Same patch used by Fedora: https://src.fedoraproject.org/rpms/R/blob/f39/f/R-CVE-2024-27322.patch

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- R

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-27322

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=589803&view=results
