### PR TITLE
Cherry-Pick kernel-uki and systemd-boot fix to 3.0

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        6.6.35.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -145,6 +145,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 6.6.35.1-5
+- Bump release to match kernel-uki
+
 * Fri Jul 05 2024 Gary Swalling <gaswal@microsoft.com> - 6.6.35.1-4
 - Bump release to match kernel
 

--- a/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
+++ b/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed Unified Kernel Image for %{buildarch} systems
 Name:           kernel-uki-signed-%{buildarch}
 Version:        6.6.35.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -65,6 +65,9 @@ popd
 /lib/modules/%{kernelver}/vmlinuz-uki.efi
 
 %changelog
+* Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 6.6.35.1-5
+- Bump release to match kernel
+
 * Fri Jul 05 2024 Gary Swalling <gaswal@microsoft.com> - 6.6.35.1-4
 - Bump release to match kernel
 

--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -14,7 +14,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -86,6 +86,9 @@ popd
 /usr/share/man/man7/systemd-boot.7.gz
 
 %changelog
+* Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 255-16
+- Bump release to match systemd spec
+
 * Tue Jun 25 2024 Thien Trung Vuong <tvuong@microsoft.com> - 255-15
 - Original version for Azure Linux.
 - License verified.

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.6.35.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +75,9 @@ done
 %endif
 
 %changelog
+* Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 6.6.35.1-5
+- Bump release to match kernel-uki
+
 * Fri Jul 05 2024 Gary Swalling <gaswal@microsoft.com> - 6.6.35.1-4
 - Bump release to match kernel
 

--- a/SPECS/kernel/kernel-uki.spec
+++ b/SPECS/kernel/kernel-uki.spec
@@ -18,7 +18,7 @@
 Summary:        Unified Kernel Image
 Name:           kernel-uki
 Version:        6.6.35.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -37,6 +37,7 @@ BuildRequires:  tpm2-tools
 BuildRequires:  cryptsetup
 BuildRequires:  device-mapper
 BuildRequires:  kbd
+ExclusiveArch:  x86_64
 
 %description
 The kernel-uki package contains the Linux kernel packaged as a Unified
@@ -69,6 +70,9 @@ ln -s /boot/vmlinuz-uki-%{kernelver}.efi %{buildroot}/lib/modules/%{kernelver}/v
 /lib/modules/%{kernelver}/vmlinuz-uki.efi
 
 %changelog
+* Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 6.6.35.1-5
+- Add tag to build exclusively on x86_64
+
 * Fri Jul 05 2024 Gary Swalling <gaswal@microsoft.com> - 6.6.35.1-4
 - Bump release to match kernel
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -30,7 +30,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.35.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -407,6 +407,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 6.6.35.1-5
+- Bump release to match kernel-uki
+
 * Fri Jul 05 2024 Gary Swalling <gaswal@microsoft.com> - 6.6.35.1-4
 - Enable SECONDARY_TRUSTED_KEYRING
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        15%{?dist}
+Release:        16%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -136,7 +136,7 @@ Patch0491:      azurelinux-use-system-auth-in-pam-systemd-user.patch
 Patch0900:      do-not-test-openssl-sm3.patch
 Patch0901:      networkd-default-use-domains.patch
 
-%ifarch %{ix86} x86_64 aarch64
+%ifarch %{ix86} x86_64
 %global want_bootloader 1
 %endif
 
@@ -1202,6 +1202,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 255-16
+- Update tag to build systemd-boot exclusively on x86_64
+
 * Tue Jun 25 2024 Thien Trung Vuong <tvuong@microsoft.com> - 255-15
 - Rename systemd-boot-unsigned to systemd-boot
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
-kernel-headers-6.6.35.1-4.azl3.noarch.rpm
+kernel-headers-6.6.35.1-5.azl3.noarch.rpm
 glibc-2.38-6.azl3.aarch64.rpm
 glibc-devel-2.38-6.azl3.aarch64.rpm
 glibc-i18n-2.38-6.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
-kernel-headers-6.6.35.1-4.azl3.noarch.rpm
+kernel-headers-6.6.35.1-5.azl3.noarch.rpm
 glibc-2.38-6.azl3.x86_64.rpm
 glibc-devel-2.38-6.azl3.x86_64.rpm
 glibc-i18n-2.38-6.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -152,7 +152,7 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.aarch64.rpm
 kbd-debuginfo-2.2.0-2.azl3.aarch64.rpm
-kernel-headers-6.6.35.1-4.azl3.noarch.rpm
+kernel-headers-6.6.35.1-5.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -157,8 +157,8 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.x86_64.rpm
 kbd-debuginfo-2.2.0-2.azl3.x86_64.rpm
-kernel-cross-headers-6.6.35.1-4.azl3.noarch.rpm
-kernel-headers-6.6.35.1-4.azl3.noarch.rpm
+kernel-cross-headers-6.6.35.1-5.azl3.noarch.rpm
+kernel-headers-6.6.35.1-5.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
A build break was stopping ARM64 to build for preview, this change fixes the issue by restricting package architecture.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- cherry pick https://github.com/microsoft/azurelinux/commit/ded92cfc965d519f0844c9d8a6c240e943b0ee09

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**
