### PR TITLE
Integrate new license checker package into image and package builds.

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -146,7 +146,7 @@ $(imager_disk_output_dir): $(STATUS_FLAGS_DIR)/imager_disk_output.flag
 	@touch $@
 	@echo Finished updating $@
 
-$(STATUS_FLAGS_DIR)/imager_disk_output.flag: $(go-imager) $(image_package_cache_summary) $(imggen_local_repo) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(assets_files)
+$(STATUS_FLAGS_DIR)/imager_disk_output.flag: $(go-imager) $(image_package_cache_summary) $(license_results_file_img) $(imggen_local_repo) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(assets_files)
 	$(if $(CONFIG_FILE),,$(error Must set CONFIG_FILE=))
 	mkdir -p $(imager_disk_output_dir) && \
 	rm -rf $(imager_disk_output_dir)/* && \
@@ -229,7 +229,7 @@ $(image_external_package_cache_summary): $(cached_file) $(go-imagepkgfetcher) $(
 
 # We need to ensure that initrd_img recursive build will never run concurrently with another build component, so add all ISO prereqs as
 # order-only-prerequisites to initrd_img
-iso_deps = $(go-isomaker) $(go-imager) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(image_package_cache_summary)
+iso_deps = $(go-isomaker) $(go-imager) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(image_package_cache_summary) $(license_results_file_img)
 # The initrd bundles these files into the image, we should rebuild it if they change
 initrd_bundled_files = $(go-liveinstaller) $(go-imager) $(assets_files) $(initrd_assets_files) $(imggen_local_repo)
 

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -32,12 +32,14 @@ cached_remote_rpms     = $(call shell_real_build_only, find $(remote_rpms_cache_
 validate-pkggen-config = $(STATUS_FLAGS_DIR)/validate-image-config-pkggen.flag
 
 # Outputs
-specs_file        = $(PKGBUILD_DIR)/specs.json
-graph_file        = $(PKGBUILD_DIR)/graph.dot
-cached_file       = $(PKGBUILD_DIR)/cached_graph.dot
-preprocessed_file = $(PKGBUILD_DIR)/preprocessed_graph.dot
-built_file        = $(PKGBUILD_DIR)/built_graph.dot
-output_csv_file   = $(PKGBUILD_DIR)/build_state.csv
+specs_file               = $(PKGBUILD_DIR)/specs.json
+graph_file               = $(PKGBUILD_DIR)/graph.dot
+cached_file              = $(PKGBUILD_DIR)/cached_graph.dot
+preprocessed_file        = $(PKGBUILD_DIR)/preprocessed_graph.dot
+built_file               = $(PKGBUILD_DIR)/built_graph.dot
+output_csv_file          = $(PKGBUILD_DIR)/build_state.csv
+pkg_license_summary_file = $(PKGBUILD_DIR)/license_issues.txt
+pkg_license_results_file = $(PKGBUILD_DIR)/license_issues.json
 
 logging_command = --log-file=$(LOGS_DIR)/pkggen/workplan/$(notdir $@).log --log-level=$(LOG_LEVEL) --log-color=$(LOG_COLOR)
 $(call create_folder,$(LOGS_DIR)/pkggen/workplan)
@@ -266,7 +268,7 @@ $(RPMS_DIR):
 	@touch $@
 endif
 
-$(STATUS_FLAGS_DIR)/build-rpms.flag: $(no_repo_acl) $(preprocessed_file) $(chroot_worker) $(go-scheduler) $(go-pkgworker) $(depend_STOP_ON_PKG_FAIL) $(CONFIG_FILE) $(depend_CONFIG_FILE) $(depend_PACKAGE_BUILD_LIST) $(depend_PACKAGE_REBUILD_LIST) $(depend_PACKAGE_IGNORE_LIST) $(depend_MAX_CASCADING_REBUILDS) $(depend_TEST_RUN_LIST) $(depend_TEST_RERUN_LIST) $(depend_TEST_IGNORE_LIST) $(pkggen_rpms) $(srpms) $(BUILD_SRPMS_DIR) $(depend_EXTRA_BUILD_LAYERS)
+$(STATUS_FLAGS_DIR)/build-rpms.flag: $(no_repo_acl) $(preprocessed_file) $(chroot_worker) $(go-scheduler) $(go-pkgworker) $(depend_STOP_ON_PKG_FAIL) $(CONFIG_FILE) $(depend_CONFIG_FILE) $(depend_PACKAGE_BUILD_LIST) $(depend_PACKAGE_REBUILD_LIST) $(depend_PACKAGE_IGNORE_LIST) $(depend_MAX_CASCADING_REBUILDS) $(depend_TEST_RUN_LIST) $(depend_TEST_RERUN_LIST) $(depend_TEST_IGNORE_LIST) $(pkggen_rpms) $(srpms) $(BUILD_SRPMS_DIR) $(depend_EXTRA_BUILD_LAYERS) $(depend_LICENSE_CHECK_MODE)
 	$(go-scheduler) \
 		--input="$(preprocessed_file)" \
 		--output="$(built_file)" \
@@ -296,6 +298,11 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(no_repo_acl) $(preprocessed_file) $(chroo
 		--ignored-tests="$(TEST_IGNORE_LIST)" \
 		--tests="$(TEST_RUN_LIST)" \
 		--rerun-tests="$(TEST_RERUN_LIST)" \
+		--license-check-mode="$(LICENSE_CHECK_MODE)" \
+		--license-check-exception-file="$(LICENSE_CHECK_EXCEPTION_FILE)" \
+		--license-check-name-file="$(LICENSE_CHECK_NAME_FILE)" \
+		--license-results-file="$(pkg_license_results_file)" \
+		--license-summary-file="$(pkg_license_summary_file)" \
 		--image-config-file="$(CONFIG_FILE)" \
 		--cpu-prof-file=$(PROFILE_DIR)/scheduler.cpu.pprof \
 		--mem-prof-file=$(PROFILE_DIR)/scheduler.mem.pprof \

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -45,16 +45,18 @@ type BuildRequest struct {
 
 // BuildResult represents the results of a build agent trying to build a given node.
 type BuildResult struct {
-	AncillaryNodes []*pkggraph.PkgNode // For SRPM builds: other nodes stemming from the same SRPM. Empty otherwise.
-	BuiltFiles     []string            // List of RPMs built by this node.
-	Err            error               // Error encountered during the build.
-	LogFile        string              // Path to the log file from the build.
-	Node           *pkggraph.PkgNode   // The main node being analyzed for the build.
-	CheckFailed    bool                // Indicator if the package test failed but the build itself was correct.
-	Ignored        bool                // Indicator if the build was ignored by user request.
-	UsedCache      bool                // Indicator if we used the cached artifacts (external or earlier local build) instead of building the node.
-	WasDelta       bool                // Indicator if we used a pre-built component from an external repository instead of building the node.
-	Freshness      uint                // The freshness of the node (used to determine if we can skip building future nodes).
+	AncillaryNodes     []*pkggraph.PkgNode // For SRPM builds: other nodes stemming from the same SRPM. Empty otherwise.
+	BuiltFiles         []string            // List of RPMs built by this node.
+	Err                error               // Error encountered during the build.
+	LogFile            string              // Path to the log file from the build.
+	Node               *pkggraph.PkgNode   // The main node being analyzed for the build.
+	CheckFailed        bool                // Indicator if the package test failed but the build itself was correct.
+	Ignored            bool                // Indicator if the build was ignored by user request.
+	UsedCache          bool                // Indicator if we used the cached artifacts (external or earlier local build) instead of building the node.
+	WasDelta           bool                // Indicator if we used a pre-built component from an external repository instead of building the node.
+	Freshness          uint                // The freshness of the node (used to determine if we can skip building future nodes).
+	HasLicenseWarnings bool                // Package has at least one license check warning
+	HasLicenseErrors   bool                // Package has at least one license check error
 }
 
 // selectNextBuildRequest selects a job based on priority:

--- a/toolkit/tools/scheduler/schedulerutils/pkglicensechecker.go
+++ b/toolkit/tools/scheduler/schedulerutils/pkglicensechecker.go
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package schedulerutils
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/directory"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/pkg/licensecheck"
+	"github.com/microsoft/azurelinux/toolkit/tools/pkg/licensecheck/licensecheckformat"
+)
+
+type PackageLicenseCheckerConfig struct {
+	BuildDirPath      string                        // The path to the build directory to create the chroot in
+	WorkerTarPath     string                        // The path to the worker tarball to extract into the chroot
+	NameFilePath      string                        // The path to the file containing the license name regexes
+	ExceptionFilePath string                        // The path to the file containing the license exception regexes
+	DistTag           string                        // The dist tag to use for the chroot
+	Mode              licensecheck.LicenseCheckMode // Control the behavior of the license checker
+	ResultsFile       string                        // (optional) Where to save the .json results file
+	SummaryFile       string                        // (optional) Where to save the human readable summary file
+}
+
+// PackageLicenseChecker is a wrapper around the licensecheck package that provides an interface optimized for use in
+// the scheduler. The PackageLicenseChecker is NOT thread safe and should not be shared between goroutines. An instance
+// should be created via NewPackageLicenseChecker() and may be reused for multiple calls to CheckPkgLicenses(). Results
+// are accumulated across calls to CheckPkgLicenses() and can be saved via SaveResults() if result or summary files are
+// given.
+type PackageLicenseChecker struct {
+	config         PackageLicenseCheckerConfig
+	licenseChecker *licensecheck.LicenseChecker
+
+	rpmDirPath  string
+	checkerMode licensecheck.LicenseCheckMode
+	resultsFile string
+	summaryFile string
+}
+
+// NewPackageLicenseChecker creates a new PackageLicenseChecker. The license checker will be initialized with the given configuration. The
+// initialization of the license checker is deferred until the first call to CheckLicenses that requires scanning RPMs.
+// The resulting PackageLicenseChecker instance should be cleaned up with CleanupPackageLicenseChecker() when it is no longer needed.
+func NewPackageLicenseChecker(config PackageLicenseCheckerConfig) (p *PackageLicenseChecker, err error) {
+	if !licensecheck.IsValidLicenseCheckMode(config.Mode) {
+		err = fmt.Errorf("invalid license check mode: %s", config.Mode)
+		return nil, err
+	}
+
+	if config.Mode == licensecheck.LicenseCheckModeNone {
+		return &PackageLicenseChecker{checkerMode: licensecheck.LicenseCheckModeNone}, nil
+	}
+
+	rpmCopyDir := filepath.Join(config.BuildDirPath, "rpms_to_scan")
+	err = directory.EnsureDirExists(rpmCopyDir)
+	if err != nil {
+		err = fmt.Errorf("failed to create directory to stage RPMs:\n%w", err)
+		return nil, err
+	}
+
+	return &PackageLicenseChecker{
+		// Lazy initialize the license checker chroot. We can wait until a build is actually done, and has RPMS to scan,
+		// before starting it. If we start it now, it will block us starting any graph processing until the chroot is
+		// ready.
+		licenseChecker: nil,
+		config:         config,
+
+		rpmDirPath:  rpmCopyDir,
+		checkerMode: config.Mode,
+		resultsFile: config.ResultsFile,
+		summaryFile: config.SummaryFile,
+	}, nil
+}
+
+// Initialize the license checker chroot if needed.
+func (p *PackageLicenseChecker) startLicenseCheckerChroot() (err error) {
+	if p.licenseChecker != nil {
+		return nil
+	}
+	p.licenseChecker, err = licensecheck.New(p.config.BuildDirPath,
+		p.config.WorkerTarPath, p.rpmDirPath, p.config.NameFilePath, p.config.ExceptionFilePath, p.config.DistTag)
+	if err != nil {
+		err = fmt.Errorf("failed to create license checker for use with packages:\n%w", err)
+		return err
+	}
+	return nil
+}
+
+func (p *PackageLicenseChecker) CleanupPackageLicenseChecker() error {
+	if p.licenseChecker != nil {
+		return p.licenseChecker.Cleanup()
+	} else {
+		return nil
+	}
+}
+
+// CheckPkgLicenses will check each RPM passed in for license issues by copying them to a dedicated folder and running
+// the license checker. This function will initialize the license checker if it has not already been initialized.
+// Each call will accumulate the results of the license checks in the license checker instance. After all RPMs have been
+// checked, the results can be saved via SaveResults().
+func (p *PackageLicenseChecker) CheckPkgLicenses(rpmPaths []string) (hasWarning, hasError bool, err error) {
+	if len(rpmPaths) == 0 || p.checkerMode == licensecheck.LicenseCheckModeNone {
+		return false, false, nil
+	}
+
+	if p.licenseChecker == nil {
+		err = p.startLicenseCheckerChroot()
+		if err != nil {
+			err = fmt.Errorf("failed to start license checker chroot:\n%w", err)
+			return false, false, err
+		}
+	}
+
+	// Clear the RPM directory before copying the new RPMs
+	err = file.RemoveDirectoryContents(p.rpmDirPath)
+	if err != nil {
+		err = fmt.Errorf("failed to clear RPM directory before scan:\n%w", err)
+		return false, false, err
+	}
+
+	// Copy the RPMs into the check directory
+	for _, rpmPath := range rpmPaths {
+		err = file.Copy(rpmPath, filepath.Join(p.rpmDirPath, filepath.Base(rpmPath)))
+		if err != nil {
+			err = fmt.Errorf("failed to copy RPMs to check directory:\n%w", err)
+			return false, false, err
+		}
+	}
+
+	latestResults, err := p.licenseChecker.CheckLicenses(true)
+	if err != nil {
+		err = fmt.Errorf("failed to check licenses for packages:\n%w", err)
+		return false, false, err
+	}
+
+	_, warnings, errors := licensecheck.SortAndFilterResults(latestResults, p.checkerMode)
+
+	// Clean up once the scan is done so no .rpm files are left behind unnecessarily
+	err = file.RemoveDirectoryContents(p.rpmDirPath)
+	if err != nil {
+		err = fmt.Errorf("failed to clear RPM directory after scan:\n%w", err)
+		return false, false, err
+	}
+
+	return len(warnings) > 0, len(errors) > 0, nil
+}
+
+func (p *PackageLicenseChecker) GetSummaryFile() string {
+	return p.summaryFile
+}
+
+func (p *PackageLicenseChecker) SaveResults() (err error) {
+	all := []licensecheck.LicenseCheckResult{}
+	if p.licenseChecker != nil {
+		all, _, _ = p.licenseChecker.GetResults(p.checkerMode)
+	}
+
+	// Save the results .json file
+	if p.resultsFile != "" {
+		err = licensecheck.SaveLicenseCheckResults(p.resultsFile, all)
+		if err != nil {
+			err = fmt.Errorf("failed to save license check results:\n%w", err)
+			return err
+		}
+	}
+
+	// Save the human readable summary file
+	if p.summaryFile != "" {
+		summary := licensecheckformat.FormatResults(all, p.checkerMode)
+		err = file.Write(summary, p.summaryFile)
+		if err != nil {
+			err = fmt.Errorf("failed to save license check summary:\n%w", err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/toolkit/tools/scheduler/schedulerutils/pkglicensechecker.go
+++ b/toolkit/tools/scheduler/schedulerutils/pkglicensechecker.go
@@ -5,6 +5,7 @@ package schedulerutils
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/directory"
@@ -121,9 +122,9 @@ func (p *PackageLicenseChecker) CheckPkgLicenses(rpmPaths []string) (hasWarning,
 
 	// Copy the RPMs into the check directory
 	for _, rpmPath := range rpmPaths {
-		err = file.Copy(rpmPath, filepath.Join(p.rpmDirPath, filepath.Base(rpmPath)))
+		err = os.Link(rpmPath, filepath.Join(p.rpmDirPath, filepath.Base(rpmPath)))
 		if err != nil {
-			err = fmt.Errorf("failed to copy RPMs to check directory:\n%w", err)
+			err = fmt.Errorf("failed to link RPMs into check directory:\n%w", err)
 			return false, false, err
 		}
 	}

--- a/toolkit/tools/scheduler/schedulerutils/printresults.go
+++ b/toolkit/tools/scheduler/schedulerutils/printresults.go
@@ -393,6 +393,16 @@ func printErrorInfoByCondition(condition bool, format string, arg ...any) {
 	}
 }
 
+// printWarningInfoByCondition prints warning or info level logs depending on the input condition.
+// If the condition is true, it prints a warning level log and an info level one otherwise.
+func printWarningInfoByCondition(condition bool, format string, arg ...any) {
+	if condition {
+		logger.Log.Warnf(color.YellowString(format, arg...))
+	} else {
+		logger.Log.Infof(color.GreenString(format, arg...))
+	}
+}
+
 // summaryLine returns padded and type-formatted string for build summary.
 func summaryLine(message string, count int) string {
 	return fmt.Sprintf("%-36s%d", message, count)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The license checker added in https://github.com/microsoft/azurelinux/pull/9060 needs to be integrated into the day-to-day build process. Currently its configured to operate with warnings only, since there are a lot of packages with licensing issues.

This change adds two integrations:
- Package build
  - As each node in the graph is processed, pass the associated RPMs to an instance of the `LicenseChecker`. The rpms are copied into a working directory and the scan is run. Each scan returns intermediate data (yes/no for errors & warnings) while the actual results are accumulated in the `LicenseChecker`. Once the full graph has been built the results are saved to a .json file and a summary file. The build summary at the end of the build will also display each package that has errors/warnings. 
![image](https://github.com/user-attachments/assets/e3ef1946-8698-43a8-93ed-a8c6dd0a9612)

- Image build
  - Use the existing image target added in #9060 as a dependency of the image build process. It depends on the image package cache folder so it will be run after the fetcher runs, but before the image itself is created.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `pkglicensechecker.go` to `schedulerutils`. It provides `PackageLicenseChecker` which makes a `LicenseChecker` suitable for use with the scheduler.
- Add build requirement `$(STATUS_FLAGS_DIR)/imager_disk_output.flag` -> `$(license_results_file_img)`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing
