### PR TITLE
Upgrade kube-vip-cloud-provider to fix CVE-2023-45142 and manually patch CVE-2023-47108

### DIFF
--- a/SPECS/kube-vip-cloud-provider/CVE-2023-47108.patch
+++ b/SPECS/kube-vip-cloud-provider/CVE-2023-47108.patch
@@ -1,0 +1,90 @@
+From d504c5110083da5246a9793559aae4b6ec0eefa9 Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Tue, 9 Jul 2024 15:57:11 +0000
+Subject: [PATCH] CVE-2023-47108
+
+---
+ .../grpc/otelgrpc/interceptor.go              | 32 +++++++++++--------
+ 1 file changed, 18 insertions(+), 14 deletions(-)
+
+diff --git a/vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go b/vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+index d4dc5de..bab0708 100644
+--- a/vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
++++ b/vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+@@ -83,7 +83,7 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
+ 			return invoker(ctx, method, req, reply, cc, callOpts...)
+ 		}
+ 
+-		name, attr := spanInfo(method, cc.Target())
++		name, attr, _ := telemetryAttributes(method, cc.Target())
+ 		var span trace.Span
+ 		ctx, span = tracer.Start(
+ 			ctx,
+@@ -258,7 +258,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
+ 			return streamer(ctx, desc, cc, method, callOpts...)
+ 		}
+ 
+-		name, attr := spanInfo(method, cc.Target())
++		name, attr, _ := telemetryAttributes(method, cc.Target())
+ 		var span trace.Span
+ 		ctx, span = tracer.Start(
+ 			ctx,
+@@ -322,7 +322,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
+ 
+ 		ctx = extract(ctx, cfg.Propagators)
+ 
+-		name, attr := spanInfo(info.FullMethod, peerFromCtx(ctx))
++		name, attr, metricAttrs := telemetryAttributes(info.FullMethod, peerFromCtx(ctx))
+ 		ctx, span := tracer.Start(
+ 			trace.ContextWithRemoteSpanContext(ctx, trace.SpanContextFromContext(ctx)),
+ 			name,
+@@ -336,8 +336,8 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
+ 		var statusCode grpc_codes.Code
+ 		defer func(t time.Time) {
+ 			elapsedTime := time.Since(t) / time.Millisecond
+-			attr = append(attr, semconv.RPCGRPCStatusCodeKey.Int64(int64(statusCode)))
+-			o := metric.WithAttributes(attr...)
++			metricAttrs = append(metricAttrs, semconv.RPCGRPCStatusCodeKey.Int64(int64(statusCode)))
++			o := metric.WithAttributes(metricAttrs...)
+ 			cfg.rpcServerDuration.Record(ctx, int64(elapsedTime), o)
+ 		}(time.Now())
+ 
+@@ -425,7 +425,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+ 
+ 		ctx = extract(ctx, cfg.Propagators)
+ 
+-		name, attr := spanInfo(info.FullMethod, peerFromCtx(ctx))
++		name, attr, _ := telemetryAttributes(info.FullMethod, peerFromCtx(ctx))
+ 		ctx, span := tracer.Start(
+ 			trace.ContextWithRemoteSpanContext(ctx, trace.SpanContextFromContext(ctx)),
+ 			name,
+@@ -448,14 +448,18 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+ 	}
+ }
+ 
+-// spanInfo returns a span name and all appropriate attributes from the gRPC
+-// method and peer address.
+-func spanInfo(fullMethod, peerAddress string) (string, []attribute.KeyValue) {
+-	attrs := []attribute.KeyValue{RPCSystemGRPC}
+-	name, mAttrs := internal.ParseFullMethod(fullMethod)
+-	attrs = append(attrs, mAttrs...)
+-	attrs = append(attrs, peerAttr(peerAddress)...)
+-	return name, attrs
++// telemetryAttributes returns a span name and span and metric attributes from
++// the gRPC method and peer address.
++func telemetryAttributes(fullMethod, peerAddress string) (string, []attribute.KeyValue, []attribute.KeyValue) {
++	name, methodAttrs := internal.ParseFullMethod(fullMethod)
++	peerAttrs := peerAttr(peerAddress)
++
++	attrs := make([]attribute.KeyValue, 0, 1+len(methodAttrs)+len(peerAttrs))
++	attrs = append(attrs, RPCSystemGRPC)
++	attrs = append(attrs, methodAttrs...)
++	metricAttrs := attrs[:1+len(methodAttrs)]
++	attrs = append(attrs, peerAttrs...)
++	return name, attrs, metricAttrs
+ }
+ 
+ // peerAttr returns attributes about the peer address.
+-- 
+2.39.4
+

--- a/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.signatures.json
+++ b/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.signatures.json
@@ -1,6 +1,6 @@
 {
-  "Signatures": {
-    "kube-vip-cloud-provider-0.0.7-vendor.tar.gz": "25cc170d2662416ecaf305873e4a567fa13affcce02f25be6ae055906689a089",
-    "kube-vip-cloud-provider-0.0.7.tar.gz": "2f0ba9c9809fd44e52ffdf064ce1e4596f7c470ba3aa65dc5bfdb574c2bbce52"
-  }
+ "Signatures": {
+  "kube-vip-cloud-provider-0.0.10-vendor.tar.gz": "944c9bcf0f4d1bb3cc04efb0fbae98667572d3892584878224d4dde74e9db64d",
+  "kube-vip-cloud-provider-0.0.10.tar.gz": "eeff169d3b0a450ba17834074470bf429ddc96b5b3bdfaedd83d16189ee138a6"
+ }
 }

--- a/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.spec
+++ b/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.spec
@@ -1,6 +1,6 @@
 Summary:        The Kube-Vip cloud provider functions as a general-purpose cloud provider for on-premises bare-metal or virtualized setups
 Name:           kube-vip-cloud-provider
-Version:        0.0.7
+Version:        0.0.10
 Release:        1%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/kube-vip/kube-vip-cloud-provider
@@ -15,21 +15,22 @@ Source0:        https://github.com/kube-vip/%{name}/archive/refs/tags/v%{version
 # Adding the vendor folder and creating a tarball
 # How to re-build this file:
 # 1. wget https://github.com/kube-vip/%%{name}/archive/refs/tags/v%%{version}tar.gz -O %%{name}-%%{version}.tar.gz
-# 2. tar -xf %%{name}-%%{version}.tar.gz
-# 3. cd %%{name}-%%{version}
-# 4. go mod vendor
-# 5. tar -cf %%{name}-%%{version}-vendor.tar.gz vendor
+# 2. <repo-root>/toolkit/scripts/build_go_vendor_cache.sh %%{name}-%%{version}.tar.gz
 
 Source1: %{name}-%{version}-vendor.tar.gz
 
-BuildRequires: golang
+Patch1:        CVE-2023-47108.patch
+
+BuildRequires: golang >= 1.22
 
 %description
 The Kube-Vip cloud provider functions as a general-purpose cloud provider for on-premises bare-metal or virtualized setups. 
 
 %prep
-%setup -q
-tar -xvf %{SOURCE1}
+%autosetup -N
+# Apply vendor before patching
+tar --no-same-owner -xf %{SOURCE1}
+%autopatch -p1
 
 %build 
 go build -mod=vendor
@@ -42,6 +43,10 @@ install kube-vip-cloud-provider %{buildroot}%{_bindir}/kube-vip-cloud-provider
 %{_bindir}/kube-vip-cloud-provider
 
 %changelog
+* Mon Jul 08 2024 Tobias Brick <tobiasb@microsoft.com> - 0.0.10-1
+- Upgrade to 0.0.10
+- Patch CVE-2023-47108
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.0.7-1
 - Auto-upgrade to 0.0.7 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.spec
+++ b/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.spec
@@ -27,10 +27,7 @@ BuildRequires: golang >= 1.22
 The Kube-Vip cloud provider functions as a general-purpose cloud provider for on-premises bare-metal or virtualized setups. 
 
 %prep
-%autosetup -N
-# Apply vendor before patching
-tar --no-same-owner -xf %{SOURCE1}
-%autopatch -p1
+%autosetup -a 1 -p1
 
 %build 
 go build -mod=vendor

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8311,8 +8311,8 @@
         "type": "other",
         "other": {
           "name": "kube-vip-cloud-provider",
-          "version": "0.0.7",
-          "downloadUrl": "https://github.com/kube-vip/kube-vip-cloud-provider/archive/refs/tags/v0.0.7.tar.gz"
+          "version": "0.0.10",
+          "downloadUrl": "https://github.com/kube-vip/kube-vip-cloud-provider/archive/refs/tags/v0.0.10.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Upgrade `kube-vip-cloud-provider` to `v0.0.10`, which fixes CVE-2023-45142. Also apply patch to fix CVE-2023-47108.

###### Change Log  <!-- REQUIRED -->
- Upgrade `kube-vip-cloud-provider` to `v0.0.10`.
- Re-create vendor tarball.
- Patch CVE-2023-47108

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-45142
- https://nvd.nist.gov/vuln/detail/CVE-2023-47108

###### Test Methodology
- Tested locally
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=602669&view=results
