### PR TITLE
Fix edk2 OVMF 4M files

### DIFF
--- a/SPECS/edk2/30-edk2-ovmf-4m-qcow2-x64-sb-enrolled.json
+++ b/SPECS/edk2/30-edk2-ovmf-4m-qcow2-x64-sb-enrolled.json
@@ -7,12 +7,12 @@
         "device": "flash",
         "mode" : "split",
         "executable": {
-            "filename": "/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.qcow2",
-            "format": "qcow2"
+            "filename": "/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.fd",
+            "format": "raw"
         },
         "nvram-template": {
-            "filename": "/usr/share/edk2/ovmf/OVMF_VARS_4M.secboot.qcow2",
-            "format": "qcow2"
+            "filename": "/usr/share/edk2/ovmf/OVMF_VARS_4M.secboot.fd",
+            "format": "raw"
         }
     },
     "targets": [

--- a/SPECS/edk2/40-edk2-ovmf-4m-qcow2-x64-sb.json
+++ b/SPECS/edk2/40-edk2-ovmf-4m-qcow2-x64-sb.json
@@ -7,12 +7,12 @@
         "device": "flash",
         "mode" : "split",
         "executable": {
-            "filename": "/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.qcow2",
-            "format": "qcow2"
+            "filename": "/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.fd",
+            "format": "raw"
         },
         "nvram-template": {
-            "filename": "/usr/share/edk2/ovmf/OVMF_VARS_4M.qcow2",
-            "format": "qcow2"
+            "filename": "/usr/share/edk2/ovmf/OVMF_VARS_4M.fd",
+            "format": "raw"
         }
     },
     "targets": [

--- a/SPECS/edk2/50-edk2-ovmf-4m-qcow2-x64-nosb.json
+++ b/SPECS/edk2/50-edk2-ovmf-4m-qcow2-x64-nosb.json
@@ -7,12 +7,12 @@
         "device": "flash",
         "mode" : "split",
         "executable": {
-            "filename": "/usr/share/edk2/ovmf/OVMF_CODE_4M.qcow2",
-            "format": "qcow2"
+            "filename": "/usr/share/edk2/ovmf/OVMF_CODE_4M.fd",
+            "format": "raw"
         },
         "nvram-template": {
-            "filename": "/usr/share/edk2/ovmf/OVMF_VARS_4M.qcow2",
-            "format": "qcow2"
+            "filename": "/usr/share/edk2/ovmf/OVMF_VARS_4M.fd",
+            "format": "raw"
         }
     },
     "targets": [

--- a/SPECS/edk2/edk2.signatures.json
+++ b/SPECS/edk2/edk2.signatures.json
@@ -1,14 +1,14 @@
 {
  "Signatures": {
-  "30-edk2-ovmf-4m-qcow2-x64-sb-enrolled.json": "827c542dee2906d261c92c19f390637c1e653165d6a920c45651edd68e7fffd0",
+  "30-edk2-ovmf-4m-qcow2-x64-sb-enrolled.json": "cdbb500dbfbf2f18f82585986e0240f219e3a47e3d9d65f247a3481d9ded2685",
   "30-edk2-ovmf-ia32-sb-enrolled.json": "8ce4600fd84968adca9d037df9531d34ce455ad566d4691d256d370acc86120d",
   "31-edk2-ovmf-2m-raw-x64-sb-enrolled.json": "e0237cf4909d129324953bd854caf79136065402a30d363f13e594fd0e493bcf",
-  "40-edk2-ovmf-4m-qcow2-x64-sb.json": "52ad30099a600dc9d03d60557a94e8c5459cd72124445109287ebf6971b879a1",
+  "40-edk2-ovmf-4m-qcow2-x64-sb.json": "566c544ce5e3b6b7052fdb87d69e90e9e10e0cde9a0f276c26e0106189c5a159",
   "40-edk2-ovmf-ia32-sb.json": "de562405d0f9a9400eb58239e10753455216196dface2631858bcf1a3c886ac7",
   "41-edk2-ovmf-2m-raw-x64-sb.json": "c9c505b6308af28f29c16b4108f7f295408f975a47c94fb7aef523cb2a999d8e",
   "50-edk2-aarch64-qcow2.json": "a62d1c8b3801a33d670863fd4824252f65b93b64af8e5fd8908e6e09d8d5db99",
   "50-edk2-arm-verbose.json": "8805fce3e313705b7b43be6f2601776871c35bac0914fa05c34d09c929044253",
-  "50-edk2-ovmf-4m-qcow2-x64-nosb.json": "a97c1339a837d106ccb25132a68cdeaf13f2b7cff3d4c7411ce4457e75b68278",
+  "50-edk2-ovmf-4m-qcow2-x64-nosb.json": "5758a4feb7b3763315365f3592efa099265b8db1dbb060e90dbb64223168624d",
   "50-edk2-ovmf-ia32-nosb.json": "b360162bd55df3b1cb4bfa8d0b7c2b46a7c7b492aabf6d0d57c3dbf3d8c7fd10",
   "50-edk2-ovmf-x64-microvm.json": "5136200cd26eff9387259b1ca0f352b64298283f990277ac7a1b7a94d87baa27",
   "51-edk2-aarch64-raw.json": "7523b4dc263748fc8bee26e763aa94463222a8d2e8b738fdbde0d2b263ad562d",

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -36,9 +36,9 @@
 %global have_usbredir 1
 %global enable_werror 0
 %global have_edk2 0
-%ifarch %{ix86} x86_64 %{arm} aarch64
-%global have_edk2 1
-%endif
+# edk2 is built according to its spec: ExclusiveArch: x86_64 
+# ovmf is needed for supported arch though, introduce have_edk2_ovmf
+%global have_edk2_ovmf 1
 %global have_pmem 0
 %ifarch x86_64
 %global have_pmem 1
@@ -927,7 +927,7 @@ Requires:       %{name}-common = %{version}-%{release}
 Requires:       seabios-bin
 Requires:       seavgabios-bin
 Requires:       sgabios-bin
-%if %{have_edk2}
+%if %{have_edk2_ovmf}
 Requires:       edk2-ovmf
 %endif
 Requires:       %{name}-ipxe = %{version}-%{release}

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -220,7 +220,7 @@ Obsoletes: %{name}-system-unicore32-core <= %{version}-%{release}
 Summary:        QEMU is a FAST! processor emulator
 Name:           qemu
 Version:        6.2.0
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        BSD AND CC-BY AND GPLv2+ AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -2312,6 +2312,9 @@ useradd -r -u 107 -g qemu -G kvm -d / -s %{_sbindir}/nologin \
 
 
 %changelog
+* Thu Jul 25 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 6.2.0-20
+- Ensure edk2 dependency
+
 * Mon Oct 30 2023 Jonathan Behrens <jbehrens@microsoft.com> - 6.2.0-19
 - Address CVE-2023-3354
 

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -36,6 +36,9 @@
 %global have_usbredir 1
 %global enable_werror 0
 %global have_edk2 0
+%ifarch %{ix86} x86_64 %{arm} aarch64
+%global have_edk2 1
+%endif
 %global have_pmem 0
 %ifarch x86_64
 %global have_pmem 1


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Mariner2.0 cannot use libvirt to create qemu VMs with edk2 OVMF qcow2 files (uefi)

###### Change Log  <!-- REQUIRED -->
- Remove fedora-specific fd (raw) to qcow2 conversion
- Modify json files referencing qcow2 files to references raw fd files
- Modify qemu to depend on edk2

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES/NO**

###### Associated issues  <!-- optional -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/52441350

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=611898&view=results
- manually used edk2 and qemu RPMs with previously broken VM domain definition
