### PR TITLE
fix: remove override_glibc logic from libxcrypt

### DIFF
--- a/SPECS/libxcrypt/libxcrypt.spec
+++ b/SPECS/libxcrypt/libxcrypt.spec
@@ -46,9 +46,6 @@
 # Fail linking if there are undefined symbols.
 # Required for proper ELF symbol versioning support.
 %global _ld_strict_symbol_defs 1
-# override_glibc and glibcversion are temporary to make libxcrypt install on top of glibc
-%define glibcversion 2.38
-%bcond_with override_glibc
 # Build the static library?
 %bcond_with new_api
 %bcond_with compat_pkg
@@ -102,7 +99,7 @@
 Summary:        Extended crypt library for descrypt, md5crypt, bcrypt, and others
 Name:           libxcrypt
 Version:        4.4.36
-Release:        1%{?dist}
+Release:        2%{?dist}
 # For explicit license breakdown, see the
 # LICENSING file in the source tarball.
 License:        LGPLv2+ AND BSD AND Public Domain
@@ -142,12 +139,7 @@ Provides:       %{name}-common = %{version}-%{release}
 Obsoletes:      %{name}-compat < %{version}-%{release}
 %endif
 # We need a version of glibc, that doesn't build libcrypt anymore.
-#Requires:       glibc%{?_isa}         >= %{glibc_minver}
-%if %{with override_glibc}
-# Require a specific glibc version so the post macro is compatible.
-BuildRequires:  glibc-devel = %{glibcversion}
-Requires:       glibc = %{glibcversion}
-%endif
+Requires:       glibc%{?_isa} >= %{glibc_minver}
 %if 0%{?fedora} >= 30
 Recommends:     mkpasswd
 %endif
@@ -325,10 +317,6 @@ install -Dpm 0644 -t %{buildroot}%{_pkgdocdir} \
 # Drop README.md as it is identical to README.
 rm -f %{buildroot}%{_pkgdocdir}/README.md
 
-%if %{with override_glibc}
-mv %{buildroot}/%{_libdir}/libcrypt.so.%{sov} %{buildroot}/%{_libdir}/libxcrypt.so.%{sov}
-%endif
-
 
 %check
 build_dirs="%{_vpath_builddir}"
@@ -346,24 +334,8 @@ for dir in ${build_dirs}; do
     }
 done
 
-%if %{with override_glibc}
-# This posttrans section is a stopgap to allow installing
-# libxcrypt on a system that already has libcrypt from glibc.
-# In a future release these will be removed and libxcrypt will be default.
-%posttrans
-rm %{_libdir}/libcrypt.so.1
-ln -s %{_libdir}/libxcrypt.so.%{sov} %{_libdir}/libcrypt.so.1
-%endif
-
 %post -p /sbin/ldconfig
-
-%postun
-# See above comments about the %%posttrans section
-%if %{with override_glibc}
-rm %{_libdir}/libcrypt.so.1
-ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
-%endif
-/sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %if %{with compat_pkg}
 %post -n compat -p /sbin/ldconfig
@@ -387,13 +359,8 @@ ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
 #%{_fipsdir}/libcrypt.so.%{soc}.hmac
 #%{_fipsdir}/libcrypt.so.%{sov}.hmac
 
-%if %{with override_glibc}
-%exclude %{_libdir}/libcrypt.so.%{soc}
-%{_libdir}/libxcrypt.so.%{sov}
-%else
 %{_libdir}/libcrypt.so.%{soc}
 %{_libdir}/libcrypt.so.%{sov}
-%endif
 
 %{_mandir}/man5/crypt.5*
 
@@ -413,16 +380,11 @@ ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
 %files devel
 %doc %{_pkgdocdir}/ChangeLog
 %doc %{_pkgdocdir}/TODO
-%if %{with override_glibc}
-%exclude %{_libdir}/libcrypt.so
-%exclude %{_includedir}/crypt.h
-%else
 %{_libdir}/libcrypt.so
-%{_includedir}/crypt.h
-%endif
 %if %{without new_api}
 %{_libdir}/libxcrypt.so
 %endif
+%{_includedir}/crypt.h
 %if %{without new_api}
 %{_includedir}/xcrypt.h
 %endif
