### PR TITLE
libarchive: update to v3.7.4 to fix CVEs 2024-26256 and 2024-37407

### DIFF
--- a/SPECS/libarchive/CVE-2024-26256.patch
+++ b/SPECS/libarchive/CVE-2024-26256.patch
@@ -1,0 +1,23 @@
+From eb7939b24a681a04648a59cdebd386b1e9dc9237 Mon Sep 17 00:00:00 2001
+From: Wei-Cheng Pan <legnaleurc@gmail.com>
+Date: Mon, 22 Apr 2024 01:55:41 +0900
+Subject: [PATCH] fix: OOB in rar e8 filter (#2135)
+
+This patch fixes an out-of-bound error in rar e8 filter.
+---
+ libarchive/archive_read_support_format_rar.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index 99a11d1700..266d0ee995 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -3615,7 +3615,7 @@ execute_filter_e8(struct rar_filter *filter, struct rar_virtual_machine *vm, siz
+   uint32_t filesize = 0x1000000;
+   uint32_t i;
+
+-  if (length > PROGRAM_WORK_SIZE || length < 4)
++  if (length > PROGRAM_WORK_SIZE || length <= 4)
+     return 0;
+
+   for (i = 0; i <= length - 5; i++)

--- a/SPECS/libarchive/CVE-2024-37407.patch
+++ b/SPECS/libarchive/CVE-2024-37407.patch
@@ -1,0 +1,24 @@
+From b6a979481b7d77c12fa17bbed94576b63bbcb0c0 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <stoeckmann@users.noreply.github.com>
+Date: Thu, 25 Apr 2024 09:18:30 +0000
+Subject: [PATCH] zip: Fix out of boundary access (#2145)
+
+If a ZIP file contains a file with an empty name and mac-ext option is
+set, then a check accesses memory out of bound of `name`.
+---
+ libarchive/archive_read_support_format_zip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libarchive/archive_read_support_format_zip.c b/libarchive/archive_read_support_format_zip.c
+index d7b6f082ee..7552a1a1a2 100644
+--- a/libarchive/archive_read_support_format_zip.c
++++ b/libarchive/archive_read_support_format_zip.c
+@@ -4089,7 +4089,7 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
+ 				 * as the actual resource fork doesn't end with '/'.
+ 				 */
+ 				size_t tmp_length = filename_length;
+-				if (name[tmp_length - 1] == '/') {
++				if (tmp_length > 0 && name[tmp_length - 1] == '/') {
+ 					tmp_length--;
+ 					r = rsrc_basename(name, tmp_length);
+ 				}

--- a/SPECS/libarchive/libarchive.signatures.json
+++ b/SPECS/libarchive/libarchive.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libarchive-3.7.4.tar.gz": "7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8"
+  "libarchive-3.7.1.tar.gz": "5d24e40819768f74daf846b99837fc53a3a9dcdf3ce1c2003fe0596db850f0f0"
  }
 }

--- a/SPECS/libarchive/libarchive.signatures.json
+++ b/SPECS/libarchive/libarchive.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "libarchive-3.7.1.tar.gz": "5d24e40819768f74daf846b99837fc53a3a9dcdf3ce1c2003fe0596db850f0f0"
-  }
+ "Signatures": {
+  "libarchive-3.7.4.tar.gz": "7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8"
+ }
 }

--- a/SPECS/libarchive/libarchive.spec
+++ b/SPECS/libarchive/libarchive.spec
@@ -1,6 +1,6 @@
 Summary:        Multi-format archive and compression library
 Name:           libarchive
-Version:        3.7.1
+Version:        3.7.4
 Release:        1%{?dist}
 # Certain files have individual licenses. For more details see contents of "COPYING".
 License:        BSD AND Public Domain AND (ASL 2.0 OR CC0 1.0 OR OpenSSL)
@@ -60,6 +60,9 @@ make %{?_smp_mflags} check
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Tue Jun 25 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.7.4-1
+- Update to v3.7.4 to fix CVE-2024-26256 and CVE-2024-37407
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.7.1-1
 - Auto-upgrade to 3.7.1 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/libarchive/libarchive.spec
