### PR TITLE
ceph: Fix high CVE-2024-38517 and CVE-2024-39684

### DIFF
--- a/SPECS/ceph/CVE-2024-38517.patch
+++ b/SPECS/ceph/CVE-2024-38517.patch
@@ -1,0 +1,64 @@
+From 9138794bd0e51fe444f14803f891924798a651ac Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Mon, 15 Jul 2024 18:33:06 +0000
+Subject: [PATCH] Prevent int underflow when parsing exponents
+
+From 8269bc2bc289e9d343bae51cdf6d23ef0950e001 Mon Sep 17 00:00:00 2001
+From: Florin Malita <fmalita@gmail.com>
+Date: Tue, 15 May 2018 22:48:07 -0400
+Subject: [PATCH] Prevent int underflow when parsing exponents
+
+When parsing negative exponents, the current implementation takes
+precautions for |exp| to not underflow int.
+
+But that is not sufficient: later on [1], |exp + expFrac| is also
+stored to an int - so we must ensure that the sum stays within int
+representable values.
+
+Update the exp clamping logic to take expFrac into account.
+
+[1] https://github.com/Tencent/rapidjson/blob/master/include/rapidjson/reader.h#L1690
+---
+ src/rapidjson/include/rapidjson/reader.h   | 11 ++++++++++-
+ src/rapidjson/test/unittest/readertest.cpp |  1 +
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/rapidjson/include/rapidjson/reader.h b/src/rapidjson/include/rapidjson/reader.h
+index 19f8849b1..a9f502307 100644
+--- a/src/rapidjson/include/rapidjson/reader.h
++++ b/src/rapidjson/include/rapidjson/reader.h
+@@ -1302,9 +1302,18 @@ private:
+             if (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
+                 exp = static_cast<int>(s.Take() - '0');
+                 if (expMinus) {
++                    // (exp + expFrac) must not underflow int => we're detecting when -exp gets
++                    // dangerously close to INT_MIN (a pessimistic next digit 9 would push it into
++                    // underflow territory):
++                    //
++                    //        -(exp * 10 + 9) + expFrac >= INT_MIN
++                    //   <=>  exp <= (expFrac - INT_MIN - 9) / 10
++                    RAPIDJSON_ASSERT(expFrac <= 0);
++                    int maxExp = (expFrac + 2147483639) / 10;
++
+                     while (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
+                         exp = exp * 10 + static_cast<int>(s.Take() - '0');
+-                        if (exp >= 214748364) {                         // Issue #313: prevent overflow exponent
++                        if (RAPIDJSON_UNLIKELY(exp > maxExp)) {
+                             while (RAPIDJSON_UNLIKELY(s.Peek() >= '0' && s.Peek() <= '9'))  // Consume the rest of exponent
+                                 s.Take();
+                         }
+diff --git a/src/rapidjson/test/unittest/readertest.cpp b/src/rapidjson/test/unittest/readertest.cpp
+index 64a1f9c3c..65163de60 100644
+--- a/src/rapidjson/test/unittest/readertest.cpp
++++ b/src/rapidjson/test/unittest/readertest.cpp
+@@ -242,6 +242,7 @@ static void TestParseDouble() {
+     TEST_DOUBLE(fullPrecision, "1e-214748363", 0.0);                                  // Maximum supported negative exponent
+     TEST_DOUBLE(fullPrecision, "1e-214748364", 0.0);
+     TEST_DOUBLE(fullPrecision, "1e-21474836311", 0.0);
++    TEST_DOUBLE(fullPrecision, "1.00000000001e-2147483638", 0.0);
+     TEST_DOUBLE(fullPrecision, "0.017976931348623157e+310", 1.7976931348623157e+308); // Max double in another form
+ 
+     // Since
+-- 
+2.34.1
+

--- a/SPECS/ceph/CVE-2024-39684.nopatch
+++ b/SPECS/ceph/CVE-2024-39684.nopatch
@@ -1,0 +1,1 @@
+CVE-2024-39684 is a duplicate of CVE-2024-38517

--- a/SPECS/ceph/ceph.spec
+++ b/SPECS/ceph/ceph.spec
@@ -5,7 +5,7 @@
 Summary:        User space components of the Ceph file system
 Name:           ceph
 Version:        16.2.10
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        LGPLv2 and LGPLv3 and CC-BY-SA and GPLv2 and Boost and BSD and MIT and Public Domain and GPLv3 and ASL-2.0
 URL:            https://ceph.io/
 Vendor:         Microsoft Corporation
@@ -16,8 +16,9 @@ Patch1:         CVE-2021-28361.patch
 Patch2:         CVE-2022-3650.patch
 Patch3:         CVE-2022-3854.patch
 Patch4:         CVE-2023-43040.patch
+Patch5:         CVE-2024-38517.patch
 
-#
+# 
 # Copyright (C) 2004-2019 The Ceph Project Developers. See COPYING file
 # at the top-level directory of this distribution and at
 # https://github.com/ceph/ceph/blob/master/COPYING
@@ -1810,6 +1811,9 @@ exit 0
 %config %{_sysconfdir}/prometheus/ceph/ceph_default_alerts.yml
 
 %changelog
+* Mon Jul 15 2024 Vince Perri <viperri@microsoft.com> - 16.2.10-5
+- Patch CVE-2024-38517
+
 * Fri May 17 2024 Henry Beberman <henry.beberman@microsoft.com> - 16.2.10-4
 - Patch CVE-2023-43040
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
High severity security fix for CVE-2024-38517 and CVE-2024-39684

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add SPECS/ceph/CVE-2024-38517.patch
- Add SPECS/ceph/CVE-2024-39684.nopatch describing this CVE as a duplicate of the above

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-38517
- https://nvd.nist.gov/vuln/detail/CVE-2024-39684

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 605590
