### PR TITLE
moby-engine: remove daemon.json with backported fix (#9551)

### DIFF
--- a/SPECS/moby-engine/daemon.json
+++ b/SPECS/moby-engine/daemon.json
@@ -1,3 +1,0 @@
-{
-  "userland-proxy-path": "/usr/libexec/docker-proxy"
-}

--- a/SPECS/moby-engine/enable-docker-proxy-libexec-search.patch
+++ b/SPECS/moby-engine/enable-docker-proxy-libexec-search.patch
@@ -1,0 +1,86 @@
+From f8c088be055b72e58005ef9e56cf4f4008bbc5dd Mon Sep 17 00:00:00 2001
+From: Brian Goff <cpuguy83@gmail.com>
+Date: Tue, 7 May 2024 21:55:36 +0000
+Subject: [PATCH] Lookup docker-proxy in libexec paths
+
+This allows distros to put docker-proxy under libexec paths as is done
+for docker-init.
+
+Also expands the lookup to to not require a `docker/` subdir in libexec
+subdir.
+Since it is a generic helper that may be used for something else in the
+future, this is only done for binaries with a `docker-`.
+
+Backported to moby 24.0.9 for AZL 2.0
+
+Signed-off-by: Brian Goff <cpuguy83@gmail.com>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+diff -Naur a/daemon/config/config_linux.go b/daemon/config/config_linux.go
+--- a/daemon/config/config_linux.go	2024-02-01 00:12:23.000000000 +0000
++++ b/daemon/config/config_linux.go	2024-06-25 18:18:00.929394951 +0000
+@@ -5,6 +5,7 @@
+ 	"net"
+ 	"os/exec"
+ 	"path/filepath"
++	"strings"
+ 
+ 	"github.com/containerd/cgroups/v3"
+ 	"github.com/docker/docker/api/types"
+@@ -118,14 +119,13 @@
+ 	return DefaultInitBinary
+ }
+ 
+-// LookupInitPath returns an absolute path to the "docker-init" binary by searching relevant "libexec" directories (per FHS 3.0 & 2.3) followed by PATH
+-func (conf *Config) LookupInitPath() (string, error) {
+-	binary := conf.GetInitPath()
++// lookupBinPath returns an absolute path to the provided binary by searching relevant "libexec" locations (per FHS 3.0 & 2.3) followed by PATH
++func lookupBinPath(binary string) (string, error) {
+ 	if filepath.IsAbs(binary) {
+ 		return binary, nil
+ 	}
+ 
+-	for _, dir := range []string{
++	lookupPaths := []string{
+ 		// FHS 3.0: "/usr/libexec includes internal binaries that are not intended to be executed directly by users or shell scripts. Applications may use a single subdirectory under /usr/libexec."
+ 		// https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html
+ 		"/usr/local/libexec/docker",
+@@ -135,7 +135,16 @@
+ 		// https://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#USRLIBLIBRARIESFORPROGRAMMINGANDPA
+ 		"/usr/local/lib/docker",
+ 		"/usr/lib/docker",
+-	} {
++	}
++
++	// According to FHS 3.0, it is not necessary to have a subdir here (see note and reference above).
++	// If the binary has a `docker-` prefix, let's look it up without the dir prefix.
++	if strings.HasPrefix(binary, "docker-") {
++		lookupPaths = append(lookupPaths, "/usr/local/libexec")
++		lookupPaths = append(lookupPaths, "/usr/libexec")
++	}
++
++	for _, dir := range lookupPaths {
+ 		// exec.LookPath has a fast-path short-circuit for paths that contain "/" (skipping the PATH lookup) that then verifies whether the given path is likely to be an actual executable binary (so we invoke that instead of reimplementing the same checks)
+ 		if file, err := exec.LookPath(filepath.Join(dir, binary)); err == nil {
+ 			return file, nil
+@@ -146,6 +155,11 @@
+ 	return exec.LookPath(binary)
+ }
+ 
++// LookupInitPath returns an absolute path to the "docker-init" binary by searching relevant "libexec" directories (per FHS 3.0 & 2.3) followed by PATH
++func (conf *Config) LookupInitPath() (string, error) {
++	return lookupBinPath(conf.GetInitPath())
++}
++
+ // GetResolvConf returns the appropriate resolv.conf
+ // Check setupResolvConf on how this is selected
+ func (conf *Config) GetResolvConf() string {
+@@ -214,7 +228,7 @@
+ 
+ 		var err error
+ 		// use rootlesskit-docker-proxy for exposing the ports in RootlessKit netns to the initial namespace.
+-		cfg.BridgeConfig.UserlandProxyPath, err = exec.LookPath(rootless.RootlessKitDockerProxyBinary)
++		cfg.BridgeConfig.UserlandProxyPath, err = lookupBinPath(rootless.RootlessKitDockerProxyBinary)
+ 		if err != nil {
+ 			return errors.Wrapf(err, "running with RootlessKit, but %s not installed", rootless.RootlessKitDockerProxyBinary)
+ 		}

--- a/SPECS/moby-engine/moby-engine.signatures.json
+++ b/SPECS/moby-engine/moby-engine.signatures.json
@@ -1,6 +1,5 @@
 {
  "Signatures": {
-  "daemon.json": "532f2e930400baed129ed953b9ba0d5158fc443aecbff6f6513f58565696db5c",
   "docker.service": "b150b3ce0947a65c655ed09dfe4e48b7464c60542f9f9902330288bbf87af38e",
   "docker.socket": "51a06786cae46bc63b7314c25d0bd5bb2e676120d80874b99e35bf60d0b0ffa8",
   "moby-engine-24.0.9.tar.gz": "c498c4aa45d208d3af5fc9be3fb0d60f3fac6d710077c0557e217f7f80fd6c96"

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -3,7 +3,7 @@
 Summary: The open-source application container engine
 Name:    moby-engine
 Version: 24.0.9
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -13,7 +13,6 @@ Distribution: Mariner
 Source0: https://github.com/moby/moby/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1: docker.service
 Source2: docker.socket
-Source3: daemon.json
 # Backport of vendored "buildkit" v0.12.5 https://github.com/moby/buildkit/pull/4604 to 0.8.4-0.20221020190723-eeb7b65ab7d6 in this package.
 # Remove once we upgrade this package at least to version 25.0+.
 Patch1:  CVE-2024-23651.patch
@@ -22,6 +21,7 @@ Patch1:  CVE-2024-23651.patch
 Patch2:  CVE-2024-23652.patch
 Patch3:  CVE-2023-45288.patch
 Patch4:  CVE-2023-44487.patch
+Patch5:  enable-docker-proxy-libexec-search.patch
 
 %{?systemd_requires}
 
@@ -100,9 +100,6 @@ mkdir -p %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/docker.service
 install -p -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/docker.socket
 
-mkdir -p -m 755 %{buildroot}%{_sysconfdir}/docker
-install -p -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/docker/daemon.json
-
 %post
 if ! grep -q "^docker:" /etc/group; then
     groupadd --system docker
@@ -121,12 +118,13 @@ fi
 # docker-proxy symlink in bindir to fix back-compat
 %{_bindir}/docker-proxy
 %{_libexecdir}/docker-proxy
-%dir %{_sysconfdir}/docker
-%config(noreplace) %{_sysconfdir}/docker/daemon.json
 %{_sysconfdir}/*
 %{_unitdir}/*
 
 %changelog
+* Tue Jun 25 2024 Henry Beberman <henry.beberman@microsoft.com> - 24.0.9-6
+- Backport upstream change to search /usr/libexec for docker-proxy without daemon.json
+
 * Thu Jun 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 24.0.9-5
 - Bump release to rebuild with go 1.21.11
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This is a cherry-pick of https://github.com/microsoft/azurelinux/pull/9551 into fasttrack.

Our moby-engine-24.0.9-1 package brought in a new daemon.json file to inform the newer moby-engine version of docker-proxy's location. Adding daemon.json to the package regressed several use cases, instead we'll rely on backporting a recent upstream change (https://github.com/moby/moby/pull/47804) that implicitly looks for docker-proxy in libexec so that we can drop daemon.json.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport https://github.com/moby/moby/pull/47804 so moby-engine finds docker-proxy in libexec
- Remove daemon.json from our moby-engine package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- fixes #8961

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
- Buddy build: [succeeded](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=598825&view=results)
- Package upgrade on a running system. Verified that moby-engine is able to find docker-proxy after the upgrade.
