### PR TITLE
irqbalance: Tweak irqbalance environment file to squelch systemd warning

### DIFF
--- a/SPECS/irqbalance/0001-define-IRQBALANCE_ARGS-as-empty-string.patch
+++ b/SPECS/irqbalance/0001-define-IRQBALANCE_ARGS-as-empty-string.patch
@@ -1,0 +1,23 @@
+From 42115bda75d9c49156a2799bc178ea105daf5003 Mon Sep 17 00:00:00 2001
+From: Cameron Baird <cameronbaird@microsoft.com>
+Date: Wed, 10 Jul 2024 23:09:32 +0000
+Subject: [PATCH] define IRQBALANCE_ARGS as empty string to squelch systemd
+ warning
+
+---
+ misc/irqbalance.env | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/misc/irqbalance.env b/misc/irqbalance.env
+index 96acb39..84cb843 100644
+--- a/misc/irqbalance.env
++++ b/misc/irqbalance.env
+@@ -41,4 +41,4 @@
+ #    Append any args here to the irqbalance daemon as documented in the man
+ #    page.
+ #
+-#IRQBALANCE_ARGS=
++IRQBALANCE_ARGS=""
+-- 
+2.34.1
+

--- a/SPECS/irqbalance/irqbalance.spec
+++ b/SPECS/irqbalance/irqbalance.spec
@@ -1,13 +1,14 @@
 Summary:        Irqbalance daemon
 Name:           irqbalance
 Version:        1.9.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 URL:            https://github.com/Irqbalance/irqbalance
 Group:          System Environment/Services
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Source0:        https://github.com/Irqbalance/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         0001-define-IRQBALANCE_ARGS-as-empty-string.patch
 BuildRequires:  systemd-devel
 BuildRequires:  glib-devel
 Requires:       systemd
@@ -56,6 +57,10 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_datadir}/*
 
 %changelog
+* Mon Jul 01 2024 Cameron Baird <cameronbaird@microsoft.com> - 1.9.3-2
+- Define IRQBALANCE_ARGS variable in EnvironmentFile for irqbalance.service
+    to squelch systemd warning. 
+
 * Wed Jan 03 2024 Muhammad Falak <mwani@microsoft.com> - 1.9.3-1
 - Drop un-needed patches
 - Bump version to 1.9.3


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Our 3.0 images produce some extra noise during boot:
irqbalance: "Referenced but unset environment variable evaluates to an empty string: IRQBALANCE_ARGS"

This is due to the variable IRQBALANCE_ARGS, referenced in irqbalance.service, not being defined in the EnvironmentFile pointed to by that service. Sed the Environment file to uncomment IRQBALANCE_ARGS, explicitly setting it to the empty string. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Sed the Environment file for irqbalance to uncomment IRQBALANCE_ARGS, explicitly setting it to the empty string

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=597498&view=results
