### PR TITLE
bind: upgrade 9.19.21 -> 9.20.0 to address CVE-CVE-2024-0760, CVE-2024-1737, CVE-2024-1975 & CVE-2024-4076

### DIFF
--- a/SPECS/bind/bind.signatures.json
+++ b/SPECS/bind/bind.signatures.json
@@ -1,18 +1,18 @@
 {
-  "Signatures": {
-    "generate-rndc-key.sh": "da0964516a9abe4074e262a1d0b7f63e63b2150c4cc2dddaaca029010383c422",
-    "named-chroot.files": "5dbc7bd2a21836fb86cb740a2d4d72eb9f2b4f341996cd0c8ae9c39e95c0d76c",
-    "named.conf.sample": "1807f11df688de4eb8cdcc97bd1a8863d81b03b1f24af96f3639de40bc8e538a",
-    "named.empty": "44e2cc6e10328cd3604148763458978f547ee54c3ff46468944d535644fc6da1",
-    "named.localhost": "9a2aa18c87202a691cc641f0c7e027dff3a2bb30917990f1b04c237e667530c8",
-    "named.logrotate": "748dd5d967d309d69b44f5451e2ce9d982af1b62448182f38ff76e83e45a4d61",
-    "named.loopback": "58a0c65ef763372a1d85e63766194526bfe19f496a413db40d9febea777ba4c9",
-    "named.rfc1912.zones": "61d2e64b8523e7d83c7cf9908538bf74b2f8f6993d52d7ab9c56cad25c23a92a",
-    "named.root": "36bf9aa06206b6b82c58a55ab74920d8901938e4cf79b754b239bb0e5dc0951c",
-    "named.root.key": "2a91cc1a1c3dd805aa149d8df6d9849d5e2ac0ad2c2ed93ddaf0234358e8c383",
-    "named.rwtab": "6a4c84b6709211d09f2d71491d4c66d1d4c0115a9db247a5ed2a9db10e575735",
-    "named.sysconfig": "8f8eff846667b7811358e289e9fe594de17d0e47f2b8cebf7840ad8db7f34816",
-    "setup-named-chroot.sh": "786fbc88c7929fadf217cf2286f2eb03b6fba14843e5da40ad43c0022dd71c3a",
-    "bind-9.19.21.tar.xz": "2b68a99b85f78c76cc87a4eac14cc510e04b64660f5036c04f5f3185b00a6e8c"
-  }
+ "Signatures": {
+  "bind-9.20.0.tar.xz": "cc580998017b51f273964058e8cb3aa5482bc785243dea71e5556ec565a13347",
+  "generate-rndc-key.sh": "da0964516a9abe4074e262a1d0b7f63e63b2150c4cc2dddaaca029010383c422",
+  "named-chroot.files": "5dbc7bd2a21836fb86cb740a2d4d72eb9f2b4f341996cd0c8ae9c39e95c0d76c",
+  "named.conf.sample": "1807f11df688de4eb8cdcc97bd1a8863d81b03b1f24af96f3639de40bc8e538a",
+  "named.empty": "44e2cc6e10328cd3604148763458978f547ee54c3ff46468944d535644fc6da1",
+  "named.localhost": "9a2aa18c87202a691cc641f0c7e027dff3a2bb30917990f1b04c237e667530c8",
+  "named.logrotate": "748dd5d967d309d69b44f5451e2ce9d982af1b62448182f38ff76e83e45a4d61",
+  "named.loopback": "58a0c65ef763372a1d85e63766194526bfe19f496a413db40d9febea777ba4c9",
+  "named.rfc1912.zones": "61d2e64b8523e7d83c7cf9908538bf74b2f8f6993d52d7ab9c56cad25c23a92a",
+  "named.root": "36bf9aa06206b6b82c58a55ab74920d8901938e4cf79b754b239bb0e5dc0951c",
+  "named.root.key": "2a91cc1a1c3dd805aa149d8df6d9849d5e2ac0ad2c2ed93ddaf0234358e8c383",
+  "named.rwtab": "6a4c84b6709211d09f2d71491d4c66d1d4c0115a9db247a5ed2a9db10e575735",
+  "named.sysconfig": "8f8eff846667b7811358e289e9fe594de17d0e47f2b8cebf7840ad8db7f34816",
+  "setup-named-chroot.sh": "786fbc88c7929fadf217cf2286f2eb03b6fba14843e5da40ad43c0022dd71c3a"
+ }
 }

