### PR TITLE
Fix CVE-2024-6104 in cert-manager by patching vendor gomodules

### DIFF
--- a/SPECS/cert-manager/CVE-2024-6104.patch
+++ b/SPECS/cert-manager/CVE-2024-6104.patch
@@ -1,0 +1,81 @@
+From ddeb1dcd5b5c1c55b0008d29c079733569621084 Mon Sep 17 00:00:00 2001
+From: Balakumaran Kannan <kumaran.4353@gmail.com>
+Date: Thu, 1 Aug 2024 12:57:34 +0000
+Subject: [PATCH] Patch CVE-2024-6104
+
+---
+ .../hashicorp/go-retryablehttp/client.go      | 28 ++++++++++++++-----
+ 1 file changed, 21 insertions(+), 7 deletions(-)
+
+diff --git a/vendor/github.com/hashicorp/go-retryablehttp/client.go b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+index f40d241..6e347eb 100644
+--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
++++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+@@ -584,9 +584,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	if logger != nil {
+ 		switch v := logger.(type) {
+ 		case LeveledLogger:
+-			v.Debug("performing request", "method", req.Method, "url", req.URL)
++			v.Debug("performing request", "method", req.Method, "url", redactURL(req.URL))
+ 		case Logger:
+-			v.Printf("[DEBUG] %s %s", req.Method, req.URL)
++			v.Printf("[DEBUG] %s %s", req.Method, redactURL(req.URL))
+ 		}
+ 	}
+ 
+@@ -641,9 +641,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 		if err != nil {
+ 			switch v := logger.(type) {
+ 			case LeveledLogger:
+-				v.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
++				v.Error("request failed", "error", err, "method", req.Method, "url", redactURL(req.URL))
+ 			case Logger:
+-				v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
++				v.Printf("[ERR] %s %s request failed: %v", req.Method, redactURL(req.URL), err)
+ 			}
+ 		} else {
+ 			// Call this here to maintain the behavior of logging all requests,
+@@ -679,7 +679,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 
+ 		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
+ 		if logger != nil {
+-			desc := fmt.Sprintf("%s %s", req.Method, req.URL)
++			desc := fmt.Sprintf("%s %s", req.Method, redactURL(req.URL))
+ 			if resp != nil {
+ 				desc = fmt.Sprintf("%s (status: %d)", desc, resp.StatusCode)
+ 			}
+@@ -735,11 +735,11 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	// communicate why
+ 	if err == nil {
+ 		return nil, fmt.Errorf("%s %s giving up after %d attempt(s)",
+-			req.Method, req.URL, attempt)
++			req.Method, redactURL(req.URL), attempt)
+ 	}
+ 
+ 	return nil, fmt.Errorf("%s %s giving up after %d attempt(s): %w",
+-		req.Method, req.URL, attempt, err)
++		req.Method, redactURL(req.URL), attempt, err)
+ }
+ 
+ // Try to read the response body so we can reuse this connection.
+@@ -820,3 +820,17 @@ func (c *Client) StandardClient() *http.Client {
+ 		Transport: &RoundTripper{Client: c},
+ 	}
+ }
++
++
++// Taken from url.URL#Redacted() which was introduced in go 1.15.
++func redactURL(u *url.URL) string {
++	if u == nil {
++		return ""
++	}
++
++	ru := *u
++	if _, has := ru.User.Password(); has {
++		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
++	}
++	return ru.String()
++}
+-- 
+2.33.8
+

--- a/SPECS/cert-manager/CVE-2024-6104.patch
+++ b/SPECS/cert-manager/CVE-2024-6104.patch
@@ -1,16 +1,17 @@
-From ddeb1dcd5b5c1c55b0008d29c079733569621084 Mon Sep 17 00:00:00 2001
+From 623808b1483ec67f7821f7fed5419a8ae70618ba Mon Sep 17 00:00:00 2001
 From: Balakumaran Kannan <kumaran.4353@gmail.com>
-Date: Thu, 1 Aug 2024 12:57:34 +0000
-Subject: [PATCH] Patch CVE-2024-6104
+Date: Tue, 27 Aug 2024 08:31:02 +0000
+Subject: [PATCH] Fix CVE-2024-6104 by patching vendor go module
 
 ---
- .../hashicorp/go-retryablehttp/client.go      | 28 ++++++++++++++-----
- 1 file changed, 21 insertions(+), 7 deletions(-)
+ .../hashicorp/go-retryablehttp/client.go      | 27 ++++++++++++++-----
+ .../hashicorp/go-retryablehttp/client.go      | 27 ++++++++++++++-----
+ 2 files changed, 40 insertions(+), 14 deletions(-)
 
