### PR TITLE
Fix CVE-2024-3360 update keras package to version 2.13.1

### DIFF
--- a/SPECS/bazel/bazel.signatures.json
+++ b/SPECS/bazel/bazel.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "bazel-5.3.2-dist.zip": "3880ad919592d1e3e40c506f13b32cd0a2e26f129d87cb6ba170f1801d7d7b82"
+    "bazel-5.4.1-dist.zip": "dcff6935756aa7aca4fc569bb2bd26e1537f0b1f6d1bda5f2b200fa835cc507f"
   }
 }

--- a/SPECS/bazel/bazel.spec
+++ b/SPECS/bazel/bazel.spec
@@ -3,7 +3,7 @@
 %define __os_install_post %{_libdir}/rpm/brp-compress %{nil}
 Summary:        Correct, reproducible, and fast builds for everyone.
 Name:           bazel
-Version:        5.3.2
+Version:        5.4.1
 Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
@@ -50,6 +50,9 @@ cp ./scripts/packages/bazel.sh %{buildroot}/%{_bindir}/bazel
 %attr(0755,root,root) %{_bindir}/bazel-real
 
 %changelog
+* Fri Aug 09 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 5.4.1
+- upgrade to 5.4.1 - CVE-2024-3660
+
 * Fri Dec 09 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.3.2-1
 - Auto-upgrade to 5.3.2 - CVE-2022-3474
 

--- a/SPECS/keras/keras.signatures.json
+++ b/SPECS/keras/keras.signatures.json
@@ -1,6 +1,5 @@
 {
     "Signatures": {
-     "keras-2.11.0.tar.gz": "e7a7c4199ac76ea750d145c1d84ae1b932e68b9bca34e83596bd66b2fc2ad79e",
-     "keras-2.11.0-cache.tar.gz":"95c82ed05500f1a4532d2c76b62f673d84373246e4e28729ea48f604ebbbedba"
+     "keras-2.13.1.tar.gz": "b3591493cce75a69adef7b192cec6be222e76e2386d132cd4e34aa190b0ecbd5"
     }
-   }
+}

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -47,9 +47,6 @@ sed -i "s/version=\"{{VERSION}}\"/version=\"%{version}\"/" oss_setup.py
 # Rename oss_setup.py to setup.py
 mv oss_setup.py setup.py
 
-# Download and set up Bazel 5.4.0
-cd "/usr/bin" && curl -fLO https://releases.bazel.build/5.4.0/release/bazel-5.4.0-linux-x86_64 && chmod +x bazel-5.4.0-linux-x86_64
-
 %build
 #%{py3_build}
 python3 pip_build.py

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -45,11 +45,11 @@ sed -i "s/name=\"{{PACKAGE}}\"/name=\"%{name}\"/" oss_setup.py
 sed -i "s/version=\"{{VERSION}}\"/version=\"%{version}\"/" oss_setup.py
 
 # Rename oss_setup.py to setup.py
-mv oss_setup.py setup.py
+cp oss_setup.py setup.py
 
 %build
-#%{py3_build}
-python3 pip_build.py
+%{py3_build}
+#python3 pip_build.py
 
 %install
 %{pyproject_install}

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -40,28 +40,11 @@ Python 3 version.
 %prep
 %autosetup -p1
 
-
 %build
-tar -xf %{SOURCE1} -C /root/
-
-ln -s %{_bindir}/python3 %{_bindir}/python
-
-bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_package
-# ---------
-# steps to create the cache tar. network connection is required to create the cache.
-#----------------------------------
-# pushd /root
-# tar -czvf cacheroot.tar.gz .cache  #creating the cache using the /root/.cache directory
-# popd
-# mv /root/cacheroot.tar.gz /usr/
-
-./bazel-bin/keras/tools/pip_package/build_pip_package pyproject-wheeldir/
-# --------
-
+%{py3_build}
 
 %install
 %{pyproject_install}
-
 
 %files -n python3-keras
 %license LICENSE
@@ -69,7 +52,7 @@ bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_
 
 
 %changelog
-* Fri Aug 8 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 2.13.1-1
+* Fri Aug 9 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 2.13.1-1
 - Update keras package to version 2.13.1.
 - Fix for CVE-2024-3660
 

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -38,10 +38,13 @@ Summary:        python-keras
 Python 3 version.
 
 %prep
-#%autosetup -p1
+%autosetup -p1
 # Rename oss_setup.py to setup.py
-#mv oss_setup.py setup.py
+mv oss_setup.py setup.py
 
+# Replace the 'name' and 'version' in setup.py
+sed -i "s/name=\"unknown\"/name=\"%{name}\"/" setup.py
+sed -i "s/version=\"unknown\"/version=\"%{version}\"/" setup.py
 
 %build
 #%{py3_build}
@@ -69,3 +72,4 @@ python3 pip_build.py
 * Mon Dec 12 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-1
 - License verified
 - Original version for CBL-Mariner
+

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -41,9 +41,13 @@ Python 3 version.
 %autosetup -p1
 # Rename oss_setup.py to setup.py
 mv oss_setup.py setup.py
+sed -i "s/^PACKAGE\s*=.*$/PACKAGE = '%{name}'/" setup.py
+sed -i "s/^VERSION\s*=.*$/VERSION = '%{version}'/" setup.py
+
 
 %build
 %{py3_build}
+#python3 pip_build.py
 
 %install
 %{pyproject_install}

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -2,15 +2,14 @@
 %global debug_package %{nil}
 Summary:        Keras is a high-level neural networks API.
 Name:           keras
