### PR TITLE
Image Customizer: Fixes for grub2-install.

### DIFF
--- a/toolkit/tools/imagecustomizer/README.md
+++ b/toolkit/tools/imagecustomizer/README.md
@@ -47,14 +47,14 @@ Disadvantages:
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
    `genisoimage`, `parted`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
    `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
-   `veritysetup`.
+   `veritysetup`, `grub2-install` (or `grub-install`).
 
    - For Ubuntu 22.04 images, run:
 
      ```bash
      sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
         sed createrepo-c squashfs-tools genisoimage parted e2fsprogs dosfstools \
-        xfsprogs zstd cryptsetup-bin
+        xfsprogs zstd cryptsetup-bin grub2-common
      ```
 
    - For Mariner 2.0, run:
@@ -62,7 +62,7 @@ Disadvantages:
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
         sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-        xfsprogs zstd veritysetup
+        xfsprogs zstd veritysetup grub2 grub2-pc
      ```
 
 4. Run the Azure Linux Image Customizer tool.

--- a/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+++ b/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
@@ -2,6 +2,6 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-      xfsprogs zstd veritysetup
+      xfsprogs zstd veritysetup grub2 grub2-pc
 
 COPY . /

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -916,10 +916,10 @@ func checkEnvironmentVars() error {
 	envHome := os.Getenv("HOME")
 	envUser := os.Getenv("USER")
 
-	if envHome != rootHome || envUser != rootUser {
+	if envHome != rootHome || (envUser != "" && envUser != rootUser) {
 		return fmt.Errorf("tool should be run as root (e.g. by using sudo):\n"+
-			"HOME must be set to '%s' and USER must be set to '%s'",
-			rootHome, rootUser)
+			"HOME must be set to '%s' (is '%s') and USER must be set to '%s' or '' (is '%s')",
+			rootHome, envHome, rootUser, envUser)
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
@@ -25,7 +25,3 @@ storage:
 
 os:
   resetBootLoaderType: hard-reset
-
-  packages:
-    install:
-    - grub2


### PR DESCRIPTION
1. Use either the `grub-install` or `grub2-install` command, whichever is available on the build host.

2. Add `grub2-install` to the image customizer prerequisites list in the README.

3. Add `grub2-install` to the image customizer container.

4. Remove the `grub2` package from the legacy boot config, since it isn't needed.

5. Allow the `USER` environment variable to be empty, which is the case in docker containers.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added image customizer UT.
