### PR TITLE
update go link commands for go-1.21 in ubuntu prereq

### DIFF
--- a/toolkit/docs/building/prerequisites-ubuntu.md
+++ b/toolkit/docs/building/prerequisites-ubuntu.md
@@ -30,9 +30,9 @@ sudo apt -y install \
     xfsprogs \
     zstd
 
-# Fix go 1.20 link
-sudo ln -vsf /usr/lib/go-1.20/bin/go /usr/bin/go
-sudo ln -vsf /usr/lib/go-1.20/bin/gofmt /usr/bin/gofmt
+# Fix go 1.21 link
+sudo ln -vsf /usr/lib/go-1.21/bin/go /usr/bin/go
+sudo ln -vsf /usr/lib/go-1.21/bin/gofmt /usr/bin/gofmt
 
 # Install and configure Docker.
 curl -fsSL https://get.docker.com -o get-docker.sh


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
With the update to use go-1.21 we should also update the link commands to do the same not go-1.20

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update docs

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

