### PR TITLE
vim: Add patch to resolve CVE-2024-41957 & CVE-2024-41965

### DIFF
--- a/SPECS/vim/CVE-2024-41957.patch
+++ b/SPECS/vim/CVE-2024-41957.patch
@@ -1,0 +1,81 @@
+Modified patch to apply to older version
+Modifed by: sumsharma@microsoft.com
+
+From 8a0bbe7b8aad6f8da28dee218c01bc8a0185a2d5 Mon Sep 17 00:00:00 2001
+From: Christian Brabandt <cb@256bit.org>
+Date: Thu, 1 Aug 2024 20:16:51 +0200
+Subject: [PATCH] patch 9.1.0647: [security] use-after-free in
+ tagstack_clear_entry
+
+Problem:  [security] use-after-free in tagstack_clear_entry
+          (Suyue Guo )
+Solution: Instead of manually calling vim_free() on each of the tagstack
+          entries, let's use tagstack_clear_entry(), which will
+          also free the stack, but using the VIM_CLEAR macro,
+          which prevents a use-after-free by setting those pointers
+          to NULL
+
+This addresses CVE-2024-41957
+
+Github advisory:
+https://github.com/vim/vim/security/advisories/GHSA-f9cr-gv85-hcr4
+
+Signed-off-by: Christian Brabandt <cb@256bit.org>
+---
+ src/proto/tag.pro | 1 +
+ src/tag.c         | 4 ++--
+ src/window.c      | 6 ++----
+ 3 files changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/src/proto/tag.pro b/src/proto/tag.pro
+index 6de463e..eec7c24 100644
+--- a/src/proto/tag.pro
++++ b/src/proto/tag.pro
+@@ -14,4 +14,5 @@ int expand_tags(int tagnames, char_u *pat, int *num_file, char_u ***file);
+ int get_tags(list_T *list, char_u *pat, char_u *buf_fname);
+ void get_tagstack(win_T *wp, dict_T *retdict);
+ int set_tagstack(win_T *wp, dict_T *d, int action);
++void tagstack_clear_entry(taggy_T *item);
+ /* vim: set ft=c : */
+diff --git a/src/tag.c b/src/tag.c
+index 8003156..31b89e7 100644
+--- a/src/tag.c
++++ b/src/tag.c
+@@ -144,7 +144,7 @@ static void print_tag_list(int new_tag, int use_tagstack, int num_matches, char_
+ #if defined(FEAT_QUICKFIX) && defined(FEAT_EVAL)
+ static int add_llist_tags(char_u *tag, int num_matches, char_u **matches);
+ #endif
+-static void tagstack_clear_entry(taggy_T *item);
++void tagstack_clear_entry(taggy_T *item);
+ 
+ static char_u	*tagmatchname = NULL;	// name of last used tag
+ 
+@@ -4225,7 +4225,7 @@ find_extra(char_u **pp)
+ /*
+  * Free a single entry in a tag stack
+  */
+-    static void
++void
+ tagstack_clear_entry(taggy_T *item)
+ {
+     VIM_CLEAR(item->tagname);
+diff --git a/src/window.c b/src/window.c
+index 55ce31c..ffffde8 100644
+--- a/src/window.c
++++ b/src/window.c
+@@ -5661,10 +5661,8 @@ win_free(
+     win_free_lsize(wp);
+ 
+     for (i = 0; i < wp->w_tagstacklen; ++i)
+-    {
+-	vim_free(wp->w_tagstack[i].tagname);
+-	vim_free(wp->w_tagstack[i].user_data);
+-    }
++	tagstack_clear_entry(&wp->w_tagstack[i]);
++
+     vim_free(wp->w_localdir);
+     vim_free(wp->w_prevdir);
+ 
+-- 
+2.25.1
+

--- a/SPECS/vim/CVE-2024-41965.patch
+++ b/SPECS/vim/CVE-2024-41965.patch
@@ -1,0 +1,45 @@
+Modified patch to apply to older version of vim
+Modified by: sumsharma@microsoft.com
+
+From b29f4abcd4b3382fa746edd1d0562b7b48c9de60 Mon Sep 17 00:00:00 2001
+From: Christian Brabandt <cb@256bit.org>
+Date: Thu, 1 Aug 2024 22:10:28 +0200
+Subject: [PATCH] patch 9.1.0648: [security] double-free in dialog_changed()
+
+Problem:  [security] double-free in dialog_changed()
+          (SuyueGuo)
+Solution: Only clear pointer b_sfname pointer, if it is different
+          than the b_ffname pointer.  Don't try to free b_fname,
+          set it to NULL instead.
+
+fixes: #15403
+
+Github Advisory:
+https://github.com/vim/vim/security/advisories/GHSA-46pw-v7qw-xc2f
+
+Signed-off-by: Christian Brabandt <cb@256bit.org>
+---
+ src/ex_cmds2.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/ex_cmds2.c b/src/ex_cmds2.c
+index 0b57fd8..ede403a 100644
+--- a/src/ex_cmds2.c
++++ b/src/ex_cmds2.c
+@@ -197,9 +197,11 @@ dialog_changed(
+ 	// restore to empty when write failed
+ 	if (empty_bufname)
+ 	{
+-	    VIM_CLEAR(buf->b_fname);
++	    // prevent double free
++	    if (buf->b_sfname != buf->b_ffname)
++		VIM_CLEAR(buf->b_sfname);
++	    buf->b_fname = NULL;
+ 	    VIM_CLEAR(buf->b_ffname);
+-	    VIM_CLEAR(buf->b_sfname);
+ 	    unchanged(buf, TRUE, FALSE);
+ 	}
+     }
+-- 
+2.25.1
+

--- a/SPECS/vim/fix_save_unnamed_buffer_correctly.patch
+++ b/SPECS/vim/fix_save_unnamed_buffer_correctly.patch
@@ -1,8 +1,11 @@
-From 4b8d5ed092391d927b4bc6ac731c743ee2255886 Mon Sep 17 00:00:00 2001
-From: Sumynwa <sumedh.alok@gmail.com>
-Date: Fri, 9 Aug 2024 13:26:00 +0530
-Subject: [PATCH] fix
+From 3c8cfa2245104ce4cb2ad3f40783aa6da6f3adde Mon Sep 17 00:00:00 2001
+From: glepnir <glephunter@gmail.com>
+Date: Tue, 2 Apr 2024 15:40:38 +0800
+Subject: [PATCH] fix(dialog): save unamed buffer correctly
 
+Problem: when bufname is empty it can not save correctly
+
+Solution: set bufname before save.
 ---
  src/ex_cmds2.c | 23 ++++++++++++++++++++---
  1 file changed, 20 insertions(+), 3 deletions(-)

--- a/SPECS/vim/fix_save_unnamed_buffer_correctly.patch
+++ b/SPECS/vim/fix_save_unnamed_buffer_correctly.patch
@@ -1,0 +1,51 @@
+From 4b8d5ed092391d927b4bc6ac731c743ee2255886 Mon Sep 17 00:00:00 2001
+From: Sumynwa <sumedh.alok@gmail.com>
+Date: Fri, 9 Aug 2024 13:26:00 +0530
+Subject: [PATCH] fix
+
+---
+ src/ex_cmds2.c | 23 ++++++++++++++++++++---
+ 1 file changed, 20 insertions(+), 3 deletions(-)
+
+diff --git a/src/ex_cmds2.c b/src/ex_cmds2.c
+index 45ccb52..0b57fd8 100644
+--- a/src/ex_cmds2.c
++++ b/src/ex_cmds2.c
+@@ -177,14 +177,31 @@ dialog_changed(
+ 
+     if (ret == VIM_YES)
+     {
++	int	empty_bufname;
++
+ #ifdef FEAT_BROWSE
+ 	// May get file name, when there is none
+ 	browse_save_fname(buf);
+ #endif
+-	if (buf->b_fname != NULL && check_overwrite(&ea, buf,
+-				    buf->b_fname, buf->b_ffname, FALSE) == OK)
++	empty_bufname = buf->b_fname == NULL ? TRUE : FALSE;
++	if (empty_bufname)
++            buf_set_name(buf->b_fnum, (char_u *)"Untitled");
++
++	if (check_overwrite(&ea, buf, buf->b_fname, buf->b_ffname, FALSE) == OK)
++	{
+ 	    // didn't hit Cancel
+-	    (void)buf_write_all(buf, FALSE);
++	    if (buf_write_all(buf, FALSE) == OK)
++		return;
++	}
++
++	// restore to empty when write failed
++	if (empty_bufname)
++	{
++	    VIM_CLEAR(buf->b_fname);
++	    VIM_CLEAR(buf->b_ffname);
++	    VIM_CLEAR(buf->b_sfname);
++	    unchanged(buf, TRUE, FALSE);
++	}
+     }
+     else if (ret == VIM_NO)
+     {
+-- 
+2.25.1
+

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -2,7 +2,7 @@
 Summary:        Text editor
 Name:           vim
 Version:        9.0.2190
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -10,6 +10,10 @@ Group:          Applications/Editors
 URL:            https://www.vim.org
 Source0:        https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        macros.vim
+Patch0:         CVE-2024-41957.patch
+Patch1:         fix_save_unnamed_buffer_correctly.patch
+Patch2:         CVE-2024-41965.patch
+
 BuildRequires:  ncurses-devel
 BuildRequires:  python3-devel
 Requires(post): sed
@@ -217,6 +221,9 @@ fi
 %{_rpmconfigdir}/macros.d/macros.vim
 
 %changelog
+* Fri Aug 09 2024 Sumedh Sharma <sumsharma@microsoft.com> - 9.0.2190-4
+- Add patch to resolve CVE-2024-41957 & CVE-2024-41965
+
 * Tue May 21 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 9.0.2190-3
 - Added vim-rpm-macros subpackage
 - Add macros.vim to the new subpackage


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch to resolve CVE-2024-41957 & CVE-2024-41965

Reference
[GHSA-f9cr-gv85-hcr4](https://github.com/vim/vim/security/advisories/GHSA-f9cr-gv85-hcr4)
[GHSA-46pw-v7qw-xc2f](https://github.com/vim/vim/security/advisories/GHSA-46pw-v7qw-xc2f)

###### Change Log  <!-- REQUIRED -->
- Add patch files

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-41957
- https://nvd.nist.gov/vuln/detail/CVE-2024-41965

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=618901&view=results)
