### PR TITLE
nghttp2: upgrade version 1.59.0 -> 1.61.0 to address CVE-2024-28182

### DIFF
--- a/SPECS/nghttp2/nghttp2.signatures.json
+++ b/SPECS/nghttp2/nghttp2.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "nghttp2-1.59.0.tar.xz": "fdc9bd71f5cf8d3fdfb63066b89364c10eb2fdeab55f3c6755cd7917b2ec4ffb"
-  }
+ "Signatures": {
+  "nghttp2-1.61.0.tar.xz": "c0e660175b9dc429f11d25b9507a834fb752eea9135ab420bb7cb7e9dbcc9654"
+ }
 }

--- a/SPECS/nghttp2/nghttp2.spec
+++ b/SPECS/nghttp2/nghttp2.spec
@@ -1,6 +1,6 @@
 Summary:        nghttp2 is an implementation of HTTP/2 and its header compression algorithm, HPACK.
 Name:           nghttp2
-Version:        1.59.0
+Version:        1.61.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -59,6 +59,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Thu Aug 08 2024 Muhammad Falak <mwani@microsoft.com> - 1.61.0-1
+- Upgrade version to 1.61.0 to address CVE-2024-28182
+
 * Thu Feb 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.59.0-1
 - Auto-upgrade to 1.59.0 - 3.0 package upgrade
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13952,8 +13952,8 @@
         "type": "other",
         "other": {
           "name": "nghttp2",
-          "version": "1.59.0",
-          "downloadUrl": "https://github.com/nghttp2/nghttp2/releases/download/v1.59.0/nghttp2-1.59.0.tar.xz"
+          "version": "1.61.0",
+          "downloadUrl": "https://github.com/nghttp2/nghttp2/releases/download/v1.61.0/nghttp2-1.61.0.tar.xz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -190,7 +190,7 @@ libsolv-devel-0.7.28-1.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm
 libssh2-devel-1.11.0-1.azl3.aarch64.rpm
 krb5-1.21.3-1.azl3.aarch64.rpm
-nghttp2-1.59.0-1.azl3.aarch64.rpm
+nghttp2-1.61.0-1.azl3.aarch64.rpm
 curl-8.8.0-1.azl3.aarch64.rpm
 curl-devel-8.8.0-1.azl3.aarch64.rpm
 curl-libs-8.8.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -190,7 +190,7 @@ libsolv-devel-0.7.28-1.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm
 libssh2-devel-1.11.0-1.azl3.x86_64.rpm
 krb5-1.21.3-1.azl3.x86_64.rpm
-nghttp2-1.59.0-1.azl3.x86_64.rpm
+nghttp2-1.61.0-1.azl3.x86_64.rpm
 curl-8.8.0-1.azl3.x86_64.rpm
 curl-devel-8.8.0-1.azl3.x86_64.rpm
 curl-libs-8.8.0-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -267,9 +267,9 @@ newt-0.52.23-1.azl3.aarch64.rpm
 newt-debuginfo-0.52.23-1.azl3.aarch64.rpm
 newt-devel-0.52.23-1.azl3.aarch64.rpm
 newt-lang-0.52.23-1.azl3.aarch64.rpm
-nghttp2-1.59.0-1.azl3.aarch64.rpm
-nghttp2-debuginfo-1.59.0-1.azl3.aarch64.rpm
-nghttp2-devel-1.59.0-1.azl3.aarch64.rpm
+nghttp2-1.61.0-1.azl3.aarch64.rpm
+nghttp2-debuginfo-1.61.0-1.azl3.aarch64.rpm
+nghttp2-devel-1.61.0-1.azl3.aarch64.rpm
 ninja-build-1.11.1-1.azl3.aarch64.rpm
 ninja-build-debuginfo-1.11.1-1.azl3.aarch64.rpm
 npth-1.6-4.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -273,9 +273,9 @@ newt-0.52.23-1.azl3.x86_64.rpm
 newt-debuginfo-0.52.23-1.azl3.x86_64.rpm
 newt-devel-0.52.23-1.azl3.x86_64.rpm
 newt-lang-0.52.23-1.azl3.x86_64.rpm
-nghttp2-1.59.0-1.azl3.x86_64.rpm
-nghttp2-debuginfo-1.59.0-1.azl3.x86_64.rpm
-nghttp2-devel-1.59.0-1.azl3.x86_64.rpm
+nghttp2-1.61.0-1.azl3.x86_64.rpm
+nghttp2-debuginfo-1.61.0-1.azl3.x86_64.rpm
+nghttp2-devel-1.61.0-1.azl3.x86_64.rpm
 ninja-build-1.11.1-1.azl3.x86_64.rpm
 ninja-build-debuginfo-1.11.1-1.azl3.x86_64.rpm
 npth-1.6-4.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- **nghttp2: upgrade version 1.59.0 -> 1.61.0 to address CVE-2024-28182**

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- **nghttp2: upgrade version 1.59.0 -> 1.61.0 to address CVE-2024-28182**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**Yes**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-28182

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Pipeline build id: [PR-10064](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=618260&view=results)
