### PR TITLE
Fix libtpms <-> SymCrypt provider compatibility

### DIFF
--- a/SPECS/libtpms/0001-Export-RSA-private-key-primes-to-OpenSSL.patch
+++ b/SPECS/libtpms/0001-Export-RSA-private-key-primes-to-OpenSSL.patch
@@ -1,0 +1,42 @@
+From 4a64addb941bf4db53f688a4396702542dc70289 Mon Sep 17 00:00:00 2001
+From: Maxwell Moyer-McKee <mamckee@microsoft.com>
+Date: Tue, 25 Jun 2024 21:12:48 +0000
+Subject: [PATCH] Export RSA private key primes to OpenSSL
+
+---
+ src/tpm2/crypto/openssl/Helpers.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/tpm2/crypto/openssl/Helpers.c b/src/tpm2/crypto/openssl/Helpers.c
+index 896e37d..8344bac 100644
+--- a/src/tpm2/crypto/openssl/Helpers.c
++++ b/src/tpm2/crypto/openssl/Helpers.c
+@@ -527,7 +527,8 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
+             ERROR_RETURN(TPM_RC_FAILURE);
+         ExpDCacheAdd(P, N, E, Q, D);
+     }
+-    if (RSA_set0_key(key, NULL, NULL, D) != 1)
++    if (RSA_set0_key(key, NULL, NULL, D) != 1 ||
++        RSA_set0_factors(key, P, Q) != 1)
+         ERROR_RETURN(TPM_RC_FAILURE);
+ 
+     DoRSACheckKey(P, Q, N, E, D);
+@@ -548,13 +549,13 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
+ 
+  Exit:
+     BN_CTX_free(ctx);
+-    BN_clear_free(P);
+-    BN_clear_free(Q);
+     BN_free(Qr);
+     RSA_free(key); // undo reference from EVP_PKEY_get1_RSA()
+ 
+     if (retVal != TPM_RC_SUCCESS) {
+         BN_clear_free(D);
++        BN_clear_free(P);
++        BN_clear_free(Q);
+ #if CRT_FORMAT_RSA == YES
+         BN_clear_free(dP);
+         BN_clear_free(dQ);
+-- 
+2.43.0
+

--- a/SPECS/libtpms/libtpms.spec
+++ b/SPECS/libtpms/libtpms.spec
@@ -9,6 +9,7 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 Source1:        %{url}/releases/download/v%{version}/v%{version}.tar.gz.asc#/%{name}-%{version}.tar.gz.asc
 # https://github.com/stefanberger.gpg
 Source2:        gpgkey-B818B9CADF9089C2D5CEC66B75AD65802A0B4211.asc
+Patch1:         0001-Export-RSA-private-key-primes-to-OpenSSL.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake

--- a/SPECS/libtpms/libtpms.spec
+++ b/SPECS/libtpms/libtpms.spec
@@ -1,6 +1,6 @@
 Name:           libtpms
 Version:        0.9.6
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Library providing Trusted Platform Module (TPM) functionality
 License:        BSD and TCGL
 
@@ -36,7 +36,7 @@ Libtpms header files and documentation.
 
 %prep
 %{gpgverify} --keyring='%{SOURCE2}' --signature='%{SOURCE1}' --data='%{SOURCE0}'
-%autosetup
+%autosetup -p1 -n %{name}-%{version}
 
 %build
 NOCONFIGURE=1 ./autogen.sh
@@ -64,6 +64,9 @@ make check
 %{_mandir}/man3/TPM*
 
 %changelog
+* Tue Jun 25 2024 Maxwell Moyer-McKee <bfjelds@microsoft.com> - 0.9.6-6
+- Add patch for compatibility with SymCrypt provider
+
 * Mon Jan 22 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 0.9.6-5
 - Initial CBL-Mariner import from Fedora 39 (license: MIT).
 - license verified (TCG license in LICENSE file)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Recent testing found an incompatibility between libtpms and the SymCrypt provider. Version 0.9.6 of libtpms is using the old OpenSSL APIs and does not export the RSA key primes as part of RSA private key export. SymCrypt expects these primes to import the RSA private key. This PR adds a patch to libtpms to export the expected primes.

The latest changes to libtpms appear to fix this issue and update to the OpenSSL 3 APIs, so this patch is only necessary until those changes make it to release.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch to fix compatibility between libtpms and the SymCrypt provider

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build. Confirmed bug is no repro
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=593381&view=results
