### PR TITLE
Fix CVE-2024-6104 in skopeo  with a patch - 3.0

### DIFF
--- a/SPECS/skopeo/CVE-2024-6104.patch
+++ b/SPECS/skopeo/CVE-2024-6104.patch
@@ -1,0 +1,81 @@
+From b6bb7dacb0086d150cfbd44f1a636c871485b42d Mon Sep 17 00:00:00 2001
+From: Sindhu Karri <lakarri@microsoft.com>
+Date: Wed, 17 Jul 2024 08:35:51 +0000
+Subject: [PATCH] Fix CVE-2024-6104
+
+---
+ .../hashicorp/go-retryablehttp/client.go      | 28 ++++++++++++++-----
+ 1 file changed, 21 insertions(+), 7 deletions(-)
+
+diff --git a/vendor/github.com/hashicorp/go-retryablehttp/client.go b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+index c9edbd0..1394fbc 100644
+--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
++++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
+@@ -609,9 +609,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	if logger != nil {
+ 		switch v := logger.(type) {
+ 		case LeveledLogger:
+-			v.Debug("performing request", "method", req.Method, "url", req.URL)
++			v.Debug("performing request", "method", req.Method, "url", redactURL(req.URL))
+ 		case Logger:
+-			v.Printf("[DEBUG] %s %s", req.Method, req.URL)
++			v.Printf("[DEBUG] %s %s", req.Method, redactURL(req.URL))
+ 		}
+ 	}
+ 
+@@ -666,9 +666,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 		if err != nil {
+ 			switch v := logger.(type) {
+ 			case LeveledLogger:
+-				v.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
++				v.Error("request failed", "error", err, "method", req.Method, "url", redactURL(req.URL))
+ 			case Logger:
+-				v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
++				v.Printf("[ERR] %s %s request failed: %v", req.Method, redactURL(req.URL), err)
+ 			}
+ 		} else {
+ 			// Call this here to maintain the behavior of logging all requests,
+@@ -704,7 +704,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 
+ 		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
+ 		if logger != nil {
+-			desc := fmt.Sprintf("%s %s", req.Method, req.URL)
++			desc := fmt.Sprintf("%s %s", req.Method, redactURL(req.URL))
+ 			if resp != nil {
+ 				desc = fmt.Sprintf("%s (status: %d)", desc, resp.StatusCode)
+ 			}
+@@ -760,11 +760,11 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
+ 	// communicate why
+ 	if err == nil {
+ 		return nil, fmt.Errorf("%s %s giving up after %d attempt(s)",
+-			req.Method, req.URL, attempt)
++			req.Method, redactURL(req.URL), attempt)
+ 	}
+ 
+ 	return nil, fmt.Errorf("%s %s giving up after %d attempt(s): %w",
+-		req.Method, req.URL, attempt, err)
++		req.Method, redactURL(req.URL), attempt, err)
+ }
+ 
+ // Try to read the response body so we can reuse this connection.
+@@ -845,3 +845,17 @@ func (c *Client) StandardClient() *http.Client {
+ 		Transport: &RoundTripper{Client: c},
+ 	}
+ }
++
++// Taken from url.URL#Redacted() which was introduced in go 1.15.
++// We can switch to using it directly if we'll bump the minimum required go version.
++func redactURL(u *url.URL) string {
++	if u == nil {
++		return ""
++	}
++
++	ru := *u
++	if _, has := ru.User.Password(); has {
++		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
++	}
++	return ru.String()
++}
+-- 
+2.33.8
+

--- a/SPECS/skopeo/skopeo.spec
+++ b/SPECS/skopeo/skopeo.spec
@@ -1,7 +1,7 @@
 Summary:        Inspect container images and repositories on registries
 Name:           skopeo
 Version:        1.14.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -9,6 +9,7 @@ Group:          Applications/Tools
 URL:            https://github.com/containers/skopeo
 Source0:        https://github.com/containers/skopeo/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Patch0:         CVE-2022-2879.patch
+Patch1:         CVE-2024-6104.patch
 
 %global debug_package %{nil}
 %define our_gopath %{_topdir}/.gopath
@@ -48,6 +49,9 @@ make test-unit-local
 %{_mandir}/man1/%%{name}*
 
 %changelog
+* Fri Aug 02 2024 Sindhu Karri <lakarri@microsoft.com> - 1.14.4-2
+- Fix CVE-2024-6104 in github.com/hashicorp/go-retryablehttp with a patch
+
 * Thu Jun 27 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 1.14.4-1
 - Upgrade to v1.14.4, address CVE-2022-2879
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fixes CVE-2024-6104 in github.com/hashicorp/go-retryablehttp with a patch

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix CVE-2024-6104 in github.com/hashicorp/go-retryablehttp with a patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-6104

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=615788&view=results
