### PR TITLE
Upgrade default golang to 1.22.5 and backport the fix for 1.18

### DIFF
--- a/SPECS/golang/CVE-2024-24790.patch
+++ b/SPECS/golang/CVE-2024-24790.patch
@@ -1,0 +1,193 @@
+diff --git a/src/net/netip/inlining_test.go b/src/net/netip/inlining_test.go
+index 107fe1f083..1250c37725 100644
+--- a/src/net/netip/inlining_test.go
++++ b/src/net/netip/inlining_test.go
+@@ -41,8 +41,6 @@ func TestInlining(t *testing.T) {
+ 		"Addr.Is4",
+ 		"Addr.Is4In6",
+ 		"Addr.Is6",
+-		"Addr.IsLoopback",
+-		"Addr.IsMulticast",
+ 		"Addr.IsInterfaceLocalMulticast",
+ 		"Addr.IsValid",
+ 		"Addr.IsUnspecified",
+diff --git a/src/net/netip/netip.go b/src/net/netip/netip.go
+index f27984ab57..310e4e5bf4 100644
+--- a/src/net/netip/netip.go
++++ b/src/net/netip/netip.go
+@@ -75,6 +75,9 @@ var (
+ // address ff02::1.
+ func IPv6LinkLocalAllNodes() Addr { return AddrFrom16([16]byte{0: 0xff, 1: 0x02, 15: 0x01}) }
+ 
++// IPv6Loopback returns the IPv6 loopback address ::1.
++func IPv6Loopback() Addr { return AddrFrom16([16]byte{15: 0x01}) }
++
+ // IPv6Unspecified returns the IPv6 unspecified address "::".
+ func IPv6Unspecified() Addr { return Addr{z: z6noz} }
+ 
+@@ -515,6 +518,9 @@ func (ip Addr) hasZone() bool {
+ 
+ // IsLinkLocalUnicast reports whether ip is a link-local unicast address.
+ func (ip Addr) IsLinkLocalUnicast() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Dynamic Configuration of IPv4 Link-Local Addresses
+ 	// https://datatracker.ietf.org/doc/html/rfc3927#section-2.1
+ 	if ip.Is4() {
+@@ -530,6 +536,9 @@ func (ip Addr) IsLinkLocalUnicast() bool {
+ 
+ // IsLoopback reports whether ip is a loopback address.
+ func (ip Addr) IsLoopback() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Requirements for Internet Hosts -- Communication Layers (3.2.1.3 Addressing)
+ 	// https://datatracker.ietf.org/doc/html/rfc1122#section-3.2.1.3
+ 	if ip.Is4() {
+@@ -545,6 +554,9 @@ func (ip Addr) IsLoopback() bool {
+ 
+ // IsMulticast reports whether ip is a multicast address.
+ func (ip Addr) IsMulticast() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Host Extensions for IP Multicasting (4. HOST GROUP ADDRESSES)
+ 	// https://datatracker.ietf.org/doc/html/rfc1112#section-4
+ 	if ip.Is4() {
+@@ -563,7 +575,7 @@ func (ip Addr) IsMulticast() bool {
+ func (ip Addr) IsInterfaceLocalMulticast() bool {
+ 	// IPv6 Addressing Architecture (2.7.1. Pre-Defined Multicast Addresses)
+ 	// https://datatracker.ietf.org/doc/html/rfc4291#section-2.7.1
+-	if ip.Is6() {
++	if ip.Is6() && !ip.Is4In6() {
+ 		return ip.v6u16(0)&0xff0f == 0xff01
+ 	}
+ 	return false // zero value
+@@ -571,6 +583,9 @@ func (ip Addr) IsInterfaceLocalMulticast() bool {
+ 
+ // IsLinkLocalMulticast reports whether ip is a link-local multicast address.
+ func (ip Addr) IsLinkLocalMulticast() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// IPv4 Multicast Guidelines (4. Local Network Control Block (224.0.0/24))
+ 	// https://datatracker.ietf.org/doc/html/rfc5771#section-4
+ 	if ip.Is4() {
+@@ -599,6 +614,9 @@ func (ip Addr) IsGlobalUnicast() bool {
+ 		return false
+ 	}
+ 
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Match package net's IsGlobalUnicast logic. Notably private IPv4 addresses
+ 	// and ULA IPv6 addresses are still considered "global unicast".
+ 	if ip.Is4() && (ip == IPv4Unspecified() || ip == AddrFrom4([4]byte{255, 255, 255, 255})) {
+@@ -616,6 +634,10 @@ func (ip Addr) IsGlobalUnicast() bool {
+ // ip is in 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, or fc00::/7. This is the
+ // same as net.IP.IsPrivate.
+ func (ip Addr) IsPrivate() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
++
+ 	// Match the stdlib's IsPrivate logic.
+ 	if ip.Is4() {
+ 		// RFC 1918 allocates 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16 as
+diff --git a/src/net/netip/netip_test.go b/src/net/netip/netip_test.go
+index d988864827..c7e458af43 100644
+--- a/src/net/netip/netip_test.go
++++ b/src/net/netip/netip_test.go
+@@ -554,10 +554,13 @@ func TestIPProperties(t *testing.T) {
+ 		ilm6     = mustIP("ff01::1")
+ 		ilmZone6 = mustIP("ff01::1%eth0")
+ 
+-		private4a = mustIP("10.0.0.1")
+-		private4b = mustIP("172.16.0.1")
+-		private4c = mustIP("192.168.1.1")
+-		private6  = mustIP("fd00::1")
++		private4a        = mustIP("10.0.0.1")
++		private4b        = mustIP("172.16.0.1")
++		private4c        = mustIP("192.168.1.1")
++		private6         = mustIP("fd00::1")
++		private6mapped4a = mustIP("::ffff:10.0.0.1")
++		private6mapped4b = mustIP("::ffff:172.16.0.1")
++		private6mapped4c = mustIP("::ffff:192.168.1.1")
+ 
+ 		unspecified4 = AddrFrom4([4]byte{})
+ 		unspecified6 = IPv6Unspecified()
+@@ -584,6 +587,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:            unicast4,
+ 			globalUnicast: true,
+ 		},
++		{
++			name:          "unicast v6 mapped v4Addr",
++			ip:            AddrFrom16(unicast4.As16()),
++			globalUnicast: true,
++		},
+ 		{
+ 			name:          "unicast v6Addr",
+ 			ip:            unicast6,
+@@ -605,6 +613,12 @@ func TestIPProperties(t *testing.T) {
+ 			linkLocalMulticast: true,
+ 			multicast:          true,
+ 		},
++		{
++			name:               "multicast v6 mapped v4Addr",
++			ip:                 AddrFrom16(multicast4.As16()),
++			linkLocalMulticast: true,
++			multicast:          true,
++		},
+ 		{
+ 			name:               "multicast v6Addr",
+ 			ip:                 multicast6,
+@@ -622,6 +636,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:               llu4,
+ 			linkLocalUnicast: true,
+ 		},
++		{
++			name:             "link-local unicast v6 mapped v4Addr",
++			ip:               AddrFrom16(llu4.As16()),
++			linkLocalUnicast: true,
++		},
+ 		{
+ 			name:             "link-local unicast v6Addr",
+ 			ip:               llu6,
+@@ -647,6 +666,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:       loopback6,
+ 			loopback: true,
+ 		},
++		{
++			name:     "loopback v6 mapped v4Addr",
++			ip:       AddrFrom16(IPv6Loopback().As16()),
++			loopback: true,
++		},
+ 		{
+ 			name:                    "interface-local multicast v6Addr",
+ 			ip:                      ilm6,
+@@ -683,6 +707,24 @@ func TestIPProperties(t *testing.T) {
+ 			globalUnicast: true,
+ 			private:       true,
+ 		},
++		{
++			name:          "private v6 mapped v4Addr 10/8",
++			ip:            private6mapped4a,
++			globalUnicast: true,
++			private:       true,
++		},
++		{
++			name:          "private v6 mapped v4Addr 172.16/12",
++			ip:            private6mapped4b,
++			globalUnicast: true,
++			private:       true,
++		},
++		{
++			name:          "private v6 mapped v4Addr 192.168/16",
++			ip:            private6mapped4c,
++			globalUnicast: true,
++			private:       true,
++		},
+ 		{
+ 			name:        "unspecified v4Addr",
+ 			ip:          unspecified4,

--- a/SPECS/golang/golang-1.18.spec
+++ b/SPECS/golang/golang-1.18.spec
@@ -13,7 +13,7 @@
 Summary:        Go
 Name:           golang
 Version:        1.18.8
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -24,9 +24,12 @@ Source1:        https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
 # CVE-2022-41717 is fixed in 1.18.9
 Patch1:         CVE-2022-41717.patch
+# CVE-2024-24790 is fixed in 1.18.8
+Patch2:		CVE-2024-24790.patch
 Obsoletes:      %{name} < %{version}
 Provides:       %{name} = %{version}
 Provides:       go = %{version}-%{release}
+
 
 %description
 Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
@@ -40,7 +43,7 @@ mv -v go go-bootstrap
 
 %setup -q -n go
 patch -Np1 --ignore-whitespace < %{PATCH1}
-
+patch -Np1 --ignore-whitespace < %{PATCH2}
 %build
 # Build go 1.4 bootstrap
 pushd %{_topdir}/BUILD/go-bootstrap/src
@@ -120,6 +123,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Mon July 29 2024 Bhagyashri Pathak bhapathak@microsoft.com - 1.18.8.4
+- Patch CVE-2024-24790
+
 * Mon Jan 23 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.8-3
 - Create spec file for golang 1.18
 

--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -1,7 +1,8 @@
 {
-  "Signatures": {
-    "go1.19.12.src.tar.gz": "ee5d50e0a7fd74ba1b137cb879609aaaef9880bf72b5d1742100e38ae72bb557",
-    "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52",
-    "go1.21.11.src.tar.gz": "42aee9bf2b6956c75a7ad6aa3f0a51b5821ffeac57f5a2e733a2d6eae1e6d9d2"
-  }
+ "Signatures": {
+  "go1.17.13.src.tar.gz": "a1a48b23afb206f95e7bbaa9b898d965f90826f6f1d1fc0c1d784ada0cd300fd",
+  "go1.21.6.src.tar.gz": "124926a62e45f78daabbaedb9c011d97633186a33c238ffc1e25320c02046248",
+  "go1.22.5.src.tar.gz": "ac9c723f224969aee624bc34fd34c9e13f2a212d75c71c807de644bb46e112f6",
+  "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
+ }
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4630,18 +4630,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.19.12",
-          "downloadUrl": "https://golang.org/dl/go1.19.12.src.tar.gz"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "other",
-        "other": {
-          "name": "golang",
-          "version": "1.21.11",
-          "downloadUrl": "https://golang.org/dl/go1.21.11.src.tar.gz"
+          "version": "1.22.5",
+          "downloadUrl": "https://golang.org/dl/go1.22.5.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ x] The toolchain/worker package manifests are up-to-date
- [ x] Any updated packages successfully build (or no packages were changed)
- [ x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ x] All package sources are available
- [ x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ x] Documentation has been updated to match any changes to the build system
- [ x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR fixes the CVE 2024-24790 in golang

###### Change Log  <!-- REQUIRED -->
Upgrade golang 1.21 to 1.22
Backport fix to golang 1.18

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
https://nvd.nist.gov/vuln/detail/CVE-2024-24790

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: in-progress
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=613645&view=results
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=613640&view=results

Local build successful