### PR TITLE
fix: upgrade walinuxagent to 2.11.1.4 and add azurelinux patch

### DIFF
--- a/SPECS/WALinuxAgent/0001-add-azurelinux-support.patch
+++ b/SPECS/WALinuxAgent/0001-add-azurelinux-support.patch
@@ -1,0 +1,57 @@
+From 7cd338bde79a5919c27f3a3c081da4cdeda34a93 Mon Sep 17 00:00:00 2001
+From: "narrieta@microsoft" <narrieta>
+Date: Mon, 15 Jul 2024 07:53:26 -0700
+Subject: [PATCH] .
+
+---
+ azurelinuxagent/common/osutil/factory.py | 2 +-
+ tests_e2e/test_suites/images.yml         | 5 ++++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/azurelinuxagent/common/osutil/factory.py b/azurelinuxagent/common/osutil/factory.py
+index 58afd0af..fd66fbb0 100644
+--- a/azurelinuxagent/common/osutil/factory.py
++++ b/azurelinuxagent/common/osutil/factory.py
+@@ -142,7 +142,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
+     if distro_name == "iosxe":
+         return IosxeOSUtil()
+ 
+-    if distro_name == "mariner":
++    if distro_name in ["mariner", "azurelinux"]:
+         return MarinerOSUtil()
+ 
+     if distro_name == "nsbsd":
+diff --git a/tests_e2e/test_suites/images.yml b/tests_e2e/test_suites/images.yml
+index fb6cc7f1..1afbce4d 100644
+--- a/tests_e2e/test_suites/images.yml
++++ b/tests_e2e/test_suites/images.yml
+@@ -17,8 +17,8 @@ image-sets:
+       - "debian_11"
+       - "flatcar"
+       - "suse_12"
+-      - "mariner_1"
+       - "mariner_2"
++      - "azure-linux_3"
+       - "suse_15"
+       - "rhel_79"
+       - "rhel_82"
+@@ -37,6 +37,7 @@ image-sets:
+       - "debian_11_arm64"
+       - "flatcar_arm64"
+       - "mariner_2_arm64"
++      - "azure-linux_3_arm64"
+       - "rhel_90_arm64"
+       - "ubuntu_2204_arm64"
+ 
+@@ -87,6 +88,8 @@ images:
+       urn: "almalinux almalinux 9-gen2 latest"
+       locations:
+          AzureChinaCloud: []
++   azure-linux_3: "microsoftcblmariner azure-linux azure-linux-3 latest"
++   azure-linux_3_arm64: "microsoftcblmariner azure-linux azure-linux-arm64 latest"
+    centos_610: "OpenLogic CentOS 6.10 latest"
+    centos_75: "OpenLogic CentOS 7.5 latest"
+    centos_79: "OpenLogic CentOS 7_9 latest"
+-- 
+2.45.1
+

