### PR TITLE
Ignore bogus case-insensitive provides results from repocloner

### DIFF
--- a/SPECS/perl-Net-SSLeay/perl-Net-SSLeay.spec
+++ b/SPECS/perl-Net-SSLeay/perl-Net-SSLeay.spec
@@ -1,7 +1,7 @@
 Summary:        Perl extension for using OpenSSL
 Name:           perl-Net-SSLeay
 Version:        1.92
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        Artistic 2.0
 Group:          Development/Libraries
 URL:            https://metacpan.org/pod/distribution/Net-SSLeay/lib/Net/SSLeay.pod
@@ -19,7 +19,7 @@ BuildRequires:  perl(English)
 BuildRequires:  perl(ExtUtils::MakeMaker)
 BuildRequires:  perl-generators
 %if 0%{?with_check}
-BuildRequires:  perl(Autoloader)
+BuildRequires:  perl(AutoLoader)
 BuildRequires:  perl(CPAN)
 BuildRequires:  perl(CPAN::Meta)
 BuildRequires:  perl(CPAN::Meta::Requirements)
@@ -81,6 +81,9 @@ make test
 %{_mandir}/man?/*
 
 %changelog
+* Mon Aug 05 2024 Daniel McIlvaney <damcilva@microsoft.com> - 1.92-5
+- Fix bad capitalization of perl(AutoLoader)
+
 * Thu May 30 2024 Andrew Phelps <anphel@microsoft.com> - 1.92-4
 - Add BR on openssl
 

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -477,7 +477,7 @@ func (r *RpmRepoCloner) WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames [
 			for _, matches := range tdnf.PackageLookupNameMatchRegex.FindAllStringSubmatch(stdout, -1) {
 				packageName := matches[tdnf.PackageNameIndex]
 				if lookupIgnoredCase {
-					logger.Log.Warnf("'%s' was found by case-insensitive lookup of '%s', but this is not a valid (Build)Requires and will be ignored", packageName, pkgVer.Name)
+					logger.Log.Warnf("'%s' was found by case-insensitive lookup of '%s', but this is not valid and will be ignored", packageName, pkgVer.Name)
 					// This is not a valid mapping of requires -> provides, so we skip it. This is not a fatal error since
 					// we may still find a valid mapping either in a subsequent repo lookup, or via a local build. If this
 					// is infact invalid, the package build will fail later with an unresolved dependency error.

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -31,6 +31,11 @@ var (
 	PackageLookupNameMatchRegex = regexp.MustCompile(`([^:\s]+(x86_64|aarch64|noarch))\s*:[^\n]*\nRepo\s+:\s+[^@]`)
 	PackageNameIndex            = 1
 
+	// Tdnf may opt to ignore case when doing a provides lookup. While this is useful for a user, it will give
+	// bad results when we're trying to match a package name to a package in the repo. This regex will match the
+	// message that indicates that case-insensitive matching is enabled.
+	DidCaseInsensitiveMatchRegex = regexp.MustCompile(`\[ignoring case for '.*'\]`)
+
 	// Every line containing a repo ID will be of the form:
 	//		[<repo_name>]
 	// For:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`tdnf provides <pkgname>` is used to find non-obvious requirements for the build (ie mapping `cap(thing)` to `thing-pkg`). `tdnf` will switch to case-insensitive matching if it can't find a result (`perl(mypkg)` will match with `perl(MyPkg)`), but this isn't actually a valid result. We convert these results into an actual `*.rpm` file path and expect future steps to be able to install this package to satisfy the requirement. During package build, we may never need to install a package so this (i.e. its a runtime requirement of a node which is never itself used in another build). Only at image generation time (or ad-hoc install by a user) will the lack of valid dependency be detected.

`tdnf` prints a message `[ignoring case for 'pkgname']` when it enters this mode, so we can watch for it and ignore those results. This may not be an actual error, future stages of the fetcher may find a match, or a local backage build may provide it, but if we skip adding the bogus result we will get a descriptive error further down the line (either as part of the image fetching process, or as part of the package build process).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- have `RpmRepoCloner.WhatProvides()` ignore any results that require case-insensitive matching
- Fix invalid case in `perl-Net-SSLeay` (`perl(Autoloader)` -> `perl(AutoLoader)`)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/52845569

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Add `Requires: symcrypt` to `words.spec`, add `"Packages": ["words"]` to `core-efi.json`. Run `sudo  make image CONFIG_FILE=./imageconfigs/core-efi.json SRPM_PACK_LIST=words DAILY_BUILD_ID=lkg`
- Check the latest 3.0-dev builds and search for "ignoring case for..." in the fetcher logs (found `perl-Net-SSLeay`).
