### PR TITLE
Update 3.0 kata-containers build invocations to use OS_VERSION=3.0

### DIFF
--- a/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
+++ b/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "mariner-coco-build-uvm.sh": "67cc429b7a63821b7738bfe58d763868db9507580cb4f6bb0da58f6abcf64142",
+    "mariner-coco-build-uvm.sh": "d9780be17493f50936c1e6b6eee789f2843edd5626de9cc8f0a316cc4d70ad5d",
     "kata-containers-cc-3.2.0.azl2.tar.gz": "49265e0ecd21af4ed8f23398d1e46ef9961786cb44f40fe582abff06c1c1a873",
     "kata-containers-cc-3.2.0.azl2-cargo.tar.gz": "ddf919a672200f0fb53d1cb6c66d6b1c401cf26368541c750d9a12e62da605a1"
   }

--- a/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
+++ b/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "mariner-coco-build-uvm.sh": "de191105ab8f6a0ad564c507306f2b543817199846cc17c4cb1ebdcfe28ebeb2",
+    "mariner-coco-build-uvm.sh": "67cc429b7a63821b7738bfe58d763868db9507580cb4f6bb0da58f6abcf64142",
     "kata-containers-cc-3.2.0.azl2.tar.gz": "49265e0ecd21af4ed8f23398d1e46ef9961786cb44f40fe582abff06c1c1a873",
     "kata-containers-cc-3.2.0.azl2-cargo.tar.gz": "ddf919a672200f0fb53d1cb6c66d6b1c401cf26368541c750d9a12e62da605a1"
   }

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -14,7 +14,7 @@
 
 Name:         kata-containers-cc
 Version:      3.2.0.azl2
-Release:      5%{?dist}
+Release:      6%{?dist}
 Summary:      Kata Confidential Containers package developed for Confidential Containers on AKS
 License:      ASL 2.0
 Vendor:       Microsoft Corporation
@@ -293,6 +293,9 @@ fi
 %exclude %{osbuilder}/tools/osbuilder/rootfs-builder/ubuntu
 
 %changelog
+* Fri Jul 19 2024 Cameron Baird <cameronbaird@microsoft.com> 3.2.0.azl2-6
+- Explicitly set OS_VERSION=3.0 for invocations of rootfs builder
+
 * Mon Jul 15 2024 Manuel Huber <mahuber@microsoft.com> - 3.2.0.azl2-5
 - Call make clean with OS distro variable
 

--- a/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh
+++ b/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh
@@ -15,7 +15,7 @@ export AGENT_SOURCE_BIN=${SCRIPT_DIR}/kata-agent
 pushd ${OSBUILDER_DIR}
 sudo make DISTRO=cbl-mariner clean
 rm -rf ${ROOTFS_DIR}
-sudo -E PATH=$PATH AGENT_POLICY=yes CONF_GUEST=yes AGENT_POLICY_FILE=allow-set-policy.rego make -B DISTRO=cbl-mariner rootfs
+sudo -E PATH=$PATH AGENT_POLICY=yes CONF_GUEST=yes AGENT_POLICY_FILE=allow-set-policy.rego make -B DISTRO=cbl-mariner OS_VERSION=3.0 rootfs
 popd
 
 MODULE_ROOTFS_DEST_DIR="${ROOTFS_DIR}/lib/modules"
@@ -43,5 +43,5 @@ sed -i 's/@BINDIR@\/@AGENT_NAME@/\/usr\/bin\/kata-agent/g'  ${ROOTFS_DIR}/usr/li
 # build image
 pushd ${OSBUILDER_DIR}
 mv rootfs-builder/rootfs-cbl-mariner cbl-mariner_rootfs
-sudo -E PATH=$PATH make DISTRO=cbl-mariner MEASURED_ROOTFS=yes DM_VERITY_FORMAT=kernelinit image
+sudo -E PATH=$PATH make DISTRO=cbl-mariner MEASURED_ROOTFS=yes DM_VERITY_FORMAT=kernelinit OS_VERSION=3.0 image
 popd

--- a/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh
+++ b/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh
@@ -43,5 +43,5 @@ sed -i 's/@BINDIR@\/@AGENT_NAME@/\/usr\/bin\/kata-agent/g'  ${ROOTFS_DIR}/usr/li
 # build image
 pushd ${OSBUILDER_DIR}
 mv rootfs-builder/rootfs-cbl-mariner cbl-mariner_rootfs
-sudo -E PATH=$PATH make DISTRO=cbl-mariner MEASURED_ROOTFS=yes DM_VERITY_FORMAT=kernelinit OS_VERSION=3.0 image
+sudo -E PATH=$PATH make DISTRO=cbl-mariner MEASURED_ROOTFS=yes DM_VERITY_FORMAT=kernelinit image
 popd