+++ b/SPECS/libarchive/libarchive.spec
@@ -1,13 +1,18 @@
 Summary:        Multi-format archive and compression library
 Name:           libarchive
-Version:        3.7.4
-Release:        1%{?dist}
+Version:        3.7.1
+Release:        2%{?dist}
 # Certain files have individual licenses. For more details see contents of "COPYING".
 License:        BSD AND Public Domain AND (ASL 2.0 OR CC0 1.0 OR OpenSSL)
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://www.libarchive.org/
 Source0:        https://github.com/libarchive/libarchive/releases/download/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-26256.patch
+# https://github.com/libarchive/libarchive/pull/2108 (needed to cleanly apply the ZIP OOB (CVE-2024-37407) patch)
+# Please remove when upgrading to v3.7.4 and above
+Patch1:         update-appledouble-support-directories.patch
+Patch2:         CVE-2024-37407.patch
 Provides:       bsdtar = %{version}-%{release}
 
 BuildRequires:  xz-libs
@@ -60,8 +65,8 @@ make %{?_smp_mflags} check
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
-* Tue Jun 25 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.7.4-1
-- Update to v3.7.4 to fix CVE-2024-26256 and CVE-2024-37407
+* Tue Jun 25 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.7.1-2
+- Patch CVE-2024-26256 and CVE-2024-37407
 
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.7.1-1
 - Auto-upgrade to 3.7.1 - Azure Linux 3.0 - package upgrades

