### PR TITLE
Patched CVE-2023-44487 in 'blobfuse2'. (CP: #9710)

### DIFF
--- a/SPECS/blobfuse2/CVE-2023-44487.patch
+++ b/SPECS/blobfuse2/CVE-2023-44487.patch
@@ -1,0 +1,169 @@
+diff --git a/vendor/google.golang.org/grpc/internal/transport/http2_server.go b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+index f960640..0bc7a7d 100644
+--- a/vendor/google.golang.org/grpc/internal/transport/http2_server.go
++++ b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+@@ -171,15 +171,10 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
+ 		ID:  http2.SettingMaxFrameSize,
+ 		Val: http2MaxFrameLen,
+ 	}}
+-	// TODO(zhaoq): Have a better way to signal "no limit" because 0 is
+-	// permitted in the HTTP2 spec.
+-	maxStreams := config.MaxStreams
+-	if maxStreams == 0 {
+-		maxStreams = math.MaxUint32
+-	} else {
++	if config.MaxStreams != math.MaxUint32 {
+ 		isettings = append(isettings, http2.Setting{
+ 			ID:  http2.SettingMaxConcurrentStreams,
+-			Val: maxStreams,
++			Val: config.MaxStreams,
+ 		})
+ 	}
+ 	dynamicWindow := true
+@@ -258,7 +253,7 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
+ 		framer:            framer,
+ 		readerDone:        make(chan struct{}),
+ 		writerDone:        make(chan struct{}),
+-		maxStreams:        maxStreams,
++		maxStreams:        config.MaxStreams,
+ 		inTapHandle:       config.InTapHandle,
+ 		fc:                &trInFlow{limit: uint32(icwz)},
+ 		state:             reachable,
+diff --git a/vendor/google.golang.org/grpc/server.go b/vendor/google.golang.org/grpc/server.go
+index e076ec7..b44c7e8 100644
+--- a/vendor/google.golang.org/grpc/server.go
++++ b/vendor/google.golang.org/grpc/server.go
+@@ -115,12 +115,6 @@ type serviceInfo struct {
+ 	mdata       interface{}
+ }
+ 
+-type serverWorkerData struct {
+-	st     transport.ServerTransport
+-	wg     *sync.WaitGroup
+-	stream *transport.Stream
+-}
+-
+ // Server is a gRPC server to serve RPC requests.
+ type Server struct {
+ 	opts serverOptions
+@@ -145,7 +139,7 @@ type Server struct {
+ 	channelzID *channelz.Identifier
+ 	czData     *channelzData
+ 
+-	serverWorkerChannel chan *serverWorkerData
++	serverWorkerChannel chan func()
+ }
+ 
+ type serverOptions struct {
+@@ -178,6 +172,7 @@ type serverOptions struct {
+ }
+ 
+ var defaultServerOptions = serverOptions{
++	maxConcurrentStreams:  math.MaxUint32,
+ 	maxReceiveMessageSize: defaultServerMaxReceiveMessageSize,
+ 	maxSendMessageSize:    defaultServerMaxSendMessageSize,
+ 	connectionTimeout:     120 * time.Second,
+@@ -389,6 +384,9 @@ func MaxSendMsgSize(m int) ServerOption {
+ // MaxConcurrentStreams returns a ServerOption that will apply a limit on the number
+ // of concurrent streams to each ServerTransport.
+ func MaxConcurrentStreams(n uint32) ServerOption {
++	if n == 0 {
++		n = math.MaxUint32
++	}
+ 	return newFuncServerOption(func(o *serverOptions) {
+ 		o.maxConcurrentStreams = n
+ 	})
+@@ -590,24 +588,19 @@ const serverWorkerResetThreshold = 1 << 16
+ // [1] https://github.com/golang/go/issues/18138
+ func (s *Server) serverWorker() {
+ 	for completed := 0; completed < serverWorkerResetThreshold; completed++ {
+-		data, ok := <-s.serverWorkerChannel
++		f, ok := <-s.serverWorkerChannel
+ 		if !ok {
+ 			return
+ 		}
+-		s.handleSingleStream(data)
++		f()
+ 	}
+ 	go s.serverWorker()
+ }
+ 
+-func (s *Server) handleSingleStream(data *serverWorkerData) {
+-	defer data.wg.Done()
+-	s.handleStream(data.st, data.stream, s.traceInfo(data.st, data.stream))
+-}
+-
+ // initServerWorkers creates worker goroutines and a channel to process incoming
+ // connections to reduce the time spent overall on runtime.morestack.
+ func (s *Server) initServerWorkers() {
+-	s.serverWorkerChannel = make(chan *serverWorkerData)
++	s.serverWorkerChannel = make(chan func())
+ 	for i := uint32(0); i < s.opts.numServerWorkers; i++ {
+ 		go s.serverWorker()
+ 	}
+@@ -966,21 +959,26 @@ func (s *Server) serveStreams(st transport.ServerTransport) {
+ 	defer st.Close(errors.New("finished serving streams for the server transport"))
+ 	var wg sync.WaitGroup
+ 
++	streamQuota := newHandlerQuota(s.opts.maxConcurrentStreams)
+ 	st.HandleStreams(func(stream *transport.Stream) {
+ 		wg.Add(1)
++
++		streamQuota.acquire()
++		f := func() {
++			defer streamQuota.release()
++			defer wg.Done()
++			s.handleStream(st, stream, s.traceInfo(st, stream))
++		}
++
+ 		if s.opts.numServerWorkers > 0 {
+-			data := &serverWorkerData{st: st, wg: &wg, stream: stream}
+ 			select {
+-			case s.serverWorkerChannel <- data:
++			case s.serverWorkerChannel <- f:
+ 				return
+ 			default:
+ 				// If all stream workers are busy, fallback to the default code path.
+ 			}
+ 		}
+-		go func() {
+-			defer wg.Done()
+-			s.handleStream(st, stream, s.traceInfo(st, stream))
+-		}()
++		go f()
+ 	}, func(ctx context.Context, method string) context.Context {
+ 		if !EnableTracing {
+ 			return ctx
+@@ -2075,3 +2073,32 @@ func validateSendCompressor(name, clientCompressors string) error {
+ 	}
+ 	return fmt.Errorf("client does not support compressor %q", name)
+ }
++
++// atomicSemaphore implements a blocking, counting semaphore. acquire should be
++// called synchronously; release may be called asynchronously.
++type atomicSemaphore struct {
++	n    int64 // accessed atomically
++	wait chan struct{}
++}
++
++func (q *atomicSemaphore) acquire() {
++	if atomic.AddInt64(&q.n, -1) < 0 {
++		// We ran out of quota.  Block until a release happens.
++		<-q.wait
++	}
++}
++
++func (q *atomicSemaphore) release() {
++	// N.B. the "<= 0" check below should allow for this to work with multiple
++	// concurrent calls to acquire, but also note that with synchronous calls to
++	// acquire, as our system does, n will never be less than -1.  There are
++	// fairness issues (queuing) to consider if this was to be generalized.
++	if atomic.AddInt64(&q.n, -1) <= 0 {
++		// An acquire was waiting on us.  Unblock it.
++		q.wait <- struct{}{}
++	}
++}
++
++func newHandlerQuota(n uint32) *atomicSemaphore {
++	return &atomicSemaphore{n: int64(n), wait: make(chan struct{}, 1)}
++}

--- a/SPECS/blobfuse2/blobfuse2.spec
+++ b/SPECS/blobfuse2/blobfuse2.spec
@@ -1,41 +1,22 @@
 %global debug_package %{nil}
 
 %define our_gopath %{_topdir}/.gopath
-%define blobfuse2_version 2.1.2
 %define blobfuse2_health_monitor bfusemon
 
 Summary:        FUSE adapter - Azure Storage
 Name:           blobfuse2
-Version:        %{blobfuse2_version}
-Release:        4%{?dist}
+Version:        2.1.2
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/Tools
 URL:            https://github.com/Azure/azure-storage-fuse/
-# Below is the Github URL where blobfuse2 is accessible. This needs to be defined until blobfuse2 GAs since the version
-# string in spec files does not allow - 
-Source0:        https://github.com/Azure/azure-storage-fuse/archive/%{name}-%{blobfuse2_version}.tar.gz#/%{name}-%{version}.tar.gz
-# Below is a manually created tarball, no download link.
-# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
-# How to re-build this file:
-#   1. wget https://github.com/Azure/azure-storage-fuse/archive/%{name}-%{version}.tar.gz -O %{name}-%{version}.tar.gz
-#   2. tar -xf %{name}-%{version}.tar.gz
-#   3. cd azure-storage-fuse-%{name}-%{version}
-#   4. go mod vendor
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
-#           --owner=0 --group=0 --numeric-owner \
-#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %{name}-%{version}-vendor.tar.gz vendor
-#
-#   NOTES:
-#       - You require GNU tar version 1.28+.
-#       - The additional options enable generation of a tarball with the same hash every time regardless of the environment.
-#         See: https://reproducible-builds.org/docs/archives/
-#       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
+Source0:        https://github.com/Azure/azure-storage-fuse/archive/%{name}-%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Leverage the `generate_source_tarball.sh` to create the vendor sources.
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2023-45288.patch
+Patch1:         CVE-2023-44487.patch
 BuildRequires:  cmake
 BuildRequires:  fuse3-devel
 BuildRequires:  gcc
@@ -80,6 +61,10 @@ install -D -m 0644 ./setup/blobfuse2-logrotate %{buildroot}%{_sysconfdir}/logrot
 %{_sysconfdir}/logrotate.d/blobfuse2
 
 %changelog
+* Mon Jul 08 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.1.2-5
+- Adding a patch for CVE-2023-44487.
+- Switched to building the vendor tarball with the generate_source_tarball.sh script.
+
 * Thu Jun 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.1.2-4
 - Bump release to rebuild with go 1.21.11
 

--- a/SPECS/blobfuse2/blobfuse2.spec
+++ b/SPECS/blobfuse2/blobfuse2.spec
@@ -30,7 +30,7 @@ Linux FUSE kernel module, and implements the filesystem operations using
 the Azure Storage REST APIs.
 
 %prep
-%autosetup -n azure-storage-fuse-%{name}-%{blobfuse2_version} -a 1 -p1
+%autosetup -n azure-storage-fuse-%{name}-%{version} -a 1 -p1
 
 %build
 export GOPATH=%{our_gopath}

--- a/SPECS/blobfuse2/generate_source_tarball.sh
+++ b/SPECS/blobfuse2/generate_source_tarball.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Quit on failure
+set -e
+
+PKG_VERSION=""
+SRC_TARBALL=""
+OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# parameters:
+#
+# --srcTarball  : src tarball file
+#                 this file contains the 'initial' source code of the component
+#                 and should be replaced with the new/modified src code
+# --outFolder   : folder where to copy the new tarball(s)
+# --pkgVersion  : package version
+#
+PARAMS=""
+while (( "$#" )); do
+    case "$1" in
+        --srcTarball)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            SRC_TARBALL=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --outFolder)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            OUT_FOLDER=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --pkgVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            PKG_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        -*|--*=) # unsupported flags
+        echo "Error: Unsupported flag $1" >&2
+        exit 1
+        ;;
+        *) # preserve positional arguments
+        PARAMS="$PARAMS $1"
+        shift
+        ;;
+  esac
+done
+
+echo "--srcTarball   -> $SRC_TARBALL"
+echo "--outFolder    -> $OUT_FOLDER"
+echo "--pkgVersion   -> $PKG_VERSION"
+
+if [ -z "$PKG_VERSION" ]; then
+    echo "--pkgVersion parameter cannot be empty"
+    exit 1
+fi
+
+echo "-- create temp folder"
+tmpdir=$(mktemp -d)
+function cleanup {
+    echo "+++ cleanup -> remove $tmpdir"
+    rm -rf $tmpdir
+}
+trap cleanup EXIT
+
+pushd $tmpdir > /dev/null
+
+echo "Unpacking source tarball..."
+tar -xf $SRC_TARBALL
+
+cd "azure-storage-fuse-blobfuse2-$PKG_VERSION"
+echo "Get vendored modules"
+go mod vendor
+
+echo "Tar vendored modules"
+VENDOR_TARBALL="$OUT_FOLDER/blobfuse2-vendor.tar.gz"
+tar  --sort=name \
+     --mtime="2021-04-26 00:00Z" \
+     --owner=0 --group=0 --numeric-owner \
+     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+     -cf "$VENDOR_TARBALL" vendor
+
+popd > /dev/null
+echo "Blobfuse2 vendored modules are available at $VENDOR_TARBALL"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Cherry-pick of #9710.

Patching CVE-2023-44487 in `blobfuse2`.

Also cleaned-up the spec a bit and switched to using the `generate_source_tarball.sh` script for building the vendor tarballs.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-44487

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
- [Buddy build.]()