### PR TITLE
keda: patch CVE-2024-28180 in vendored gopkg.in/square/go-jose.v2

### DIFF
--- a/SPECS/keda/CVE-2024-28180.patch
+++ b/SPECS/keda/CVE-2024-28180.patch
@@ -1,0 +1,90 @@
+From a02a1f7454cfbc033c1d07ab735992bfb9088b23 Mon Sep 17 00:00:00 2001
+From: Sean Dougherty <sdougherty@microsoft.com>
+Date: Mon, 1 Jul 2024 22:08:36 +0000
+Subject: [PATCH] patch vendored go-jose.v2 v2.5.2 with upstream backport fix
+ for CVE-2024-28180
+
+---
+ vendor/gopkg.in/square/go-jose.v2/crypter.go  |  6 ++++++
+ vendor/gopkg.in/square/go-jose.v2/encoding.go | 21 +++++++++++++++----
+ 2 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/vendor/gopkg.in/square/go-jose.v2/crypter.go b/vendor/gopkg.in/square/go-jose.v2/crypter.go
+index d24cabf..a628386 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/crypter.go
++++ b/vendor/gopkg.in/square/go-jose.v2/crypter.go
+@@ -405,6 +405,9 @@ func (ctx *genericEncrypter) Options() EncrypterOptions {
+ // Decrypt and validate the object and return the plaintext. Note that this
+ // function does not support multi-recipient, if you desire multi-recipient
+ // decryption use DecryptMulti instead.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >10x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) {
+ 	headers := obj.mergedHeaders(nil)
+ 
+@@ -469,6 +472,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error)
+ // with support for multiple recipients. It returns the index of the recipient
+ // for which the decryption was successful, the merged headers for that recipient,
+ // and the plaintext.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >3x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Header, []byte, error) {
+ 	globalHeaders := obj.mergedHeaders(nil)
+ 
+diff --git a/vendor/gopkg.in/square/go-jose.v2/encoding.go b/vendor/gopkg.in/square/go-jose.v2/encoding.go
+index 70f7385..ab9e086 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/encoding.go
++++ b/vendor/gopkg.in/square/go-jose.v2/encoding.go
+@@ -21,6 +21,7 @@ import (
+ 	"compress/flate"
+ 	"encoding/base64"
+ 	"encoding/binary"
++	"fmt"
+ 	"io"
+ 	"math/big"
+ 	"strings"
+@@ -85,7 +86,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
+ 	}
+ }
+ 
+-// Compress with DEFLATE
++// deflate compresses the input.
+ func deflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 
+@@ -97,15 +98,27 @@ func deflate(input []byte) ([]byte, error) {
+ 	return output.Bytes(), err
+ }
+ 
+-// Decompress with DEFLATE
++// inflate decompresses the input.
++//
++// Errors if the decompressed data would be >250kB or >10x the size of the
++// compressed data, whichever is larger.
+ func inflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 	reader := flate.NewReader(bytes.NewBuffer(input))
+ 
+-	_, err := io.Copy(output, reader)
+-	if err != nil {
++	maxCompressedSize := 10 * int64(len(input))
++	if maxCompressedSize < 250000 {
++		maxCompressedSize = 250000
++	}
++
++	limit := maxCompressedSize + 1
++	n, err := io.CopyN(output, reader, limit)
++	if err != nil && err != io.EOF {
+ 		return nil, err
+ 	}
++	if n == limit {
++		return nil, fmt.Errorf("uncompressed data would be too large (>%d bytes)", maxCompressedSize)
++	}
+ 
+ 	err = reader.Close()
+ 	return output.Bytes(), err
+-- 
+2.33.8
+

--- a/SPECS/keda/keda.spec
+++ b/SPECS/keda/keda.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes-based Event Driven Autoscaling
 Name:           keda
 Version:        2.4.0
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -31,6 +31,10 @@ Source1:        %{name}-%{version}-vendor-v2.tar.gz
 Patch0:         CVE-2022-21698.patch
 Patch1:         CVE-2023-44487.patch
 Patch2:         CVE-2021-44716.patch
+# Patches the version of go-jose.v2 used in the vendored source. This does not need to be applied before creating the vendored tarball. 
+# This vulnerable vendored package is not present in 2.14.0 or later.
+Patch3:         CVE-2024-28180.patch
+
 
 BuildRequires:  golang >= 1.15
 
@@ -66,6 +70,9 @@ cp ./bin/keda-adapter %{buildroot}%{_bindir}
 %{_bindir}/%{name}-adapter
 
 %changelog
+* Mon Jul 01 2024 Sean Dougherty <sdougherty@microsoft.com> - 2.4.0-21
+- Address CVE-2024-28180 by patching vendored gopkg.in/square/go-jose.v2
+
 * Thu Jun 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.0-20
 - Bump release to rebuild with go 1.21.11
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR patches a vendored dependency, `go-jose.v2`, in the keda package to address CVE-2024-28180. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch CVE-2024-28180.patch to keda

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-28180

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Pipeline build id: ](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=597540&view=results)
