### PR TITLE
Image Customizer: Improve error message for missing filesystem entry.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -63,13 +63,17 @@ func (s *Storage) IsValid() error {
 
 			partitionSet[partition.Id] = partition
 
-			// Ensure special partitions have the correct filesystem type.
 			fileSystem, hasFileSystem := fileSystemSet[partition.Id]
+			if !hasFileSystem {
+				return fmt.Errorf("invalid disk at index %d:\npartition (%s) at index %d must have a corresponding filesystem entry",
+					i, partition.Id, j)
+			}
 
+			// Ensure special partitions have the correct filesystem type.
 			if partition.IsESP() {
 				espPartitionExists = true
 
-				if !hasFileSystem || fileSystem.Type != FileSystemTypeFat32 {
+				if fileSystem.Type != FileSystemTypeFat32 {
 					return fmt.Errorf("ESP partition must have 'fat32' filesystem type")
 				}
 			}
@@ -77,7 +81,7 @@ func (s *Storage) IsValid() error {
 			if partition.IsBiosBoot() {
 				biosBootPartitionExists = true
 
-				if !hasFileSystem || fileSystem.Type != FileSystemTypeFat32 {
+				if fileSystem.Type != FileSystemTypeFat32 {
 					return fmt.Errorf("BIOS boot partition must have 'fat32' filesystem type")
 				}
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
@@ -84,7 +84,7 @@ func partitionToImager(partition imagecustomizerapi.Partition, fileSystems []ima
 		},
 	)
 	if !foundMountPoint {
-		return configuration.Partition{}, fmt.Errorf("failed to find mount point with ID (%s)", partition.Id)
+		return configuration.Partition{}, fmt.Errorf("failed to find filesystem entry with ID (%s)", partition.Id)
 	}
 
 	imagerStart := partition.Start / diskutils.MiB


### PR DESCRIPTION
Add a pre-check for the case where a partition is specified but there isn't a corresponding filesystem entry. This both reports the problem earlier and provides a more useful error message.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added new UT.
- Ran existing UTs.

