### PR TITLE
add patch to fix python 3.11 compat for ptest in python-iniparse

### DIFF
--- a/SPECS/python-iniparse/python-3.11-test-compat.patch
+++ b/SPECS/python-iniparse/python-3.11-test-compat.patch
@@ -1,0 +1,93 @@
+From d9a083bafaa2df338a3176ee9f1433718b3a1090 Mon Sep 17 00:00:00 2001
+From: Jiri Hnidek <jhnidek@redhat.com>
+Date: Wed, 11 May 2022 14:29:27 +0200
+Subject: [PATCH] Fix compatibility issues with Python 3.11
+
+* Fixes: https://github.com/candlepin/python-iniparse/issues/23
+* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2019017
+* Replaced few deprecated methods with new methods
+---
+ tests/test_compat.py | 20 ++++++++++----------
+ tests/test_fuzz.py   |  2 +-
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/tests/test_compat.py b/tests/test_compat.py
+index ad36683..c8e6aca 100644
+--- a/tests/test_compat.py
++++ b/tests/test_compat.py
+@@ -96,16 +96,16 @@ def test_basic(self):
+         eq(cf.get('Spaces', 'key with spaces'), 'value')
+         eq(cf.get('Spaces', 'another with spaces'), 'splat!')
+ 
+-        self.failIf('__name__' in cf.options("Foo Bar"),
++        self.assertFalse('__name__' in cf.options("Foo Bar"),
+                     '__name__ "option" should not be exposed by the API!')
+ 
+         # Make sure the right things happen for remove_option();
+         # added to include check for SourceForge bug #123324:
+-        self.failUnless(cf.remove_option('Foo Bar', 'foo'),
++        self.assertTrue(cf.remove_option('Foo Bar', 'foo'),
+                         "remove_option() failed to report existance of option")
+-        self.failIf(cf.has_option('Foo Bar', 'foo'),
++        self.assertFalse(cf.has_option('Foo Bar', 'foo'),
+                     "remove_option() failed to remove option")
+-        self.failIf(cf.remove_option('Foo Bar', 'foo'),
++        self.assertFalse(cf.remove_option('Foo Bar', 'foo'),
+                     "remove_option() failed to report non-existance of option"
+                     " that was removed")
+ 
+@@ -127,10 +127,10 @@ def test_case_sensitivity(self):
+         eq(cf.options("a"), ["b"])
+         eq(cf.get("a", "b"), "value",
+            "could not locate option, expecting case-insensitive option names")
+-        self.failUnless(cf.has_option("a", "b"))
++        self.assertTrue(cf.has_option("a", "b"))
+         cf.set("A", "A-B", "A-B value")
+         for opt in ("a-b", "A-b", "a-B", "A-B"):
+-            self.failUnless(
++            self.assertTrue(
+                 cf.has_option("A", opt),
+                 "has_option() returned false for option which should exist")
+         eq(cf.options("A"), ["a-b"])
+@@ -147,7 +147,7 @@ def test_case_sensitivity(self):
+         # SF bug #561822:
+         cf = self.fromstring("[section]\nnekey=nevalue\n",
+                              defaults={"key":"value"})
+-        self.failUnless(cf.has_option("section", "Key"))
++        self.assertTrue(cf.has_option("section", "Key"))
+ 
+     def test_default_case_sensitivity(self):
+         cf = self.newconfig({"foo": "Bar"})
+@@ -182,7 +182,7 @@ def test_query_errors(self):
+         cf = self.newconfig()
+         self.assertEqual(cf.sections(), [],
+                          "new ConfigParser should have no defined sections")
+-        self.failIf(cf.has_section("Foo"),
++        self.assertFalse(cf.has_section("Foo"),
+                     "new ConfigParser should have no acknowledged sections")
+         self.assertRaises(ConfigParser.NoSectionError,
+                           cf.options, "Foo")
+@@ -221,8 +221,8 @@ def test_boolean(self):
+             "E5=FALSE AND MORE"
+             )
+         for x in range(1, 5):
+-            self.failUnless(cf.getboolean('BOOLTEST', 't%d' % x))
+-            self.failIf(cf.getboolean('BOOLTEST', 'f%d' % x))
++            self.assertTrue(cf.getboolean('BOOLTEST', 't%d' % x))
++            self.assertFalse(cf.getboolean('BOOLTEST', 'f%d' % x))
+             self.assertRaises(ValueError,
+                               cf.getboolean, 'BOOLTEST', 'e%d' % x)
+ 
+diff --git a/tests/test_fuzz.py b/tests/test_fuzz.py
+index df568bb..874ef2e 100644
+--- a/tests/test_fuzz.py
++++ b/tests/test_fuzz.py
+@@ -102,7 +102,7 @@ def test_fuzz(self):
+                 cc = compat.RawConfigParser()
+                 cc.readfp(StringIO(s))
+                 cc_py = configparser.RawConfigParser()
+-                cc_py.readfp(StringIO(s))
++                cc_py.read_file(StringIO(s))
+                 # compare the two configparsers
+                 self.assertEqualConfig(cc_py, cc)
+                 # check that tidy does not change semantics

--- a/SPECS/python-iniparse/python-iniparse.spec
+++ b/SPECS/python-iniparse/python-iniparse.spec
@@ -1,13 +1,15 @@
 Summary:        Python Module for Accessing and Modifying Configuration Data in INI files
 Name:           python-iniparse
 Version:        0.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT OR Python
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Development/Libraries
 URL:            https://github.com/candlepin/python-iniparse
 Source0:        https://files.pythonhosted.org/packages/4c/9a/02beaf11fc9ea7829d3a9041536934cd03990e09c359724f99ee6bd2b41b/iniparse-%{version}.tar.gz 
+Patch0:         python-3.11-test-compat.patch
+
 BuildArch:      noarch
 
 %description
@@ -51,6 +53,9 @@ mv %{buildroot}%{_docdir}/iniparse-%{version} %{buildroot}%{_docdir}/%{name}-%{v
 %{python3_sitelib}/*
 
 %changelog
+* Thu Jul 11 2024 Sam Meluch <sammeluch@microsoft.com> - 0.5-2
+- add patch for ptests for python 3.11+ compat
+
 * Thu Mar 03 2022 Nick Samson <nisamson@microsoft.com> - 0.5-1
 - Updated to 0.5
 - Removed unnecessary compatibility patch


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Package tests for python-iniparse are failing. This is due to python 3.11 compatibility issues. Adding a patch from upstream to fix this.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add upstream patch to fix the package tests

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=603515&view=results
