### PR TITLE
Upgrade OpenSSH to 9.8p1 to resolve the Regresshion CVE

### DIFF
--- a/SPECS/openssh/openssh.signatures.json
+++ b/SPECS/openssh/openssh.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "openssh-9.7p1.tar.gz": "490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd",
+  "openssh-9.8p1.tar.gz": "dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3",
   "pam_ssh_agent_auth-0.10.3.tar.bz2": "3c53d358d6eaed1b211239df017c27c6f9970995d14102ae67bae16d4f47a763",
   "pam_ssh_agent-rmheaders": "468ed01777cae90b31244130d66dfcf7dad9d5cafd9746e6f155440d8c9b16d7",
   "sshd-keygen.service": "331515a4fb37951122ac8447111b126368386a49ac429f500fe3819ba25a70be",

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -263,7 +263,7 @@ fi
 
 %changelog
 * Mon Jul 01 2024 Jon Slobodzian <joslobo@microsoft.com> - 9.8p1-1
-* Upgrade to version 9.8p1. This fixes CVE-2024-6387 (a regression to CVE-2006-5051) in OpenSSH's server.
+- Upgrade to version 9.8p1. This fixes CVE-2024-6387 (a regression to CVE-2006-5051) in OpenSSH's server.
 
 * Thu May 02 2024 Tobias Brick <tobiasb@microsoft.com> - 9.7p1-1
 - Upgrade to version 9.7p1

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -262,7 +262,7 @@ fi
 %{_mandir}/man8/ssh-sk-helper.8.gz
 
 %changelog
-* Mon Jul 01 2024 Jon Slobodzian <joslobo@microsoft.com - 9.8p1-1
+* Mon Jul 01 2024 Jon Slobodzian <joslobo@microsoft.com> - 9.8p1-1
 * Upgrade to version 9.8p1. This fixes CVE-2024-6387 (a regression to CVE-2006-5051) in OpenSSH's server.
 
 * Thu May 02 2024 Tobias Brick <tobiasb@microsoft.com> - 9.7p1-1

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -1,4 +1,4 @@
-%global openssh_ver 9.8p1
+\%global openssh_ver 9.8p1
 %global pam_ssh_agent_ver 0.10.3
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh
@@ -263,7 +263,7 @@ fi
 
 %changelog
 * Mon Jul 01 2024 Jon Slobodzian <joslobo@microsoft.com - 9.8p1-1
-* Upgrade to version 9.8p1. This fixes a regression to CVE-2006-5051 in OpenSSH's server.
+* Upgrade to version 9.8p1. This fixes CVE-2024-6387 (a regression to CVE-2006-5051) in OpenSSH's server.
 
 * Thu May 02 2024 Tobias Brick <tobiasb@microsoft.com> - 9.7p1-1
 - Upgrade to version 9.7p1

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -226,6 +226,7 @@ fi
 /lib/systemd/system/sshd-keygen.service
 /lib/systemd/system/sshd.service
 %{_sbindir}/sshd
+%{_libexecdir}/sshd-session
 %{_libexecdir}/sftp-server
 %{_mandir}/man5/sshd_config.5.gz
 %{_mandir}/man8/sshd.8.gz

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -1,4 +1,4 @@
-%global openssh_ver 9.7p1
+%global openssh_ver 9.8p1
 %global pam_ssh_agent_ver 0.10.3
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh
@@ -261,6 +261,9 @@ fi
 %{_mandir}/man8/ssh-sk-helper.8.gz
 
 %changelog
+* Mon Jul 01 2024 Jon Slobodzian <joslobo@microsoft.com - 9.8p1-1
+* Upgrade to version 9.8p1. This fixes a regression to CVE-2006-5051 in OpenSSH's server.
+
 * Thu May 02 2024 Tobias Brick <tobiasb@microsoft.com> - 9.7p1-1
 - Upgrade to version 9.7p1
 

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -1,4 +1,4 @@
-\%global openssh_ver 9.8p1
+%global openssh_ver 9.8p1
 %global pam_ssh_agent_ver 0.10.3
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -15143,8 +15143,8 @@
         "type": "other",
         "other": {
           "name": "openssh",
-          "version": "9.7p1",
-          "downloadUrl": "https://ftp.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.7p1.tar.gz"
+          "version": "9.8p1",
+          "downloadUrl": "https://ftp.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.8p1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This upgrade resolves Critical CVE-2024-6387 which is a regression for CVE-2006-5051.  Note that this version of openssh splits the server into two binaries, so there is a packaging difference from the previous version.  The server/listener (sshd) and a separate binary that hosts the session (sshd-session). 



###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-6387

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Buddy build and manually installed the client and server package.  Verified that I could connect to the server and verified that the ssh client functioned.

Note that the pTest currently fails for ssh because the Azure Linux version of openssh does not include the secure-key (libraries).  A separate bug is tracking to resolve post GA.
