### PR TITLE
rapidjson: fix CVE-2024-38517 and CVE-2024-39684

### DIFF
--- a/SPECS/rapidjson/CVE-2024-38517.patch
+++ b/SPECS/rapidjson/CVE-2024-38517.patch
@@ -1,0 +1,59 @@
+From 8269bc2bc289e9d343bae51cdf6d23ef0950e001 Mon Sep 17 00:00:00 2001
+From: Florin Malita <fmalita@gmail.com>
+Date: Tue, 15 May 2018 22:48:07 -0400
+Subject: [PATCH] Prevent int underflow when parsing exponents
+
+When parsing negative exponents, the current implementation takes
+precautions for |exp| to not underflow int.
+
+But that is not sufficient: later on [1], |exp + expFrac| is also
+stored to an int - so we must ensure that the sum stays within int
+representable values.
+
+Update the exp clamping logic to take expFrac into account.
+
+[1] https://github.com/Tencent/rapidjson/blob/master/include/rapidjson/reader.h#L1690
+---
+ include/rapidjson/reader.h   | 11 ++++++++++-
+ test/unittest/readertest.cpp |  1 +
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/include/rapidjson/reader.h b/include/rapidjson/reader.h
+index 7441eda4..f95aef42 100644
+--- a/include/rapidjson/reader.h
++++ b/include/rapidjson/reader.h
+@@ -1632,9 +1632,18 @@ private:
+             if (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
+                 exp = static_cast<int>(s.Take() - '0');
+                 if (expMinus) {
++                    // (exp + expFrac) must not underflow int => we're detecting when -exp gets
++                    // dangerously close to INT_MIN (a pessimistic next digit 9 would push it into
++                    // underflow territory):
++                    //
++                    //        -(exp * 10 + 9) + expFrac >= INT_MIN
++                    //   <=>  exp <= (expFrac - INT_MIN - 9) / 10
++                    RAPIDJSON_ASSERT(expFrac <= 0);
++                    int maxExp = (expFrac + 2147483639) / 10;
++
+                     while (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
+                         exp = exp * 10 + static_cast<int>(s.Take() - '0');
+-                        if (exp >= 214748364) {                         // Issue #313: prevent overflow exponent
++                        if (RAPIDJSON_UNLIKELY(exp > maxExp)) {
+                             while (RAPIDJSON_UNLIKELY(s.Peek() >= '0' && s.Peek() <= '9'))  // Consume the rest of exponent
+                                 s.Take();
+                         }
+diff --git a/test/unittest/readertest.cpp b/test/unittest/readertest.cpp
+index e5308019..c4800b93 100644
+--- a/test/unittest/readertest.cpp
++++ b/test/unittest/readertest.cpp
+@@ -242,6 +242,7 @@ static void TestParseDouble() {
+     TEST_DOUBLE(fullPrecision, "1e-214748363", 0.0);                                  // Maximum supported negative exponent
+     TEST_DOUBLE(fullPrecision, "1e-214748364", 0.0);
+     TEST_DOUBLE(fullPrecision, "1e-21474836311", 0.0);
++    TEST_DOUBLE(fullPrecision, "1.00000000001e-2147483638", 0.0);
+     TEST_DOUBLE(fullPrecision, "0.017976931348623157e+310", 1.7976931348623157e+308); // Max double in another form
+ 
+     // Since
+-- 
+2.34.1
+

--- a/SPECS/rapidjson/CVE-2024-39684.nopatch
+++ b/SPECS/rapidjson/CVE-2024-39684.nopatch
@@ -1,0 +1,1 @@
+CVE-2024-39684 is a duplicate of CVE-2024-38517

--- a/SPECS/rapidjson/rapidjson.spec
+++ b/SPECS/rapidjson/rapidjson.spec
@@ -1,7 +1,7 @@
 Summary:        A fast JSON parser/generator for C++ with both SAX/DOM style API
 Name:           rapidjson
 Version:        1.1.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        BSD and JSON and MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Patch0:         0000-Supress-implicit-fallthrough-in-GCC.patch
 Patch1:         0001-Onley-apply-to-GCC-7.patch
 Patch2:         0002-Correct-object-copying-in-document_h.patch
+Patch3:         CVE-2024-38517.patch
 %global debug_package %{nil}
 BuildRequires:  cmake
 BuildRequires:  gcc
@@ -52,6 +53,9 @@ make test
 %{_datadir}
 
 %changelog
+* Wed Jul 17 2024 Xiaohong Deng <xiaohongdeng@microsoft.com> - 1.1.0-8
+- Patch CVE-2024-38517
+
 * Mon Apr 11 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.1.0-7
 - Fixing invalid source URL.
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix for high severity CVE-2024038517 and CVE-2024-39684

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- patch file for CVE-2024-38517
- nopatch file for CVE-2024-39684 as it is a duplicate of CVE-2024-38517

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-38517
- https://nvd.nist.gov/vuln/detail/CVE-2024-39684

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 607293
