### PR TITLE
Kata-CC: Add explicit systemd dependencies for UVM

### DIFF
--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -30,6 +30,9 @@ Requires:       lz4
 Requires:       procps-ng
 Requires:       readline
 Requires:       sed
+# Note: We currently only support using systemd for our init process, not the kata-agent. 
+# When we go to add support for AGENT_INIT=yes, can drop this.
+# https://github.com/microsoft/kata-containers/blob/msft-main/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh#L10 
 Requires:       systemd
 Requires:       tar
 Requires:       tzdata
@@ -44,6 +47,7 @@ Summary:        Metapackage to install the set of packages inside a Kata confide
 Requires:       %{name} = %{version}-%{release}
 Requires:       cifs-utils
 Requires:       device-mapper
+# Note: This assumes we are using systemd which may not always be the case when we support AGENT_INIT=yes
 Requires:       systemd-udev
 
 %description    coco

--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage for Kata UVM components
 Name:           kata-packages-uvm
 Version:        1.0.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -30,6 +30,7 @@ Requires:       lz4
 Requires:       procps-ng
 Requires:       readline
 Requires:       sed
+Requires:       systemd
 Requires:       tar
 Requires:       tzdata
 Requires:       util-linux
@@ -43,6 +44,7 @@ Summary:        Metapackage to install the set of packages inside a Kata confide
 Requires:       %{name} = %{version}-%{release}
 Requires:       cifs-utils
 Requires:       device-mapper
+Requires:       systemd-udev
 
 %description    coco
 
@@ -95,6 +97,9 @@ Requires:       golang
 %files coco-sign
 
 %changelog
+* Wed Jun 19 2024 Cameron Baird <cameronbaird@microsoft.com> - 1.0.0-5
+- Add explicit systemd dependencies for UVM
+
 * Fri May 03 2024 Saul Paredes <saulparedes@microsoft.com> - 1.0.0-4
 - Remove opa
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Due to udevadm being moved to systemd-udev subpackage, implicit behavior we relied upon for baking UVM images in 2.0 went away. To restore systemd-udevd.service functionality in UVM images, explicitly require systemd-udev. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- explicitly require systemd-udev for Kata-CC UVM images

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Manually built UVM with systemd-udev added, see that kata-cc pods come up now. 
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=589712&view=results 
