### PR TITLE
Clear systemd state when creating an image

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -175,6 +175,10 @@ A sample `ParitionSettings` entry using `overlay` algorithm:
 ### EnableGrubMkconfig
 EnableGrubMkconfig is a optional boolean that controls whether the image uses grub2-mkconfig to generate the boot configuration (/boot/grub2/grub.cfg) or not. If EnableGrubMkconfig is specified, only valid values are `true` and `false`. Default is `true`.
 
+### EnableSystemdFirstboot
+
+EnableSystemdFirstboot is a optional boolean that controls whether the image will run the systemd-firstboot service on first boot. Setting to `true` will set `/etc/machine-id` to `"uninitialized"`, while setting to `false` will leave `/etc/machine-id` blank. See [https://www.freedesktop.org/software/systemd/man/latest/machine-id.html] for more information. By default firstboot is disabled.
+
 ### PackageLists
 
 PackageLists key consists of an array of relative paths to the package lists (JSON files).

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -16,33 +16,34 @@ import (
 
 // SystemConfig defines how each system present on the image is supposed to be configured.
 type SystemConfig struct {
-	IsDefault            bool                      `json:"IsDefault"`
-	IsKickStartBoot      bool                      `json:"IsKickStartBoot"`
-	IsIsoInstall         bool                      `json:"IsIsoInstall"`
-	BootType             string                    `json:"BootType"`
-	EnableGrubMkconfig   bool                      `json:"EnableGrubMkconfig"`
-	Hostname             string                    `json:"Hostname"`
-	Name                 string                    `json:"Name"`
-	PackageLists         []string                  `json:"PackageLists"`
-	Packages             []string                  `json:"Packages"`
-	KernelOptions        map[string]string         `json:"KernelOptions"`
-	KernelCommandLine    KernelCommandLine         `json:"KernelCommandLine"`
-	AdditionalFiles      map[string]FileConfigList `json:"AdditionalFiles"`
-	PartitionSettings    []PartitionSetting        `json:"PartitionSettings"`
-	PreInstallScripts    []InstallScript           `json:"PreInstallScripts"`
-	PostInstallScripts   []InstallScript           `json:"PostInstallScripts"`
-	FinalizeImageScripts []InstallScript           `json:"FinalizeImageScripts"`
-	Networks             []Network                 `json:"Networks"`
-	PackageRepos         []PackageRepo             `json:"PackageRepos"`
-	Groups               []Group                   `json:"Groups"`
-	Users                []User                    `json:"Users"`
-	Encryption           RootEncryption            `json:"Encryption"`
-	RemoveRpmDb          bool                      `json:"RemoveRpmDb"`
-	PreserveTdnfCache    bool                      `json:"PreserveTdnfCache"`
-	ReadOnlyVerityRoot   ReadOnlyVerityRoot        `json:"ReadOnlyVerityRoot"`
-	EnableHidepid        bool                      `json:"EnableHidepid"`
-	DisableRpmDocs       bool                      `json:"DisableRpmDocs"`
-	OverrideRpmLocales   string                    `json:"OverrideRpmLocales"`
+	IsDefault              bool                      `json:"IsDefault"`
+	IsKickStartBoot        bool                      `json:"IsKickStartBoot"`
+	IsIsoInstall           bool                      `json:"IsIsoInstall"`
+	BootType               string                    `json:"BootType"`
+	EnableGrubMkconfig     bool                      `json:"EnableGrubMkconfig"`
+	EnableSystemdFirstboot bool                      `json:"EnableSystemdFirstboot"`
+	Hostname               string                    `json:"Hostname"`
+	Name                   string                    `json:"Name"`
+	PackageLists           []string                  `json:"PackageLists"`
+	Packages               []string                  `json:"Packages"`
+	KernelOptions          map[string]string         `json:"KernelOptions"`
+	KernelCommandLine      KernelCommandLine         `json:"KernelCommandLine"`
+	AdditionalFiles        map[string]FileConfigList `json:"AdditionalFiles"`
+	PartitionSettings      []PartitionSetting        `json:"PartitionSettings"`
+	PreInstallScripts      []InstallScript           `json:"PreInstallScripts"`
+	PostInstallScripts     []InstallScript           `json:"PostInstallScripts"`
+	FinalizeImageScripts   []InstallScript           `json:"FinalizeImageScripts"`
+	Networks               []Network                 `json:"Networks"`
+	PackageRepos           []PackageRepo             `json:"PackageRepos"`
+	Groups                 []Group                   `json:"Groups"`
+	Users                  []User                    `json:"Users"`
+	Encryption             RootEncryption            `json:"Encryption"`
+	RemoveRpmDb            bool                      `json:"RemoveRpmDb"`
+	PreserveTdnfCache      bool                      `json:"PreserveTdnfCache"`
+	ReadOnlyVerityRoot     ReadOnlyVerityRoot        `json:"ReadOnlyVerityRoot"`
+	EnableHidepid          bool                      `json:"EnableHidepid"`
+	DisableRpmDocs         bool                      `json:"DisableRpmDocs"`
+	OverrideRpmLocales     string                    `json:"OverrideRpmLocales"`
 }
 
 const (

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -873,6 +873,7 @@ func clearSystemdState(installChroot *safechroot.Chroot, enableSystemdFirstboot 
 			return err
 		}
 
+		// Do an explicit check for existence so we can log the file removal.
 		if exists {
 			ReportActionf("Removing systemd state file (%s)", filePath)
 			err = file.RemoveFileIfExists(fullPath)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -863,7 +863,8 @@ func clearSystemdState(installChroot *safechroot.Chroot, enableSystemdFirstboot 
 		return err
 	}
 
-	// These files should not be present in the image, but we should be thorough and double-check.
+	// These files should not be present in the image, but per https://systemd.io/BUILDING_IMAGES/ we should
+	// be thorough and double-check.
 	for _, filePath := range otherFilesToRemove {
 		fullPath := filepath.Join(installChroot.RootDir(), filePath)
 		exists, err = file.PathExists(fullPath)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -834,7 +834,7 @@ func clearSystemdState(installChroot *safechroot.Chroot, enableSystemdFirstboot 
 	// create an empty file so that read-only configurations will work as expected. If the user requests that firstboot
 	// be enabled we will set it to "uninitalized" as per option 3).
 
-	ReportAction("Clearing systemd state files for first boot")
+	ReportAction("Configuring systemd state files for first boot")
 
 	// The systemd package will create this file, but if its not installed, we need to create it.
 	exists, err := file.PathExists(filepath.Join(installChroot.RootDir(), machineIDFile))

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -852,10 +852,10 @@ func clearSystemdState(installChroot *safechroot.Chroot, enableSystemdFirstboot 
 	}
 
 	if enableSystemdFirstboot {
-		ReportActionf("Enabling systemd firstboot")
+		ReportAction("Enabling systemd firstboot")
 		err = file.Write(machineIDFirstBootOn, filepath.Join(installChroot.RootDir(), machineIDFile))
 	} else {
-		ReportActionf("Disabling systemd firstboot")
+		ReportAction("Disabling systemd firstboot")
 		err = file.Write(machineIDFirstbootOff, filepath.Join(installChroot.RootDir(), machineIDFile))
 	}
 	if err != nil {

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -851,15 +851,13 @@ func clearSystemdState(installChroot *safechroot.Chroot, enableSystemdFirstboot 
 		}
 	}
 
-	var machineIdContent string
 	if enableSystemdFirstboot {
 		ReportActionf("Enabling systemd firstboot")
-		machineIdContent = machineIDFirstBootOn
+		err = file.Write(machineIDFirstBootOn, filepath.Join(installChroot.RootDir(), machineIDFile))
 	} else {
 		ReportActionf("Disabling systemd firstboot")
-		machineIdContent = machineIDFirstbootOff
+		err = file.Write(machineIDFirstbootOff, filepath.Join(installChroot.RootDir(), machineIDFile))
 	}
-	err = file.Write(machineIdContent, filepath.Join(installChroot.RootDir(), machineIDFile))
 	if err != nil {
 		err = fmt.Errorf("failed to write empty machine-id:\n%w", err)
 		return err

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -829,11 +829,10 @@ func clearSystemdState(installChroot *safechroot.Chroot, enableSystemdFirstboot 
 	//     If according to the above rules a first boot is detected, units with ConditionFirstBoot=yes will be run and
 	//     systemd will perform additional initialization steps, in particular presetting units.
 	//
-	// However, the detailed guide for creating images (https://systemd.io/BUILDING_IMAGES/) suggests that the
-	// machine-id file should be "uninitialized\n" to trigger first-boot mode. This is because the machine-id file is
-	// used to determine if the image is being booted for the first time. If the file is empty, systemd will assume it
-	// is not the first boot and will not perform first-boot actions.
-	// (see https://www.freedesktop.org/software/systemd/man/latest/systemd-firstboot.html)
+	// We will use option 4) by default since AZL has traditionally not used firstboot mechanisms. All configuration
+	// that systemd-firstboot would set should have already been configured by the imager tool. It is important to
+	// create an empty file so that read-only configurations will work as expected. If the user requests that firstboot
+	// be enabled we will set it to "uninitalized" as per option 3).
 
 	ReportAction("Clearing systemd state files for first boot")
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The systemd package creates `/etc/machine-id` when it installs (in m2 it did not create this file). If this file is populated on a vm image, every instance of that vm will have the same id. This will break networking, k8s, etc. To avoid this, we need to clear the state before creating the image. The correct first-boot behavior is to set the id to 'uninitialized' and let the system generate a new one on boot. Clearing the file is similar, systemd will generate a new id on boot, but it will not run the first-boot setup.

We will keep the current behavior with `/etc/machine-id` being empty. A new config flag will allow an image to use the first-boot flow.

As part of https://systemd.io/BUILDING_IMAGES several other files are listed that should be cleared out. Currently we don't seem to have them but for correctness I've also included a check that will delete them if found. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- replace `addMachineId()` with `clearSystemdState()`
  - Set `/etc/machine-id` to `uninitalized\n` if `EnableSystemdFirstboot=true` , otherwise keep the 2.0 behavior of creating an empty file
  - Also clear `/var/lib/systemd/random-seed`, `boot/efi/loader/random-seed`, `/var/lib/systemd/credential.secret` if any are in the image.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_queries/edit/51856148/?triage=true

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds with basic validation (boots, login possible, systemd seems ok)
  - Local hyper-v test with core-efi (machine-id is generated, firstboot runs)
  - MIC based dm-verity read-only test (machine-id is ephemeral but generates as expected, firstboot does not run since /etc is not writable)
  - Azure marketplace gen2 (same as local hyper-v)
