### PR TITLE
Fix CVE-2024-6655 in gtk2 and gtk3

### DIFF
--- a/SPECS/gtk2/CVE-2024-6655.patch
+++ b/SPECS/gtk2/CVE-2024-6655.patch
@@ -1,0 +1,35 @@
+From 3bbf0b6176d42836d23c36a6ac410e807ec0a7a7 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Sat, 15 Jun 2024 14:18:01 -0400
+Subject: [PATCH] Stop looking for modules in cwd
+
+This is just not a good idea. It is surprising, and can be misused.
+
+Fixes: #6786
+---
+ gtk/gtkmodules.c | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/gtk/gtkmodules.c b/gtk/gtkmodules.c
+index 704e412aeb5..f93101c272e 100644
+--- a/gtk/gtkmodules.c
++++ b/gtk/gtkmodules.c
+@@ -214,13 +214,8 @@ find_module (const gchar *name)
+   gchar *module_name;
+ 
+   module_name = _gtk_find_module (name, "modules");
+-  if (!module_name)
+-    {
+-      /* As last resort, try loading without an absolute path (using system
+-       * library path)
+-       */
+-      module_name = g_module_build_path (NULL, name);
+-    }
++  if (module_name == NULL)
++    return NULL;
+ 
+   module = g_module_open (module_name, G_MODULE_BIND_LOCAL | G_MODULE_BIND_LAZY);
+ 
+-- 
+GitLab
+

--- a/SPECS/gtk2/gtk2.spec
+++ b/SPECS/gtk2/gtk2.spec
@@ -15,7 +15,7 @@
 Summary:        GTK+ graphical user interface library
 Name:           gtk2
 Version:        2.24.32
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,7 @@ Patch15:        window-dragging.patch
 # Backported from upstream:
 Patch20:        0001-calendar-Use-the-new-OB-format-if-supported.patch
 Patch21:        0001-Fix-compiler-warnings-with-GCC-8.1.patch
+Patch22:        CVE-2024-6655.patch
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  cairo-devel
@@ -317,6 +318,9 @@ gtk-query-immodules-2.0-%{__isa_bits} --update-cache
 %doc tmpdocs/examples
 
 %changelog
+* Thu Jul 25 2024 Rohit Rawat <rohitrawat@microsoft.com> - 2.24.32-12
+- Fix CVE-2024-6655
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.24.32-11
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/SPECS/gtk3/CVE-2024-6655.patch
+++ b/SPECS/gtk3/CVE-2024-6655.patch
@@ -1,0 +1,35 @@
+From 3bbf0b6176d42836d23c36a6ac410e807ec0a7a7 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Sat, 15 Jun 2024 14:18:01 -0400
+Subject: [PATCH] Stop looking for modules in cwd
+
+This is just not a good idea. It is surprising, and can be misused.
+
+Fixes: #6786
+---
+ gtk/gtkmodules.c | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/gtk/gtkmodules.c b/gtk/gtkmodules.c
+index 704e412aeb5..f93101c272e 100644
+--- a/gtk/gtkmodules.c
++++ b/gtk/gtkmodules.c
+@@ -214,13 +214,8 @@ find_module (const gchar *name)
+   gchar *module_name;
+ 
+   module_name = _gtk_find_module (name, "modules");
+-  if (!module_name)
+-    {
+-      /* As last resort, try loading without an absolute path (using system
+-       * library path)
+-       */
+-      module_name = g_module_build_path (NULL, name);
+-    }
++  if (module_name == NULL)
++    return NULL;
+ 
+   module = g_module_open (module_name, G_MODULE_BIND_LOCAL | G_MODULE_BIND_LAZY);
+ 
+-- 
+GitLab
+

--- a/SPECS/gtk3/gtk3.spec
+++ b/SPECS/gtk3/gtk3.spec
@@ -15,7 +15,7 @@
 Summary:        GTK+ graphical user interface library
 Name:           gtk3
 Version:        3.24.28
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -24,6 +24,7 @@ Source0:        https://download.gnome.org/sources/gtk+/3.24/gtk+-%{version}.tar
 # https://bugzilla.redhat.com/show_bug.cgi?id=1946133
 # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3387
 Patch0:         3387.patch
+Patch1:         CVE-2024-6655.patch
 BuildRequires:  cairo-devel >= %{cairo_version}
 BuildRequires:  cairo-gobject-devel >= %{cairo_version}
 BuildRequires:  cups-devel
@@ -289,6 +290,9 @@ gtk-query-immodules-3.0-%{__isa_bits} --update-cache &>/dev/null || :
 %{_datadir}/installed-tests/
 
 %changelog
+* Thu Jul 25 2024 Rohit Rawat <rohitrawat@microsoft.com> - 3.24.28-10
+- Fix CVE-2024-6655
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 3.24.28-9
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2024-6655 in gtk2 and gtk3

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2024-6655

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-6655

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Github PR Checks
