### PR TITLE
Remove unexpected default vim mappings

### DIFF
--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -55,11 +55,6 @@ color desert
 if (&term == "iterm") || (&term == "putty")
   set background=dark
 endif
-" Binds
-nmap <F2> :w<CR>
-imap <F2> <Esc>:w<CR>
-nmap <F10> :q!<CR>
-nmap <Esc><Esc> :q<CR>
 " Use 4 space characters instead of tab for python files
 au BufEnter,BufNew *.py set tabstop=4 shiftwidth=4 expandtab
 " Move the swap file location to protect against CVE-2017-1000382


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR removes the default vim key mapping overrides in /etc/vimrc. The current mappings create unexpected behavior (for example, vim will exit if you press the ESC key).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove default vim mapping overrides.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: TBD, a maintainer needs to allow CI to run on this PR.
