### PR TITLE
compiler-rt: fix path issue

### DIFF
--- a/SPECS/compiler-rt/compiler-rt.spec
+++ b/SPECS/compiler-rt/compiler-rt.spec
@@ -1,11 +1,11 @@
-%global maj_ver %(echo %{version} | cut -d. -f1)
+%global maj_ver 18
 
 %global compiler_rt_srcdir llvm-project-llvmorg-%{version}
 
 Summary:        LLVM compiler support routines
 Name:           compiler-rt
 Version:        18.1.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache 2.0 WITH exceptions
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -30,9 +30,10 @@ BlocksRuntime is an implementation of Apple "blocks" interface.
 %build
 mkdir -p build
 cd build
-%cmake -DCMAKE_BUILD_TYPE=Release  \
-	-DCOMPILER_RT_INSTALL_PATH=%{_prefix}/lib/clang/%{maj_ver} \
-       -Wno-dev ../compiler-rt
+%cmake \
+        -DCMAKE_BUILD_TYPE=Release  \
+        -DCOMPILER_RT_INSTALL_PATH=%{_prefix}/lib/clang/%{maj_ver} \
+        -Wno-dev ../compiler-rt
 
 %make_build
 
@@ -43,13 +44,15 @@ cd build
 %files
 %defattr(-,root,root)
 %license LICENSE.TXT
-
 %{_libdir}/clang/%{maj_ver}/bin/*
 %{_libdir}/clang/%{maj_ver}/include/*
 %{_libdir}/clang/%{maj_ver}/lib/*
 %{_libdir}/clang/%{maj_ver}/share/*
 
 %changelog
+* Thu Jul 25 2024 Andrew Phelps <anphel@microsoft.com> - 18.1.2-3
+- Fix installation path
+
 * Wed May 29 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 18.1.2-2
 - Bump release to build with new llvm to fix CVE-2024-31852
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -10360,16 +10360,6 @@
       "component": {
         "type": "other",
         "other": {
-          "name": "libomp",
-          "version": "10.0.1",
-          "downloadUrl": "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/openmp-10.0.1.src.tar.xz"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "other",
-        "other": {
           "name": "libomxil-bellagio",
           "version": "0.9.3",
           "downloadUrl": "http://downloads.sourceforge.net/omxil/libomxil-bellagio-0.9.3.tar.gz"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix the path used for libraries in compiler-rt from `/usr/lib/clang/18.1.2/...` to `/usr/lib/clang/18/...`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change compiler-rt to fix path
- Remove cgmanifest entry for unused `libomp` package. This was removed in #5244 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=612114&view=results
