### PR TITLE
Patch CVE-2019-0205 for influxdb in 3.0

### DIFF
--- a/SPECS/influxdb/CVE-2019-0205.patch
+++ b/SPECS/influxdb/CVE-2019-0205.patch
@@ -12,16 +12,7 @@ diff --git a/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go b/vendor
 index 45fa202..432a0cf 100644
 --- a/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go
 +++ b/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go
-@@ -88,14 +88,12 @@ func SkipDefaultDepth(prot TProtocol, typeId TType) (err error) {
- 
- // Skips over the next data element from the provided input TProtocol object.
- func Skip(self TProtocol, fieldType TType, maxDepth int) (err error) {
--	
--    if maxDepth <= 0 {
--		return NewTProtocolExceptionWithType( DEPTH_LIMIT, errors.New("Depth limit exceeded"))
-+
-+	if maxDepth <= 0 {
-+		return NewTProtocolExceptionWithType(DEPTH_LIMIT, errors.New("Depth limit exceeded"))
+@@ -94,8 +94,6 @@ func Skip(self TProtocol, fieldType TType, maxDepth int) (err error) {
  	}
  
  	switch fieldType {

--- a/SPECS/influxdb/CVE-2019-0205.patch
+++ b/SPECS/influxdb/CVE-2019-0205.patch
@@ -1,0 +1,35 @@
+From b06a03dac935bd5539a75a2808b91111093dcdf0 Mon Sep 17 00:00:00 2001
+From: Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com>
+Date: Wed, 10 Jul 2024 12:50:39 -0700
+Subject: [PATCH] patched CVE-2019-0205 in vendored go module. Patch taken from
+ https://github.com/apache/thrift/pull/1993
+
+---
+ .../github.com/uber/jaeger-client-go/thrift/protocol.go   | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go b/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go
+index 45fa202..432a0cf 100644
+--- a/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go
++++ b/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go
+@@ -88,14 +88,12 @@ func SkipDefaultDepth(prot TProtocol, typeId TType) (err error) {
+ 
+ // Skips over the next data element from the provided input TProtocol object.
+ func Skip(self TProtocol, fieldType TType, maxDepth int) (err error) {
+-	
+-    if maxDepth <= 0 {
+-		return NewTProtocolExceptionWithType( DEPTH_LIMIT, errors.New("Depth limit exceeded"))
++
++	if maxDepth <= 0 {
++		return NewTProtocolExceptionWithType(DEPTH_LIMIT, errors.New("Depth limit exceeded"))
+ 	}
+ 
+ 	switch fieldType {
+-	case STOP:
+-		return
+ 	case BOOL:
+ 		_, err = self.ReadBool()
+ 		return
+-- 
+2.45.2.windows.1
+

--- a/SPECS/influxdb/influxdb.spec
+++ b/SPECS/influxdb/influxdb.spec
@@ -18,7 +18,7 @@
 Summary:        Scalable datastore for metrics, events, and real-time analytics
 Name:           influxdb
 Version:        2.7.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -56,6 +56,7 @@ Source4:        influxdb.tmpfiles
 Source5:        config.yaml
 Source6:        influxdb-user.conf
 Patch0:         CVE-2021-4238.patch
+Patch1:         CVE-2019-0205.patch
 BuildRequires:  clang
 BuildRequires:  golang
 BuildRequires:  kernel-headers
@@ -145,6 +146,9 @@ go test ./...
 %{_tmpfilesdir}/influxdb.conf
 
 %changelog
+* Wed Jul 10 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.7.3-4
+- Patched CVE-2019-0205
+
 * Wed Jun 19 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 2.7.3-3
 - Address CVE-2021-4238
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR patches CVE-2019-0205 within vendored go module for `influxdb`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- adds patch for CVE-2019-0205

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2019-0205

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=602751&view=results
