### PR TITLE
Ptest Fix for package conda

### DIFF
--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -388,15 +388,17 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_version_star[libmamba] \
 	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_free[libmamba] \
 	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_no_upperbound[libmamba] \
+    --deselect=tests/core/test_solve.py::test_update_prune_5[libmamba] \
+	--deselect=tests/cli/test_main_notices.py::test_notices_does_not_interrupt_command_on_failure \
 	--deselect=tests/models/test_prefix_graph.py::test_windows_sort_orders_1[libmamba] \
 	--deselect=tests/models/test_prefix_graph.py::test_sort_without_prep[libmamba] \
-	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_with_capture_output[libmamba] \
-	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_without_capture_output[libmamba] \
-	--deselect=tests/gateways/test_delete.py::test_auto_remove_file[libmamba] \
-	--deselect=tests/gateways/test_delete.py::test_auto_remove_file_to_trash[libmamba] \
-	--deselect=tests/gateways/test_permissions.py::test_make_writable[libmamba] \
-	--deselect=tests/gateways/test_permissions.py::test_recursive_file_to_trash[libmamba] \
-	--deselect=tests/gateways/test_permissions.py::test_make_executable[libmamba] \
+	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_with_capture_output \
+	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_without_capture_output \
+	--deselect=tests/gateways/test_delete.py::test_auto_remove_file \
+	--deselect=tests/gateways/test_delete.py::test_auto_remove_file_to_trash \
+	--deselect=tests/gateways/test_permissions.py::test_make_writable \
+	--deselect=tests/gateways/test_permissions.py::test_recursive_file_to_trash \
+	--deselect=tests/gateways/test_permissions.py::test_make_executable \
     conda tests
 %endif
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,7 +185,8 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec iniconfig flask pytest-xprocess menuinst zstandard conda-package-streaming flaky
+pip3 install archspec iniconfig flask pytest-xprocess zstandard conda-package-streaming flaky
+conda install menuinst
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -1,7 +1,7 @@
 Summary:        Cross-platform, Python-agnostic binary package manager
 Name:           conda
 Version:        24.1.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD-3-Clause AND Apache-2.0
 # The conda code is BSD-3-Clause
 # adapters/ftp.py is Apache-2.0
@@ -30,6 +30,9 @@ BuildRequires:  python3-hatchling
 BuildRequires:  python3-pathspec
 BuildRequires:  python3-pip
 BuildRequires:  python3-pluggy
+%if 0%{?with_check}
+BuildRequires:  python3-pytest
+%endif
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-setuptools_scm
 BuildRequires:  python3-trove-classifiers
@@ -182,6 +185,7 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
+pip3 install archspec
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 
@@ -320,6 +324,9 @@ py.test-%{python3_version} -vv -m "not integration" \
 %{_datadir}/conda/condarc.d/
 
 %changelog
+* Fri Jun 14 2024 Sam Meluch <sammeluch@microsoft.com> - 24.1.2-2
+- Add pytest and pip install archspec to fix package tests
+
 * Mon Apr 22 2024 Andrew Phelps <anphel@microsoft.com> - 24.1.2-1
 - Upgrade to version 24.1.2 referencing Fedora 40 (license: MIT)
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,8 +185,8 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec iniconfig flask pytest-xprocess zstandard conda-package-streaming flaky
-conda install menuinst
+pip3 install archspec iniconfig flask pytest-xprocess zstandard conda-package-streaming flaky pytest-timeout
+%{buildroot}%{_bindir}/conda install menuinst
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,7 +185,7 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec iniconfig
+pip3 install archspec iniconfig flask
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,7 +185,7 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec
+pip3 install archspec iniconfig
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -215,6 +215,53 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 # tests/core/test_solve.py libmamba - some depsolving differences - TODO
 # tests/core/test_prefix_graph.py libmamba - some depsolving differences - TODO
 # tests/trust/test_signature_verification.py requires conda_content_trust - not yet packaged
