### PR TITLE
Ptest Fix for Package python-jsonschema

### DIFF
--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -21,6 +21,9 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-vcversioner
 BuildRequires:  python3-xml
 BuildRequires:  python3-wheel
+%if 0%{?with_check}
+BuildRequires:  python3-pip
+%endif
 Requires:       python3
 
 %description -n python3-jsonschema

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -20,9 +20,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-vcversioner
 BuildRequires:  python3-xml
-%if 0%{?with_check}
 BuildRequires:  python3-wheel
-%endif
 Requires:       python3
 
 %description -n python3-jsonschema
@@ -40,7 +38,8 @@ http://tools.ietf.org/html/draft-zyp-json-schema-03
 ln -s jsonschema %{buildroot}%{_bindir}/jsonschema3
 
 %check
-%python3 setup.py test
+pip install tox<4.0.0
+LANG=en_US.UTF-8 tox -v -e py%{python3_version_nodots}
 
 %files -n python3-jsonschema
 %defattr(-,root,root)

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -1,7 +1,7 @@
 Summary:        An implementation of JSON Schema validation for Python
 Name:           python-jsonschema
 Version:        2.6.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -37,7 +37,7 @@ http://tools.ietf.org/html/draft-zyp-json-schema-03
 ln -s jsonschema %{buildroot}%{_bindir}/jsonschema3
 
 %check
-%python3 setup test
+%python3 setup.py test
 
 %files -n python3-jsonschema
 %defattr(-,root,root)
@@ -47,6 +47,9 @@ ln -s jsonschema %{buildroot}%{_bindir}/jsonschema3
 %{_bindir}/jsonschema3
 
 %changelog
+* Thu Jul 11 2024 Sam Meluch <sammeluch@microsoft.com> - 2.6.0-7
+- directly call setup.py during ptest to fix test
+
 * Wed Oct 20 2021 Thomas Crain <thcrain@microsoft.com> - 2.6.0-6
 - Remove python2 package
 - Lint spec

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -8,6 +8,7 @@ Distribution:   Azure Linux
 Group:          Development/Languages/Python
 URL:            https://pypi.python.org/pypi/jsonschema
 Source0:        https://pypi.python.org/packages/source/j/jsonschema/jsonschema-%{version}.tar.gz
+Patch0:         tox-test.patch
 BuildArch:      noarch
 
 %description
@@ -23,6 +24,7 @@ BuildRequires:  python3-xml
 BuildRequires:  python3-wheel
 %if 0%{?with_check}
 BuildRequires:  python3-pip
+BuildRequires:  python3-virtualenv
 %endif
 Requires:       python3
 
@@ -31,7 +33,7 @@ jsonschema is JSON Schema validator currently based on
 http://tools.ietf.org/html/draft-zyp-json-schema-03
 
 %prep
-%autosetup -n jsonschema-%{version}
+%autosetup -p1 -n jsonschema-%{version}
 
 %build
 %py3_build
@@ -53,7 +55,7 @@ LANG=en_US.UTF-8 tox -v -e py%{python3_version_nodots}
 
 %changelog
 * Thu Jul 11 2024 Sam Meluch <sammeluch@microsoft.com> - 2.6.0-7
-- directly call setup.py during ptest to fix test
+- switch to tox test per README, massage test config to work with python3.12
 
 * Wed Oct 20 2021 Thomas Crain <thcrain@microsoft.com> - 2.6.0-6
 - Remove python2 package

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -38,7 +38,7 @@ http://tools.ietf.org/html/draft-zyp-json-schema-03
 ln -s jsonschema %{buildroot}%{_bindir}/jsonschema3
 
 %check
-pip install tox<4.0.0
+pip3 install 'tox<4.0.0'
 LANG=en_US.UTF-8 tox -v -e py%{python3_version_nodots}
 
 %files -n python3-jsonschema

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -42,7 +42,7 @@ http://tools.ietf.org/html/draft-zyp-json-schema-03
 ln -s jsonschema %{buildroot}%{_bindir}/jsonschema3
 
 %check
