### PR TITLE
Image Customizer: Add package tests.

### DIFF
--- a/toolkit/tools/imagecustomizer/DEV.md
+++ b/toolkit/tools/imagecustomizer/DEV.md
@@ -1,0 +1,42 @@
+# Developers guide
+
+## Build Image Customizer binary
+
+Run:
+
+```bash
+sudo make -C ./toolkit go-imagecustomizer
+```
+
+## Run toolkit tests
+
+Run:
+
+```bash
+sudo go test -C ./toolkit/tools ./...
+```
+
+## Run Image Customizer specific tests
+
+1. Build (or download) the
+   [core-efi](https://github.com/microsoft/CBL-Mariner/blob/2.0/toolkit/imageconfigs/core-efi.json)
+   vhdx image file for Azure Linux 2.0.
+
+2. Download the test RPM files:
+
+   ```bash
+   ./toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/download-test-rpms.sh
+   ```
+
+3. Run the tests:
+
+   ```bash
+   AZURE_LINUX_2_CORE_EFI_VHDX="<core-efi-2.0.vhdx>"
+
+   sudo go test -C ./toolkit/tools ./pkg/imagecustomizerlib -args \
+     --base-image-core-efi "$AZURE_LINUX_2_CORE_EFI_VHDX"
+   ```
+
+   Where:
+
+   - `<core-efi-2.0.vhdx>`: The vhdx image file you acquired in step 1.

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesAddOfflineDir")
+
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	downloadedRpmsDir := getDownloadedRpmsDir(t, "2.0")
+
+	testCustomizeImagePackagesAddHelper(t, testTmpDir, baseImage, false, /*useBaseImageRpmRepos*/
+		[]string{downloadedRpmsDir})
+}
+
+func TestCustomizeImagePackagesAddOfflineLocalRepo(t *testing.T) {
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesAddOfflineLocalRepo")
+
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	downloadedRpmsRepoFile := getDownloadedRpmsRepoFile(t, "2.0")
+
+	testCustomizeImagePackagesAddHelper(t, testTmpDir, baseImage, false, /*useBaseImageRpmRepos*/
+		[]string{downloadedRpmsRepoFile})
+}
+
+func testCustomizeImagePackagesAddHelper(t *testing.T, testTmpDir string, baseImage string, useBaseImageRpmRepos bool,
+	rpmSources []string,
+) {
+	buildDir := filepath.Join(testTmpDir, "build")
+
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+	configFile := filepath.Join(testDir, "packages-add-config.yaml")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, rpmSources, outImageFilePath, "raw", "",
+		useBaseImageRpmRepos, false /*enableShrinkFilesystems*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imageConnection, err := connectToCoreEfiImage(buildDir, outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Ensure packages were installed.
+	ensureFilesExist(t, imageConnection,
+		"/usr/bin/jq",
+		"/usr/bin/go",
+	)
+}
+
+func TestCustomizeImagePackagesUpdate(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesUpdate")
+	buildDir := filepath.Join(testTmpDir, "build")
+
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+	configFile := filepath.Join(testDir, "packages-update-config.yaml")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imageConnection, err := connectToCoreEfiImage(buildDir, outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Ensure packages were installed.
+	ensureFilesExist(t, imageConnection,
+		"/usr/bin/jq",
+		"/usr/bin/go",
+	)
+
+	// Ensure packages were removed.
+	ensureFilesNotExist(t, imageConnection,
+		"/usr/bin/which")
+}
+
+func TestCustomizeImagePackagesDiskSpace(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesDiskSpace")
+	buildDir := filepath.Join(testTmpDir, "build")
+
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+	configFile := filepath.Join(testDir, "install-package-disk-space.yaml")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	assert.ErrorContains(t, err, "failed to customize raw image")
+	assert.ErrorContains(t, err, "failed to install package (gcc)")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -482,16 +482,19 @@ func verifyFilePermissionsSame(t *testing.T, origPath string, newPath string) {
 
 func ensureFilesExist(t *testing.T, imageConnection *ImageConnection, filePaths ...string) {
 	for _, filePath := range filePaths {
-		_, err := os.Stat(filepath.Join(imageConnection.chroot.RootDir(), filePath))
+		// Note: Symbolic links might be broken as we are not checking under the chroot.
+		// Hence, the use of lstat instead of stat.
+		_, err := os.Lstat(filepath.Join(imageConnection.chroot.RootDir(), filePath))
 		assert.NoErrorf(t, err, "check file exists (%s)", filePath)
 	}
 }
 
 func ensureFilesNotExist(t *testing.T, imageConnection *ImageConnection, filePaths ...string) {
 	for _, filePath := range filePaths {
-		exists, err := file.PathExists(filepath.Join(imageConnection.chroot.RootDir(), filePath))
-		assert.NoErrorf(t, err, "check if file exists (%s)", filePath)
-		assert.Falsef(t, exists, "ensure file does not exist (%s)", filePath)
+		// Note: Symbolic links might be broken as we are not checking under the chroot.
+		// Hence, the use of lstat instead of stat.
+		_, err := os.Lstat(filepath.Join(imageConnection.chroot.RootDir(), filePath))
+		assert.ErrorIsf(t, err, os.ErrNotExist, "ensure file does not exist (%s)", filePath)
 	}
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -487,6 +487,14 @@ func ensureFilesExist(t *testing.T, imageConnection *ImageConnection, filePaths 
 	}
 }
 
+func ensureFilesNotExist(t *testing.T, imageConnection *ImageConnection, filePaths ...string) {
+	for _, filePath := range filePaths {
+		exists, err := file.PathExists(filepath.Join(imageConnection.chroot.RootDir(), filePath))
+		assert.NoErrorf(t, err, "check if file exists (%s)", filePath)
+		assert.Falsef(t, exists, "ensure file does not exist (%s)", filePath)
+	}
+}
+
 func verifyKernelCommandLine(t *testing.T, imageConnection *ImageConnection, existsArgs []string,
 	notExistsArgs []string,
 ) {

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -5,12 +5,15 @@ package imagecustomizerlib
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/buildpipeline"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 type baseImageType string
@@ -78,4 +81,26 @@ func checkSkipForCustomizeImage(t *testing.T, baseImageType baseImageType) strin
 	}
 
 	return ""
+}
+
+func getDownloadedRpmsDir(t *testing.T, azureLinuxVersion string) string {
+	downloadedRpmsDir := filepath.Join(testDir, "testrpms/downloadedrpms", azureLinuxVersion)
+	dirExists, err := file.DirExists(downloadedRpmsDir)
+	if !assert.NoErrorf(t, err, "cannot access downloaded RPMs dir (%s)", downloadedRpmsDir) {
+		t.FailNow()
+	}
+	if !assert.True(t, dirExists) {
+		t.Logf("test requires offline RPMs")
+		t.Logf("please run toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/download-test-rpms.sh -t %s",
+			azureLinuxVersion)
+		t.FailNow()
+	}
+
+	return downloadedRpmsDir
+}
+
+func getDownloadedRpmsRepoFile(t *testing.T, azureLinuxVersion string) string {
+	dir := getDownloadedRpmsDir(t, azureLinuxVersion)
+	repoFile := filepath.Join(dir, "../", fmt.Sprintf("rpms-%s.repo", azureLinuxVersion))
+	return repoFile
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/install-package-disk-space.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/install-package-disk-space.yaml
@@ -3,7 +3,7 @@ storage:
   - partitionTableType: gpt
 
     # Create a small-ish disk.
-    maxSize: 768M
+    maxSize: 704M
     partitions:
     - id: esp
       type: esp

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/lists/golang.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/lists/golang.yaml
@@ -1,0 +1,2 @@
+packages:
+- golang

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/packages-add-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/packages-add-config.yaml
@@ -1,0 +1,7 @@
+os:
+  packages:
+    install:
+    - jq
+
+    installLists:
+    - lists/golang.yaml

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/packages-update-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/packages-update-config.yaml
@@ -6,10 +6,10 @@ os:
     - which
 
     install:
-    - setools-console
+    - jq
 
     installLists:
-    - lists/dracut-fips.yaml
+    - lists/golang.yaml
 
     update:
-    - setools-console
+    - jq

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/.gitignore
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/.gitignore
@@ -1,0 +1,1 @@
+/downloadedrpms

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/download-test-rpms.sh
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/download-test-rpms.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+CONTAINER_TAG="imagecustomizertestrpms:latest"
+DOCKERFILE_DIR="$SCRIPT_DIR/downloader"
+
+AZURELINUX_2_CONTAINER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core:2.0"
+
+IMAGE_VERSION="2.0"
+
+while getopts "t:" flag
+do
+    case "${flag}" in
+        t) IMAGE_VERSION="$OPTARG";;
+        h) ;;&
+        ?)
+            echo "Usage: download-test-rpms.sh [-t IMAGE_VERSION]"
+            echo ""
+            echo "Args:"
+            echo "  -t IMAGE_VERSION   The Azure Image version to download the RPMs for."
+            echo "  -h Show help"
+            exit 1;;
+    esac
+done
+
+case "${IMAGE_VERSION}" in
+  2.0)
+    CONTAINER_IMAGE="$AZURELINUX_2_CONTAINER_IMAGE"
+    ;;
+  *)
+    echo "error: unsupported Azure Linux version: $IMAGE_VERSION"
+    exit 1;;
+esac
+
+set -x
+
+DOWNLOADER_RPMS_DIRS="$SCRIPT_DIR/downloadedrpms"
+OUT_DIR="$DOWNLOADER_RPMS_DIRS/$IMAGE_VERSION"
+REPO_FILE="$DOWNLOADER_RPMS_DIRS/rpms-$IMAGE_VERSION.repo"
+
+mkdir -p "$OUT_DIR"
+
+# Build a container image that contains the RPMs.
+docker build \
+  --build-arg "baseimage=$AZURELINUX_2_CONTAINER_IMAGE" \
+  --tag "$CONTAINER_TAG" \
+  "$DOCKERFILE_DIR"
+
+# Extract the RPM files.
+docker run \
+  --rm \
+   -v $OUT_DIR:/outdir:z \
+   "$CONTAINER_TAG" \
+   cp -r /downloadedrpms/. "/outdir"
+
+# Create repo file.
+cat << EOF > "$REPO_FILE"
+[localrpms]
+name=Local RPMs repo
+baseurl=file://$OUT_DIR
+enabled=1
+EOF

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/downloader/Dockerfile
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/downloader/Dockerfile
@@ -1,0 +1,14 @@
+ARG baseimage
+FROM ${baseimage}
+
+RUN tdnf update -y && \
+   tdnf install -y dnf dnf-plugins-core createrepo_c
+
+# Download the RPMs needed by the following tests:
+# - TestCustomizeImageAddPackage
+RUN dnf download -y --resolve --alldeps --destdir /downloadedrpms \
+    jq \
+    golang
+
+# Add repo metadata, so that the directory can be used in a .repo file.
+RUN createrepo --compatibility --update /downloadedrpms


### PR DESCRIPTION
1. Add tests for installing/updating/removing packages, including variants for both online and offline installs.

2. Add a script that will download the RPM files needed for the offline package install tests.

3. Add a developers guide, which includes building the image customizer tool and how to run the tests.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran new UTs.

