### PR TITLE
Image Customizer: Validate fields on FileConfig.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/fileconfig_test.go
+++ b/toolkit/tools/imagecustomizerapi/fileconfig_test.go
@@ -55,3 +55,11 @@ func TestParseFileConfigInvalidFilePermissions(t *testing.T) {
 	// Empty string.
 	testInvalidYamlValue[*FileConfigList](t, "{ \"path\": \"/b.txt\", \"permissions\": \"7777\" }")
 }
+
+func TestParseFileConfigValidStructBadField(t *testing.T) {
+	testInvalidYamlValue[*FileConfigList](t, "{ \"pat\": \"/b.txt\" }")
+}
+
+func TestParseFileConfigValidArrayStructBadField(t *testing.T) {
+	testInvalidYamlValue[*FileConfigList](t, "[ { \"pat\": \"/b.txt\" } ]")
+}


### PR DESCRIPTION
When you implement a custom unmarshaller, the `KnownFields()` option to the YAML parser is ignored when you call `yaml.Node.Decode()`. So, we have to manually enforce this check.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran existing UTs.
- Added UTs.