-pip3 install 'tox<4.0.0' 'webcolors<24.6.0'
+pip3 install 'tox<4.0.0'
 LANG=en_US.UTF-8 tox -v -e py%{python3_version_nodots}
 
 %files -n python3-jsonschema

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -42,7 +42,7 @@ http://tools.ietf.org/html/draft-zyp-json-schema-03
 ln -s jsonschema %{buildroot}%{_bindir}/jsonschema3
 
 %check
-pip3 install 'tox<4.0.0'
+pip3 install 'tox<4.0.0' 'webcolors<24.6.0'
 LANG=en_US.UTF-8 tox -v -e py%{python3_version_nodots}
 
 %files -n python3-jsonschema

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -20,6 +20,9 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-vcversioner
 BuildRequires:  python3-xml
+%if 0%{?with_check}
+BuildRequires:  python3-wheel
+%endif
 Requires:       python3
 
 %description -n python3-jsonschema

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -24,7 +24,6 @@ BuildRequires:  python3-xml
 BuildRequires:  python3-wheel
 %if 0%{?with_check}
 BuildRequires:  python3-pip
-BuildRequires:  python3-virtualenv
 %endif
 Requires:       python3
 

--- a/SPECS/python-jsonschema/tox-test.patch
+++ b/SPECS/python-jsonschema/tox-test.patch
@@ -1,12 +1,13 @@
-From c473a1b1be5fce8710b9ac188fb879dd5a6b15b4 Mon Sep 17 00:00:00 2001
+From f7598efbd043c3e744fafe7a946068c3c74fa0df Mon Sep 17 00:00:00 2001
 From: Sam Meluch <sammeluch@microsoft.com>
 Date: Fri, 12 Jul 2024 15:29:29 -0700
-Subject: [PATCH] remove py27, add py312 for tests, update webcolors import
+Subject: [PATCH] remove py27, add py212 for tests, update webcolors import,
+ require lower webcolors version
 
 ---
  jsonschema/_format.py |  4 ++--
- tox.ini               | 18 +++++++++---------
- 2 files changed, 11 insertions(+), 11 deletions(-)
+ tox.ini               | 19 ++++++++++---------
+ 2 files changed, 12 insertions(+), 11 deletions(-)
 
 diff --git a/jsonschema/_format.py b/jsonschema/_format.py
 index caae127..32738a7 100644
@@ -29,7 +30,7 @@ index caae127..32738a7 100644
          return is_css_color_code(instance)
  
 diff --git a/tox.ini b/tox.ini
-index b8d5d90..1c5c1ac 100644
+index b8d5d90..ed0400f 100644
 --- a/tox.ini
 +++ b/tox.ini
 @@ -1,22 +1,22 @@
@@ -60,7 +61,7 @@ index b8d5d90..1c5c1ac 100644
      {envtmpdir}/venv/bin/pip install --quiet wheel
  
      {envtmpdir}/venv/bin/python {toxinidir}/setup.py --quiet bdist_wheel --dist-dir={envtmpdir}/wheel
-@@ -28,13 +28,13 @@ commands =
+@@ -28,13 +28,14 @@ commands =
  deps =
      -e{toxinidir}[format]
  
@@ -75,6 +76,7 @@ index b8d5d90..1c5c1ac 100644
 -    py{27,35,py}: sphinx
 +    py{35,312}: lxml
 +    py{35,312,py}: sphinx
++	py{35,312,py}: webcolors<24.6.0
  
  
  [testenv:coverage]

