### PR TITLE
Don't include epoch in rpm name when resolving conflicts

### DIFF
--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -64,8 +64,9 @@ const (
 
 const (
 	installedRPMRegexRPMIndex        = 1
-	installedRPMRegexArchIndex       = 2
-	installedRPMRegexExpectedMatches = 3
+	installedRPMRegexVersionIndex    = 2
+	installedRPMRegexArchIndex       = 3
+	installedRPMRegexExpectedMatches = 4
 
 	rpmProgram      = "rpm"
 	rpmSpecProgram  = "rpmspec"
@@ -84,12 +85,12 @@ var (
 
 	// Output from 'rpm' prints installed RPMs in a line with the following format:
 	//
-	//	D: ========== +++ [name]-[version]-[release].[distribution] [architecture]-linux [hex_value]
+	//	D: ========== +++ [name]-([epoch]:)[version]-[release].[distribution] [architecture]-linux [hex_value]
 	//
 	// Example:
 	//
 	//	D: ========== +++ systemd-devel-239-42.azl3 x86_64-linux 0x0
-	installedRPMRegex = regexp.MustCompile(`^D: =+ \+{3} (\S+) (\S+)-linux.*$`)
+	installedRPMRegex = regexp.MustCompile(`^D: =+ \+{3} (\S+)-([^-]+-[^-]+) (\S+)-linux.*$`)
 
 	// For most use-cases, the distro name abbreviation and major version are set by the exe package. However, if the
 	// module is used outside of the main Azure Linux build system, the caller can override these values with SetDistroMacros().
@@ -466,15 +467,29 @@ func ResolveCompetingPackages(rootDir string, rpmPaths ...string) (resolvedRPMs 
 	splitStdout := strings.Split(stderr, "\n")
 	uniqueResolvedRPMs := map[string]bool{}
 	for _, line := range splitStdout {
-		matches := installedRPMRegex.FindStringSubmatch(line)
-		if len(matches) == installedRPMRegexExpectedMatches {
-			rpmName := fmt.Sprintf("%s.%s", matches[installedRPMRegexRPMIndex], matches[installedRPMRegexArchIndex])
+		if match, rpmName := extractCompetingPackageInfoFromLine(line); match {
 			uniqueResolvedRPMs[rpmName] = true
 		}
 	}
 
 	resolvedRPMs = sliceutils.SetToSlice(uniqueResolvedRPMs)
 	return
+}
+
+func extractCompetingPackageInfoFromLine(line string) (match bool, pkgName string) {
+	matches := installedRPMRegex.FindStringSubmatch(line)
+	if len(matches) == installedRPMRegexExpectedMatches {
+		pkgName := matches[installedRPMRegexRPMIndex]
+		version := matches[installedRPMRegexVersionIndex]
+		arch := matches[installedRPMRegexArchIndex]
+		// Names should not contain the epoch, strip everything before the ":"" in the string. "Version": "0:1.2-3", becomes "1.2-3"
+		if strings.Contains(version, ":") {
+			version = strings.Split(version, ":")[1]
+		}
+
+		return true, fmt.Sprintf("%s-%s.%s", pkgName, version, arch)
+	}
+	return false, ""
 }
 
 // SpecExclusiveArchIsCompatible verifies the "ExclusiveArch" tag is compatible with the current machine's architecture.

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -458,3 +458,39 @@ func TestGetMacroDirWithRpmAvailable(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedMacroDir, macroDir)
 }
+
+func TestConflictingPackageRegex(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputLine      string
+		expectedMatch  bool
+		expectedOutput string
+	}{
+		{
+			name:           "perl with epoch",
+			inputLine:      "D: ========== +++ perl-4:5.34.1-489.cm2 x86_64-linux 0x0",
+			expectedMatch:  true,
+			expectedOutput: "perl-5.34.1-489.cm2.x86_64",
+		},
+		{
+			name:           "systemd no epoch",
+			inputLine:      "D: ========== +++ systemd-devel-239-42.cm2 x86_64-linux 0x0",
+			expectedMatch:  true,
+			expectedOutput: "systemd-devel-239-42.cm2.x86_64",
+		},
+		{
+			name:           "non-matching line",
+			inputLine:      "D: ========== tsorting packages (order, #predecessors, #succesors, depth)",
+			expectedMatch:  false,
+			expectedOutput: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, actualOut := extractCompetingPackageInfoFromLine(tt.inputLine)
+			assert.Equal(t, tt.expectedMatch, match)
+			assert.Equal(t, tt.expectedOutput, actualOut)
+		})
+	}
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Don't include the epoch when deriving the cached rpm paths for conflicting rpms in `WhatProvides()`. Previously we would do:
`D: ========== +++ perl-4:5.34.1-489.cm2 x86_64-linux 0x0` -> `perl-4:5.34.1-489.cm2.x86_64`, but actual rpms don't include the epoch. We want:
`perl-5.34.1-489.cm2.x86_64` instead.

This results in the build scheduler thinking some of these rpms are missing, since its looking for files that include the epoch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove epoch from rpm names generated by `ResolveCompetingPackages()`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://teams.microsoft.com/l/message/19:2ba2ab8d23224ab88eadf431ebee29c1@thread.v2/1721255564669?context=%7B%22contextType%22%3A%22chat%22%7D

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing only, was unable to directly repo issue