-diff --git a/vendor/github.com/hashicorp/go-retryablehttp/client.go b/vendor/github.com/hashicorp/go-retryablehttp/client.go
-index f40d241..6e347eb 100644
---- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
-+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+diff --git a/cmd/controller/vendor/github.com/hashicorp/go-retryablehttp/client.go b/cmd/controller/vendor/github.com/hashicorp/go-retryablehttp/client.go
+index f40d241..7a7d5f1 100644
+--- a/cmd/controller/vendor/github.com/hashicorp/go-retryablehttp/client.go
++++ b/cmd/controller/vendor/github.com/hashicorp/go-retryablehttp/client.go
 @@ -584,9 +584,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
  	if logger != nil {
  		switch v := logger.(type) {
@@ -58,11 +59,78 @@ index f40d241..6e347eb 100644
  }
  
  // Try to read the response body so we can reuse this connection.
-@@ -820,3 +820,17 @@ func (c *Client) StandardClient() *http.Client {
+@@ -820,3 +820,16 @@ func (c *Client) StandardClient() *http.Client {
  		Transport: &RoundTripper{Client: c},
  	}
  }
 +
++// Taken from url.URL#Redacted() which was introduced in go 1.15.
++func redactURL(u *url.URL) string {
++	if u == nil {
++		return ""
++	}
++
++	ru := *u
++	if _, has := ru.User.Password(); has {
++		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
++	}
++	return ru.String()
++}
+diff --git a/vendor/github.com/hashicorp/go-retryablehttp/client.go b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+index f40d241..c7ebb37 100644
+--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
++++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+@@ -584,9 +584,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	if logger != nil {
+ 		switch v := logger.(type) {
+ 		case LeveledLogger:
+-			v.Debug("performing request", "method", req.Method, "url", req.URL)
++			v.Debug("performing request", "method", req.Method, "url", redactURL(redactURL(req.URL)))
+ 		case Logger:
+-			v.Printf("[DEBUG] %s %s", req.Method, req.URL)
++			v.Printf("[DEBUG] %s %s", req.Method, redactURL(redactURL(req.URL)))
+ 		}
+ 	}
+ 
+@@ -641,9 +641,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 		if err != nil {
+ 			switch v := logger.(type) {
+ 			case LeveledLogger:
+-				v.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
++				v.Error("request failed", "error", err, "method", req.Method, "url", redactURL(redactURL(req.URL)))
+ 			case Logger:
+-				v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
++				v.Printf("[ERR] %s %s request failed: %v", req.Method, redactURL(redactURL(req.URL)), err)
+ 			}
+ 		} else {
+ 			// Call this here to maintain the behavior of logging all requests,
+@@ -679,7 +679,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 
+ 		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
+ 		if logger != nil {
+-			desc := fmt.Sprintf("%s %s", req.Method, req.URL)
++			desc := fmt.Sprintf("%s %s", req.Method, redactURL(redactURL(req.URL)))
+ 			if resp != nil {
+ 				desc = fmt.Sprintf("%s (status: %d)", desc, resp.StatusCode)
+ 			}
+@@ -735,11 +735,11 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	// communicate why
+ 	if err == nil {
+ 		return nil, fmt.Errorf("%s %s giving up after %d attempt(s)",
+-			req.Method, req.URL, attempt)
++			req.Method, redactURL(redactURL(req.URL)), attempt)
+ 	}
+ 
+ 	return nil, fmt.Errorf("%s %s giving up after %d attempt(s): %w",
+-		req.Method, req.URL, attempt, err)
++		req.Method, redactURL(redactURL(req.URL)), attempt, err)
+ }
+ 
+ // Try to read the response body so we can reuse this connection.
+@@ -820,3 +820,16 @@ func (c *Client) StandardClient() *http.Client {
+ 		Transport: &RoundTripper{Client: c},
+ 	}
+ }
 +
 +// Taken from url.URL#Redacted() which was introduced in go 1.15.
 +func redactURL(u *url.URL) string {

--- a/SPECS/cert-manager/CVE-2024-6104.patch
+++ b/SPECS/cert-manager/CVE-2024-6104.patch
@@ -1,12 +1,11 @@
-From 623808b1483ec67f7821f7fed5419a8ae70618ba Mon Sep 17 00:00:00 2001
+From 002323062ceaa0e3a46f72bc7598c8f144b18bd5 Mon Sep 17 00:00:00 2001
 From: Balakumaran Kannan <kumaran.4353@gmail.com>
 Date: Tue, 27 Aug 2024 08:31:02 +0000
 Subject: [PATCH] Fix CVE-2024-6104 by patching vendor go module
 
 ---
  .../hashicorp/go-retryablehttp/client.go      | 27 ++++++++++++++-----
- .../hashicorp/go-retryablehttp/client.go      | 27 ++++++++++++++-----
- 2 files changed, 40 insertions(+), 14 deletions(-)
+ 1 file changed, 20 insertions(+), 7 deletions(-)
 
 diff --git a/cmd/controller/vendor/github.com/hashicorp/go-retryablehttp/client.go b/cmd/controller/vendor/github.com/hashicorp/go-retryablehttp/client.go
 index f40d241..7a7d5f1 100644
@@ -56,74 +55,6 @@ index f40d241..7a7d5f1 100644
  	return nil, fmt.Errorf("%s %s giving up after %d attempt(s): %w",
 -		req.Method, req.URL, attempt, err)
 +		req.Method, redactURL(req.URL), attempt, err)
