### PR TITLE
Bump frr to 9.1.1 to fix CVE-224-31950 & CVE-2024-31951

### DIFF
--- a/SPECS/frr/frr.signatures.json
+++ b/SPECS/frr/frr.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "frr-9.1.tar.gz": "c4516fa3ef4286c665af809cfbe3a6e7e24a254a7bfb7247e1f7744dcd3bd5da",
+  "frr-9.1.1.tar.gz": "6eb254c72dca867fefffd5ded80a6c2d5ce8df223ce93263302db4b8bfbb19c4",
   "frr-sysusers.conf": "c6f5a54402aa5f11e21dac3bd0e6cdeadfbf7937e9b34775b5fd368a9ca96fa4",
   "frr-tmpfiles.conf": "edd7b01b11f2be66bb6b4531496d1eaf6536add9f4b549c659b27f5a32cdc512"
  }

--- a/SPECS/frr/frr.spec
+++ b/SPECS/frr/frr.spec
@@ -2,8 +2,8 @@
 
 Summary:        Routing daemon
 Name:           frr
-Version:        9.1
-Release:        2%{?dist}
+Version:        9.1.1
+Release:        1%{?dist}
 License:        GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -198,6 +198,9 @@ rm tests/lib/*grpc*
 %{_sysusersdir}/%{name}.conf
 
 %changelog
+* Tue Aug 06 2024 Sumedh Sharma <sumsharma@microsoft.com> - 9.1.1-1
+- Bump version to 9.1.1 to fix CVE-2024-31950 & CVE-2024-31951
+
 * Wed Apr 24 2024 Tobias Brick <tobiasb@microsoft.com> - 9.1-2
 - Remove FIPS_mode patch
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3900,8 +3900,8 @@
         "type": "other",
         "other": {
           "name": "frr",
-          "version": "9.1",
-          "downloadUrl": "https://github.com/FRRouting/frr/archive/refs/tags/frr-9.1.tar.gz"
+          "version": "9.1.1",
+          "downloadUrl": "https://github.com/FRRouting/frr/archive/refs/tags/frr-9.1.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Bump version to 9.1.1 to fix CVE-2024-31950 & CVE-2024-31951
https://github.com/FRRouting/frr/releases/tag/frr-9.1.1

###### Change Log  <!-- REQUIRED -->
- bump version
- update cgmanifest entry

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-31950
- https://nvd.nist.gov/vuln/detail/CVE-2024-31951

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=617196&view=results)
[install failure due to known libcrypto.so.3()(64bit) issue]