### PR TITLE
Toolkit: Do not give GPT partitions a default label of "primary".

### DIFF
--- a/toolkit/tools/imagegen/configuration/partitiontabletype.go
+++ b/toolkit/tools/imagegen/configuration/partitiontabletype.go
@@ -29,7 +29,7 @@ var partitionTableTypeToPartedArgument = map[PartitionTableType]string{
 }
 
 func (p PartitionTableType) String() string {
-	return fmt.Sprintf(string(p))
+	return string(p)
 }
 
 // GetValidPartitionTableTypes returns a list of all the supported

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -554,7 +554,7 @@ func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		// Partition label.
 		if partition.Name == "" {
 			// Since parted is a scripting language, you have to specify "" to represent an empty string.
-			mkpartArgs = append(mkpartArgs, "\"\"")
+			mkpartArgs = append(mkpartArgs, `""`)
 		} else {
 			mkpartArgs = append(mkpartArgs, partition.Name)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -65,6 +65,14 @@ func TestCustomizeImagePartitions(t *testing.T) {
 	}
 	defer imageConnection.Close()
 
+	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
+	if assert.NoError(t, err, "read partition table") {
+		assert.Equal(t, "", partitions[1].PartLabel)
+		assert.Equal(t, "", partitions[2].PartLabel)
+		assert.Equal(t, "rootfs", partitions[3].PartLabel)
+		assert.Equal(t, "", partitions[4].PartLabel)
+	}
+
 	// Check for key files/directories on the partitions.
 	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/usr/bin/bash"))
 	assert.NoError(t, err, "check for /usr/bin/bash")
@@ -72,7 +80,7 @@ func TestCustomizeImagePartitions(t *testing.T) {
 	_, err = os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), "/var/log"))
 	assert.NoError(t, err, "check for /var/log")
 
-	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
+	partitions, err = diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	assert.NoError(t, err, "get disk partitions")
 
 	// Check that the fstab entries are correct.

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
@@ -13,6 +13,7 @@ storage:
       end: 108M
 
     - id: rootfs
+      label: rootfs
       start: 108M
       end: 2G
 


### PR DESCRIPTION
When creating partitions using `parted`, the API is:

- MBR: `parted mkpart <partition-type> <fs-type> ...`
- GPT: `parted mkpart <partition-label> <fs-type> ...`

But currently we are treating the first param as always being the `<partition-type>`, when for GPT it is `<partition-label>`. This has the effect that GPT partitions are given a default label of "primary", which is a tad silly. (If an explicit label is provided by the user, then the label is overridden in a subsequent step.)

This change fixes this behavior so that GPT partitions have a default label of nothing ("").

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.
- Added UT.


