### PR TITLE
Fix encrypted root handling for new grub mkconfig flow

### DIFF
--- a/toolkit/tools/internal/resources/assets/efi/grub/grub.cfg
+++ b/toolkit/tools/internal/resources/assets/efi/grub/grub.cfg
@@ -1,5 +1,6 @@
+{{.CryptoMountCommand}}
 # The bootUUID in which the menuentry grub.cfg is defined;
-# Can be either its own separate partition or part of the rootfs partition. 
+# Can be either its own separate partition or part of the rootfs partition.
 search -n -u {{.BootUUID}} -s
 # For images using grub2-mkconfig, $prefix is the variable
 # grub expects to be populated with the proper path to the grub.cfg, grubenv.

--- a/toolkit/tools/internal/resources/assets/efi/grub/grubEncrypt.cfg
+++ b/toolkit/tools/internal/resources/assets/efi/grub/grubEncrypt.cfg
@@ -1,4 +1,0 @@
-cryptomount -a
-search -n -u {{.BootUUID}} -s
-set bootprefix={{.BootPrefix}}
-configfile $bootprefix/grub2/grub.cfg


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The new grub config flow did not handle the specialized `grubEncrypt.cfg` file. This file is almost identical to the normal grub config, so unify them into one file.

We also have not used `{{.EncryptedVolume}}` in the grub config for a very long time, so repurpose the existing `setGrubCfgEncryptedVolume()` function to instead optionally add `cryptomount -a` to the start of the EFI grub config via `{{.CryptoMountCommand}}` instead.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `grubEncrypt.cfg` template file
- Add `{{.CryptoMountCommand}}` to the normal EFI `grub.cfg` file.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/52146800

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing of ISO
- ~Will test offline build as well~ Encryption isn't really supported for offline