--- a/SPECS/python-jsonschema/tox-test.patch
+++ b/SPECS/python-jsonschema/tox-test.patch
@@ -1,0 +1,62 @@
+From d677a41f5bfdf22279b883daf0d6d47dfd82400f Mon Sep 17 00:00:00 2001
+From: Sam Meluch <sammeluch@microsoft.com>
+Date: Fri, 12 Jul 2024 15:29:29 -0700
+Subject: [PATCH] remove py27, add py312 for tox testing
+
+---
+ tox.ini | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/tox.ini b/tox.ini
+index b8d5d90..1c5c1ac 100644
+--- a/tox.ini
++++ b/tox.ini
+@@ -1,22 +1,22 @@
+ [tox]
+-envlist = py{27,35,py}, docs, style
++envlist = py{35,312,py}, docs, style
+ 
+ 
+ [testenv]
+ setenv =
+     JSON_SCHEMA_TEST_SUITE = {toxinidir}/json
+ whitelist_externals =
+-    python2.7
++    python3.12
+     sh
+     virtualenv
+ commands =
+-    py{27,35,py,py3}: {envbindir}/green [] jsonschema
++    py{35,312,py,py3}: {envbindir}/green [] jsonschema
+ 
+     {envpython} -m doctest {toxinidir}/README.rst
+-    py{27,35}: {envbindir}/sphinx-build -b doctest {toxinidir}/docs {envtmpdir}/html
++    py{35,312}: {envbindir}/sphinx-build -b doctest {toxinidir}/docs {envtmpdir}/html
+ 
+     # Check to make sure that releases build and install properly
+-    virtualenv --quiet --python=python2.7 {envtmpdir}/venv
++    virtualenv --quiet --python=python3.12 {envtmpdir}/venv
+     {envtmpdir}/venv/bin/pip install --quiet wheel
+ 
+     {envtmpdir}/venv/bin/python {toxinidir}/setup.py --quiet bdist_wheel --dist-dir={envtmpdir}/wheel
+@@ -28,13 +28,13 @@ commands =
+ deps =
+     -e{toxinidir}[format]
+ 
+-    py{27,35,py,py3},coverage: green
++    py{35,312,py,py3},coverage: green
+     coverage: coverage
+ 
+-    py{27,py,py3},coverage: mock
++    py{py,py3},coverage: mock
+ 
+-    py{27,35}: lxml
+-    py{27,35,py}: sphinx
++    py{35,312}: lxml
++    py{35,312,py}: sphinx
+ 
+ 
+ [testenv:coverage]
+-- 
+2.34.1
+

--- a/SPECS/python-jsonschema/tox-test.patch
+++ b/SPECS/python-jsonschema/tox-test.patch
@@ -1,13 +1,13 @@
-From f7598efbd043c3e744fafe7a946068c3c74fa0df Mon Sep 17 00:00:00 2001
+From 7e934da39b92e2704bbd40b79f942a9a8d1d89aa Mon Sep 17 00:00:00 2001
 From: Sam Meluch <sammeluch@microsoft.com>
 Date: Fri, 12 Jul 2024 15:29:29 -0700
-Subject: [PATCH] remove py27, add py212 for tests, update webcolors import,
- require lower webcolors version
+Subject: [PATCH] remove py27, add py212 for tests, remove docs tests, update
+ webcolors import, require lower webcolors version
 
 ---
  jsonschema/_format.py |  4 ++--
- tox.ini               | 19 ++++++++++---------
- 2 files changed, 12 insertions(+), 11 deletions(-)
+ tox.ini               | 28 ++++++++--------------------
+ 2 files changed, 10 insertions(+), 22 deletions(-)
 
 diff --git a/jsonschema/_format.py b/jsonschema/_format.py
 index caae127..32738a7 100644
@@ -30,10 +30,10 @@ index caae127..32738a7 100644
          return is_css_color_code(instance)
  
 diff --git a/tox.ini b/tox.ini
-index b8d5d90..ed0400f 100644
+index b8d5d90..30b3f72 100644
 --- a/tox.ini
 +++ b/tox.ini
-@@ -1,22 +1,22 @@
+@@ -1,40 +1,28 @@
  [tox]
 -envlist = py{27,35,py}, docs, style
 +envlist = py{35,312,py}, docs, style
@@ -51,17 +51,19 @@ index b8d5d90..ed0400f 100644
 -    py{27,35,py,py3}: {envbindir}/green [] jsonschema
 +    py{35,312,py,py3}: {envbindir}/green [] jsonschema
  
