### PR TITLE
azcopy: upgrade version to 10.25.1 to fix CVE-2024-35255

### DIFF
--- a/SPECS/azcopy/azcopy.signatures.json
+++ b/SPECS/azcopy/azcopy.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "azure-storage-azcopy-10.24.0-vendor.tar.gz": "b0b0436e8e8aa280007d2daf5cb1ea06346d54e070062042c792a9fbd110e690",
-  "azure-storage-azcopy-10.24.0.tar.gz": "bbb09bee00207eb6e6e80a3ecf58ac39beb956c94f500b62888ed3404580430d"
+  "azure-storage-azcopy-10.25.1-vendor.tar.gz": "2e51019e29834b9b4ea2480fa80eaa95d2ce09601eb1be2edcf5febd927e5a4e",
+  "azure-storage-azcopy-10.25.1.tar.gz": "d62f0a88e8899a611d9ef627252e4379bee8530177caca081f155e28917e70d3"
  }
 }

--- a/SPECS/azcopy/azcopy.spec
+++ b/SPECS/azcopy/azcopy.spec
@@ -1,6 +1,6 @@
 Summary:        The new Azure Storage data transfer utility - AzCopy v10
 Name:           azcopy
-Version:        10.24.0
+Version:        10.25.1
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -61,6 +61,9 @@ go test -mod=vendor
 %{_bindir}/azcopy
 
 %changelog
+* Tue Aug 06 2024 Archana Choudhary <archana1@microsoft.com> - 10.25.1-1
+- Upgrade azcopy to latest 10.25.1 to fix multiple security issues  
+
 * Thu May 23 2024 Sudipta Pandit <sudpandit@microsoft.com> - 10.24.0-1
 - Upgrade azcopy to latest 10.24.0 to fix multiple security issues
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -835,8 +835,8 @@
         "type": "other",
         "other": {
           "name": "azcopy",
-          "version": "10.24.0",
-          "downloadUrl": "https://github.com/Azure/azure-storage-azcopy/archive/refs/tags/v10.24.0.tar.gz"
+          "version": "10.25.1",
+          "downloadUrl": "https://github.com/Azure/azure-storage-azcopy/archive/refs/tags/v10.25.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Cherry-picked from https://github.com/microsoft/azurelinux/pull/9581

Buddy Build Link: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=617231&view=results