### PR TITLE
Upgrade cert-manager to 1.12.12 to fix CVE-2023-45142 and CVE-2024-26147

### DIFF
--- a/SPECS/cert-manager/cert-manager.signatures.json
+++ b/SPECS/cert-manager/cert-manager.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "cert-manager-1.11.2-govendor.tar.gz": "19fd0c6c70b04906a0bfccb0e900ab018cae2f677519523e927b39a724540b75",
-  "cert-manager-1.11.2.tar.gz": "43755f8b58824de92a3f0b48820068c63599c7a75f1e6a0d994fc0e0a04f808b"
+  "cert-manager-1.12.12-vendor.tar.gz": "eb2c70859fb2b73880f682e0c69eaeeec523481f94386b7d0150440799d7eecc",
+  "cert-manager-1.12.12.tar.gz": "2bdcc466ed77457616ea8732d002c4985524998da2c3dcc579d6e8f2af708484"
  }
 }

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -63,7 +63,6 @@ Webhook component providing API validation, mutation and conversion functionalit
 %build
 
 LOCAL_BIN_DIR=$(realpath bin)
-# LOCAL_MOD_DIR=$(realpath vendor)
 go -C cmd/acmesolver build -mod=vendor -o "${LOCAL_BIN_DIR}"/acmesolver main.go
 go -C cmd/controller build -mod=vendor -o "${LOCAL_BIN_DIR}"/controller main.go
 go -C cmd/cainjector build -mod=vendor -o "${LOCAL_BIN_DIR}"/cainjector main.go

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -1,7 +1,7 @@
 Summary:        Automatically provision and manage TLS certificates in Kubernetes
 Name:           cert-manager
-Version:        1.11.2
-Release:        8%{?dist}
+Version:        1.12.12
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -9,16 +9,10 @@ URL:            https://github.com/jetstack/cert-manager
 Source0:        https://github.com/jetstack/%{name}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated GO dependencies from this tarball, since network is disabled during build time.
-#   1. wget https://github.com/jetstack/%%{name}/archive/refs/tags/v%%{version}.tar.gz -o %%{name}-%%{version}.tar.gz
-#   2. tar -xf %%{name}-%%{version}.tar.gz
-#   3. cd %%{name}-%%{version}
-#   4. go mod vendor
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
-#           --owner=0 --group=0 --numeric-owner \
-#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %%{name}-%%{version}-govendor.tar.gz vendor
-Source1:        %{name}-%{version}-govendor.tar.gz
+# How to re-build this file:
+# 1. wget https://github.com/jetstack/%%{name}/archive/refs/tags/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
+# 2. <repo-root>/SPECS/cert-manager/generate_source_tarball.sh --srcTarball %%{name}-%%{version}.tar.gz --pkgVersion %%{version}
+Source1:        %{name}-%{version}-vendor.tar.gz
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
 Requires:       %{name}-cainjector
@@ -67,11 +61,14 @@ Webhook component providing API validation, mutation and conversion functionalit
 %setup -q -T -D -a 1
 
 %build
-go build -o bin/acmesolver cmd/acmesolver/main.go
-go build -o bin/cainjector cmd/cainjector/main.go
-go build -o bin/controller cmd/controller/main.go
-go build -o bin/cmctl cmd/ctl/main.go
-go build -o bin/webhook cmd/webhook/main.go
+
+LOCAL_BIN_DIR=$(realpath bin)
+# LOCAL_MOD_DIR=$(realpath vendor)
+go -C cmd/acmesolver build -mod=vendor -o "${LOCAL_BIN_DIR}"/acmesolver main.go
+go -C cmd/controller build -mod=vendor -o "${LOCAL_BIN_DIR}"/controller main.go
+go -C cmd/cainjector build -mod=vendor -o "${LOCAL_BIN_DIR}"/cainjector main.go
+go -C cmd/ctl build -mod=vendor -o "${LOCAL_BIN_DIR}"/cmctl main.go
+go -C cmd/webhook build -mod=vendor -o "${LOCAL_BIN_DIR}"/webhook main.go
 
 %install
 mkdir -p %{buildroot}%{_bindir}
@@ -109,6 +106,9 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %{_bindir}/webhook
 
 %changelog
+* Wed Jul 10 2024 Tobias Brick <tobiasb@microsoft.com> - 1.12.12-1
+- Upgrade to 1.12.12 to fix CVE-2024-26147 and CVE-2023-45142
+
 * Wed May 29 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 1.11.2-8
 - Bump release to build with new helm to fix CVE-2024-25620
 

