### PR TITLE
moby-engine: remove daemon.json with backported fix

### DIFF
--- a/SPECS/moby-engine/daemon.json
+++ b/SPECS/moby-engine/daemon.json
@@ -1,3 +1,0 @@
-{
-  "userland-proxy-path": "/usr/libexec/docker-proxy"
-}

--- a/SPECS/moby-engine/enable-docker-proxy-libexec-search.patch
+++ b/SPECS/moby-engine/enable-docker-proxy-libexec-search.patch
@@ -1,0 +1,95 @@
+From f8c088be055b72e58005ef9e56cf4f4008bbc5dd Mon Sep 17 00:00:00 2001
+From: Brian Goff <cpuguy83@gmail.com>
+Date: Tue, 7 May 2024 21:55:36 +0000
+Subject: [PATCH] Lookup docker-proxy in libexec paths
+
+This allows distros to put docker-proxy under libexec paths as is done
+for docker-init.
+
+Also expands the lookup to to not require a `docker/` subdir in libexec
+subdir.
+Since it is a generic helper that may be used for something else in the
+future, this is only done for binaries with a `docker-`.
+
+Backported to moby 25.0.3 for AZL 3.0
+
+Signed-off-by: Brian Goff <cpuguy83@gmail.com>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+diff -Naur a/daemon/config/config_linux.go b/daemon/config/config_linux.go
+--- a/daemon/config/config_linux.go	2024-02-06 18:43:34.000000000 +0000
++++ b/daemon/config/config_linux.go	2024-08-09 19:20:50.901608004 +0000
+@@ -6,6 +6,7 @@
+ 	"net"
+ 	"os/exec"
+ 	"path/filepath"
++	"strings"
+ 
+ 	"github.com/containerd/cgroups/v3"
+ 	"github.com/containerd/log"
+@@ -112,14 +113,13 @@
+ 	return DefaultInitBinary
+ }
+ 
+-// LookupInitPath returns an absolute path to the "docker-init" binary by searching relevant "libexec" directories (per FHS 3.0 & 2.3) followed by PATH
+-func (conf *Config) LookupInitPath() (string, error) {
+-	binary := conf.GetInitPath()
++// lookupBinPath returns an absolute path to the provided binary by searching relevant "libexec" locations (per FHS 3.0 & 2.3) followed by PATH
++func lookupBinPath(binary string) (string, error) {
+ 	if filepath.IsAbs(binary) {
+ 		return binary, nil
+ 	}
+ 
+-	for _, dir := range []string{
++	lookupPaths := []string{
+ 		// FHS 3.0: "/usr/libexec includes internal binaries that are not intended to be executed directly by users or shell scripts. Applications may use a single subdirectory under /usr/libexec."
+ 		// https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html
+ 		"/usr/local/libexec/docker",
+@@ -129,7 +129,16 @@
+ 		// https://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#USRLIBLIBRARIESFORPROGRAMMINGANDPA
+ 		"/usr/local/lib/docker",
+ 		"/usr/lib/docker",
+-	} {
++	}
++
++	// According to FHS 3.0, it is not necessary to have a subdir here (see note and reference above).
++	// If the binary has a `docker-` prefix, let's look it up without the dir prefix.
++	if strings.HasPrefix(binary, "docker-") {
++		lookupPaths = append(lookupPaths, "/usr/local/libexec")
++		lookupPaths = append(lookupPaths, "/usr/libexec")
++	}
++
++	for _, dir := range lookupPaths {
+ 		// exec.LookPath has a fast-path short-circuit for paths that contain "/" (skipping the PATH lookup) that then verifies whether the given path is likely to be an actual executable binary (so we invoke that instead of reimplementing the same checks)
+ 		if file, err := exec.LookPath(filepath.Join(dir, binary)); err == nil {
+ 			return file, nil
+@@ -140,6 +149,11 @@
+ 	return exec.LookPath(binary)
+ }
+ 
++// LookupInitPath returns an absolute path to the "docker-init" binary by searching relevant "libexec" directories (per FHS 3.0 & 2.3) followed by PATH
++func (conf *Config) LookupInitPath() (string, error) {
++	return lookupBinPath(conf.GetInitPath())
++}
++
+ // GetResolvConf returns the appropriate resolv.conf
+ // Check setupResolvConf on how this is selected
+ func (conf *Config) GetResolvConf() string {
+@@ -230,7 +244,7 @@
+ 
+ 		var err error
+ 		// use rootlesskit-docker-proxy for exposing the ports in RootlessKit netns to the initial namespace.
+-		cfg.BridgeConfig.UserlandProxyPath, err = exec.LookPath(rootless.RootlessKitDockerProxyBinary)
++		cfg.BridgeConfig.UserlandProxyPath, err = lookupBinPath(rootless.RootlessKitDockerProxyBinary)
+ 		if err != nil {
+ 			return errors.Wrapf(err, "running with RootlessKit, but %s not installed", rootless.RootlessKitDockerProxyBinary)
+ 		}
+@@ -249,7 +263,7 @@
+ 		cfg.Pidfile = filepath.Join(runtimeDir, "docker.pid")
+ 	} else {
+ 		var err error
+-		cfg.BridgeConfig.UserlandProxyPath, err = exec.LookPath(userlandProxyBinary)
++		cfg.BridgeConfig.UserlandProxyPath, err = lookupBinPath(userlandProxyBinary)
+ 		if err != nil {
+ 			// Log, but don't error here. This allows running a daemon with
+ 			// userland-proxy disabled (which does not require the binary

--- a/SPECS/moby-engine/moby-engine.signatures.json
+++ b/SPECS/moby-engine/moby-engine.signatures.json
@@ -1,6 +1,5 @@
 {
  "Signatures": {
-  "daemon.json": "532f2e930400baed129ed953b9ba0d5158fc443aecbff6f6513f58565696db5c",
   "docker.service": "b150b3ce0947a65c655ed09dfe4e48b7464c60542f9f9902330288bbf87af38e",
   "docker.socket": "51a06786cae46bc63b7314c25d0bd5bb2e676120d80874b99e35bf60d0b0ffa8",
   "moby-engine-25.0.3.tar.gz": "4cdb516f5d6f5caf8b3bcf93c2962277ba727cfd2d1620176a3bb0cf153b3590"

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -3,7 +3,7 @@
 Summary: The open-source application container engine
 Name:    moby-engine
 Version: 25.0.3
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -13,9 +13,9 @@ Distribution: Azure Linux
 Source0: https://github.com/moby/moby/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1: docker.service
 Source2: docker.socket
-Source3: daemon.json
 
 Patch0:  CVE-2022-2879.patch
+Patch1:  enable-docker-proxy-libexec-search.patch
 
 %{?systemd_requires}
 
@@ -92,9 +92,6 @@ mkdir -p %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/docker.service
 install -p -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/docker.socket
 
-mkdir -p -m 755 %{buildroot}%{_sysconfdir}/docker
-install -p -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/docker/daemon.json
-
 %post
 if ! grep -q "^docker:" /etc/group; then
     groupadd --system docker
@@ -110,12 +107,13 @@ fi
 %license LICENSE NOTICE
 %{_bindir}/dockerd
 %{_libexecdir}/docker-proxy
-%dir %{_sysconfdir}/docker
-%config(noreplace) %{_sysconfdir}/docker/daemon.json
 %{_sysconfdir}/*
 %{_unitdir}/*
 
 %changelog
+* Fri Aug 09 2024 Henry Beberman <henry.beberman@microsoft.com> - 25.0.3-4
+- Backport upstream change to search /usr/libexec for docker-proxy without daemon.json
+
 * Tue Jun 25 2024 Nicolas Guibourge <nicolasg@microsoft.com> - 25.0.3-3
 - Address CVE-2022-2879
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
---

###### Summary <!-- REQUIRED -->
When upgrading to moby-engine version 25 we brought in a new daemon.json file to inform the newer moby-engine version of docker-proxy's location. Adding daemon.json to the package regressed several use cases, instead we'll rely on backporting a recent upstream change (https://github.com/moby/moby/pull/47804) that implicitly looks for docker-proxy in libexec so that we can drop daemon.json.

###### Change Log  <!-- REQUIRED -->
- Backport https://github.com/moby/moby/pull/47804 so moby-engine finds docker-proxy in libexec
- Remove daemon.json from our moby-engine package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Issue reported (and [fixed](https://github.com/microsoft/azurelinux/pull/9551)) in Azure Linux 2.0 https://github.com/microsoft/azurelinux/issues/8961

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=619256
- Updated the package on a running system and observed that moby-engine is still able to find docker-proxy after the upgrade.
