### PR TITLE
ntopng: add patches for CVE-2017-18214 and CVE-2022-33099

### DIFF
--- a/SPECS/ntopng/CVE-2017-18214.patch
+++ b/SPECS/ntopng/CVE-2017-18214.patch
@@ -1,0 +1,25 @@
+From 6d5e54393d3a0ec0d18a51a6f584f2f497c2ddf4 Mon Sep 17 00:00:00 2001
+From: Andrew Phelps <anphel@microsoft.com>
+Date: Tue, 9 Jul 2024 23:39:38 +0000
+Subject: [PATCH] fix CVE-2017-18214 using
+ https://github.com/moment/moment/commit/69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch
+
+---
+ httpdocs/js/moment.js | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/httpdocs/js/moment.js b/httpdocs/js/moment.js
+index a9947fb69..91fc5e4ae 100644
+--- a/httpdocs/js/moment.js
++++ b/httpdocs/js/moment.js
+@@ -707,7 +707,7 @@ var matchTimestamp = /[+-]?\d+(\.\d{1,3})?/; // 123456789 123456789.123
+ 
+ // any word (or two) characters or numbers including two/three word month in arabic.
+ // includes scottish gaelic two word and hyphenated months
+-var matchWord = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
++var matchWord = /[0-9]{0,256}['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{1,256}|[\u0600-\u06FF\/]{1,256}(\s*?[\u0600-\u06FF]{1,256}){1,2}/i;
+ 
+ 
+ var regexes = {};
+-- 
+2.33.8

--- a/SPECS/ntopng/CVE-2022-33099.patch
+++ b/SPECS/ntopng/CVE-2022-33099.patch
@@ -1,0 +1,58 @@
+From 42d40581dd919fb134c07027ca1ce0844c670daf Mon Sep 17 00:00:00 2001
+From: Roberto Ierusalimschy <roberto@inf.puc-rio.br>
+Date: Fri, 20 May 2022 13:14:33 -0300
+Subject: [PATCH] Save stack space while handling errors
+
+Because error handling (luaG_errormsg) uses slots from EXTRA_STACK,
+and some errors can recur (e.g., string overflow while creating an
+error message in 'luaG_runerror', or a C-stack overflow before calling
+the message handler), the code should use stack slots with parsimony.
+
+This commit fixes the bug "Lua-stack overflow when C stack overflows
+while handling an error".
+---
+ ldebug.c | 5 ++++-
+ lvm.c    | 6 ++++--
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/third-party/lua-5.4.3/src/ldebug.c b/third-party/lua-5.4.3/src/ldebug.c
+index a716d95e2..fa15eaf68 100644
+--- a/third-party/lua-5.4.3/src/ldebug.c
++++ b/third-party/lua-5.4.3/src/ldebug.c
+@@ -824,8 +824,11 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
+   va_start(argp, fmt);
+   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
+   va_end(argp);
+-  if (isLua(ci))  /* if Lua function, add source:line information */
++  if (isLua(ci)) {  /* if Lua function, add source:line information */
+     luaG_addinfo(L, msg, ci_func(ci)->p->source, getcurrentline(ci));
++    setobjs2s(L, L->top - 2, L->top - 1);  /* remove 'msg' from the stack */
++    L->top--;
++  }
+   luaG_errormsg(L);
+ }
+ 
+diff --git a/lvm.c b/lvm.c
+index e8c2e9627..cd992aada 100644
+--- a/third-party/lua-5.4.3/src/lvm.c
++++ b/third-party/lua-5.4.3/src/lvm.c
+@@ -656,8 +656,10 @@ void luaV_concat (lua_State *L, int total) {
+       /* collect total length and number of strings */
+       for (n = 1; n < total && tostring(L, s2v(top - n - 1)); n++) {
+         size_t l = vslen(s2v(top - n - 1));
+-        if (l_unlikely(l >= (MAX_SIZE/sizeof(char)) - tl))
++        if (l_unlikely(l >= (MAX_SIZE/sizeof(char)) - tl)) {
++          L->top = top - total;  /* pop strings to avoid wasting stack */
+           luaG_runerror(L, "string length overflow");
++        }
+         tl += l;
+       }
+       if (tl <= LUAI_MAXSHORTLEN) {  /* is result a short string? */
+@@ -672,7 +674,7 @@ void luaV_concat (lua_State *L, int total) {
+       setsvalue2s(L, top - n, ts);  /* create result */
+     }
+     total -= n-1;  /* got 'n' strings to create 1 new */
+-    L->top -= n-1;  /* popped 'n' strings and pushed one */
++    L->top = top - (n - 1);  /* popped 'n' strings and pushed one */
+   } while (total > 1);  /* repeat until only 1 result left */
+ }

--- a/SPECS/ntopng/ntopng.spec
+++ b/SPECS/ntopng/ntopng.spec
@@ -2,7 +2,7 @@
 Summary:        Web-based Network Traffic Monitoring Application
 Name:           ntopng
 Version:        5.2.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -14,6 +14,8 @@ Source0:        %{name}-%{version}.tar.gz
 Source1:        nDPI-%{nDPIver}.tar.gz
 Patch1:         CVE-2021-45985.patch
 Patch2:         CVE-2022-28805.patch
+Patch3:         CVE-2017-18214.patch
+Patch4:         CVE-2022-33099.patch
 BuildRequires:  curl-devel
 BuildRequires:  gcc
 BuildRequires:  glib-devel
@@ -63,6 +65,9 @@ mv nDPI-%{nDPIver} nDPI
 %{_datadir}/ntopng/*
 
 %changelog
+* Mon Jul 08 2024 Andrew Phelps <anphel@microsoft.com> - 5.2.1-4
+- Add patches for CVE-2017-18214 and CVE-2022-33099
+
 * Wed Jun 05 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 5.2.1-3
 - Patch CVE-2022-28805 on integrated lua source
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add patches to ntopng for bundled software; for CVE-2022-33099 (lua) and CVE-2017-18214 (moment.js)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add CVE patches to `ntopng`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-33099
- https://nvd.nist.gov/vuln/detail/CVE-2017-18214

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=602179&view=results