--- a/SPECS/kata-containers/kata-containers.signatures.json
+++ b/SPECS/kata-containers/kata-containers.signatures.json
@@ -1,7 +1,7 @@
 {
   "Signatures": {
     "50-kata": "fb108c6337b3d3bf80b43ab04f2bf9a3bdecd29075ebd16320aefe8f81c502a7",
-    "mariner-build-uvm.sh": "e64749c8bac0aae54c007db7c8e702cef99d02389d7e088c3c932c3df6378617",
+    "mariner-build-uvm.sh": "0777a17a6fab43ccbf167b18e2170d3db2b5727885843468037a9953cad9df0a",
     "kata-containers-3.2.0.azl2-cargo.tar.gz": "830c90cc6e44f492e6366012f8834ae6fc84bd790edf678c23003368c288b98c",
     "kata-containers-3.2.0.azl2.tar.gz": "ab65f23787347fae11cf07e0a380e925e9f7b6f0f862ef6440a683b816206011"
   }

--- a/SPECS/kata-containers/kata-containers.signatures.json
+++ b/SPECS/kata-containers/kata-containers.signatures.json
@@ -1,7 +1,7 @@
 {
   "Signatures": {
     "50-kata": "fb108c6337b3d3bf80b43ab04f2bf9a3bdecd29075ebd16320aefe8f81c502a7",
-    "mariner-build-uvm.sh": "da67e7bfa7a150d0dd54236bde9494fb37feec1c9b8d5a1f20dbbe3f605c0862",
+    "mariner-build-uvm.sh": "e64749c8bac0aae54c007db7c8e702cef99d02389d7e088c3c932c3df6378617",
     "kata-containers-3.2.0.azl2-cargo.tar.gz": "830c90cc6e44f492e6366012f8834ae6fc84bd790edf678c23003368c288b98c",
     "kata-containers-3.2.0.azl2.tar.gz": "ab65f23787347fae11cf07e0a380e925e9f7b6f0f862ef6440a683b816206011"
   }

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -40,7 +40,7 @@
 Summary:        Kata Containers
 Name:           kata-containers
 Version:        3.2.0.azl2
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 URL:            https://github.com/microsoft/kata-containers
@@ -216,6 +216,9 @@ ln -sf %{_bindir}/kata-runtime %{buildroot}%{_prefix}/local/bin/kata-runtime
 %exclude %{kataosbuilderdir}/rootfs-builder/ubuntu
 
 %changelog
+* Fri Jul 19 2024 Cameron Baird <cameronbaird@microsoft.com> 3.2.0.azl2-4
+- Explicitly set OS_VERSION=3.0 for invocations of rootfs builder
+
 * Mon Jul 15 2024 Manuel Huber <mahuber@microsoft.com> - 3.2.0.azl2-3
 - Call make clean with OS distro variable
 

--- a/SPECS/kata-containers/mariner-build-uvm.sh
+++ b/SPECS/kata-containers/mariner-build-uvm.sh
@@ -20,5 +20,5 @@ cp ${SCRIPT_DIR}/agent/usr/lib/systemd/system/kata-agent.service   ${ROOTFS_DIR}
 
 # build initrd
 pushd ${OSBUILDER_DIR}
-sudo -E PATH=$PATH make DISTRO=cbl-mariner TARGET_ROOTFS=${ROOTFS_DIR} OS_VERSION=3.0 initrd
+sudo -E PATH=$PATH make DISTRO=cbl-mariner TARGET_ROOTFS=${ROOTFS_DIR} initrd
 popd

--- a/SPECS/kata-containers/mariner-build-uvm.sh
+++ b/SPECS/kata-containers/mariner-build-uvm.sh
@@ -11,7 +11,7 @@ export AGENT_SOURCE_BIN=${SCRIPT_DIR}/agent/usr/bin/kata-agent
 pushd ${OSBUILDER_DIR}
 sudo make DISTRO=cbl-mariner clean
 rm -rf ${ROOTFS_DIR}
-sudo -E PATH=$PATH make -B DISTRO=cbl-mariner rootfs
+sudo -E PATH=$PATH make -B DISTRO=cbl-mariner OS_VERSION=3.0 rootfs
 popd
 
 # copy service files
@@ -20,5 +20,5 @@ cp ${SCRIPT_DIR}/agent/usr/lib/systemd/system/kata-agent.service   ${ROOTFS_DIR}
 
 # build initrd
 pushd ${OSBUILDER_DIR}
-sudo -E PATH=$PATH make DISTRO=cbl-mariner TARGET_ROOTFS=${ROOTFS_DIR} initrd
+sudo -E PATH=$PATH make DISTRO=cbl-mariner TARGET_ROOTFS=${ROOTFS_DIR} OS_VERSION=3.0 initrd
 popd


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Use OS_VERSION=3.0 for invocation of the UVM image builder. Needed to fix an issue where UVM builder tried to pull from PMC/azurelinux/2.0, which 404s. The correct path is PMC/azurelinux/3.0.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use OS_VERSION=3.0 for invocation of the UVM image builder

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build https://dev.azure.com/mariner-org/mariner/_build/results?buildId=602692&view=results 