- }
- 
- // Try to read the response body so we can reuse this connection.
-@@ -820,3 +820,16 @@ func (c *Client) StandardClient() *http.Client {
- 		Transport: &RoundTripper{Client: c},
- 	}
- }
-+
-+// Taken from url.URL#Redacted() which was introduced in go 1.15.
-+func redactURL(u *url.URL) string {
-+	if u == nil {
-+		return ""
-+	}
-+
-+	ru := *u
-+	if _, has := ru.User.Password(); has {
-+		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
-+	}
-+	return ru.String()
-+}
-diff --git a/vendor/github.com/hashicorp/go-retryablehttp/client.go b/vendor/github.com/hashicorp/go-retryablehttp/client.go
-index f40d241..c7ebb37 100644
---- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
-+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
-@@ -584,9 +584,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
- 	if logger != nil {
- 		switch v := logger.(type) {
- 		case LeveledLogger:
--			v.Debug("performing request", "method", req.Method, "url", req.URL)
-+			v.Debug("performing request", "method", req.Method, "url", redactURL(redactURL(req.URL)))
- 		case Logger:
--			v.Printf("[DEBUG] %s %s", req.Method, req.URL)
-+			v.Printf("[DEBUG] %s %s", req.Method, redactURL(redactURL(req.URL)))
- 		}
- 	}
- 
-@@ -641,9 +641,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
- 		if err != nil {
- 			switch v := logger.(type) {
- 			case LeveledLogger:
--				v.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
-+				v.Error("request failed", "error", err, "method", req.Method, "url", redactURL(redactURL(req.URL)))
- 			case Logger:
--				v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
-+				v.Printf("[ERR] %s %s request failed: %v", req.Method, redactURL(redactURL(req.URL)), err)
- 			}
- 		} else {
- 			// Call this here to maintain the behavior of logging all requests,
-@@ -679,7 +679,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
- 
- 		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
- 		if logger != nil {
--			desc := fmt.Sprintf("%s %s", req.Method, req.URL)
-+			desc := fmt.Sprintf("%s %s", req.Method, redactURL(redactURL(req.URL)))
- 			if resp != nil {
- 				desc = fmt.Sprintf("%s (status: %d)", desc, resp.StatusCode)
- 			}
-@@ -735,11 +735,11 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
- 	// communicate why
- 	if err == nil {
- 		return nil, fmt.Errorf("%s %s giving up after %d attempt(s)",
--			req.Method, req.URL, attempt)
-+			req.Method, redactURL(redactURL(req.URL)), attempt)
- 	}
- 
- 	return nil, fmt.Errorf("%s %s giving up after %d attempt(s): %w",
--		req.Method, req.URL, attempt, err)
-+		req.Method, redactURL(redactURL(req.URL)), attempt, err)
  }
  
  // Try to read the response body so we can reuse this connection.

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -1,7 +1,7 @@
 Summary:        Automatically provision and manage TLS certificates in Kubernetes
 Name:           cert-manager
 Version:        1.12.12
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -14,6 +14,7 @@ Source0:        https://github.com/jetstack/%{name}/archive/refs/tags/v%{version
 # 2. <repo-root>/SPECS/cert-manager/generate_source_tarball.sh --srcTarball %%{name}-%%{version}.tar.gz --pkgVersion %%{version}
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2024-25620.patch
+Patch1:         CVE-2024-6104.patch
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
 Requires:       %{name}-cainjector
@@ -106,6 +107,9 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %{_bindir}/webhook
 
 %changelog
+* Thu Aug 01 2024 Bala <balakumaran.kannan@microsoft.com> - 1.12.12-3
+- Patch for CVE-2024-6104
+
 * Wed Aug 07 2024 Bhagyashri Pathak <bhapathak@microsoft.com> - 1.12.12-2
 - Patch for CVE-2024-25620
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix CVE-2024-6104 in cert-manager by patching vendor gomodules

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix CVE-2024-6104 in cert-manager by patching vendor gomodules

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-6104

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [629162](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=629162&view=results)