--- a/SPECS/cert-manager/generate_source_tarball.sh
+++ b/SPECS/cert-manager/generate_source_tarball.sh
@@ -90,9 +90,7 @@ tar -xf "${SRC_TARBALL}"
 cd "cert-manager-${PKG_VERSION}"
 
 # We need to individually vendor each cmd we will build
-cmd_directories=("cmd/acmesolver" "cmd/cainjector" "cmd/controller" "cmd/ctl" "cmd/webhook")
 vendor_directories=()
-
 
 echo "Get vendored modules for each command"
 for dir in cmd/*; do

--- a/SPECS/cert-manager/generate_source_tarball.sh
+++ b/SPECS/cert-manager/generate_source_tarball.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Quit on failure
+set -e
+
+PKG_VERSION=""
+SRC_TARBALL=""
+OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# parameters:
+#
+# --srcTarball  : src tarball file
+#                 this file contains the 'initial' source code of the component
+#                 and should be replaced with the new/modified src code
+# --outFolder   : folder where to copy the new tarball(s)
+# --pkgVersion  : package version
+#
+PARAMS=""
+while (( "$#" )); do
+    case "$1" in
+        --srcTarball)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            SRC_TARBALL=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --outFolder)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            OUT_FOLDER=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --pkgVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            PKG_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        -*|--*=) # unsupported flags
+        echo "Error: Unsupported flag $1" >&2
+        exit 1
+        ;;
+        *) # preserve positional arguments
+        PARAMS="${PARAMS} $1"
+        shift
+        ;;
+  esac
+done
+
+echo "--srcTarball   -> ${SRC_TARBALL}"
+echo "--outFolder    -> ${OUT_FOLDER}"
+echo "--pkgVersion   -> ${PKG_VERSION}"
+
+if [ -z "${SRC_TARBALL}" ]; then
+    echo "--srcTarball parameter cannot be empty"
+    exit 1
+fi
+
+SRC_TARBALL=$(realpath "${SRC_TARBALL}")
+
+if [ -z "${PKG_VERSION}" ]; then
+    echo "--pkgVersion parameter cannot be empty"
+    exit 1
+fi
+
+echo "-- create temp folder"
+tmpdir=$(mktemp -d)
+function cleanup {
+    echo "+++ cleanup -> remove ${tmpdir}"
+    rm -rf ${tmpdir}
+}
+trap cleanup EXIT
+
+pushd "${tmpdir}" > /dev/null
+
+echo "Unpacking source tarball..."
+tar -xf "${SRC_TARBALL}"
+
+cd "cert-manager-${PKG_VERSION}"
+
+# We need to individually vendor each cmd we will build
+cmd_directories=("cmd/acmesolver" "cmd/cainjector" "cmd/controller" "cmd/ctl" "cmd/webhook")
+vendor_directories=()
+
+
+echo "Get vendored modules for each command"
+for dir in cmd/*; do
+    if [ -d "${dir}" ]; then
+        echo "Vendoring '${dir}'"
+        pushd "${dir}" > /dev/null
+        go mod vendor
+        vendor_directories+=("${dir}/vendor")
+        popd > /dev/null
+    fi
+done
+
+echo "Tar vendored modules"
+VENDOR_TARBALL="${OUT_FOLDER}/cert-manager-${PKG_VERSION}-vendor.tar.gz"
+tar  --sort=name \
+     --mtime="2021-04-26 00:00Z" \
+     --owner=0 --group=0 --numeric-owner \
+     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+     -cf "${VENDOR_TARBALL}" ${vendor_directories[@]}
+
+popd > /dev/null
+echo "cert-manager vendored modules are available at ${VENDOR_TARBALL}"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1547,8 +1547,8 @@
         "type": "other",
         "other": {
           "name": "cert-manager",
-          "version": "1.11.2",
-          "downloadUrl": "https://github.com/jetstack/cert-manager/archive/refs/tags/v1.11.2.tar.gz"
+          "version": "1.12.12",
+          "downloadUrl": "https://github.com/jetstack/cert-manager/archive/refs/tags/v1.12.12.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Upgrade `cert-manager` to `1.12.12`, which fixes CVE-2023-45142 and CVE-2024-26147. There are more recent version, but `1.13.0` has some notes about breaking changes and it feels too close to GA to take that risk.

###### Change Log  <!-- REQUIRED -->
- Upgrade to `1.12.12`.
- Change how we vendor and build the code -- they did a refactor that means we need to build slightly differently.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-45142
- https://nvd.nist.gov/vuln/detail/CVE-2024-26147

###### Test Methodology
- Local Build
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=602798&view=results
