### PR TITLE
Image Customizer: Add ISO tests.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -4,12 +4,201 @@
 package imagecustomizerlib
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
+
+// Tests:
+// - vhdx to ISO, with OS changes.
+// - ISO to ISO, with no OS changes.
+// - Kernel command-line arg append.
+// - .iso.additionalFiles
+func TestCustomizeImageLiveCd1(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCd1")
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.iso")
+	configFile := filepath.Join(testDir, "iso-files-and-args-config.yaml")
+
+	// Customize vhdx to ISO, with OS changes.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "iso", "", true, false)
+	assert.NoError(t, err)
+
+	// Attach ISO.
+	isoImageLoopDevice, err := safeloopback.NewLoopback(outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer isoImageLoopDevice.Close()
+
+	isoMountDir := filepath.Join(testTempDir, "iso-mount")
+	isoImageMount, err := safemount.NewMount(isoImageLoopDevice.DevicePath(), isoMountDir,
+		"iso9660" /*fstype*/, unix.MS_RDONLY /*flags*/, "" /*data*/, true /*makeAndDelete*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer isoImageMount.Close()
+
+	// Check for the copied a.txt file.
+	aOrigPath := filepath.Join(testDir, "files/a.txt")
+	aIsoPath := filepath.Join(isoMountDir, "a.txt")
+	verifyFileContentsSame(t, aOrigPath, aIsoPath)
+
+	// Ensure grub.cfg file has the extra kernel command-line args.
+	grubCfgFilePath := filepath.Join(isoMountDir, "/boot/grub2/grub.cfg")
+	grubCfgContents, err := file.Read(grubCfgFilePath)
+	assert.NoError(t, err, "read grub.cfg file")
+	assert.Regexp(t, "linux.* rd.info ", grubCfgContents)
+
+	// Check the iso-kernel-args.txt file.
+	isoKernelArgsPath := filepath.Join(isoMountDir, savedConfigIsoDir, savedKernelArgsFileName)
+	isoKernelArgsContents, err := file.Read(isoKernelArgsPath)
+	assert.NoErrorf(t, err, "read (%s) file", savedKernelArgsFileName)
+	assert.Equal(t, "rd.info", isoKernelArgsContents)
+
+	err = isoImageMount.CleanClose()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = isoImageLoopDevice.CleanClose()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Customize ISO to ISO, with no OS changes.
+	b2FilePerms := imagecustomizerapi.FilePermissions(0o600)
+	config := imagecustomizerapi.Config{
+		Iso: &imagecustomizerapi.Iso{
+			KernelCommandLine: imagecustomizerapi.KernelCommandLine{
+				ExtraCommandLine: "rd.debug",
+			},
+			AdditionalFiles: imagecustomizerapi.AdditionalFilesMap{
+				"files/b.txt": []imagecustomizerapi.FileConfig{
+					{
+						Path: "/b1.txt",
+					},
+					{
+						Path:        "/b2.txt",
+						Permissions: &b2FilePerms,
+					},
+				},
+			},
+		},
+	}
+	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "iso", "", false, false)
+	assert.NoError(t, err)
+
+	// Attach ISO.
+	isoImageLoopDevice, err = safeloopback.NewLoopback(outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer isoImageLoopDevice.Close()
+
+	isoImageMount, err = safemount.NewMount(isoImageLoopDevice.DevicePath(), isoMountDir,
+		"iso9660" /*fstype*/, unix.MS_RDONLY /*flags*/, "" /*data*/, true /*makeAndDelete*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer isoImageMount.Close()
+
+	// Check that the a.txt stayed around.
+	verifyFileContentsSame(t, aOrigPath, aIsoPath)
+
+	// Check for copied b.txt file.
+	bOrigPath := filepath.Join(testDir, "files/b.txt")
+	b1IsoPath := filepath.Join(isoMountDir, "b1.txt")
+	b2IsoPath := filepath.Join(isoMountDir, "b2.txt")
+	verifyFileContentsSame(t, bOrigPath, b1IsoPath)
+	verifyFileContentsSame(t, bOrigPath, b2IsoPath)
+	verifyFilePermissions(t, os.FileMode(b2FilePerms), b2IsoPath)
+
+	// Ensure grub.cfg file has the extra kernel command-line args from both runs.
+	grubCfgContents, err = file.Read(grubCfgFilePath)
+	assert.NoError(t, err, "read grub.cfg file")
+	assert.Regexp(t, "linux.* rd.info ", grubCfgContents)
+	assert.Regexp(t, "linux.* rd.debug ", grubCfgContents)
+
+	// Check the iso-kernel-args.txt file.
+	isoKernelArgsContents, err = file.Read(isoKernelArgsPath)
+	assert.NoErrorf(t, err, "read (%s) file", savedKernelArgsFileName)
+	assert.Equal(t, "rd.info rd.debug", isoKernelArgsContents)
+}
+
+// Tests:
+// - vhdx to ISO, with no OS changes.
+// - ISO to ISO, with OS changes.
+func TestCustomizeImageLiveCd2(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCd2")
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.raw")
+	outIsoFilePath := filepath.Join(testTempDir, "image.iso")
+
+	// Customize vhdx with ISO prereqs.
+	configFile := filepath.Join(testDir, "iso-os-prereqs-config.yaml")
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "", true, false)
+	assert.NoError(t, err)
+
+	// Customize image to ISO, with no OS changes.
+	config := imagecustomizerapi.Config{
+		Iso: &imagecustomizerapi.Iso{},
+	}
+	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outIsoFilePath, "iso", "", false, false)
+	assert.NoError(t, err)
+
+	// Customize ISO to ISO, with OS changes.
+	configFile = filepath.Join(testDir, "addfiles-config.yaml")
+	err = CustomizeImageWithConfigFile(buildDir, configFile, outIsoFilePath, nil, outIsoFilePath, "iso", "", true, false)
+	assert.NoError(t, err)
+
+	// Attach ISO.
+	isoImageLoopDevice, err := safeloopback.NewLoopback(outIsoFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer isoImageLoopDevice.Close()
+
+	isoMountDir := filepath.Join(testTempDir, "iso-mount")
+	isoImageMount, err := safemount.NewMount(isoImageLoopDevice.DevicePath(), isoMountDir,
+		"iso9660" /*fstype*/, unix.MS_RDONLY /*flags*/, "" /*data*/, true /*makeAndDelete*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer isoImageMount.Close()
+
+	// Attach squashfs file.
+	squashfsPath := filepath.Join(isoMountDir, liveOSDir, liveOSImage)
+	squashfsLoopDevice, err := safeloopback.NewLoopback(squashfsPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer squashfsLoopDevice.Close()
+
+	squashfsMountDir := filepath.Join(testTempDir, "iso-squashfs")
+	squashfsMount, err := safemount.NewMount(squashfsLoopDevice.DevicePath(), squashfsMountDir,
+		"squashfs" /*fstype*/, unix.MS_RDONLY /*flags*/, "" /*data*/, true /*makeAndDelete*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer squashfsMount.Close()
+
+	// Check that a.txt is in the squashfs file.
+	aOrigPath := filepath.Join(testDir, "files/a.txt")
+	aIsoPath := filepath.Join(squashfsMountDir, "a.txt")
+	verifyFileContentsSame(t, aOrigPath, aIsoPath)
+}
 
 func TestCustomizeImageLiveCdIsoNoShimEfi(t *testing.T) {
 	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-files-and-args-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-files-and-args-config.yaml
@@ -1,0 +1,13 @@
+iso:
+  additionalFiles:
+    files/a.txt: /a.txt
+
+  kernelCommandLine:
+    extraCommandLine: rd.info
+
+os:
+  packages:
+    install:
+    - squashfs-tools
+    - tar
+    - device-mapper

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-os-prereqs-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-os-prereqs-config.yaml
@@ -1,0 +1,6 @@
+os:
+  packages:
+    install:
+    - squashfs-tools
+    - tar
+    - device-mapper


### PR DESCRIPTION
Add tests for:

- vhdx to ISO, with and without OS changes.
- ISO to ISO, with and without OS changes.
- Kernel command-line args.
- .iso.additionalFiles

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran new UTs
