### PR TITLE
Fix CVE-2024-6104 in cri-o by patching vendor package source

### DIFF
--- a/SPECS/cri-o/CVE-2024-6104.patch
+++ b/SPECS/cri-o/CVE-2024-6104.patch
@@ -1,0 +1,76 @@
+From ab64e79170aea240fa050a929b52607d72c62c9e Mon Sep 17 00:00:00 2001
+From: Balakumaran Kannan <kumaran.4353@gmail.com>
+Date: Thu, 1 Aug 2024 07:01:21 +0000
+Subject: [PATCH] Patch CVE-2024-6104
+
+---
+ .../hashicorp/go-retryablehttp/client.go      | 26 ++++++++++++++-----
+ 1 file changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/vendor/github.com/hashicorp/go-retryablehttp/client.go b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+index 7bfa759..aead5e1 100644
+--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
++++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+@@ -467,9 +467,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	if logger != nil {
+ 		switch v := logger.(type) {
+ 		case Logger:
+-			v.Printf("[DEBUG] %s %s", req.Method, req.URL)
++			v.Printf("[DEBUG] %s %s", req.Method, redactURL(req.URL))
+ 		case LeveledLogger:
+-			v.Debug("performing request", "method", req.Method, "url", req.URL)
++			v.Debug("performing request", "method", req.Method, "url", redactURL(req.URL))
+ 		}
+ 	}
+ 
+@@ -516,9 +516,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 		if err != nil {
+ 			switch v := logger.(type) {
+ 			case Logger:
+-				v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
++				v.Printf("[ERR] %s %s request failed: %v", req.Method, redactURL(req.URL), err)
+ 			case LeveledLogger:
+-				v.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
++				v.Error("request failed", "error", err, "method", req.Method, "url", redactURL(req.URL))
+ 			}
+ 		} else {
+ 			// Call this here to maintain the behavior of logging all requests,
+@@ -558,7 +558,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 		}
+ 
+ 		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
+-		desc := fmt.Sprintf("%s %s", req.Method, req.URL)
++		desc := fmt.Sprintf("%s %s", req.Method, redactURL(req.URL))
+ 		if code > 0 {
+ 			desc = fmt.Sprintf("%s (status: %d)", desc, code)
+ 		}
+@@ -590,7 +590,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	}
+ 	c.HTTPClient.CloseIdleConnections()
+ 	return nil, fmt.Errorf("%s %s giving up after %d attempts",
+-		req.Method, req.URL, c.RetryMax+1)
++		req.Method, redactURL(req.URL), c.RetryMax+1)
+ }
+ 
+ // Try to read the response body so we can reuse this connection.
+@@ -663,3 +663,17 @@ func PostForm(url string, data url.Values) (*http.Response, error) {
+ func (c *Client) PostForm(url string, data url.Values) (*http.Response, error) {
+ 	return c.Post(url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+ }
++
++
++// Taken from url.URL#Redacted() which was introduced in go 1.15.
++func redactURL(u *url.URL) string {
++	if u == nil {
++		return ""
++	}
++
++	ru := *u
++	if _, has := ru.User.Password(); has {
++		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
++	}
++	return ru.String()
++}
+-- 
+2.33.8
+

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.22.3
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -66,6 +66,7 @@ Patch10:        CVE-2024-21626.patch
 Patch11:        CVE-2024-3154.patch
 Patch12:        CVE-2024-3727.patch
 Patch13:        CVE-2021-43565.patch
+Patch14:        CVE-2024-6104.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  fdupes
@@ -218,6 +219,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Thu Aug 01 2024 Bala <balakumaran.kannan@microsoft.com> - 1.22.3-6
+- Patch CVE-2024-6104
+
 * Mon Jul 22 2024 Archana Choudhary <archana1@microsoft.com> - 1.22.3-5
 - Patch CVE-2021-43565
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix CVE-2024-6104 in cri-o by patching vendor package source

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add new patch to fix CVE-2024-6104 in cri-o package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-6104

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [615191](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=615191&view=results)