--- a/SPECS/libarchive/update-appledouble-support-directories.patch
+++ b/SPECS/libarchive/update-appledouble-support-directories.patch
@@ -1,0 +1,189 @@
+From 91f27004a5c88589658e38d68e46d223da6b75ca Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Matu=C5=A1ka?= <martin@matuska.org>
+Date: Sun, 21 Apr 2024 05:23:22 +0200
+Subject: [PATCH] Update AppleDouble support for directories (#2108)
+
+This is a clone of the reverted pull request #2100. Due to the latest
+circumstances we should require a more deep review of each new PR.
+
+---------
+
+Co-authored-by: Justin Vreeland <j_vreeland@apple.com>
+---
+ libarchive/archive_read_support_format_zip.c  | 13 ++-
+ libarchive/archive_write_disk_posix.c         |  3 +-
+ libarchive/test/test_write_disk_appledouble.c | 84 +++++++++++++++++++
+ .../test_write_disk_appledouble_zip.zip.uu    | 27 ++++++
+ 4 files changed, 125 insertions(+), 2 deletions(-)
+ create mode 100644 libarchive/test/test_write_disk_appledouble_zip.zip.uu
+
+diff --git a/libarchive/archive_read_support_format_zip.c b/libarchive/archive_read_support_format_zip.c
+index 212bfff9fa..d7b6f082ee 100644
+--- a/libarchive/archive_read_support_format_zip.c
++++ b/libarchive/archive_read_support_format_zip.c
+@@ -4083,6 +4083,17 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
+ 			} else {
+ 				/* Generate resource fork name to find its
+ 				 * resource file at zip->tree_rsrc. */
++
++				/* If this is an entry ending with slash,
++				 * make the resource for name slash-less
++				 * as the actual resource fork doesn't end with '/'.
++				 */
++				size_t tmp_length = filename_length;
++				if (name[tmp_length - 1] == '/') {
++					tmp_length--;
++					r = rsrc_basename(name, tmp_length);
++				}
++
+ 				archive_strcpy(&(zip_entry->rsrcname),
+ 				    "__MACOSX/");
+ 				archive_strncat(&(zip_entry->rsrcname),
+@@ -4090,7 +4101,7 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
+ 				archive_strcat(&(zip_entry->rsrcname), "._");
+ 				archive_strncat(&(zip_entry->rsrcname),
+ 				    name + (r - name),
+-				    filename_length - (r - name));
++				    tmp_length - (r - name));
+ 				/* Register an entry to RB tree to sort it by
+ 				 * file offset. */
+ 				__archive_rb_tree_insert_node(&zip->tree,
+diff --git a/libarchive/archive_write_disk_posix.c b/libarchive/archive_write_disk_posix.c
+index 58265ee0dc..92db4ff05b 100644
+--- a/libarchive/archive_write_disk_posix.c
++++ b/libarchive/archive_write_disk_posix.c
+@@ -4427,7 +4427,8 @@ fixup_appledouble(struct archive_write_disk *a, const char *pathname)
+ #else
+ 		la_stat(datafork.s, &st) == -1 ||
+ #endif
+-	    (st.st_mode & AE_IFMT) != AE_IFREG)
++	    (((st.st_mode & AE_IFMT) != AE_IFREG) &&
++		((st.st_mode & AE_IFMT) != AE_IFDIR)))
+ 		goto skip_appledouble;
+
+ 	/*
+diff --git a/libarchive/test/test_write_disk_appledouble.c b/libarchive/test/test_write_disk_appledouble.c
+index 3265a94d2f..8de6c8b504 100644
+--- a/libarchive/test/test_write_disk_appledouble.c
++++ b/libarchive/test/test_write_disk_appledouble.c
+@@ -236,3 +236,87 @@ DEFINE_TEST(test_write_disk_appledouble)
+ 	assertEqualFile("hfscmp/file3", "nocmp/file3");
+ #endif
+ }
++
++/* Test writing apple doubles to disk from zip format */
++DEFINE_TEST(test_write_disk_appledouble_zip)
++{
++#if !defined(__APPLE__) || !defined(UF_COMPRESSED) || !defined(HAVE_SYS_XATTR_H)\
++	|| !defined(HAVE_ZLIB_H)
++	skipping("MacOS-specific AppleDouble test");
++#else
++	const char *refname = "test_write_disk_appledouble_zip.zip";
++	struct archive *ad, *a;
++	struct archive_entry *ae;
++	struct stat st;
++
++	extract_reference_file(refname);
++
++	/*
++	 * Extract an archive to disk.
++	 */
++	assert((ad = archive_write_disk_new()) != NULL);
++	assertEqualIntA(ad, ARCHIVE_OK,
++	    archive_write_disk_set_standard_lookup(ad));
++	assertEqualIntA(ad, ARCHIVE_OK,
++	    archive_write_disk_set_options(ad,
++		ARCHIVE_EXTRACT_TIME |
++		ARCHIVE_EXTRACT_SECURE_SYMLINKS |
++		ARCHIVE_EXTRACT_SECURE_NODOTDOT));
++
++	assert((a = archive_read_new()) != NULL);
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a,
++	    refname, 512 * 20));
++
++	/* Skip The top level directory */
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
++	assertEqualString("apple_double_dir/", archive_entry_pathname(ae));
++
++	/* Extract apple_double_test */
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
++	assertEqualString("apple_double_dir/apple_double_dir_test/", archive_entry_pathname(ae));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_extract2(a, ae, ad));
++
++	/* Extract ._apple_double_dir_test which will be merged into apple_double_dir_test as metadata. */
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
++	assertEqualString("apple_double_dir/._apple_double_dir_test", archive_entry_pathname(ae));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_extract2(a, ae, ad));
++
++	/* Extract test_file */
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
++	assertEqualString("apple_double_dir/test_file", archive_entry_pathname(ae));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_extract2(a, ae, ad));
++
++	/* Extract ._test_file which will be merged into test_file as metadata. */
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
++	assertEqualString("apple_double_dir/._test_file", archive_entry_pathname(ae));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_extract2(a, ae, ad));
++
++	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
++	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
++	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
++
++	/* Test test_file */
++	assertEqualInt(0, stat("apple_double_dir/test_file", &st));
++	assertFileSize("apple_double_dir/test_file", 5);
++	failure("'%s' should have Resource Fork", "test_file");
++	assertEqualInt(1, has_xattr("apple_double_dir/test_file", "com.apple.ResourceFork"));
++
++	/* Test apple_double_dir_test */
++	failure("'%s' should have quarantine xattr", "apple_double_dir_test");
++	assertEqualInt(1, has_xattr("apple_double_dir/apple_double_dir_test", "com.apple.quarantine"));
++
++	/* Test ._test_file. */
++	failure("'apple_double_dir/._test_file' should be merged and removed");
++	assertFileNotExists("apple_double_dir/._test_file");
++
++	/* Test ._apple_double_dir_test */
++	failure("'apple_double_dir/._._apple_double_dir_test' should be merged and removed");
++	assertFileNotExists("apple_double_dir/._apple_double_dir_test");
++
++	assertChdir("..");
++
++#endif
++}
+diff --git a/libarchive/test/test_write_disk_appledouble_zip.zip.uu b/libarchive/test/test_write_disk_appledouble_zip.zip.uu
+new file mode 100644
+index 0000000000..5ab67533d5
+--- /dev/null
++++ b/libarchive/test/test_write_disk_appledouble_zip.zip.uu
+@@ -0,0 +1,27 @@
++begin 644 test_write_disk_appledouble_zip.zip
++M4$L#!`H```````MM?%@````````````````1`!``87!P;&5?9&]U8FQE7V1I
++M<B]56`P`O=4%9K75!6;U`10`4$L#!`H```````MM?%@````````````````G
++M`!``87!P;&5?9&]U8FQE7V1I<B]A<'!L95]D;W5B;&5?9&ER7W1E<W0O55@,
++M`+W5!6:UU05F]0$4`%!+`P04``@`"``+;7Q8````````````````*``0`&%P
++M<&QE7V1O=6)L95]D:7(O+E]A<'!L95]D;W5B;&5?9&ER7W1E<W156`P`O=4%
++M9K75!6;U`10`8V`58V=@8F#P34Q6\`]6B%"``I`8`R<0&P%Q!1"#^*L8B`*.
++M(2%!4"9(QPP@%D)3PH@0%TW.S]5++"C(2=4K+$TL2LPKR<Q+92C4-S"P,+8V
++M@`)K:P8`4$L'"!2N=6M7````J@```%!+`P04``@`"`!93GQ8````````````
++M````&@`0`&%P<&QE7V1O=6)L95]D:7(O=&5S=%]F:6QE55@,`+'5!6;IGP5F
++M]0$4`"M)+2[A`@!02P<(QC6Y.P<````%````4$L#!!0`"``(`%E.?%@`````
++M```````````<`!``87!P;&5?9&]U8FQE7V1I<B\N7W1E<W1?9FEL9558#`"Q
++MU05FZ9\%9O4!%`!C8!5C9V!B8/!-3%;P#U:(4(`"D!@#)Q`;`;$;$(/X%4#,
++MQT`0.(:$!$&9%5",`8I2B_-+BY)3%=+RB[*Y`%!+!P@HPLP3/@```(8```!0
++M2P$"%0,*```````+;7Q8````````````````$0`,``````````!`[4$`````
++M87!P;&5?9&]U8FQE7V1I<B]56`@`O=4%9K75!6902P$"%0,*```````+;7Q8
++M````````````````)P`,``````````!`[4$_````87!P;&5?9&]U8FQE7V1I
++M<B]A<'!L95]D;W5B;&5?9&ER7W1E<W0O55@(`+W5!6:UU05F4$L!`A4#%``(
++M``@`"VU\6!2N=6M7````J@```"@`#```````````0*2!E````&%P<&QE7V1O
++M=6)L95]D:7(O+E]A<'!L95]D;W5B;&5?9&ER7W1E<W156`@`O=4%9K75!690
++M2P$"%0,4``@`"`!93GQ8QC6Y.P<````%````&@`,``````````!`I(%1`0``
++M87!P;&5?9&]U8FQE7V1I<B]T97-T7V9I;&556`@`L=4%9NF?!6902P$"%0,4
++M``@`"`!93GQ8*,+,$SX```"&````'``,``````````!`I(&P`0``87!P;&5?
++M9&]U8FQE7V1I<B\N7W1E<W1?9FEL9558"`"QU05FZ9\%9E!+!08`````!0`%
+++`+@!``!(`@``````
++`
++end

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8641,8 +8641,8 @@
         "type": "other",
         "other": {
           "name": "libarchive",
-          "version": "3.7.1",
-          "downloadUrl": "https://github.com/libarchive/libarchive/releases/download/v3.7.1/libarchive-3.7.1.tar.gz"
+          "version": "3.7.4",
+          "downloadUrl": "https://github.com/libarchive/libarchive/releases/download/v3.7.4/libarchive-3.7.4.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8641,8 +8641,8 @@
         "type": "other",
         "other": {
           "name": "libarchive",
-          "version": "3.7.4",
-          "downloadUrl": "https://github.com/libarchive/libarchive/releases/download/v3.7.4/libarchive-3.7.4.tar.gz"
+          "version": "3.7.1",
+          "downloadUrl": "https://github.com/libarchive/libarchive/releases/download/v3.7.1/libarchive-3.7.1.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -174,8 +174,8 @@ openssl-static-3.3.0-1.azl3.aarch64.rpm
 libcap-2.69-1.azl3.aarch64.rpm
 libcap-devel-2.69-1.azl3.aarch64.rpm
 debugedit-5.0-2.azl3.aarch64.rpm
-libarchive-3.7.4-1.azl3.aarch64.rpm
-libarchive-devel-3.7.4-1.azl3.aarch64.rpm
+libarchive-3.7.1-2.azl3.aarch64.rpm
+libarchive-devel-3.7.1-2.azl3.aarch64.rpm
 rpm-4.18.2-1.azl3.aarch64.rpm
 rpm-build-4.18.2-1.azl3.aarch64.rpm
 rpm-build-libs-4.18.2-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -174,8 +174,8 @@ openssl-static-3.3.0-1.azl3.aarch64.rpm
 libcap-2.69-1.azl3.aarch64.rpm
 libcap-devel-2.69-1.azl3.aarch64.rpm
 debugedit-5.0-2.azl3.aarch64.rpm
-libarchive-3.7.1-1.azl3.aarch64.rpm
-libarchive-devel-3.7.1-1.azl3.aarch64.rpm
+libarchive-3.7.4-1.azl3.aarch64.rpm
+libarchive-devel-3.7.4-1.azl3.aarch64.rpm
 rpm-4.18.2-1.azl3.aarch64.rpm
 rpm-build-4.18.2-1.azl3.aarch64.rpm
 rpm-build-libs-4.18.2-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -174,8 +174,8 @@ openssl-static-3.3.0-1.azl3.x86_64.rpm
 libcap-2.69-1.azl3.x86_64.rpm
 libcap-devel-2.69-1.azl3.x86_64.rpm
 debugedit-5.0-2.azl3.x86_64.rpm
-libarchive-3.7.1-1.azl3.x86_64.rpm
-libarchive-devel-3.7.1-1.azl3.x86_64.rpm
+libarchive-3.7.4-1.azl3.x86_64.rpm
+libarchive-devel-3.7.4-1.azl3.x86_64.rpm
 rpm-4.18.2-1.azl3.x86_64.rpm
 rpm-build-4.18.2-1.azl3.x86_64.rpm
 rpm-build-libs-4.18.2-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -174,8 +174,8 @@ openssl-static-3.3.0-1.azl3.x86_64.rpm
 libcap-2.69-1.azl3.x86_64.rpm
 libcap-devel-2.69-1.azl3.x86_64.rpm
 debugedit-5.0-2.azl3.x86_64.rpm
-libarchive-3.7.4-1.azl3.x86_64.rpm
-libarchive-devel-3.7.4-1.azl3.x86_64.rpm
+libarchive-3.7.1-2.azl3.x86_64.rpm
+libarchive-devel-3.7.1-2.azl3.x86_64.rpm
 rpm-4.18.2-1.azl3.x86_64.rpm
 rpm-build-4.18.2-1.azl3.x86_64.rpm
 rpm-build-libs-4.18.2-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -160,9 +160,9 @@ krb5-1.21.2-1.azl3.aarch64.rpm
 krb5-debuginfo-1.21.2-1.azl3.aarch64.rpm
 krb5-devel-1.21.2-1.azl3.aarch64.rpm
 krb5-lang-1.21.2-1.azl3.aarch64.rpm
-libarchive-3.7.4-1.azl3.aarch64.rpm
-libarchive-debuginfo-3.7.4-1.azl3.aarch64.rpm
-libarchive-devel-3.7.4-1.azl3.aarch64.rpm
+libarchive-3.7.1-2.azl3.aarch64.rpm
+libarchive-debuginfo-3.7.1-2.azl3.aarch64.rpm
+libarchive-devel-3.7.1-2.azl3.aarch64.rpm
 libassuan-2.5.6-1.azl3.aarch64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.aarch64.rpm
 libassuan-devel-2.5.6-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -160,9 +160,9 @@ krb5-1.21.2-1.azl3.aarch64.rpm
 krb5-debuginfo-1.21.2-1.azl3.aarch64.rpm
 krb5-devel-1.21.2-1.azl3.aarch64.rpm
 krb5-lang-1.21.2-1.azl3.aarch64.rpm
-libarchive-3.7.1-1.azl3.aarch64.rpm
-libarchive-debuginfo-3.7.1-1.azl3.aarch64.rpm
-libarchive-devel-3.7.1-1.azl3.aarch64.rpm
+libarchive-3.7.4-1.azl3.aarch64.rpm
+libarchive-debuginfo-3.7.4-1.azl3.aarch64.rpm
+libarchive-devel-3.7.4-1.azl3.aarch64.rpm
 libassuan-2.5.6-1.azl3.aarch64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.aarch64.rpm
 libassuan-devel-2.5.6-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -166,9 +166,9 @@ krb5-1.21.2-1.azl3.x86_64.rpm
 krb5-debuginfo-1.21.2-1.azl3.x86_64.rpm
 krb5-devel-1.21.2-1.azl3.x86_64.rpm
 krb5-lang-1.21.2-1.azl3.x86_64.rpm
-libarchive-3.7.4-1.azl3.x86_64.rpm
-libarchive-debuginfo-3.7.4-1.azl3.x86_64.rpm
-libarchive-devel-3.7.4-1.azl3.x86_64.rpm
+libarchive-3.7.1-2.azl3.x86_64.rpm
+libarchive-debuginfo-3.7.1-2.azl3.x86_64.rpm
+libarchive-devel-3.7.1-2.azl3.x86_64.rpm
 libassuan-2.5.6-1.azl3.x86_64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.x86_64.rpm
 libassuan-devel-2.5.6-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -166,9 +166,9 @@ krb5-1.21.2-1.azl3.x86_64.rpm
 krb5-debuginfo-1.21.2-1.azl3.x86_64.rpm
 krb5-devel-1.21.2-1.azl3.x86_64.rpm
 krb5-lang-1.21.2-1.azl3.x86_64.rpm
-libarchive-3.7.1-1.azl3.x86_64.rpm
-libarchive-debuginfo-3.7.1-1.azl3.x86_64.rpm
-libarchive-devel-3.7.1-1.azl3.x86_64.rpm
+libarchive-3.7.4-1.azl3.x86_64.rpm
+libarchive-debuginfo-3.7.4-1.azl3.x86_64.rpm
+libarchive-devel-3.7.4-1.azl3.x86_64.rpm
 libassuan-2.5.6-1.azl3.x86_64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.x86_64.rpm
 libassuan-devel-2.5.6-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
update libarchive to v3.7.4 to fix CVEs 2024-26256 and 2024-37407

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- update to v3.7.4 to fix CVEs 2024-26256 and 2024-37407

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-26256
- https://nvd.nist.gov/vuln/detail/CVE-2024-37407

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build successful
- Successful buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=593425&view=results. Failures are unrelated to changes