### PR TITLE
selinux-policy: Add udev and kmod fixes.

### DIFF
--- a/SPECS/selinux-policy/0033-cloud-init-and-kmod-fixes.patch
+++ b/SPECS/selinux-policy/0033-cloud-init-and-kmod-fixes.patch
@@ -1,0 +1,57 @@
+From 4f0a5864edceb52060f9beba46c598480591b24c Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <chpebeni@linux.microsoft.com>
+Date: Mon, 1 Jul 2024 09:27:04 -0400
+Subject: [PATCH 33/33] cloud-init and kmod fixes.
+
+---
+ policy/modules/system/modutils.fc | 2 ++
+ policy/modules/system/modutils.te | 4 ++++
+ policy/modules/system/udev.te     | 4 ++++
+ 3 files changed, 10 insertions(+)
+
+diff --git a/policy/modules/system/modutils.fc b/policy/modules/system/modutils.fc
+index 323120062..de9f88fa8 100644
+--- a/policy/modules/system/modutils.fc
++++ b/policy/modules/system/modutils.fc
+@@ -8,6 +8,8 @@ ifdef(`distro_gentoo',`
+ /etc/modprobe\.devfs.*		--	gen_context(system_u:object_r:modules_conf_t,s0)
+ ')
+ 
++/run/modprobe\.d(/.*)?			gen_context(system_u:object_r:modules_conf_t,s0)
++
+ ifdef(`init_systemd',`
+ /run/tmpfiles\.d/kmod\.conf	--	gen_context(system_u:object_r:kmod_tmpfiles_conf_t,s0)
+ /run/tmpfiles\.d/static-nodes\.conf --  gen_context(system_u:object_r:kmod_tmpfiles_conf_t,s0)
+diff --git a/policy/modules/system/modutils.te b/policy/modules/system/modutils.te
+index 996ecac85..6af867650 100644
+--- a/policy/modules/system/modutils.te
++++ b/policy/modules/system/modutils.te
+@@ -141,6 +141,10 @@ optional_policy(`
+ 	apt_use_ptys(kmod_t)
+ ')
+ 
++optional_policy(`
++	cloudinit_append_inherited_tmp_files(kmod_t)
++')
++
+ optional_policy(`
+ 	# for postinst of a new kernel package
+ 	dpkg_manage_script_tmp_files(kmod_t)
+diff --git a/policy/modules/system/udev.te b/policy/modules/system/udev.te
+index 8af0d90e0..5d2ff060a 100644
+--- a/policy/modules/system/udev.te
++++ b/policy/modules/system/udev.te
+@@ -437,6 +437,10 @@ storage_getattr_fixed_disk_dev(udevadm_t)
+ 
+ userdom_use_user_terminals(udevadm_t)
+ 
++optional_policy(`
++	cloudinit_append_inherited_tmp_files(udevadm_t)
++')
++
+ optional_policy(`
+ 	rpm_read_inherited_tmp_files(udevadm_t)
+ 	rpm_append_inherited_tmp_files(udevadm_t)
+-- 
+2.45.2
+

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -51,6 +51,7 @@ Patch29:        0029-filesystem-systemd-memory.pressure-fixes.patch
 Patch30:        0030-init-Add-homectl-dbus-access.patch
 Patch31:        0031-Temporary-workaround-for-memory.pressure-labeling-is.patch
 Patch32:        0032-rpm-Fixes-from-various-post-scripts.patch
+Patch33:        0033-cloud-init-and-kmod-fixes.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -334,6 +335,9 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Mon Jul 01 2024 Chris PeBenito <chpebeni@microsoft.com> - 2.20240226-4
+- Add cloud-init and kmod fixes.
+
 * Tue May 14 2024 Chris PeBenito <chpebeni@microsoft.com> - 2.20240226-3
 - Fix systemd-analyze issues.
 - Add selinux-policy-modules to selinux.json package list since it has rules for cloud-init


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix udevadm and kmod issues when run from cloud-init.

###### Change Log  <!-- REQUIRED -->
- Add labeling for /run/modprobe.d
- Add permissions for udevadm and kmod to log to cloud-init (redirected stdout)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 597242
