### PR TITLE
Image Customizer: Validate HOME and USER env vars.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -922,7 +922,7 @@ func checkEnvironmentVars() error {
 
 	if envHome != rootHome || envUser != rootUser {
 		return fmt.Errorf("tool should be run as root (e.g. by using sudo):\n"+
-			"HOME should be set to '%s' and USER should be set to '%s'",
+			"HOME must be set to '%s' and USER must be set to '%s'",
 			rootHome, rootUser)
 	}
 


### PR DESCRIPTION
The gpg command, and by extension, the tdnf command expects the USER and HOME environment variables to be valid for the OS they are running under (including under chroot). Since, the image customizer tool is typically run under `sudo` and since root is always a valid user, this generally isn't a problem. But this isn't true if `sudo -E` is used. And this can result in strange difficult to diganose errors in tdnf. So, this change verifies that `sudo -E` isn't being used.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually tested image customizer tool.

