### PR TITLE
Toolkit: Fix JSON parsing of util-linux commands.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/fstab.go
+++ b/toolkit/tools/imagegen/diskutils/fstab.go
@@ -140,9 +140,11 @@ func ReadFstabFile(fstabPath string) ([]FstabEntry, error) {
 	}
 
 	var output findmntOutput
-	err = json.Unmarshal([]byte(jsonString), &output)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read fstab file (%s): json parse error:\n%w", fstabPath, err)
+	if jsonString != "" {
+		err = json.Unmarshal([]byte(jsonString), &output)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read fstab file (%s): json parse error:\n%w", fstabPath, err)
+		}
 	}
 
 	return output.FileSystems, nil


### PR DESCRIPTION
Prior to util-linux v2.37, when a command is outputting a list in JSON and there aren't any items, then stdout would be empty. This change checks for this scenario and handles it appropriately.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Bug
https://microsoft.visualstudio.com/OS/_workitems/edit/52123611

###### Test Methodology

- Manually ran the image customizer tool.
