### PR TITLE
Image Customizer: Improve copy directory error message.

### DIFF
--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -114,13 +114,12 @@ func CopyDir(src, dst string, newDirPermissions, childFilePermissions fs.FileMod
 	}
 
 	if !isDstExist {
-		logger.Log.Infof("Creating destination directory on chroot (%s)", dst)
+		logger.Log.Debugf("Creating destination directory (%s)", dst)
 		// Create dst dir
 		err = os.MkdirAll(dst, newDirPermissions)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create directory (%s):\n%w", dst, err)
 		}
-
 	}
 
 	// Open the source directory
@@ -142,7 +141,7 @@ func CopyDir(src, dst string, newDirPermissions, childFilePermissions fs.FileMod
 		} else {
 			// If it's a file, copy it and set file permissions
 			if err := NewFileCopyBuilder(srcPath, dstPath).SetFileMode(childFilePermissions).Run(); err != nil {
-				return err
+				return fmt.Errorf("failed to copy file (%s) to (%s):\n%w", srcPath, dstPath, err)
 			}
 		}
 	}

--- a/toolkit/tools/internal/file/filecopybuilder.go
+++ b/toolkit/tools/internal/file/filecopybuilder.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/sirupsen/logrus"
 )
 
 type FileCopyBuilder struct {
@@ -48,8 +49,6 @@ func (b FileCopyBuilder) SetNoDereference() FileCopyBuilder {
 }
 
 func (b FileCopyBuilder) Run() (err error) {
-	const squashErrors = false
-
 	logger.Log.Debugf("Copying (%s) to (%s)", b.Src, b.Dst)
 
 	if b.NoDereference && b.ChangeFileMode {
@@ -86,7 +85,10 @@ func (b FileCopyBuilder) Run() (err error) {
 
 	args = append(args, "--preserve=mode", b.Src, b.Dst)
 
-	err = shell.ExecuteLive(squashErrors, "cp", args...)
+	err = shell.NewExecBuilder("cp", args...).
+		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
+		ErrorStderrLines(1).
+		Execute()
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -178,7 +178,7 @@ func copyAdditionalFiles(baseConfigPath string, additionalFiles imagecustomizera
 func copyAdditionalDirs(baseConfigPath string, additionalDirs imagecustomizerapi.DirConfigList, imageChroot *safechroot.Chroot) error {
 	for _, dirConfigElement := range additionalDirs {
 		absSourceDir := file.GetAbsPathWithBase(baseConfigPath, dirConfigElement.SourcePath)
-		logger.Log.Infof("Copying %s into %s", absSourceDir, dirConfigElement.DestinationPath)
+		logger.Log.Infof("Copying %s to %s", absSourceDir, dirConfigElement.DestinationPath)
 
 		// Setting permissions values. They are set to a default value if they have not been specified.
 		newDirPermissionsValue := fs.FileMode(defaultFilePermissions)
@@ -199,7 +199,7 @@ func copyAdditionalDirs(baseConfigPath string, additionalDirs imagecustomizerapi
 		}
 		err := imageChroot.AddDirs(dirToCopy)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to copy directory (%s) to (%s):\n%w", absSourceDir, dirConfigElement.DestinationPath, err)
 		}
 	}
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -272,6 +272,9 @@ func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Make a directory that contains an infinite file.
+	// Specifically, a file that symlinks to /dev/zero, which is a virtual file that contains
+	// infinite bytes of 0. This should cause the copy operation to run out of free space on
+	// the disk.
 	srcDirPath := filepath.Join(testTmpDir, "a")
 	infiniteFilePath := filepath.Join(srcDirPath, "zero")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/infinite-file-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/infinite-file-config.yaml
@@ -1,0 +1,3 @@
+os:
+  additionalFiles:
+    /dev/zero: /zero.txt


### PR DESCRIPTION
1. When calling `cp`, include the last line of `stderr` in the error message.

2. Ensure that the `file.CopyDir` function adds useful information to the error message.

3. Add path information to error message for `.os.additionalDirs` errors.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added image customizer UTs.

