### PR TITLE
Image Customizer: Fix network in verity example.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/files/89-ethernet.network
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/files/89-ethernet.network
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT-0
+#
+# This example config file is installed as part of systemd.
+# It may be freely copied and edited (following the MIT No Attribution license).
+#
+# To use the file, one of the following methods may be used:
+# 1. add a symlink from /etc/systemd/network to the current location of this file,
+# 2. copy the file into /etc/systemd/network or one of the other paths checked
+#    by systemd-networkd and edit it there.
+# This file should not be edited in place, because it'll be overwritten on upgrades.
+
+# Enable DHCPv4 and DHCPv6 on all physical ethernet links
+[Match]
+Kind=!*
+Type=ether
+
+[Network]
+DHCP=yes

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -76,6 +76,8 @@ os:
   additionalFiles:
     # Change the directory that the sshd-keygen service writes the SSH host keys to.
     files/sshd-keygen.service: /usr/lib/systemd/system/sshd-keygen.service
+    # Enable DHCP client on all of the physical NICs.
+    files/89-ethernet.network: /etc/systemd/network/89-ethernet.network
 
   services:
     enable:
@@ -92,3 +94,12 @@ scripts:
   postCustomization:
     # Move the SSH host keys off of the read-only /etc directory, so that sshd can run.
   - path: scripts/ssh-move-host-keys.sh
+
+  finalizeCustomization:
+  - content: |
+      set -eux
+
+      # Configure the /etc/resolv.conf file to use systemd-resolved.
+      # Typically, this file is created during first-boot. But this cannot happen when the filesystem is read-only.
+      ln -srT ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+    name: Fix resolv.conf file


### PR DESCRIPTION
Firstly, create the `/etc/resolv.conf` symlink since it cannot be created during first-boot since the filesystem is read-only.

Secondly, add a network config that enables the DHCP client on all physical NICs. This is particularly important for Azure Linux 3.0 which removed the default network settings.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.