--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -9,7 +9,7 @@
 
 Summary:        Domain Name System software
 Name:           bind
-Version:        9.19.21
+Version:        9.20.0
 Release:        1%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
@@ -523,6 +523,10 @@ fi;
 %{_mandir}/man1/named-nzd2nzf.1*
 
 %changelog
+* Wed Jul 24 2024 Muhammad Falak <mwani@microsoft.com> - 9.20.0-1
+- Upgrade version to 9.20.0 to address CVE-CVE-2024-0760, CVE-2024-1737, CVE-2024-1975 & CVE-2024-4076
+- Refresh patches to apply cleanly
+
 * Tue Feb 20 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.19.21-1
 - Auto-upgrade to 9.19.21 - Mariner 3.0 package upgrade
 - Update the locations of files in the new build

--- a/SPECS/bind/nongit-fix.patch
+++ b/SPECS/bind/nongit-fix.patch
@@ -1,20 +1,23 @@
-From 26d6eeabf3925d6fb7da4bbdabed6091c10c87e6 Mon Sep 17 00:00:00 2001
+From 431fa0dcec199512effecb4842a889eee5884c72 Mon Sep 17 00:00:00 2001
 From: alejandro-microsoft <alejandroma@microsoft.com>
 Date: Fri, 1 Mar 2024 17:49:51 -0800
 Subject: [PATCH] Fix issue where bind directory isn't downloaded via git
 
+Ported to v.9.20.0 from v9.19.21 by @mfrw on 24-July-2024
+
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
 ---
  configure.ac | 6 ++++--
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 512cb83..1f31c35 100644
+index a911163..b58d5be 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -19,7 +19,7 @@ m4_define([bind_VERSION_MINOR], 19)dnl
- m4_define([bind_VERSION_PATCH], 21)dnl
+@@ -19,7 +19,7 @@ m4_define([bind_VERSION_MINOR], 20)dnl
+ m4_define([bind_VERSION_PATCH], 0)dnl
  m4_define([bind_VERSION_EXTRA], )dnl
- m4_define([bind_DESCRIPTION], [(Development Release)])dnl
+ m4_define([bind_DESCRIPTION], [(Stable Release)])dnl
 -m4_define([bind_SRCID], [m4_esyscmd_s([git rev-parse --short HEAD | cut -b1-7])])dnl
 +m4_define([bind_SRCID], [m4_esyscmd_s([git rev-parse --short HEAD 2>/dev/null || echo "unsetID" | cut -b1-7])])dnl 
  m4_define([bind_PKG_VERSION], [[bind_VERSION_MAJOR.bind_VERSION_MINOR.bind_VERSION_PATCH]bind_VERSION_EXTRA])dnl
@@ -32,5 +35,5 @@ index 512cb83..1f31c35 100644
  
  #
 -- 
-2.34.1
+2.40.1
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1077,8 +1077,8 @@
         "type": "other",
         "other": {
           "name": "bind",
-          "version": "9.19.21",
-          "downloadUrl": "https://ftp.isc.org/isc/bind9/9.19.21/bind-9.19.21.tar.xz"
+          "version": "9.20.0",
+          "downloadUrl": "https://ftp.isc.org/isc/bind9/9.20.0/bind-9.20.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- **bind: upgrade 9.19.21 -> 9.20.0 to address CVE-CVE-2024-0760, CVE-2024-1737, CVE-2024-1975 & CVE-2024-4076**

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- **bind: upgrade 9.19.21 -> 9.20.0 to address CVE-CVE-2024-0760, CVE-2024-1737, CVE-2024-1975 & CVE-2024-4076**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-0760
- https://nvd.nist.gov/vuln/detail/CVE-2024-1737
- https://nvd.nist.gov/vuln/detail/CVE-2024-1975
- https://nvd.nist.gov/vuln/detail/CVE-2024-4076

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y
- Pipeline build id: [PR-9918](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=611570&view=results)
