### PR TITLE
cloud-hypervisor-cvm: update to 38.0.72.2 (#9609)

### DIFF
--- a/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.signatures.json
+++ b/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.signatures.json
@@ -1,7 +1,7 @@
 {
-    "Signatures": {
-        "cloud-hypervisor-cvm-38.0.72-vendor.tar.gz": "6092868ed042c0397e4e96f2572a59d80491662b6c68fd210fe458a8f7d0d429",
-        "cloud-hypervisor-cvm-38.0.72.tar.gz": "e6d15d99c5d9ec4bede43ef8fac971d2cc0ae49a7eafffc6ca7e5b948ed4282a",
-        "config.toml": "74c28b7520c157109b8990b325fe8f13504e56561a9bac51499d4c6bf4a66e52"
-    }
+ "Signatures": {
+  "cloud-hypervisor-cvm-38.0.72.2-cargo.tar.gz": "12190a4f2fbd29b2c6c197388a958eab5dff91e8d75927841669d81d794eadf4",
+  "cloud-hypervisor-cvm-38.0.72.2.tar.gz": "1a357a0805f7b6d90993d5ae246c2dedff88cf98c9c0eab0903dc8071be0dae2",
+  "config.toml": "74c28b7520c157109b8990b325fe8f13504e56561a9bac51499d4c6bf4a66e52"
+ }
 }

--- a/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.spec
+++ b/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.spec
@@ -4,8 +4,8 @@
 
 Name:           cloud-hypervisor-cvm
 Summary:        Cloud Hypervisor CVM is an open source Virtual Machine Monitor (VMM) that enables running SEV SNP enabled VMs on top of MSHV using the IGVM file format as payload.
-Version:        38.0.72
-Release:        2%{?dist}
+Version:        38.0.72.2
+Release:        1%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -20,7 +20,7 @@ Source0:        https://github.com/microsoft/cloud-hypervisor/archive/refs/tags/
 #   cargo vendor > config.toml
 #   tar -czf %{name}-%{version}-cargo.tar.gz vendor/
 # rename the tarball to %{name}-%{version}-cargo.tar.gz when updating version
-Source1:        %{name}-%{version}-vendor.tar.gz
+Source1:        %{name}-%{version}-cargo.tar.gz
 Source2:        config.toml
 %endif
 
@@ -69,7 +69,7 @@ Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on to
 
 %prep
 
-%setup -q -n cloud-hypervisor-%{version}
+%setup -q -n cloud-hypervisor-msft-v%{version}
 %if 0%{?using_vendored_crates}
 tar xf %{SOURCE1}
 mkdir -p .cargo
@@ -136,6 +136,10 @@ cargo build --release --target=%{rust_musl_target} %{cargo_pkg_feature_opts} %{c
 %license LICENSE-BSD-3-Clause
 
 %changelog
+* Fri Jul 12 2024 Archana Choudhary <archana1@microsoft.com> - 38.0.72.2-1
+- Upgrade to v38.0.72.2
+- Fixes CVE-2023-45853, CVE-2018-25032, CVE-2023-5363, CVE-2023-5678, CVE-2023-6129, CVE-2023-6237, CVE-2024-0727, CVE-2024-4603
+
 * Tue Jun 25 2024 Chris Co <chrco@microsoft.com> - 38.0.72-2
 - Remove conflicts with cloud-hypervisor
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1767,8 +1767,8 @@
         "type": "other",
         "other": {
           "name": "cloud-hypervisor-cvm",
-          "version": "38.0.72",
-          "downloadUrl": "https://github.com/microsoft/cloud-hypervisor/archive/refs/tags/msft/v38.0.72.tar.gz"
+          "version": "38.0.72.2",
+          "downloadUrl": "https://github.com/microsoft/cloud-hypervisor/archive/refs/tags/msft/v38.0.72.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
This is a pull request to cherry-pick commit https://github.com/microsoft/azurelinux/commit/96142f62a7c084ab76f70b75d40b19773bc0a2cc to 3.0-dev. Original PR: https://github.com/microsoft/azurelinux/pull/9609

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=603777&view=results