### PR TITLE
Fix call to `parted mkpart`.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -570,7 +570,7 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 				mkpartArgs = append(mkpartArgs, `""`)
 			} else {
 				// This version of parted has no way to specify an empty partition name. :-(
-				// So, use ' ' instead.
+				// So, use the legacy label of "primary" (which was used in Azure Linux 2.0) instead.
 				logger.Log.Warnf("parted version <3.5 does not support empty partition names: using partition name '%s' instead",
 					LegacyDefaultParitionName)
 				mkpartArgs = append(mkpartArgs, LegacyDefaultParitionName)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -65,12 +65,17 @@ func TestCustomizeImagePartitions(t *testing.T) {
 	}
 	defer imageConnection.Close()
 
+	defaultPartitionName := diskutils.LegacyDefaultParitionName
+	if partedSupportsEmptyString, _ := diskutils.PartedSupportsEmptyString(); partedSupportsEmptyString {
+		defaultPartitionName = ""
+	}
+
 	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if assert.NoError(t, err, "read partition table") {
-		assert.Equal(t, "", partitions[1].PartLabel)
-		assert.Equal(t, "", partitions[2].PartLabel)
+		assert.Equal(t, defaultPartitionName, partitions[1].PartLabel)
+		assert.Equal(t, defaultPartitionName, partitions[2].PartLabel)
 		assert.Equal(t, "rootfs", partitions[3].PartLabel)
-		assert.Equal(t, "", partitions[4].PartLabel)
+		assert.Equal(t, defaultPartitionName, partitions[4].PartLabel)
 	}
 
 	// Check for key files/directories on the partitions.


### PR DESCRIPTION
In PR #9932, a bug fix was made to ensure that GPT partitions don't receive a default label of "primary". Unfortunately, that change relies on a bug fix to `parted` that was made in v3.5, which is relatively recent.

For reference:

- Ubuntu 22.04: 3.4
- Ubuntu 24.04: 3.6
- Azure Linux 2.0: 3.4
- Azure Linux 3.0: 3.6

This change provides a workaround by giving partitions a default name of "primary", if the build host has an older version of parted.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran image customizer UTs on Ubuntu 22.04 and Mariner 2.0.
