### PR TITLE
Image Customizer: Add check for installed kernel.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -116,5 +116,10 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 		}
 	}
 
+	err = checkForInstalledKernel(imageChroot)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
+)
+
+// Check if the user accidentally uninstalled the kernel package without installing a substitute package.
+func checkForInstalledKernel(imageChroot *safechroot.Chroot) error {
+	kernelModulesDir := filepath.Join(imageChroot.RootDir(), "/lib/modules")
+
+	kernels, err := os.ReadDir(kernelModulesDir)
+	if err != nil {
+		return fmt.Errorf("failed to read installed kernels list:\n%w", err)
+	}
+
+	for _, kernel := range kernels {
+		// There is a bug in Azure Linux 2.0, where uninstalling the kernel package doesn't remove the directory
+		// /lib/modules/<ver>. Instead the directory is just emptied. So, ensure the directory isn't empty.
+		files, err := os.ReadDir(filepath.Join(kernelModulesDir, kernel.Name()))
+		if err != nil {
+			return fmt.Errorf("failed to read installed kernel (%s) module directory:\n%w", kernel.Name(), err)
+		}
+
+		if len(files) > 0 {
+			// Found at least 1 kernel.
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no installed kernel found")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomizeImageMissingKernel(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageMissingKernel")
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "no-kernel-config.yaml")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	assert.ErrorContains(t, err, "no installed kernel found")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/no-kernel-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/no-kernel-config.yaml
@@ -1,0 +1,4 @@
+os:
+  packages:
+    remove:
+    - kernel


### PR DESCRIPTION
Add a check to ensure the user didn't uninstall the kernel package without installing a substitute package.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added UT.

