### PR TITLE
Remove unnecessary Requires:libselinux from coreutils to fix Circular dependency

### DIFF
--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:        Basic system utilities
 Name:           coreutils
 Version:        9.4
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -16,7 +16,6 @@ Patch2:         CVE-2024-0684.patch
 BuildRequires:  libselinux-devel
 BuildRequires:  libselinux-utils
 Requires:       gmp
-Requires:       libselinux
 Conflicts:      toybox
 Provides:       sh-utils
 %if 0%{?with_check}
@@ -93,6 +92,10 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
+* Thu Aug 1 2024 Riken Maharjan <rmaharjan@microsoft.com> - 9.4-5
+- Remove unecessary Requires on libselinux imported from Fedora 40 (License: MIT)
+- libselinux causes dependency cycle.
+
 * Tue Jul 23 2024 Muhammad Falak <mwani@microsoft.com> - 9.4-4
 - Address CVE-2024-0684
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -41,8 +41,8 @@ ncurses-libs-6.4-2.azl3.aarch64.rpm
 ncurses-term-6.4-2.azl3.aarch64.rpm
 readline-8.2-1.azl3.aarch64.rpm
 readline-devel-8.2-1.azl3.aarch64.rpm
-coreutils-9.4-4.azl3.aarch64.rpm
-coreutils-lang-9.4-4.azl3.aarch64.rpm
+coreutils-9.4-5.azl3.aarch64.rpm
+coreutils-lang-9.4-5.azl3.aarch64.rpm
 bash-5.2.15-2.azl3.aarch64.rpm
 bash-devel-5.2.15-2.azl3.aarch64.rpm
 bash-lang-5.2.15-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -41,8 +41,8 @@ ncurses-libs-6.4-2.azl3.x86_64.rpm
 ncurses-term-6.4-2.azl3.x86_64.rpm
 readline-8.2-1.azl3.x86_64.rpm
 readline-devel-8.2-1.azl3.x86_64.rpm
-coreutils-9.4-4.azl3.x86_64.rpm
-coreutils-lang-9.4-4.azl3.x86_64.rpm
+coreutils-9.4-5.azl3.x86_64.rpm
+coreutils-lang-9.4-5.azl3.x86_64.rpm
 bash-5.2.15-2.azl3.x86_64.rpm
 bash-devel-5.2.15-2.azl3.x86_64.rpm
 bash-lang-5.2.15-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -47,9 +47,9 @@ chkconfig-debuginfo-1.25-1.azl3.aarch64.rpm
 chkconfig-lang-1.25-1.azl3.aarch64.rpm
 cmake-3.29.6-1.azl3.aarch64.rpm
 cmake-debuginfo-3.29.6-1.azl3.aarch64.rpm
-coreutils-9.4-4.azl3.aarch64.rpm
-coreutils-debuginfo-9.4-4.azl3.aarch64.rpm
-coreutils-lang-9.4-4.azl3.aarch64.rpm
+coreutils-9.4-5.azl3.aarch64.rpm
+coreutils-debuginfo-9.4-5.azl3.aarch64.rpm
+coreutils-lang-9.4-5.azl3.aarch64.rpm
 cpio-2.14-1.azl3.aarch64.rpm
 cpio-debuginfo-2.14-1.azl3.aarch64.rpm
 cpio-lang-2.14-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -48,9 +48,9 @@ chkconfig-debuginfo-1.25-1.azl3.x86_64.rpm
 chkconfig-lang-1.25-1.azl3.x86_64.rpm
 cmake-3.29.6-1.azl3.x86_64.rpm
 cmake-debuginfo-3.29.6-1.azl3.x86_64.rpm
-coreutils-9.4-4.azl3.x86_64.rpm
-coreutils-debuginfo-9.4-4.azl3.x86_64.rpm
-coreutils-lang-9.4-4.azl3.x86_64.rpm
+coreutils-9.4-5.azl3.x86_64.rpm
+coreutils-debuginfo-9.4-5.azl3.x86_64.rpm
+coreutils-lang-9.4-5.azl3.x86_64.rpm
 cpio-2.14-1.azl3.x86_64.rpm
 cpio-debuginfo-2.14-1.azl3.x86_64.rpm
 cpio-lang-2.14-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
coreutils brings in libselinux which causes dependency cycle when combined with [this PR](https://github.com/microsoft/azurelinux/pull/9977).
Change imported from fedora.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change: Remove runtime requires on libselinux for coreutils
![image](https://github.com/user-attachments/assets/73fdd6fd-6813-45dd-aee0-005b052dbb58)
libselinux is no more a requirement similar to what we seen in fedora's runtime requirement.
Previously we had an unnecessary requires on libselinux as show in the diagram below. 
![image](https://github.com/user-attachments/assets/e37627f4-0d9f-4eb4-aa46-9f198152953e)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**
YES

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [615339](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=615339&view=results)
- Toolchain build: [615347](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=615347&view=results)
