### PR TITLE
Image Customizer: Account for GPT footer when validating partitions.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -15,7 +15,7 @@ func TestConfigIsValid(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2 * diskutils.MiB,
+				MaxSize:            3 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",
@@ -52,7 +52,7 @@ func TestConfigIsValidLegacy(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2 * diskutils.MiB,
+				MaxSize:            3 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "boot",
@@ -109,7 +109,7 @@ func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2 * diskutils.MiB,
+				MaxSize:            3 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",
@@ -260,7 +260,7 @@ func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2 * diskutils.MiB,
+				MaxSize:            3 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",
@@ -298,7 +298,7 @@ func TestConfigIsValidKernelCLI(t *testing.T) {
 		Storage: &Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            2 * diskutils.MiB,
+				MaxSize:            3 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "esp",

--- a/toolkit/tools/imagecustomizerapi/disksize.go
+++ b/toolkit/tools/imagecustomizerapi/disksize.go
@@ -92,7 +92,8 @@ func parseDiskSize(diskSizeString string) (DiskSize, error) {
 
 	// The imager's diskutils works in MiB. So, restrict disk and partition sizes to multiples of 1 MiB.
 	if num%DefaultPartitionAlignment != 0 {
-		return 0, fmt.Errorf("(%s) must be a multiple of 1 MiB", diskSizeString)
+		return 0, fmt.Errorf("(%s) must be a multiple of %s", diskSizeString,
+			DiskSize(DefaultPartitionAlignment).HumanReadable())
 	}
 
 	return DiskSize(num), nil

--- a/toolkit/tools/imagecustomizerapi/disksize.go
+++ b/toolkit/tools/imagecustomizerapi/disksize.go
@@ -40,6 +40,25 @@ func (s *DiskSize) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+func (s DiskSize) HumanReadable() string {
+	switch {
+	case s%diskutils.TiB == 0:
+		return fmt.Sprintf("%d TiB", s/diskutils.TiB)
+
+	case s%diskutils.GiB == 0:
+		return fmt.Sprintf("%d GiB", s/diskutils.GiB)
+
+	case s%diskutils.MiB == 0:
+		return fmt.Sprintf("%d MiB", s/diskutils.MiB)
+
+	case s%diskutils.KiB == 0:
+		return fmt.Sprintf("%d KiB", s/diskutils.KiB)
+
+	default:
+		return fmt.Sprintf("%d bytes", s)
+	}
+}
+
 func parseDiskSize(diskSizeString string) (DiskSize, error) {
 	match := diskSizeRegex.FindStringSubmatch(diskSizeString)
 	if match == nil {
@@ -72,8 +91,8 @@ func parseDiskSize(diskSizeString string) (DiskSize, error) {
 	}
 
 	// The imager's diskutils works in MiB. So, restrict disk and partition sizes to multiples of 1 MiB.
-	if num%diskutils.MiB != 0 {
-		return 0, fmt.Errorf("(%d) must be a multiple of 1 MiB", num)
+	if num%DefaultPartitionAlignment != 0 {
+		return 0, fmt.Errorf("(%s) must be a multiple of 1 MiB", diskSizeString)
 	}
 
 	return DiskSize(num), nil

--- a/toolkit/tools/imagecustomizerapi/disksize_test.go
+++ b/toolkit/tools/imagecustomizerapi/disksize_test.go
@@ -73,3 +73,23 @@ func TestDiskSizeBadFormat(t *testing.T) {
 	err := UnmarshalYaml([]byte("2M2"), &diskSize)
 	assert.ErrorContains(t, err, "has incorrect format")
 }
+
+func TestDiskSizeHumanReadableTiB(t *testing.T) {
+	assert.Equal(t, DiskSize(diskutils.TiB).HumanReadable(), "1 TiB")
+}
+
+func TestDiskSizeHumanReadableGiB(t *testing.T) {
+	assert.Equal(t, DiskSize(diskutils.GiB).HumanReadable(), "1 GiB")
+}
+
+func TestDiskSizeHumanReadableMiB(t *testing.T) {
+	assert.Equal(t, DiskSize(diskutils.MiB).HumanReadable(), "1 MiB")
+}
+
+func TestDiskSizeHumanReadableKiB(t *testing.T) {
+	assert.Equal(t, DiskSize(diskutils.KiB).HumanReadable(), "1 KiB")
+}
+
+func TestDiskSizeHumanReadableBytes(t *testing.T) {
+	assert.Equal(t, DiskSize(1).HumanReadable(), "1 bytes")
+}

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -222,7 +222,7 @@ func TestStorageIsValidDuplicatePartitionId(t *testing.T) {
 		Disks: []Disk{
 			{
 				PartitionTableType: PartitionTableTypeGpt,
-				MaxSize:            3 * diskutils.MiB,
+				MaxSize:            4 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "a",
@@ -288,7 +288,7 @@ func TestStorageIsValidUniqueLabel(t *testing.T) {
 		Disks: []Disk{
 			{
 				PartitionTableType: PartitionTableTypeGpt,
-				MaxSize:            3 * diskutils.MiB,
+				MaxSize:            4 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "a",
@@ -335,7 +335,7 @@ func TestStorageIsValidDuplicateLabel(t *testing.T) {
 		Disks: []Disk{
 			{
 				PartitionTableType: PartitionTableTypeGpt,
-				MaxSize:            3 * diskutils.MiB,
+				MaxSize:            4 * diskutils.MiB,
 				Partitions: []Partition{
 					{
 						Id:    "a",


### PR DESCRIPTION
For disks partitioned with the GPT partitioning scheme, the last few sectors of the disk are used for storing the GPT footer (which contains the backup partition table). The Image Customizer tool does fail if you try to use this space for a partition, but only because `parted` is doing the check. This change properly accounts for this footer in the config validation, so that a nicer error message can be provided to the user.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Fixed existing UTs.

