### PR TITLE
Upgrade python-nocasedict to fix ptests

### DIFF
--- a/SPECS/python-nocasedict/python-nocasedict.signatures.json
+++ b/SPECS/python-nocasedict/python-nocasedict.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "nocasedict-2.0.1.tar.gz": "d2052d842ea59878cc6196faaac89cad7308d3a4cc21ec7318db9946397b13a6"
+    "nocasedict-2.0.3.tar.gz": "8b8585f9aac8f2b6a4955ecb581c410a16576b0bed3364e71e4bf1a0c13a55af"
   }
 }

--- a/SPECS/python-nocasedict/python-nocasedict.spec
+++ b/SPECS/python-nocasedict/python-nocasedict.spec
@@ -45,7 +45,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} tox -e py%{python3_version_nodots}
 
 %files -n python3-%{pkgname}
 %license LICENSE
-%doc README.rst
+%doc README.md
 %{python3_sitelib}/%{pkgname}
 %{python3_sitelib}/*.egg-info
 

--- a/SPECS/python-nocasedict/python-nocasedict.spec
+++ b/SPECS/python-nocasedict/python-nocasedict.spec
@@ -50,6 +50,9 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} tox -e py%{python3_version_nodots}
 %{python3_sitelib}/*.egg-info
 
 %changelog
+* Thu Jul 11 2024 Sam Meluch <sammeluch@microsoft.com> - 2.0.3-1
+- Upgrade to 2.0.3
+
 * Fri Nov 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.0.1-1
 - Auto-upgrade to 2.0.1 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/python-nocasedict/python-nocasedict.spec
+++ b/SPECS/python-nocasedict/python-nocasedict.spec
@@ -2,7 +2,7 @@
 %define six_version 1.14.0
 Summary:        Case-insensitive ordered dictionary library for Python
 Name:           python-%{pkgname}
-Version:        2.0.1
+Version:        2.0.3
 Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -23193,8 +23193,8 @@
         "type": "other",
         "other": {
           "name": "python-nocasedict",
-          "version": "2.0.1",
-          "downloadUrl": "https://github.com/pywbem/nocasedict/archive/refs/tags/2.0.1.tar.gz"
+          "version": "2.0.3",
+          "downloadUrl": "https://github.com/pywbem/nocasedict/archive/refs/tags/2.0.3.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
the ptests are failing for python-nocasedict due to incompatibilities with python versions. The minor version upgrade fixes these.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade python-nocasedict to version 2.0.3

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=603515&view=results
