### PR TITLE
Image Customizer: Fix container build.

### DIFF
--- a/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+++ b/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
@@ -2,17 +2,6 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-      xfsprogs zstd veritysetup curl tar
-
-# Set environment variables for ORAS installation.
-ARG ARCH="amd64"
-ARG VERSION="1.1.0"
-
-# Install ORAS CLI tool.
-RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_${ARCH}.tar.gz" && \
-    mkdir -p oras-install/ && \
-    tar -zxf oras_${VERSION}_linux_${ARCH}.tar.gz -C oras-install/ && \
-    sudo mv oras-install/oras /usr/local/bin/ && \
-    rm -rf oras_${VERSION}_linux_${ARCH}.tar.gz oras-install/
+      xfsprogs zstd veritysetup
 
 COPY . /

--- a/toolkit/tools/imagecustomizer/container/build-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-mic-container.sh
@@ -4,7 +4,10 @@
 set -e
 
 scriptDir="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-enlistmentRoot=$scriptDir/../../../..
+enlistmentRoot="$scriptDir/../../../.."
+
+ARCH="amd64"
+ORAS_VERSION="1.1.0"
 
 function showUsage() {
     echo
@@ -29,29 +32,41 @@ fi
 
 # ---- main ----
 
-containerStagingFolder=$(mktemp -d)
+buildDir="$(mktemp -d)"
+containerStagingFolder="$buildDir/container"
 
 function cleanUp() {
     local exit_code=$?
-    rm -rf $containerStagingFolder
+    rm -rf "$buildDir"
     exit $exit_code
 }
 trap 'cleanUp' ERR
 
-micLocalFile=$enlistmentRoot/toolkit/out/tools/imagecustomizer
-micContainerFolder=/usr/bin
+micLocalFile="$enlistmentRoot/toolkit/out/tools/imagecustomizer"
+stagingBinDir="${containerStagingFolder}/usr/local/bin"
 
-dockerFile=$enlistmentRoot/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+dockerFile="$scriptDir/Dockerfile.mic-container"
+runScriptPath="$scriptDir/run.sh"
 
 # stage those files that need to be in the container
-mkdir -p ${containerStagingFolder}${micContainerFolder}
-cp $micLocalFile ${containerStagingFolder}${micContainerFolder}
+mkdir -p "${stagingBinDir}"
+cp "$micLocalFile" "${stagingBinDir}"
+cp "$runScriptPath" "${stagingBinDir}"
+
 touch ${containerStagingFolder}/.mariner-toolkit-ignore-dockerenv
 
+# Download oras
+ORAS_TAR="${buildDir}/oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz"
+
+curl -L "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz" \
+  -o "$ORAS_TAR"
+
+mkdir "${buildDir}/oras-install/"
+tar -zxf "$ORAS_TAR" -C "${buildDir}/oras-install/"
+mv "${buildDir}/oras-install/oras" "${stagingBinDir}"
+
 # build the container
-pushd $containerStagingFolder
-docker build -f $dockerFile . -t "$containerTag"
-popd
+docker build -f "$dockerFile" "$containerStagingFolder" -t "$containerTag"
 
 # clean-up
 cleanUp


### PR DESCRIPTION
There is currently an issue where `oras` can't be downloaded when the container is being built because the container doesn't have the `ca-certificates` package installed. This problem could be fixed by adding `ca-certificates` to the list of packages installed. But instead, this change downloads `oras` binary outside of the `Dockerfile`. Doing it this way will help reduce the size of the container.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Built and ran MIC container.