+#
+# tests skipped for missing presence of conda_libmamba_solver
+# tests/test_solvers.py::TestLibMambaSolver
+# tests/base/test_context.py::test_target_prefix \
+# tests/cli/test_compare.py::test_compare_success \
+# tests/cli/test_compare.py::test_compare_fail \
+# tests/cli/test_main_notices.py::test_target_prefix \
+# tests/core/test_package_cache_data.py::test_instantiating_package_cache_when_both_tar_bz2_and_conda_exist_read_only \
+# tests/core/test_solve.py::test_solve_1[libmamba] \
+# tests/core/test_solve.py::test_solve_msgs_exclude_vp[libmamba] \
+# tests/core/test_solve.py::test_cuda_1[libmamba] \
+# tests/core/test_solve.py::test_cuda_2[libmamba] \
+# tests/core/test_solve.py::test_cuda_fail_2[libmamba] \
+# tests/core/test_solve.py::test_cuda_constrain_absent[libmamba] \
+# tests/core/test_solve.py::test_cuda_glibc_sat[libmamba] \
+# tests/core/test_solve.py::test_update_prune_1[libmamba] \
+# tests/core/test_solve.py::test_update_prune_4[libmamba] \
+# tests/core/test_solve.py::test_update_prune_5[libmamba] \
+# tests/core/test_solve.py::test_no_deps_1[libmamba] \
+# tests/core/test_solve.py::test_only_deps_1[libmamba] \
+# tests/core/test_solve.py::test_only_deps_2[libmamba] \
+# tests/core/test_solve.py::test_update_all_1[libmamba] \
+# tests/core/test_solve.py::test_unfreeze_when_required[libmamba] \
+# tests/core/test_solve.py::test_auto_update_conda[libmamba] \
+# tests/core/test_solve.py::test_explicit_conda_downgrade[libmamba] \
+# tests/core/test_solve.py::test_aggressive_update_packages[libmamba] \
+# tests/core/test_solve.py::test_update_deps_1[libmamba] \
+# tests/core/test_solve.py::test_no_update_deps_1[libmamba] \
+# tests/core/test_solve.py::test_force_reinstall_1[libmamba] \
+# tests/core/test_solve.py::test_force_reinstall_2[libmamba] \
+# tests/core/test_solve.py::test_channel_priority_churn_minimized[libmamba] \
+# tests/core/test_solve.py::test_current_repodata_usage[libmamba] \
+# tests/core/test_solve.py::test_current_repodata_fallback[libmamba] \
+# tests/core/test_solve.py::test_downgrade_python_prevented_with_sane_message[libmamba] \
+# tests/core/test_solve.py::test_packages_in_solution_change_already_newest[libmamba] \
+# tests/core/test_solve.py::test_packages_in_solution_change_needs_update[libmamba] \
+# tests/core/test_solve.py::test_packages_in_solution_change_constrained[libmamba] \
+# tests/core/test_solve.py::test_determine_constricting_specs_conflicts[libmamba] \
+# tests/core/test_solve.py::test_determine_constricting_specs_conflicts_upperbound[libmamba] \
+# tests/core/test_solve.py::test_determine_constricting_specs_multi_conflicts[libmamba] \
+# tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_upperbound_compound_depends[libmamba] \
+# tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_version_star[libmamba] \
+# tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_free[libmamba] \
+# tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_no_upperbound[libmamba] \
+# tests/models/test_prefix_graph.py::test_windows_sort_orders_1[libmamba] \
+# tests/models/test_prefix_graph.py::test_sort_without_prep[libmamba] \
+
 %pytest -vv -m "not integration" \
     --deselect=tests/test_cli.py::TestJson::test_list \
     --deselect=tests/test_cli.py::test_run_returns_int \
@@ -223,7 +270,6 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
     --deselect=tests/test_cli.py::test_run_readonly_env \
 	--ignore=tests/test_create.py \
     --deselect=tests/test_misc.py::test_explicit_missing_cache_entries \
-	--deselect=tests/test_solvers.py::TestLibMambaSolver \
     --ignore=tests/env/specs/test_binstar.py \
     --deselect=tests/env/test_create.py::test_create_update_remote_env_file \
     --deselect='tests/cli/test_common.py::test_is_active_prefix[active_prefix-True]' \
@@ -300,6 +346,57 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
     --deselect=tests/core/test_prefix_data.py::test_set_unset_environment_env_vars \
     --deselect=tests/core/test_prefix_data.py::test_set_unset_environment_env_vars_no_exist \
     --ignore=tests/trust \