--- a/SPECS/WALinuxAgent/0002-fix-bump-version-to-2.11.8.8.patch
+++ b/SPECS/WALinuxAgent/0002-fix-bump-version-to-2.11.8.8.patch
@@ -1,0 +1,30 @@
+From e2f24e98cd7f495d5cf6ef436625d9dad22785eb Mon Sep 17 00:00:00 2001
+From: Chris Co <chrco@microsoft.com>
+Date: Sat, 3 Aug 2024 22:25:04 -0700
+Subject: [PATCH] fix: bump version to 2.11.8.8
+
+In order to prevent further 2.11 agent upgrades, bump the version to
+2.11.8.8 so any upcoming 2.11 hotfixes are not applied. 2.12 will be
+released soon and the agent will take the 2.12 upgrade correctly.
+
+Signed-off-by: Chris Co <chrco@microsoft.com>
+---
+ azurelinuxagent/common/version.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/azurelinuxagent/common/version.py b/azurelinuxagent/common/version.py
+index c1715ff7..b4e93e81 100644
+--- a/azurelinuxagent/common/version.py
++++ b/azurelinuxagent/common/version.py
+@@ -209,7 +209,7 @@ AGENT_LONG_NAME = "Azure Linux Agent"
+ #
+ #            When doing a release, be sure to use the actual agent version. Current agent version: 2.4.0.0
+ #
+-AGENT_VERSION = '2.11.1.4'
++AGENT_VERSION = '2.11.8.8'
+ AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
+ AGENT_DESCRIPTION = """
+ The Azure Linux Agent supports the provisioning and running of Linux
+-- 
+2.45.1
+

--- a/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
+++ b/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
@@ -3,6 +3,6 @@
   "WALinuxAgent-2.11.1.4.tar.gz": "956f12e31b0903f304cc070ddcbe4c8130c10e7ccc2597061e6467e911bc085d",
   "ephemeral-disk-warning": "8b18fc001e5dfa43a1f559a074e334330e6fc4fe5b8c586eafc894800cc1c1ad",
   "ephemeral-disk-warning.conf": "128e531c029e04afdab591f44d2b0a69d5a4eb9dec8867282d0acb1ebded76d0",
-  "ephemeral-disk-warning.service": "f6c5787acd016896e3686b7161b20b95890dfe07d2116b316a5ba29ed0503e71"
+  "ephemeral-disk-warning.service": "46b96609266ba56d28b09e4562a1bb03d874b06b929a7930b4df3292d7fcd303"
  }
 }

--- a/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
+++ b/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "WALinuxAgent-2.9.0.4.tar.gz": "040969f507f73f3a2c95d5b0568225ad68f7f91bfec99bd92154c3fa9e28034b",
+  "WALinuxAgent-2.11.1.4.tar.gz": "956f12e31b0903f304cc070ddcbe4c8130c10e7ccc2597061e6467e911bc085d",
   "ephemeral-disk-warning": "8b18fc001e5dfa43a1f559a074e334330e6fc4fe5b8c586eafc894800cc1c1ad",
   "ephemeral-disk-warning.conf": "128e531c029e04afdab591f44d2b0a69d5a4eb9dec8867282d0acb1ebded76d0",
   "ephemeral-disk-warning.service": "f6c5787acd016896e3686b7161b20b95890dfe07d2116b316a5ba29ed0503e71"

--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -117,7 +117,7 @@ python3 setup.py check && python3 setup.py test
 - Fix installation path from /usr/lib/systemd to /lib/systemd and /usr/bin to /usr/sbin
 - Add /etc/logrotate.d/waagent.logrotate to %files section
 
-* Tue Nov 10 2022 Nan Liu <liunan@microsoft.com> - 2.3.1.1-3
+* Thu Nov 10 2022 Nan Liu <liunan@microsoft.com> - 2.3.1.1-3
 - Add ephemeral-disk-warning.service
 
 * Tue Jan 25 2022 Henry Beberman <henry.beberman@microsoft.com> - 2.3.1.1-2

--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -19,6 +19,9 @@ Patch0:         0001-add-azurelinux-support.patch
 # mechanism, which would end up removing azurelinux support. This patch
 # should also be removed in the next 2.12 update to this package.
 Patch1:         0002-fix-bump-version-to-2.11.8.8.patch
+# This patch fixes a failure to assign IP address for infiband interfaces.
+# It should be removed in an upcoming release.
+Patch2:         fix-argument-to-goalstate.patch
 BuildRequires:  python3-distro
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-xml

--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -63,13 +63,12 @@ install -vdm 755 %{buildroot}/%{_sysconfdir}/udev/rules.d
 install -m 644 config/99-azure-product-uuid.rules %{buildroot}/%{_sysconfdir}/udev/rules.d
 install -m 644 config/66-azure-storage.rules %{buildroot}/%{_sysconfdir}/udev/rules.d
 # python refers to python2 version on CBL-Mariner hence update to use python3
-sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_sbindir}/waagent
-sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_sbindir}/waagent2.0
-sed -i 's,/usr/bin/python ,/usr/bin/python3 ,' %{buildroot}/lib/systemd/system/waagent.service
-sed -i 's,/usr/bin/waagent,/usr/sbin/waagent,' %{buildroot}/lib/systemd/system/waagent.service
-install -m 644 %{SOURCE1} %{buildroot}/lib/systemd/system/ephemeral-disk-warning.service
+sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_bindir}/waagent
+sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_bindir}/waagent2.0
+sed -i 's,/usr/bin/python ,/usr/bin/python3 ,' %{buildroot}/%{_libdir}/systemd/system/waagent.service
+install -m 644 %{SOURCE1} %{buildroot}/%{_libdir}/systemd/system/ephemeral-disk-warning.service
 install -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/ephemeral-disk-warning.conf
-install -m 644 %{SOURCE3} %{buildroot}%{_sbindir}/ephemeral-disk-warning
+install -m 644 %{SOURCE3} %{buildroot}%{_bindir}/ephemeral-disk-warning
 
 %check
 python3 setup.py check && python3 setup.py test
@@ -85,13 +84,13 @@ python3 setup.py check && python3 setup.py test
 %systemd_postun_with_restart waagent.service
 
 %files
-/lib/systemd/system/*
+%{_libdir}/systemd/system/*
 %{_sysconfdir}/udev/rules.d/*
 %defattr(0644,root,root,0755)
 %license LICENSE.txt
-%attr(0755,root,root) %{_sbindir}/waagent
-%attr(0755,root,root) %{_sbindir}/waagent2.0
-%attr(0755,root,root) %{_sbindir}/ephemeral-disk-warning
+%attr(0755,root,root) %{_bindir}/waagent
+%attr(0755,root,root) %{_bindir}/waagent2.0
+%attr(0755,root,root) %{_bindir}/ephemeral-disk-warning
 %config %{_sysconfdir}/waagent.conf
 %config %{_sysconfdir}/ephemeral-disk-warning.conf
 %{_sysconfdir}/logrotate.d/waagent.logrotate
@@ -105,6 +104,8 @@ python3 setup.py check && python3 setup.py test
 - Upgrade to version 2.11.1.4
 - Add patch for azurelinux support
 - Add patch to change reported version for targeting update
+- Use /usr/bin and /usr/lib/systemd paths as defined in upstream MarinerOSUtil class
+- Remove sed to waagent.service file since waagent path should be /usr/bin/waagent
 
 * Tue Apr 02 2024 Sudipta Pandit <sudpandit@microsoft.com> - 2.9.0.4-3
 - Fix ephemeral-disk-warning script path from /usr/bin to /usr/sbin

--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -1,7 +1,7 @@
 Summary:        The Windows Azure Linux Agent
 Name:           WALinuxAgent
-Version:        2.9.0.4
-Release:        3%{?dist}
+Version:        2.11.1.4
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,14 @@ Source0:        https://github.com/Azure/WALinuxAgent/archive/refs/tags/v%{versi
 Source1:        ephemeral-disk-warning.service
 Source2:        ephemeral-disk-warning.conf
 Source3:        ephemeral-disk-warning
+# This patch adds azurelinux support into WALinuxAgent. The patch should be
+# removed in the next 2.12 update of WALinuxAgent.
+Patch0:         0001-add-azurelinux-support.patch
+# This patch modifies the version of the WALinuxAgent so it does not take any
+# 2.11 updates pushed live to the system through the normal agent upgrade
+# mechanism, which would end up removing azurelinux support. This patch
+# should also be removed in the next 2.12 update to this package.
+Patch1:         0002-fix-bump-version-to-2.11.8.8.patch
 BuildRequires:  python3-distro
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-xml
@@ -38,7 +46,7 @@ VMs in the Windows Azure cloud. This package should be installed on Linux disk
 images that are built to run in the Windows Azure environment.
 
 %prep
-%setup -q -n %{name}-%{version}
+%autosetup -p1 -n %{name}-%{version}
 
 %pre -p /bin/sh
 
@@ -93,6 +101,11 @@ python3 setup.py check && python3 setup.py test
 
 
 %changelog
+* Sat Aug 03 2024 Chris Co <chrco@microsoft.com> - 2.11.1.4-1
+- Upgrade to version 2.11.1.4
+- Add patch for azurelinux support
+- Add patch to change reported version for targeting update
+
 * Tue Apr 02 2024 Sudipta Pandit <sudpandit@microsoft.com> - 2.9.0.4-3
 - Fix ephemeral-disk-warning script path from /usr/bin to /usr/sbin
 

--- a/SPECS/WALinuxAgent/ephemeral-disk-warning.service
+++ b/SPECS/WALinuxAgent/ephemeral-disk-warning.service
@@ -7,7 +7,7 @@ ConditionPathExists=/dev/disk/azure/resource-part1
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/ephemeral-disk-warning
+ExecStart=/usr/bin/ephemeral-disk-warning
 RemainAfterExit=yes
 StandardOutput=journal+console
 

--- a/SPECS/WALinuxAgent/fix-argument-to-goalstate.patch
+++ b/SPECS/WALinuxAgent/fix-argument-to-goalstate.patch
@@ -1,0 +1,23 @@
+From 8ac7e66b2773ba16a33abee41262ad0144c80cd3 Mon Sep 17 00:00:00 2001
+From: Norberto Arrieta <narrieta@users.noreply.github.com>
+Date: Wed, 28 Feb 2024 18:55:49 -0800
+Subject: [PATCH] Fix argument to GoalState.__init__ (#3073)
+
+Co-authored-by: narrieta <narrieta>
+---
+ azurelinuxagent/daemon/main.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/azurelinuxagent/daemon/main.py b/azurelinuxagent/daemon/main.py
+index 342daf4ac9..3a3923a8ff 100644
+--- a/azurelinuxagent/daemon/main.py
++++ b/azurelinuxagent/daemon/main.py
+@@ -160,7 +160,7 @@ def daemon(self, child_args=None):
+                 #   current values.
+                 protocol = self.protocol_util.get_protocol()
+ 
+-                goal_state = GoalState(protocol, goal_state_properties=GoalStateProperties.SharedConfig)
++                goal_state = GoalState(protocol.client, goal_state_properties=GoalStateProperties.SharedConfig)
+ 
+                 setup_rdma_device(nd_version, goal_state.shared_conf)
+             except Exception as e:

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29356,8 +29356,8 @@
         "type": "other",
         "other": {
           "name": "WALinuxAgent",
-          "version": "2.9.0.4",
-          "downloadUrl": "https://github.com/Azure/WALinuxAgent/archive/refs/tags/v2.9.0.4.tar.gz"
+          "version": "2.11.1.4",
+          "downloadUrl": "https://github.com/Azure/WALinuxAgent/archive/refs/tags/v2.11.1.4.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade WALinuxAgent to the most recent release - 2.11.1.4.

Add patch to include azurelinux support into the agent. The patch should
be removed in the next 2.12 update.

Also because WALinuxAgent will automatically update at runtime, thus
removing the patched-in support for azurelinux, add another patch to
bump the version to 2.11.8.8 so further 2.11 hotfixes are not taken.
Since 2.12 will have azurelinux support, the agent will be able to
automatically upgrade to 2.12 at runtime.

fix: correct changelog date warning

fix: use /usr/bin and /usr/lib/systemd paths 

In the upstream code's setup.py, the bin path and systemd path are set
through calls into the distro's osutil class. In our case, since we pass
--lnx-distro='mariner', the code will use the MarinerOsUtil derived
class for these paths, which are /usr/bin and /usr/lib/systemd
respectively.

In addition, now that the paths are set correctly again, remove the sed
operation to the waagent.service so the waagent path points to the
correct location again.

Also fix the ephemeral-disk-warning.service to use the proper path as
well.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/52061747

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [616327](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=616327&view=results)
