### PR TITLE
dracut: add fix for initrd not showing prompt when root device is locked (#10039)

### DIFF
--- a/SPECS/dracut/0013-revert-fix-crypt-unlock-encrypted-devices-by-default.patch
+++ b/SPECS/dracut/0013-revert-fix-crypt-unlock-encrypted-devices-by-default.patch
@@ -1,0 +1,25 @@
+See issue: https://github.com/dracut-ng/dracut-ng/issues/492
+
+This reverts commit 2339acfaeee60d6bb26a1103db2e53bc8f9cb2d1
+
+Signed-off by: Thien Trung Vuong <tvuong@microsoft.com>
+---
+ modules.d/90crypt/parse-crypt.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules.d/90crypt/parse-crypt.sh b/modules.d/90crypt/parse-crypt.sh
+index 9567a4a9..e46e347a 100755
+--- a/modules.d/90crypt/parse-crypt.sh
++++ b/modules.d/90crypt/parse-crypt.sh
+@@ -174,7 +174,7 @@ else
+                 } >> "$hookdir/emergency/90-crypt.sh"
+             fi
+         done
+-    elif getargbool 1 rd.auto; then
++    elif getargbool 0 rd.auto; then
+         if [ -z "$DRACUT_SYSTEMD" ]; then
+             {
+                 printf -- 'ENV{ID_FS_TYPE}=="crypto_LUKS", RUN+="%s ' "$(command -v initqueue)"
+-- 
+2.42.0
+

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        102
-Release:        1%{?dist}
+Release:        2%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -34,6 +34,7 @@ Patch:          0006-dracut.sh-validate-instmods-calls.patch
 Patch:          0007-feat-dracut.sh-support-multiple-config-dirs.patch
 Patch:          0011-Remove-reference-to-kernel-module-zlib-in-fips-module.patch
 Patch:          0012-fix-dracut-functions-avoid-awk-in-get_maj_min.patch
+Patch:          0013-revert-fix-crypt-unlock-encrypted-devices-by-default.patch
 
 BuildRequires:  bash
 BuildRequires:  kmod-devel
@@ -276,6 +277,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Tue Aug 06 2024 Thien Trung Vuong <tvuong@microsoft.com> - 102-2
+- Add fix for initrd not showing prompt when root device is locked
+
 * Tue Jun 25 2024 Cameron Baird <cameronbaird@microsoft.com> - 102-1
 - Update to 102
 


### PR DESCRIPTION
Signed-off-by: Thien Trung Vuong <tvuong@microsoft.com>
(cherry picked from commit c6b19b50301ead2dd853d1051129a1f1c53cfc84)
