### PR TITLE
Image Customizer: Verity: Use loopback + Add tests.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
@@ -424,25 +424,6 @@ func replaceKernelCommandLineArgValueAll(inputGrubCfgContent string, name string
 	return outputGrubCfgContent, oldValues, nil
 }
 
-// Finds an existing kernel command-line arg and replaces its value.
-//
-// Params:
-// - inputGrubCfgContent: The string contents of the grub.cfg file.
-// - name: The name of the command-line arg to replace.
-// - value: The value to set the command-line arg to.
-//
-// Returns:
-// - outputGrubCfgContent: The new string contents of the grub.cfg file.
-// - oldValue: The previous value of the arg.
-func replaceKernelCommandLineArgValue(inputGrubCfgContent string, name string, value string,
-) (outputGrubCfgContent string, oldValue string, err error) {
-	outputGrubCfgContent, oldValues, err := replaceKernelCommandLineArgValueAll(inputGrubCfgContent, name, value, false /*allowMultiple*/)
-	if err != nil {
-		return "", "", err
-	}
-	return outputGrubCfgContent, oldValues[0], nil
-}
-
 func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, newArgs []string,
 	allowMultiple bool, requireKernelOpts bool) (string, error) {
 	lines, err := findLinuxOrInitrdLineAll(grub2Config, linuxCommand, allowMultiple /*allowMultiple*/)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -178,7 +178,7 @@ func updateGrubConfigForVerity(dataPartitionIdType imagecustomizerapi.IdType, da
 }
 
 // idToPartitionBlockDevicePath returns the block device path for a given idType and id.
-func idToPartitionBlockDevicePath(idType imagecustomizerapi.IdType, id string, nbdDevice string, diskPartitions []diskutils.PartitionInfo) (string, error) {
+func idToPartitionBlockDevicePath(idType imagecustomizerapi.IdType, id string, diskPartitions []diskutils.PartitionInfo) (string, error) {
 	// Iterate over each partition to find the matching id.
 	for _, partition := range diskPartitions {
 		switch idType {
@@ -230,32 +230,4 @@ func systemdFormatCorruptionOption(corruptionOption imagecustomizerapi.Corruptio
 	default:
 		return "", fmt.Errorf("invalid corruptionOption provided (%s)", string(corruptionOption))
 	}
-}
-
-// findFreeNBDDevice finds the first available NBD device.
-func findFreeNBDDevice() (string, error) {
-	files, err := filepath.Glob("/sys/class/block/nbd*")
-	if err != nil {
-		return "", err
-	}
-
-	for _, file := range files {
-		// Check if the pid file exists. If it does not exist, the device is likely free.
-		pidFile := filepath.Join(file, "pid")
-		if _, err := os.Stat(pidFile); os.IsNotExist(err) {
-			return "/dev/" + filepath.Base(file), nil
-		}
-	}
-
-	return "", fmt.Errorf("no free nbd devices available")
-}
-
-func isNbdLoaded() (bool, error) {
-	files, err := filepath.Glob("/sys/class/block/nbd*")
-	if err != nil {
-		return false, err
-	}
-
-	isNbdLoaded := len(files) > 0
-	return isNbdLoaded, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestCustomizeImageVerity(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageVerity")
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.raw")
+	configFile := filepath.Join(testDir, "verity-config.yaml")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "", true, false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Connect to customized image.
+	mountPoints := []mountPoint{
+		{
+			PartitionNum:   3,
+			Path:           "/",
+			FileSystemType: "ext4",
+			Flags:          unix.MS_RDONLY,
+		},
+		{
+			PartitionNum:   2,
+			Path:           "/boot",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   1,
+			Path:           "/boot/efi",
+			FileSystemType: "vfat",
+		},
+		{
+			PartitionNum:   5,
+			Path:           "/var",
+			FileSystemType: "ext4",
+		},
+	}
+
+	imageConnection, err := connectToImage(buildDir, outImageFilePath, mountPoints)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Verify verity kernel args.
+	grubCfgPath := filepath.Join(imageConnection.chroot.RootDir(), "/boot/grub2/grub.cfg")
+	grubCfgContents, err := file.Read(grubCfgPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Regexp(t, "linux.* rd.systemd.verity=1 ", grubCfgContents)
+	assert.Regexp(t, "linux.* systemd.verity_root_data=PARTLABEL=root ", grubCfgContents)
+	assert.Regexp(t, "linux.* systemd.verity_root_hash=PARTLABEL=root-hash ", grubCfgContents)
+	assert.Regexp(t, "linux.* systemd.verity_root_options=panic-on-corruption ", grubCfgContents)
+
+	// Read root hash from grub.cfg file.
+	roothashRegexp, err := regexp.Compile("linux.* roothash=([a-fA-F0-9]*) ")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	roothashMatches := roothashRegexp.FindStringSubmatch(grubCfgContents)
+	if !assert.Equal(t, 2, len(roothashMatches)) {
+		return
+	}
+
+	roothash := roothashMatches[1]
+
+	// Verify verity hashes.
+	err = shell.ExecuteLive(false, "veritysetup", "verify", partitionDevPath(imageConnection, 3),
+		partitionDevPath(imageConnection, 4), roothash)
+	assert.NoError(t, err)
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -66,6 +66,7 @@ os:
     - vim
 
   verity:
+    corruptionOption: panic
     dataPartition:
       idType: part-label
       id: root


### PR DESCRIPTION
Firstly, replace the use of `qemu-nbd` with a loopback block device.

Secondly, add a test for verity. This verifies that the grub.cfg kernel args are set and that running `veritysetup verify` succeeds.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran added UTs.
- Manually ran image customizer tool.