+	--deselect=tests/test_solvers.py::TestLibMambaSolver \
+	--deselect=tests/base/test_context.py::test_target_prefix \
+	--deselect=tests/cli/test_compare.py::test_compare_success \
+	--deselect=tests/cli/test_compare.py::test_compare_fail \
+	--deselect=tests/cli/test_main_notices.py::test_target_prefix \
+	--deselect=tests/core/test_package_cache_data.py::test_instantiating_package_cache_when_both_tar_bz2_and_conda_exist_read_only \
+	--deselect=tests/core/test_solve.py::test_solve_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_solve_msgs_exclude_vp[libmamba] \
+	--deselect=tests/core/test_solve.py::test_cuda_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_cuda_2[libmamba] \
+	--deselect=tests/core/test_solve.py::test_cuda_fail_2[libmamba] \
+	--deselect=tests/core/test_solve.py::test_cuda_constrain_absent[libmamba] \
+	--deselect=tests/core/test_solve.py::test_cuda_glibc_sat[libmamba] \
+	--deselect=tests/core/test_solve.py::test_update_prune_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_update_prune_4[libmamba] \
+	--deselect=tests/core/test_solve.py::test_update_prune_5[libmamba] \
+	--deselect=tests/core/test_solve.py::test_no_deps_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_only_deps_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_only_deps_2[libmamba] \
+	--deselect=tests/core/test_solve.py::test_update_all_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_unfreeze_when_required[libmamba] \
+	--deselect=tests/core/test_solve.py::test_auto_update_conda[libmamba] \
+	--deselect=tests/core/test_solve.py::test_explicit_conda_downgrade[libmamba] \
+	--deselect=tests/core/test_solve.py::test_aggressive_update_packages[libmamba] \
+	--deselect=tests/core/test_solve.py::test_update_deps_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_no_update_deps_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_force_reinstall_1[libmamba] \
+	--deselect=tests/core/test_solve.py::test_force_reinstall_2[libmamba] \
+	--deselect=tests/core/test_solve.py::test_channel_priority_churn_minimized[libmamba] \
+	--deselect=tests/core/test_solve.py::test_current_repodata_usage[libmamba] \
+	--deselect=tests/core/test_solve.py::test_current_repodata_fallback[libmamba] \
+	--deselect=tests/core/test_solve.py::test_downgrade_python_prevented_with_sane_message[libmamba] \
+	--deselect=tests/core/test_solve.py::test_packages_in_solution_change_already_newest[libmamba] \
+	--deselect=tests/core/test_solve.py::test_packages_in_solution_change_needs_update[libmamba] \
+	--deselect=tests/core/test_solve.py::test_packages_in_solution_change_constrained[libmamba] \
+	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_conflicts[libmamba] \
+	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_conflicts_upperbound[libmamba] \
+	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_multi_conflicts[libmamba] \
+	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_upperbound_compound_depends[libmamba] \
+	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_version_star[libmamba] \
+	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_free[libmamba] \
+	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_no_upperbound[libmamba] \
+	--deselect=tests/models/test_prefix_graph.py::test_windows_sort_orders_1[libmamba] \
+	--deselect=tests/models/test_prefix_graph.py::test_sort_without_prep[libmamba] \
+	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_with_capture_output[libmamba] \
+	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_without_capture_output[libmamba] \
+	--deselect=tests/gateways/test_delete.py::test_auto_remove_file[libmamba] \
+	--deselect=tests/gateways/test_delete.py::test_auto_remove_file_to_trash[libmamba] \
+	--deselect=tests/gateways/test_permissions.py::test_make_writable[libmamba] \
+	--deselect=tests/gateways/test_permissions.py::test_recursive_file_to_trash[libmamba] \
+	--deselect=tests/gateways/test_permissions.py::test_make_executable[libmamba] \
     conda tests
 %endif
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -215,7 +215,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 # tests/core/test_solve.py libmamba - some depsolving differences - TODO
 # tests/core/test_prefix_graph.py libmamba - some depsolving differences - TODO
 # tests/trust/test_signature_verification.py requires conda_content_trust - not yet packaged
-py.test-%{python3_version} -vv -m "not integration" \
+%pytest -vv -m "not integration" \
     --deselect=tests/test_cli.py::TestJson::test_list \
     --deselect=tests/test_cli.py::test_run_returns_int \
     --deselect=tests/test_cli.py::test_run_returns_nonzero_errorlevel \

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -186,9 +186,9 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 %check
 %if 0%{?with_check}
 pip3 install archspec iniconfig flask pytest-xprocess zstandard conda-package-streaming flaky pytest-timeout
-%{buildroot}%{_bindir}/conda install menuinst
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
+%{buildroot}%{_bindir}/conda install menuinst
 
 # Integration tests generally require network, so skip them.
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -361,7 +361,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 	--deselect=tests/core/test_solve.py::test_cuda_glibc_sat[libmamba] \
 	--deselect=tests/core/test_solve.py::test_update_prune_1[libmamba] \
 	--deselect=tests/core/test_solve.py::test_update_prune_4[libmamba] \
-	--deselect=tests/core/test_solve.py::test_update_prune_5[libmamba] \
+	--deselect=tests/core/test_solve.py::test_update_prune_5[libmamba-True] \
 	--deselect=tests/core/test_solve.py::test_no_deps_1[libmamba] \
 	--deselect=tests/core/test_solve.py::test_only_deps_1[libmamba] \
 	--deselect=tests/core/test_solve.py::test_only_deps_2[libmamba] \
@@ -388,17 +388,16 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_version_star[libmamba] \
 	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_free[libmamba] \
 	--deselect=tests/core/test_solve.py::test_determine_constricting_specs_no_conflicts_no_upperbound[libmamba] \
