### PR TITLE
dracut-overlayfs improvement to be general.

### DIFF
--- a/SPECS/dracut/dracut.signatures.json
+++ b/SPECS/dracut/dracut.signatures.json
@@ -9,6 +9,6 @@
   "lgpl-2.1.txt": "dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551",
   "megaraid.conf": "914824cdbe0c525b71efa05a75e453335b0068beb8bc28bef2a5866d74bf7dd4",
   "module-setup.sh": "8f5a0d3cc393d78bcb523b0d53c578d2767d688f00e84b525355bbb31d753da4",
-  "overlayfs-mount.sh": "f049d0ad2e4a1d98acb329765900690883520fdc8fc9463f5081f6e7fb679695"
+  "overlayfs-mount.sh": "a12b93de348e2680293ef6faaae1c84525e9c0824e5056b668cda5579afd6c14"
  }
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
General improvements to make the features more generic. Dracut module on AzureLinux repo should be usable by users other than Trident.

The corresponding changes for MIC API will be kicked off shortly.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change1: Provide overlayfs mount `-o` option so that `ro` / `rw` can be set. By default the overlay should be mount `rw` for generic usage.
- Change2: No upperdir / workdir needed for volatile overlays.
- Change3: No upperdir / workdir needed for `ro` overlays.
- Change4: Verify Overlay non-volatile partition exists.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Internal story tracking: https://dev.azure.com/mariner-org/ECF/_sprints/taskboard/Mariner%20Operator%20Edge/ECF/2408?workitem=7969

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: buddybuild: TODO.
