### PR TITLE
libcontainers-common: introduce patch to address CVE-2024-37298

### DIFF
--- a/SPECS/libcontainers-common/CVE-2024-37298.patch
+++ b/SPECS/libcontainers-common/CVE-2024-37298.patch
@@ -1,0 +1,67 @@
+From 651e204dafeecb3d4c93ed2da533b1816036ca28 Mon Sep 17 00:00:00 2001
+From: Muhammad Falak R Wani <falakreyaz@gmail.com>
+Date: Tue, 9 Jul 2024 21:35:27 +0530
+Subject: [PATCH] decoder: limit slice creation based on configurable maxSize
+
+Fixes: GHSA-3669-72x9-r9p3
+Fixes: CVE-2024-37298
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ vendor/github.com/gorilla/schema/decoder.go | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/github.com/gorilla/schema/decoder.go b/vendor/github.com/gorilla/schema/decoder.go
+index 025e438..0fd1bfe 100644
+--- a/vendor/github.com/gorilla/schema/decoder.go
++++ b/vendor/github.com/gorilla/schema/decoder.go
+@@ -12,9 +12,13 @@ import (
+ 	"strings"
+ )
+ 
++const (
++	defaultMaxSize = 16000
++)
++
+ // NewDecoder returns a new Decoder.
+ func NewDecoder() *Decoder {
+-	return &Decoder{cache: newCache()}
++	return &Decoder{cache: newCache(), maxSize: defaultMaxSize}
+ }
+ 
+ // Decoder decodes values from a map[string][]string to a struct.
+@@ -22,6 +26,7 @@ type Decoder struct {
+ 	cache             *cache
+ 	zeroEmpty         bool
+ 	ignoreUnknownKeys bool
++	maxSize           int
+ }
+ 
+ // SetAliasTag changes the tag used to locate custom field aliases.
+@@ -54,6 +59,13 @@ func (d *Decoder) IgnoreUnknownKeys(i bool) {
+ 	d.ignoreUnknownKeys = i
+ }
+ 
++// MaxSize limits the size of slices for URL nested arrays or object arrays.
++// Choose MaxSize carefully; large values may create many zero-value slice elements.
++// Example: "items.100000=apple" would create a slice with 100,000 empty strings.
++func (d *Decoder) MaxSize(size int) {
++	d.maxSize = size
++}
++
+ // RegisterConverter registers a converter function for a custom type.
+ func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) {
+ 	d.cache.registerConverter(value, converterFunc)
+@@ -219,6 +231,10 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values
+ 	// Slice of structs. Let's go recursive.
+ 	if len(parts) > 1 {
+ 		idx := parts[0].index
++		// a defensive check to avoid creating a large slice based on user input index
++		if idx > d.maxSize {
++			return fmt.Errorf("%v index %d is larger than the configured maxSize %d", v.Kind(), idx, d.maxSize)
++		}
+ 		if v.IsNil() || v.Len() < idx+1 {
+ 			value := reflect.MakeSlice(t, idx+1, idx+1)
+ 			if v.Len() < idx+1 {
+-- 
+2.40.1
+

--- a/SPECS/libcontainers-common/libcontainers-common.spec
+++ b/SPECS/libcontainers-common/libcontainers-common.spec
@@ -26,7 +26,7 @@
 Summary:        Configuration files common to github.com/containers
 Name:           libcontainers-common
 Version:        20210626
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0 AND GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,6 +48,8 @@ Source8:        default.yaml
 Source9:        %{name}-common-%{commonver}.tar.gz
 Source10:       containers.conf
 Patch0:         CVE-2021-44716.patch
+#Note (mfrw): The patch for CVE-2024-37298 only applies to podman.
+Patch1:         CVE-2024-37298.patch
 BuildRequires:  go-go-md2man
 Requires(post): grep
 Requires(post): util-linux
@@ -62,7 +64,10 @@ github.com/containers libraries, such as Buildah, CRI-O, Podman and Skopeo.
 %prep
 %setup -q -T -D -b 0 -n image-%{imagever}
 %setup -q -T -D -b 1 -n storage-%{storagever}
+
 %setup -q -T -D -b 7 -n podman-%{podmanver}
+%patch 1 -p1
+
 %setup -q -T -D -b 9 -n common-%{commonver}
 %patch 0 -p1
 # copy the LICENSE file in the build root
@@ -160,6 +165,9 @@ fi
 %license LICENSE
 
 %changelog
+* Wed Jul 24 2024 Muhammad Falak <mwani@microsoft.com> - 20210526-4
+- Address CVE-2024-37298 by patching vendored github.com/gorilla/schema
+
 * Mon Feb 05 2024 Osama Esmail <osamaesmail@microsoft.com> - 20210526-3
 - Patching CVE-2021-44716
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Introduce patch to address CVE-2021-44716

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Introduce patch to address CVE-2021-44716

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #9737

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-37298

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y
- Pipeline build id: [PR-9917](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=611000&view=results)
