### PR TITLE
Changed 'installutils.go' to print out the entire tdnf debug log

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -641,6 +641,7 @@ func TdnfInstallWithProgress(packageName, installRoot string, currentPackagesIns
 		const tdnfInstallPrefix = "Installing/Updating: "
 
 		// Only process lines that match tdnfInstallPrefix
+		logger.Log.Debug(line)
 		if !strings.HasPrefix(line, tdnfInstallPrefix) {
 			return
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->


###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This one line change causes the build tools to output the entire tdnf log when installing packages in any build process. There were instances when developers did not understand what errors were causing a tdnf install failure, leading to further confusion due to the lack of logs. This change provides more context for the developer and helps in the debugging process.

###### Change Log  <!-- REQUIRED -->
- Added a single line to 'installutils.go' in the TdnfInstallWithProgress function (line 599).


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Used build tools and checked logs to see if the full output was logged.