-Version:        2.11.0
-Release:        3%{?dist}
+Version:        2.13.1
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Languages/Python
 URL:            https://keras.io/
 Source0:        https://github.com/keras-team/keras/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Source1:        %{name}-%{version}-cache.tar.gz
 BuildRequires:  bazel
 BuildRequires:  build-essential
 BuildRequires:  git
@@ -70,6 +69,10 @@ bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_
 
 
 %changelog
+* Fri Aug 8 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 2.13.1-1
+- Update keras package to version 2.13.1.
+- Fix for CVE-2024-3660
+
 * Fri May 24 2024 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-3
 - Explicitly BR python3-h5py.
 

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -39,12 +39,14 @@ Python 3 version.
 
 %prep
 %autosetup -p1
+
+# Replace the 'name' and 'version' in setup.py
+sed -i "s/name=\"{{PACKAGE}}\"/name=\"%{name}\"/" oss_setup.py
+sed -i "s/version=\"{{VERSION}}\"/version=\"%{version}\"/" oss_setup.py
+
 # Rename oss_setup.py to setup.py
 mv oss_setup.py setup.py
 
-# Replace the 'name' and 'version' in setup.py
-sed -i "s/name=\"unknown\"/name=\"%{name}\"/" setup.py
-sed -i "s/version=\"unknown\"/version=\"%{version}\"/" setup.py
 
 %build
 #%{py3_build}

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -10,7 +10,7 @@ Distribution:   Mariner
 Group:          Development/Languages/Python
 URL:            https://keras.io/
 Source0:        https://github.com/keras-team/keras/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-BuildRequires:  bazel
+BuildRequires:  bazel >= 5.4.0
 BuildRequires:  build-essential
 BuildRequires:  git
 BuildRequires:  libstdc++-devel

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -39,6 +39,8 @@ Python 3 version.
 
 %prep
 %autosetup -p1
+# Rename oss_setup.py to setup.py
+mv oss_setup.py setup.py
 
 %build
 %{py3_build}

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -47,6 +47,8 @@ sed -i "s/version=\"{{VERSION}}\"/version=\"%{version}\"/" oss_setup.py
 # Rename oss_setup.py to setup.py
 mv oss_setup.py setup.py
 
+# Download and set up Bazel 5.4.0
+cd "/usr/bin" && curl -fLO https://releases.bazel.build/5.4.0/release/bazel-5.4.0-linux-x86_64 && chmod +x bazel-5.4.0-linux-x86_64
 
 %build
 #%{py3_build}

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -38,16 +38,14 @@ Summary:        python-keras
 Python 3 version.
 
 %prep
-%autosetup -p1
+#%autosetup -p1
 # Rename oss_setup.py to setup.py
-mv oss_setup.py setup.py
-sed -i "s/^PACKAGE\s*=.*$/PACKAGE = '%{name}'/" setup.py
-sed -i "s/^VERSION\s*=.*$/VERSION = '%{version}'/" setup.py
+#mv oss_setup.py setup.py
 
 
 %build
-%{py3_build}
-#python3 pip_build.py
+#%{py3_build}
+python3 pip_build.py
 
 %install
 %{pyproject_install}

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8111,8 +8111,8 @@
         "type": "other",
         "other": {
           "name": "keras",
-          "version": "2.11.0",
-          "downloadUrl": "https://github.com/keras-team/keras/archive/refs/tags/v2.11.0.tar.gz"
+          "version": "2.13.2",
+          "downloadUrl": "https://github.com/keras-team/keras/archive/refs/tags/v2.13.1.tar.gz"
         }
       }
     },
@@ -12173,6 +12173,16 @@
           "name": "livepatch-5.15.131.1-3.cm2",
           "version": "1.0.0",
           "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.131.1.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "livepatch-5.15.162.2-1.cm2",
+          "version": "1.0.0",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner-2/5.15.162.2.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8111,7 +8111,7 @@
         "type": "other",
         "other": {
           "name": "keras",
-          "version": "2.13.2",
+          "version": "2.13.1",
           "downloadUrl": "https://github.com/keras-team/keras/archive/refs/tags/v2.13.1.tar.gz"
         }
       }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -995,8 +995,8 @@
         "type": "other",
         "other": {
           "name": "bazel",
-          "version": "5.3.2",
-          "downloadUrl": "https://github.com/bazelbuild/bazel/releases/download/5.3.2/bazel-5.3.2-dist.zip"
+          "version": "5.4.1",
+          "downloadUrl": "https://github.com/bazelbuild/bazel/releases/download/5.4.1/bazel-5.4.1-dist.zip"
         }
       }
     },


### PR DESCRIPTION
Fix [CVE-2024-3660](https://github.com/advisories/GHSA-vmxm-7mh7-6wxv) update keras package to version 2.13.1
 Changes to be committed:
	modified:   SPECS/keras/keras.signatures.json
	modified:   SPECS/keras/keras.spec
	modified:   cgmanifest.json


###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fix [CVE-2024-3660](https://github.com/advisories/GHSA-vmxm-7mh7-6wxv) update keras package to version 2.13.1

###### Change Log  <!-- REQUIRED -->
 Changes to be committed:
	modified:   SPECS/keras/keras.signatures.json
	modified:   SPECS/keras/keras.spec
	modified:   cgmanifest.json


###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-3360

###### Test Methodology
- Pipeline build id: 10093
