### PR TITLE
containerized-rpmbuild: switch up strategy for defaults and return command exit codes

### DIFF
--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -230,16 +230,6 @@ sed -i "s~<REPO_BRANCH>~${repo_branch}~" $tmp_dir/welcome.txt
 sed -i "s~<AARCH>~$(uname -m)~" $tmp_dir/welcome.txt
 cp resources/setup_functions.sh $tmp_dir/setup_functions.sh
 sed -i "s~<TOPDIR>~${topdir}~" $tmp_dir/setup_functions.sh
-# TODO: Remove when PMC is available for 3.0
-if [[ "${version}" == "3.0" ]]; then # Add 3.0 DailyBuild repo
-    cp resources/azl-3_repo $tmp_dir/azl-3_repo
-    sed -i "s~<DAILY_BUILD_ID>~${DAILY_BUILD_ID}~" $tmp_dir/azl-3_repo
-    if [[ $(uname -m) == "x86_64" ]]; then
-        sed -i "s~<ARCH>~x86-64~" $tmp_dir/azl-3_repo
-    else
-        sed -i "s~<ARCH>~aarch64~" $tmp_dir/azl-3_repo
-    fi
-fi
 
 # ============ Build the image ============
 dockerfile="${script_dir}/resources/azl.Dockerfile"

--- a/toolkit/scripts/containerized-build/resources/azl-3_repo
+++ b/toolkit/scripts/containerized-build/resources/azl-3_repo
@@ -1,9 +1,0 @@
-[azl-3.0-daily-build]
-name=Azure Linux 3.0 Daily Build Repo
-baseurl=https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-<DAILY_BUILD_ID>-<ARCH>
-gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
-gpgcheck=0
-repo_gpgcheck=0
-enabled=1
-skip_if_unavailable=True
-sslverify=0

--- a/toolkit/scripts/containerized-build/resources/azl.Dockerfile
+++ b/toolkit/scripts/containerized-build/resources/azl.Dockerfile
@@ -8,9 +8,7 @@ ARG extra_packages
 LABEL containerized-rpmbuild=$azl_repo/build
 
 COPY resources/local_repo /etc/yum.repos.d/local_repo.disabled_repo
-
-# This is used by setup_functions.sh to determine tdnf default arguments
-ENV CONTAINERIZED_RPMBUILD_AZL_VERSION=${version}
+COPY resources/macros.with-check /usr/lib/rpm/macros.d
 
 RUN echo "source /azl_setup_dir/setup_functions.sh"          >> /root/.bashrc && \
     echo "if [[ ! -L /repo ]]; then ln -s /mnt/RPMS/ /repo; fi"  >> /root/.bashrc
@@ -25,5 +23,5 @@ RUN if [[ "${mode}" == "build" ]]; then echo "cd /usr/src/azl || { echo \"ERROR:
 RUN if [[ "${mode}" == "test" ]]; then echo "cd /mnt || { echo \"ERROR: Could not change directory to /mnt \"; exit 1; }"  >> /root/.bashrc; fi
 
 # Install packages from bashrc so we can use the previously setup tdnf defaults.
-RUN echo "echo installing packages vim git ${extra_packages}" >> /root/.bashrc && \
-    echo "tdnf install -qy vim git ${extra_packages}" >> /root/.bashrc
+RUN echo "echo installing packages azurelinux-release vim git ${extra_packages}" >> /root/.bashrc && \
+    echo "tdnf install --releasever=${version} -qy azurelinux-release vim git ${extra_packages}" >> /root/.bashrc

--- a/toolkit/scripts/containerized-build/resources/macros.with-check
+++ b/toolkit/scripts/containerized-build/resources/macros.with-check
@@ -1,0 +1,1 @@
+%with_check         1


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change simplifies the `containerized-rpmbuild` scripts in a few ways, which makes it easier to maintain and simpler to use.

###### Change Log  <!-- REQUIRED -->
1. Completely remove `azl-3_repo` and the associated settings. It ends up being the same as the "real" repo, so it only added complexity.
2. Switched from using a `MACROS` environment variable that wrapper functions like `rpmspec` and `rpm` had to use in favor of a `macros.with-check` file that gets copied to the appropriate place and does the same thing without the need to use the environment variable. This allowed me to completely remove the `rpmspec` wrapper function.
3. Similar with `TDNF_ARGS`. Since we no longer need to point to `azl-3_repo`, all it had was `--releasever=3.0`. So instead, we install `azurelinux-release`, which sets that up properly. This allowed me to completely remove the `tdnf` wrapper function.
4. Changed the remaining wrapper functions `rpm` and `rpmbuild` to return the exit code from the function they wrap, to allow scripts to use the exit code properly.


###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Built and used `containerized-rpmbuild` on my machine.
- Full Pipelines: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=618572&view=results
