### PR TITLE
kata-cc: Fix make clean call in UVM build

### DIFF
--- a/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
+++ b/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "mariner-coco-build-uvm.sh": "4f2be6965d8c4d7919fd201a68160fc8ab02a1be50a336abbfea13f16a6ffb89",
+    "mariner-coco-build-uvm.sh": "de191105ab8f6a0ad564c507306f2b543817199846cc17c4cb1ebdcfe28ebeb2",
     "kata-containers-cc-3.2.0.azl2.tar.gz": "49265e0ecd21af4ed8f23398d1e46ef9961786cb44f40fe582abff06c1c1a873",
     "kata-containers-cc-3.2.0.azl2-cargo.tar.gz": "ddf919a672200f0fb53d1cb6c66d6b1c401cf26368541c750d9a12e62da605a1"
   }

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -288,6 +288,9 @@ install -D -m 0755 %{_builddir}/%{name}-%{version}/tools/osbuilder/image-builder
 %exclude %{osbuilder}/tools/osbuilder/rootfs-builder/ubuntu
 
 %changelog
+* Mon Jul 15 2024 Manuel Huber <mahuber@microsoft.com> - 3.2.0.azl2-4
+- Call make clean with OS distro variable
+
 * Fri Jul 12 2024 Manuel Huber <mahuber@microsoft.com> - 3.2.0.azl2-3
 - Adapt make install target parameters to cope with upstream
   fork Makefile changes

--- a/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh
+++ b/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh
@@ -13,7 +13,7 @@ export AGENT_SOURCE_BIN=${SCRIPT_DIR}/kata-agent
 
 # build rootfs
 pushd ${OSBUILDER_DIR}
-sudo make clean
+sudo make DISTRO=cbl-mariner clean
 rm -rf ${ROOTFS_DIR}
 sudo -E PATH=$PATH AGENT_POLICY=yes CONF_GUEST=yes AGENT_POLICY_FILE=allow-set-policy.rego make -B DISTRO=cbl-mariner rootfs
 popd

--- a/SPECS/kata-containers/kata-containers.signatures.json
+++ b/SPECS/kata-containers/kata-containers.signatures.json
@@ -1,7 +1,7 @@
 {
   "Signatures": {
     "50-kata": "fb108c6337b3d3bf80b43ab04f2bf9a3bdecd29075ebd16320aefe8f81c502a7",
-    "mariner-build-uvm.sh": "a0fbee4def82ee492eab64a8b5a948c2fef125fa1ca5686aafa0a80c64144068",
+    "mariner-build-uvm.sh": "da67e7bfa7a150d0dd54236bde9494fb37feec1c9b8d5a1f20dbbe3f605c0862",
     "kata-containers-3.2.0.azl2-cargo.tar.gz": "830c90cc6e44f492e6366012f8834ae6fc84bd790edf678c23003368c288b98c",
     "kata-containers-3.2.0.azl2.tar.gz": "ab65f23787347fae11cf07e0a380e925e9f7b6f0f862ef6440a683b816206011"
   }

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -39,7 +39,7 @@
 Summary:        Kata Containers
 Name:           kata-containers
 Version:        3.2.0.azl2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 URL:            https://github.com/microsoft/kata-containers
@@ -215,6 +215,9 @@ ln -sf %{_bindir}/kata-runtime %{buildroot}%{_prefix}/local/bin/kata-runtime
 %exclude %{kataosbuilderdir}/rootfs-builder/ubuntu
 
 %changelog
+* Mon Jul 15 2024 Manuel Huber <mahuber@microsoft.com> - 3.2.0.azl2-3
+- Call make clean with OS distro variable
+
 * Thu Jun 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.2.0.azl2-2
 - Bump release to rebuild with go 1.21.11
 

--- a/SPECS/kata-containers/mariner-build-uvm.sh
+++ b/SPECS/kata-containers/mariner-build-uvm.sh
@@ -7,11 +7,9 @@ readonly INITRD_DIR="/var/cache/kata-containers/osbuilder-images/kernel-uvm"
 
 export AGENT_SOURCE_BIN=${SCRIPT_DIR}/agent/usr/bin/kata-agent
 
-rm -rf ${ROOTFS_DIR}
-
 # build rootfs
 pushd ${OSBUILDER_DIR}
-sudo make clean
+sudo make DISTRO=cbl-mariner clean
 rm -rf ${ROOTFS_DIR}
 sudo -E PATH=$PATH make -B DISTRO=cbl-mariner rootfs
 popd


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
During UVM build, the default OS' clean target is executed - which is Ubuntu.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change make clean call to clean up the artifacts for the cbl-mariner distro: `rm -rf /opt/kata-containers/uvm/tools/osbuilder/.ubuntu_rootfs.done /opt/kata-containers/uvm/tools/osbuilder/ubuntu_rootfs`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 605606, showing the clean-up for: `rm -rf /opt/kata-containers/uvm/tools/osbuilder/.cbl-mariner_rootfs.done /opt/kata-containers/uvm/tools/osbuilder/cbl-mariner_rootfs`