-    --deselect=tests/core/test_solve.py::test_update_prune_5[libmamba] \
 	--deselect=tests/cli/test_main_notices.py::test_notices_does_not_interrupt_command_on_failure \
 	--deselect=tests/models/test_prefix_graph.py::test_windows_sort_orders_1[libmamba] \
 	--deselect=tests/models/test_prefix_graph.py::test_sort_without_prep[libmamba] \
 	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_with_capture_output \
 	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_without_capture_output \
-	--deselect=tests/gateways/test_delete.py::test_auto_remove_file \
-	--deselect=tests/gateways/test_delete.py::test_auto_remove_file_to_trash \
-	--deselect=tests/gateways/test_permissions.py::test_make_writable \
-	--deselect=tests/gateways/test_permissions.py::test_recursive_file_to_trash \
-	--deselect=tests/gateways/test_permissions.py::test_make_executable \
+	--deselect=tests/gateways/disk/test_delete.py::test_auto_remove_file \
+	--deselect=tests/gateways/disk/test_delete.py::test_auto_remove_file_to_trash \
+	--deselect=tests/gateways/disk/test_permissions.py::test_make_writable \
+	--deselect=tests/gateways/disk/test_permissions.py::test_recursive_file_to_trash \
+	--deselect=tests/gateways/disk/test_permissions.py::test_make_executable \
     conda tests
 %endif
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,7 +185,7 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec iniconfig flask pytest-xprocess menuinst zstandard conda-package-streaming
+pip3 install archspec iniconfig flask pytest-xprocess menuinst zstandard conda-package-streaming flaky
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,7 +185,7 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec iniconfig flask xprocess
+pip3 install archspec iniconfig flask pytest-xprocess
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,7 +185,7 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec iniconfig flask
+pip3 install archspec iniconfig flask xprocess
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -188,7 +188,6 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 pip3 install archspec iniconfig flask pytest-xprocess zstandard conda-package-streaming flaky pytest-timeout
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
-%{buildroot}%{_bindir}/conda install menuinst
 
 # Integration tests generally require network, so skip them.
 
@@ -222,6 +221,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
     --deselect=tests/test_cli.py::test_run_returns_nonzero_errorlevel \
     --deselect=tests/test_cli.py::test_run_returns_zero_errorlevel \
     --deselect=tests/test_cli.py::test_run_readonly_env \
+	--ignore=tests/test_create.py \
     --deselect=tests/test_misc.py::test_explicit_missing_cache_entries \
     --ignore=tests/env/specs/test_binstar.py \
     --deselect=tests/env/test_create.py::test_create_update_remote_env_file \

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -223,6 +223,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
     --deselect=tests/test_cli.py::test_run_readonly_env \
 	--ignore=tests/test_create.py \
     --deselect=tests/test_misc.py::test_explicit_missing_cache_entries \
+	--deselect=tests/test_solvers.py::TestLibMambaSolver \
     --ignore=tests/env/specs/test_binstar.py \
     --deselect=tests/env/test_create.py::test_create_update_remote_env_file \
     --deselect='tests/cli/test_common.py::test_is_active_prefix[active_prefix-True]' \

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -185,7 +185,7 @@ install -m 0644 -Dt %{buildroot}%{bash_completionsdir}/ %SOURCE1
 
 %check
 %if 0%{?with_check}
-pip3 install archspec iniconfig flask pytest-xprocess
+pip3 install archspec iniconfig flask pytest-xprocess menuinst zstandard conda-package-streaming
 export PATH=%{buildroot}%{_bindir}:$PATH
 PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -393,10 +393,10 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} conda info
 	--deselect=tests/models/test_prefix_graph.py::test_sort_without_prep[libmamba] \
 	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_with_capture_output \
 	--deselect=tests/gateways/test_subprocess.py::test_subprocess_call_without_capture_output \
-	--deselect=tests/gateways/disk/test_delete.py::test_auto_remove_file \
-	--deselect=tests/gateways/disk/test_delete.py::test_auto_remove_file_to_trash \
+	--deselect=tests/gateways/disk/test_delete.py::test_remove_file \
+	--deselect=tests/gateways/disk/test_delete.py::test_remove_file_to_trash \
 	--deselect=tests/gateways/disk/test_permissions.py::test_make_writable \
-	--deselect=tests/gateways/disk/test_permissions.py::test_recursive_file_to_trash \
+	--deselect=tests/gateways/disk/test_permissions.py::test_recursive_make_writable \
 	--deselect=tests/gateways/disk/test_permissions.py::test_make_executable \
     conda tests
 %endif


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The ptest for conda has been failing due to dependency issues. Additionally, some test can be skipped for the lack of an external conda package, `conda_libmamba_solver`, which we don't ship so these tests must be skipped.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add missing dependencies via pip install and BuildRequires
- Add skips for tests using `conda_libmamba_solver` 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=588908&view=results
