### PR TITLE
Disable SELinux if it is disabled in the image config

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -45,6 +45,9 @@ const (
 	// CmdlineSELinuxSecurityArg is the "security" arg needed for enabling SELinux.
 	CmdlineSELinuxSecurityArg = "security=selinux"
 
+	// CmdlineSELinuxEnabledArg is the "selinux" arg needed for disabling SELinux.
+	CmdlineSELinuxDisabledArg = "selinux=0"
+
 	// CmdlineSELinuxEnabledArg is the "selinux" arg needed for enabling SELinux.
 	CmdlineSELinuxEnabledArg = "selinux=1"
 
@@ -2389,7 +2392,7 @@ func setGrubCfgSELinux(grubPath string, kernelCommandline configuration.KernelCo
 	case configuration.SELinuxPermissive, configuration.SELinuxEnforcing:
 		selinux = CmdlineSELinuxSettings
 	case configuration.SELinuxOff:
-		selinux = ""
+		selinux = CmdlineSELinuxDisabledArg
 	}
 
 	logger.Log.Debugf("Adding SELinuxConfiguration('%s') to '%s'", selinux, grubPath)

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
@@ -92,7 +92,7 @@ func TestBootCustomizerSELinuxMode20(t *testing.T) {
 	expectedGrubCfgDiff = `22c22
 < 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline   $kernelopts
 ---
-> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline        $kernelopts
+> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline       selinux=0 $kernelopts
 `
 	checkDiffs20(t, b, expectedGrubCfgDiff, "")
 }
@@ -141,7 +141,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff = `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity      "
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity     selinux=0 "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
@@ -550,7 +550,7 @@ func selinuxModeToArgs(selinuxMode imagecustomizerapi.SELinuxMode) ([]string, er
 	newSELinuxArgs := []string(nil)
 	switch selinuxMode {
 	case imagecustomizerapi.SELinuxModeDisabled:
-		newSELinuxArgs = nil
+		newSELinuxArgs = []string{installutils.CmdlineSELinuxDisabledArg}
 
 	case imagecustomizerapi.SELinuxModeForceEnforcing:
 		newSELinuxArgs = []string{installutils.CmdlineSELinuxSecurityArg, installutils.CmdlineSELinuxEnabledArg,


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Disable SELinux if it is disabled in the image config. Now that SELinux is the default major LSM, selinuxfs gets mounted by systemd. Some userspace programs do not correctly determine if SELinux is enabled.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `selinux=0` to kernel command line if it is disabled in the image config.
- Add `selinux=0` to kernel command line if it is disabled in MIC

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 598562
