### PR TITLE
Add Patch in terraform for CVE-2024-6257.

### DIFF
--- a/SPECS/terraform/CVE-2024-6257.patch
+++ b/SPECS/terraform/CVE-2024-6257.patch
@@ -1,0 +1,128 @@
+From 9906874a23919a81eff097d84fdb8f98525ac880 Mon Sep 17 00:00:00 2001
+From: dduzgun-security <deniz.duzgun@hashicorp.com>
+Date: Thu, 20 Jun 2024 10:06:56 -0400
+Subject: [PATCH 1/2] recreate git config during update to prevent config
+ alteration
+
+Modified to apply to vendored code by: Sumedh Sharma <sumsharma@microsoft.com>
+ - Adjusted paths to work for vendored version
+ - Removed test code since it is not included in vendor trace
+---
+ vendor/github.com/hashicorp/go-getter/get_git.go | 81 +++++++++++++++----
+ 1 file changed, 67 insertions(+), 14 deletions(-)
+
+diff --git a/vendor/github.com/hashicorp/go-getter/get_git.go b/vendor/github.com/hashicorp/go-getter/get_git.go
+index 5227db7..51a898b 100644
+--- a/vendor/github.com/hashicorp/go-getter/get_git.go
++++ b/vendor/github.com/hashicorp/go-getter/get_git.go
+@@ -125,7 +125,7 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
+ 		return err
+ 	}
+ 	if err == nil {
+-		err = g.update(ctx, dst, sshKeyFile, ref, depth)
++		err = g.update(ctx, dst, sshKeyFile, u, ref, depth)
+ 	} else {
+ 		err = g.clone(ctx, dst, sshKeyFile, u, ref, depth)
+ 	}
+@@ -228,28 +228,64 @@ func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.UR
+ 	return nil
+ }
+ 
+-func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile, ref string, depth int) error {
+-	// Determine if we're a branch. If we're NOT a branch, then we just
+-	// switch to master prior to checking out
+-	cmd := exec.CommandContext(ctx, "git", "show-ref", "-q", "--verify", "refs/heads/"+ref)
++func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile string, u *url.URL, ref string, depth int) error {
++	// Remove all variations of .git directories
++	err := removeCaseInsensitiveGitDirectory(dst)
++	if err != nil {
++		return err
++	}
++
++	// Initialize the git repository
++	cmd := exec.CommandContext(ctx, "git", "init")
++	cmd.Dir = dst
++	err = getRunCommand(cmd)
++	if err != nil {
++		return err
++	}
++
++	// Add the git remote
++	cmd = exec.CommandContext(ctx, "git", "remote", "add", "origin", "--", u.String())
++	cmd.Dir = dst
++	err = getRunCommand(cmd)
++	if err != nil {
++		return err
++	}
++
++	// Fetch the remote ref
++	cmd = exec.CommandContext(ctx, "git", "fetch", "--tags")
++	cmd.Dir = dst
++	err = getRunCommand(cmd)
++	if err != nil {
++		return err
++	}
++
++	// Fetch the remote ref
++	cmd = exec.CommandContext(ctx, "git", "fetch", "origin", "--", ref)
+ 	cmd.Dir = dst
++	err = getRunCommand(cmd)
++	if err != nil {
++		return err
++	}
+ 
+-	if getRunCommand(cmd) != nil {
+-		// Not a branch, switch to default branch. This will also catch
+-		// non-existent branches, in which case we want to switch to default
+-		// and then checkout the proper branch later.
+-		ref = findDefaultBranch(ctx, dst)
++	// Reset the branch to the fetched ref
++	cmd = exec.CommandContext(ctx, "git", "reset", "--hard", "FETCH_HEAD")
++	cmd.Dir = dst
++	err = getRunCommand(cmd)
++	if err != nil {
++		return err
+ 	}
+ 
+-	// We have to be on a branch to pull
+-	if err := g.checkout(ctx, dst, ref); err != nil {
++	// Checkout ref branch
++	err = g.checkout(ctx, dst, ref)
++	if err != nil {
+ 		return err
+ 	}
+ 
++	// Pull the latest changes from the ref branch
+ 	if depth > 0 {
+-		cmd = exec.CommandContext(ctx, "git", "pull", "--depth", strconv.Itoa(depth), "--ff-only")
++		cmd = exec.CommandContext(ctx, "git", "pull", "origin", "--depth", strconv.Itoa(depth), "--ff-only", "--", ref)
+ 	} else {
+-		cmd = exec.CommandContext(ctx, "git", "pull", "--ff-only")
++		cmd = exec.CommandContext(ctx, "git", "pull", "origin", "--ff-only", "--", ref)
+ 	}
+ 
+ 	cmd.Dir = dst
+@@ -374,3 +410,20 @@ func checkGitVersion(ctx context.Context, min string) error {
+ 
+ 	return nil
+ }
++
++// removeCaseInsensitiveGitDirectory removes all .git directory variations
++func removeCaseInsensitiveGitDirectory(dst string) error {
++	files, err := os.ReadDir(dst)
++	if err != nil {
++		return fmt.Errorf("Failed to read the destination directory %s during git update", dst)
++	}
++	for _, f := range files {
++		if strings.EqualFold(f.Name(), ".git") && f.IsDir() {
++			err := os.RemoveAll(filepath.Join(dst, f.Name()))
++			if err != nil {
++				return fmt.Errorf("Failed to remove the .git directory in the destination directory %s during git update", dst)
++			}
++		}
++	}
++	return nil
++}
+-- 
+2.25.1
+

--- a/SPECS/terraform/terraform.spec
+++ b/SPECS/terraform/terraform.spec
@@ -1,7 +1,7 @@
 Summary:        Infrastructure as code deployment management tool
 Name:           terraform
 Version:        1.3.2
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -29,6 +29,7 @@ Source0:        https://github.com/hashicorp/terraform/archive/refs/tags/v%{vers
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2023-44487.patch
 Patch1:         CVE-2024-3817.patch
+Patch2:         CVE-2024-6257.patch
 
 %global debug_package %{nil}
 %define our_gopath %{_topdir}/.gopath
@@ -62,6 +63,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./terraform
 %{_bindir}/terraform
 
 %changelog
+* Thu Jul 25 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.3.2-16
+- Patch CVE-2024-6257 in vendored hashicorp/go-getter
+
 * Thu Jun 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.3.2-15
 - Bump release to rebuild with go 1.21.11
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Patch CVE-2024-6257

go-getter versions until 1.7.4 is affected. Version 1.7.5 fixes the issue.
The patch is based on the diff between release tags 1.7.4 & 1.7.5.
Reference:
https://discuss.hashicorp.com/t/hcsec-2024-13-hashicorp-go-getter-vulnerable-to-code-execution-on-git-update-via-git-config-manipulation/68081
https://github.com/hashicorp/go-getter/compare/v1.7.4...v1.7.5

###### Change Log  <!-- REQUIRED -->
- Add patch for CVE-2024-6257

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-6257

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
