### PR TITLE
Fix error when doing password hashing for aarch64 offline image builds

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -552,7 +552,7 @@ The table below are the keys for the users.
 |Name               |string             |Cannot be empty
 |UID                |string             |Must be in range 0-60000
 |PasswordHashed     |bool               |
-|Password           |string             |
+|Password           |string             |If 'PasswordHashed=true', use `openssl passwd ...` to generate the password hash
 |PasswordExpiresDays|number             |Must be in range 0-99999 or -1 for no expiration
 |SSHPubKeyPaths     |array of strings   |
 |PrimaryGroup       |string             |
@@ -566,7 +566,9 @@ An example usage for users "root" and "basicUser" would look like:
 "Users": [
     {
         "Name": "root",
-        "Password": "somePassword"
+        "PasswordHashed": true,
+        "Password": "$6$salt$wOtvukzJqb0A06u2VivFf07FzmuSIt/VBzKtDMYbM88aJf3KzJHM.PDI6Uo5sKSRX1uzMktf71.eNyqRUZFim/",
+        "_comment": "Generated with `openssl passwd -6 -salt <SALT> <PASSWORD>`",
     },
     {
         "Name": "basicUser",

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -567,7 +567,7 @@ An example usage for users "root" and "basicUser" would look like:
     {
         "Name": "root",
         "PasswordHashed": true,
-        "Password": "$6$salt$wOtvukzJqb0A06u2VivFf07FzmuSIt/VBzKtDMYbM88aJf3KzJHM.PDI6Uo5sKSRX1uzMktf71.eNyqRUZFim/",
+        "Password": "$6$<SALT>$<HASHED PASSWORD>",
         "_comment": "Generated with `openssl passwd -6 -salt <SALT> <PASSWORD>`",
     },
     {

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -167,6 +167,7 @@ gtk-doc-1.33.2-1.azl3.noarch.rpm
 autoconf-2.72-2.azl3.noarch.rpm
 automake-1.16.5-2.azl3.noarch.rpm
 ocaml-srpm-macros-9-4.azl3.noarch.rpm
+openssl-3.3.0-2.azl3.aarch64.rpm
 openssl-devel-3.3.0-2.azl3.aarch64.rpm
 openssl-libs-3.3.0-2.azl3.aarch64.rpm
 openssl-perl-3.3.0-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -167,6 +167,7 @@ gtk-doc-1.33.2-1.azl3.noarch.rpm
 autoconf-2.72-2.azl3.noarch.rpm
 automake-1.16.5-2.azl3.noarch.rpm
 ocaml-srpm-macros-9-4.azl3.noarch.rpm
+openssl-3.3.0-2.azl3.x86_64.rpm
 openssl-devel-3.3.0-2.azl3.x86_64.rpm
 openssl-libs-3.3.0-2.azl3.x86_64.rpm
 openssl-perl-3.3.0-2.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In https://github.com/microsoft/azurelinux/pull/9037/files#diff-4399971797c1c0942b710773d3f583fb0c697de6dd1edc655a5b80e4e1f79462R169 we accidentally dropped the `openssl` command line tools from the chroot environment. This won't have affected most packages since they will be using `openssl-devel`, or have explicit `BuildRequires: openssl`, but it DOES affect offline image build (since that uses the chroot as an isolation layer). A call to `openssl passwd ...` to hash a plain-text password from the user would fail with `exec: "openssl": executable file not found in $PATH`. (But only for aarch64, we install `grub2-pc` https://github.com/microsoft/azurelinux/blob/0f0a7df7243ed42e37621802793d96efe4be3818/toolkit/tools/imagegen/installutils/installutils.go#L114 for x86_64 which has a runtime dependency on openssl so we would get it installed by happenstance).

This **may have some unexpected impacts on packages!** While I believe the impact will be fairly minor, I cannot exclude the possibility that some packages may run `./configure` or similar and detect the absence/presence of the `openssl` command line tool without having an explicit build requirement for it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Restore `openssl` to the chroot
- Add some more documentation for pre-hashed passwords

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES** (sort of, the implicit build dependencies provided by the chroot can have big knock-on affects).

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/53161885


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=620320&view=results
