### PR TITLE
Better toolchain downloader

### DIFF
--- a/toolkit/scripts/toolchain/download_toolchain_rpm.sh
+++ b/toolkit/scripts/toolchain/download_toolchain_rpm.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+# Usage print
+function usage() {
+    echo "Usage: $0 --downloader-tool <downloader_tool> --rpm-name <rpm_name> --dst <dst_file> --log-base <log_base>" \
+    "--url-list <url_list> [--cert <cert>] [--key <key>] [--enforce-signatures] [--allowable-gpg-keys <allowable_gpg_keys>]"
+
+    echo "-t|--downloader-tool: Path to our go downloader tool"
+    echo "-r|--rpm-name: Name of the RPM to download"
+    echo "-d|--dst: Destination file path"
+    echo "-l|--log-base: Base path for log files. Each attempt will have a log file named <log_base>.<attempt_num>"
+    echo "--hydrate: Print alternate log message for hydrate operations"
+    echo "-h|--help: Print this help message"
+    echo "-u|--url-list: Space separated list of base URLs to attempt to download the RPM from. The URLs will be tried in order"
+    echo "           until the RPM is successfully downloaded. Full URL will be <url>/<rpm_name>"
+    echo "-c|--certificate: Optional path to a certificate file to use for the download"
+    echo "-k|--private-key: Optional path to a private key file to use for the download"
+    exit 1
+}
+
+# Default values
+downloader_tool=""
+rpm_name=""
+dst_file=""
+log_file=""
+hydrate=false
+url_list=""
+cert=""
+key=""
+
+while (( "$#")); do
+    case "$1" in
+        -t|--downloader-tool)
+            downloader_tool=$2
+            shift 2
+            ;;
+        -r|--rpm-name)
+            rpm_name=$2
+            shift 2
+            ;;
+        -d|--dst)
+            dst_file=$2
+            shift 2
+            ;;
+        -l|--log-base)
+            log_file=$2
+            shift 2
+            ;;
+        --hydrate)
+            hydrate=true
+            shift
+            ;;
+        -u|--url-list)
+            url_list=$2
+            shift 2
+            ;;
+        -c|--certificate)
+            cert=$2
+            shift 2
+            ;;
+        -k|--private-key)
+            key=$2
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            ;;
+    esac
+done
+
+if [ -z "$downloader_tool" ]; then
+    usage
+fi
+
+if [ -z "$rpm_name" ]; then
+    usage
+fi
+
+if [ -z "$dst_file" ]; then
+    usage
+fi
+
+if [ -z "$log_file" ]; then
+    usage
+fi
+
+if [ -z "$url_list" ]; then
+    usage
+fi
+
+if [ -n "$cert" ]; then
+    cert="--certificate=$cert"
+fi
+
+if [ -n "$key" ]; then
+    key="--private-key=$key"
+fi
+
+function download() {
+    # Ensure the destination directory exists
+    dst_dir=$(dirname "$dst_file")
+    mkdir -p "$dst_dir"
+
+    if $hydrate; then
+        echo Attempting to download toolchain RPM:  $rpm_name | tee "$log_file"
+    else
+        echo "Downloading toolchain RPM: $rpm_name" | tee "$log_file"
+    fi
+
+    log_num=0
+    for url in $url_list; do
+        log_num=$((log_num + 1))
+        attempt_log_file="$log_file.$log_num"
+        src_url="$url/$rpm_name"
+
+        echo "$src_url -> $attempt_log_file" >> "$log_file"
+        { $downloader_tool $cert $key --no-clobber --output-file="$dst_file" --log-file="$attempt_log_file" "$src_url" 1>/dev/null 2>&1 ; res=$? ; } || true
+
+        if [ $res = 0 ]; then
+            echo "Downloaded toolchain RPM: $rpm_name" >> "$attempt_log_file"
+
+            echo "SUCCESS" >> "$log_file"
+            touch "$dst_file"
+            return
+        else
+            echo "Failed to download toolchain RPM: $rpm_name" >> "$attempt_log_file"
+            echo "FAILURE" >> "$log_file"
+        fi
+    done
+
+    exit 1
+}
+
+mkdir -p "$(dirname "$log_file")"
+
+download

--- a/toolkit/scripts/toolchain/download_toolchain_rpm.sh
+++ b/toolkit/scripts/toolchain/download_toolchain_rpm.sh
@@ -7,7 +7,7 @@ set -e
 # Usage print
 function usage() {
     echo "Usage: $0 --downloader-tool <downloader_tool> --rpm-name <rpm_name> --dst <dst_file> --log-base <log_base>" \
-    "--url-list <url_list> [--cert <cert>] [--key <key>] [--enforce-signatures] [--allowable-gpg-keys <allowable_gpg_keys>]"
+    "--url-list <url_list> [--certificate <cert>] [--private-key <key>]"
 
     echo "-t|--downloader-tool: Path to our go downloader tool"
     echo "-r|--rpm-name: Name of the RPM to download"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In preparation for a new explicit validation mechanism break out the toolchain downloader logic into a real script.

The new script will handle the logic that was previously baked into the makefile, while also addressing the issue of log overwriting.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move toolchain download logic into `download_toolchain_rpms.sh`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