-     {envpython} -m doctest {toxinidir}/README.rst
+-    {envpython} -m doctest {toxinidir}/README.rst
 -    py{27,35}: {envbindir}/sphinx-build -b doctest {toxinidir}/docs {envtmpdir}/html
-+    py{35,312}: {envbindir}/sphinx-build -b doctest {toxinidir}/docs {envtmpdir}/html
- 
-     # Check to make sure that releases build and install properly
+-
+-    # Check to make sure that releases build and install properly
 -    virtualenv --quiet --python=python2.7 {envtmpdir}/venv
-+    virtualenv --quiet --python=python3.12 {envtmpdir}/venv
-     {envtmpdir}/venv/bin/pip install --quiet wheel
- 
-     {envtmpdir}/venv/bin/python {toxinidir}/setup.py --quiet bdist_wheel --dist-dir={envtmpdir}/wheel
-@@ -28,13 +28,14 @@ commands =
+-    {envtmpdir}/venv/bin/pip install --quiet wheel
+-
+-    {envtmpdir}/venv/bin/python {toxinidir}/setup.py --quiet bdist_wheel --dist-dir={envtmpdir}/wheel
+-    sh -c '{envbindir}/pip install --quiet --upgrade --force-reinstall {envtmpdir}/wheel/jsonschema*.whl'
+-
+-    python2.7 {toxinidir}/setup.py --quiet sdist --dist-dir={envtmpdir}/sdist --format=gztar,zip
+-    sh -c '{envbindir}/pip install --quiet --upgrade --force-reinstall {envtmpdir}/sdist/jsonschema*.tar.gz'
+-    sh -c '{envbindir}/pip install --quiet --upgrade --force-reinstall {envtmpdir}/sdist/jsonschema*.zip'
  deps =
      -e{toxinidir}[format]
  

--- a/SPECS/python-jsonschema/tox-test.patch
+++ b/SPECS/python-jsonschema/tox-test.patch
@@ -1,12 +1,33 @@
-From d677a41f5bfdf22279b883daf0d6d47dfd82400f Mon Sep 17 00:00:00 2001
+From c473a1b1be5fce8710b9ac188fb879dd5a6b15b4 Mon Sep 17 00:00:00 2001
 From: Sam Meluch <sammeluch@microsoft.com>
 Date: Fri, 12 Jul 2024 15:29:29 -0700
-Subject: [PATCH] remove py27, add py312 for tox testing
+Subject: [PATCH] remove py27, add py312 for tests, update webcolors import
 
 ---
- tox.ini | 18 +++++++++---------
- 1 file changed, 9 insertions(+), 9 deletions(-)
+ jsonschema/_format.py |  4 ++--
+ tox.ini               | 18 +++++++++---------
+ 2 files changed, 11 insertions(+), 11 deletions(-)
 
+diff --git a/jsonschema/_format.py b/jsonschema/_format.py
+index caae127..32738a7 100644
+--- a/jsonschema/_format.py
++++ b/jsonschema/_format.py
+@@ -256,13 +256,13 @@ else:
+     def is_css21_color(instance):
+         if (
+             not isinstance(instance, str_types) or
+-            instance.lower() in webcolors.css21_names_to_hex
++            instance.lower() in webcolors.CSS21_NAMES_TO_HEX
+         ):
+             return True
+         return is_css_color_code(instance)
+ 
+     def is_css3_color(instance):
+-        if instance.lower() in webcolors.css3_names_to_hex:
++        if instance.lower() in webcolors.CSS3_NAMES_TO_HEX:
+             return True
+         return is_css_color_code(instance)
+ 
 diff --git a/tox.ini b/tox.ini
 index b8d5d90..1c5c1ac 100644
 --- a/tox.ini


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
since the upgrade being reverted, the ptests for python-jsonschema have been failing. This pr adds a patch to fix the ptests via deps management and removal of docs test, as well as adding a py312 environment

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for tox environment fixes

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=605559&view=results