@@ -454,6 +416,9 @@ ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
 
 
 %changelog
+* Tue Jun 04 2024 Chris Co <chrco@microsoft.com> - 4.4.36-2
+- Remove override_glibc logic so libxcrypt can supply libcrypt correctly to glibc
+
 * Mon Nov 27 2023 Andrew Phelps <anphel@microsoft.com> - 4.4.36-1
 - Upgrade to version 4.4.36
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -255,5 +255,5 @@ python3-rpm-generators-14-11.azl3.noarch.rpm
 python3-packaging-23.2-2.azl3.noarch.rpm
 audit-3.1.2-1.azl3.aarch64.rpm
 audit-libs-3.1.2-1.azl3.aarch64.rpm
-libxcrypt-4.4.36-1.azl3.aarch64.rpm
-libxcrypt-devel-4.4.36-1.azl3.aarch64.rpm
+libxcrypt-4.4.36-2.azl3.aarch64.rpm
+libxcrypt-devel-4.4.36-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -255,5 +255,5 @@ python3-rpm-generators-14-11.azl3.noarch.rpm
 python3-packaging-23.2-2.azl3.noarch.rpm
 audit-3.1.2-1.azl3.x86_64.rpm
 audit-libs-3.1.2-1.azl3.x86_64.rpm
-libxcrypt-4.4.36-1.azl3.x86_64.rpm
-libxcrypt-devel-4.4.36-1.azl3.x86_64.rpm
+libxcrypt-4.4.36-2.azl3.x86_64.rpm
+libxcrypt-devel-4.4.36-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -229,9 +229,9 @@ libtasn1-debuginfo-4.19.0-1.azl3.aarch64.rpm
 libtasn1-devel-4.19.0-1.azl3.aarch64.rpm
 libtool-2.4.7-1.azl3.aarch64.rpm
 libtool-debuginfo-2.4.7-1.azl3.aarch64.rpm
-libxcrypt-4.4.36-1.azl3.aarch64.rpm
-libxcrypt-debuginfo-4.4.36-1.azl3.aarch64.rpm
-libxcrypt-devel-4.4.36-1.azl3.aarch64.rpm
+libxcrypt-4.4.36-2.azl3.aarch64.rpm
+libxcrypt-debuginfo-4.4.36-2.azl3.aarch64.rpm
+libxcrypt-devel-4.4.36-2.azl3.aarch64.rpm
 libxml2-2.11.5-1.azl3.aarch64.rpm
 libxml2-debuginfo-2.11.5-1.azl3.aarch64.rpm
 libxml2-devel-2.11.5-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -238,9 +238,9 @@ libtool-debuginfo-2.4.7-1.azl3.x86_64.rpm
 libxml2-2.11.5-1.azl3.x86_64.rpm
 libxml2-debuginfo-2.11.5-1.azl3.x86_64.rpm
 libxml2-devel-2.11.5-1.azl3.x86_64.rpm
-libxcrypt-4.4.36-1.azl3.x86_64.rpm
-libxcrypt-debuginfo-4.4.36-1.azl3.x86_64.rpm
-libxcrypt-devel-4.4.36-1.azl3.x86_64.rpm
+libxcrypt-4.4.36-2.azl3.x86_64.rpm
+libxcrypt-debuginfo-4.4.36-2.azl3.x86_64.rpm
+libxcrypt-devel-4.4.36-2.azl3.x86_64.rpm
 libxslt-1.1.39-1.azl3.x86_64.rpm
 libxslt-debuginfo-1.1.39-1.azl3.x86_64.rpm
 libxslt-devel-1.1.39-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Now that glibc no longer builds libcrypt.so, we can directly use libxcrypt's version of libcrypt.so
and remove the override macros in the libxcrypt spec.

The override_glibc logic was added by us to workaround an issue with adding this improved version of libcrypt into Mariner 1.0 while it was already released. And in 1.0, 2.0, and pre-Nov 2023 3.0, the macro was %bcond_without override_glibc, but after Nov 2023, the macro was changed to %bcond_with override_glibc which means all these overrides are currently inert and are now just diffs from the original spec.

The only real functional change here is the addition of `Requires: glibc%{?_isa} >= %{glibc_minver}` 

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/47158360

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [592855](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=592855&view=results)
