### PR TITLE
ImageCustomizer: Implement new MIC Overlays APIs.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -346,31 +346,73 @@ Specifies the configuration for the generated ISO media.
 
 Specifies the configuration for overlay filesystem.
 
-- `lowerDir`: This directory acts as the read-only layer in the overlay
-  filesystem. It contains the base files and directories which will be overlaid
-  by the upperDir. Changes to the overlay filesystem do not affect the contents
-  of lowerDir.
+- `lowerDir`: (Required)
 
-- `upperDir`: This directory is the writable layer of the overlay filesystem.
-  Any modifications, such as file additions, deletions, or changes, are made in
-  the upperDir. These changes are what make the overlay filesystem appear
-  different from the lowerDir alone.
+  This directory acts as the read-only layer in the overlay filesystem. It
+  contains the base files and directories which will be overlaid by the
+  upperDir. Changes to the overlay filesystem do not affect the contents of
+  lowerDir. 
+  
+  Example: `/etc`
 
-- `workDir`: This is a required directory used for preparing files before they
-  are merged into the upperDir. It needs to be on the same filesystem as the
-  upperDir and is used for temporary storage by the overlay filesystem to ensure
-  atomic operations. The workDir is not directly accessible to users.
+- `upperDir`: (Required)
 
-- `partition`: Optional field: If configured, a partition will be attached to
-  the current targeted overlay, making it persistent and ensuring that changes
-  are retained. If not configured, the overlay will be volatile.
+  This directory is the writable layer of the overlay filesystem. Any
+  modifications, such as file additions, deletions, or changes, are made in the
+  upperDir. These changes are what make the overlay filesystem appear different
+  from the lowerDir alone. 
+  
+  Example: `/var/overlays/etc/upper`
 
-  - `idType`: Specifies the type of id for the partition. The options are
-    `part-label` (partition label), `uuid` (filesystem UUID), and `part-uuid`
-    (partition UUID).
+- `workDir`: (Required)
 
-  - `id`: The unique identifier value of the partition, corresponding to the
-    specified IdType.
+  This is a required directory used for preparing files before they are merged
+  into the upperDir. It needs to be on the same filesystem as the upperDir and
+  is used for temporary storage by the overlay filesystem to ensure atomic
+  operations. The workDir is not directly accessible to users. 
+  
+  Example: `/var/overlays/etc/work`
+
+- `mountPoint`: (Required)
+
+  The directory where the overlay filesystem will be mounted.
+
+  Example: `/var/mountpoint`
+
+- `isRootfsOverlay`: (Optional, Default: `false`)
+
+  A boolean flag indicating whether this overlay is part of the root filesystem.
+  If set to true, specific adjustments will be made, such as prefixing certain
+  paths with /sysroot will be added to fstab file.
+
+  Example: `true`
+
+- `mountDependency`: (Optional)
+
+  Specifies a directory that must be mounted before this overlay.
+
+  **Important**: If the directory specified in mountDependency needs to be
+  available during the initrd phase, you must ensure that this directory's mount
+  configuration in the fileSystems section includes the x-initrd.mount option.
+  For example:
+
+  ```
+  fileSystems:
+    - deviceId: var
+      type: ext4
+      mountPoint:
+        path: /var
+        options: defaults,x-initrd.mount
+  ```
+
+  Example: `/var`
+
+- `mountOptions`: (Optional)
+
+  A string of additional mount options that can be applied to the overlay mount.
+  Multiple options should be separated by commas.
+
+  Example: `noatime,nodiratime`
 
 Example:
 
@@ -378,17 +420,12 @@ Example:
 os:
   overlays:
     - lowerDir: /etc
-      upperDir: /upper_etc
-      workDir: /work_etc
-      partition:
-        idType: part-label
-        id: partition-etc
-    - lowerDir: /var/lib
-      upperDir: /upper_var_lib
-      workDir: /work_var_lib
-    - lowerDir: /var/log
-      upperDir: /upper_var_log
-      workDir: /work_var_log
+      upperDir: /var/overlays/etc/upper
+      workDir: /var/overlays/etc/work
+      mountPoint: /var/mountpoint
+      isRootfsOverlay: true
+      mountDependency: /var
+      mountOptions: "noatime,nodiratime"
 ```
 
 ## verity type

--- a/toolkit/tools/imagecustomizerapi/overlay.go
+++ b/toolkit/tools/imagecustomizerapi/overlay.go
@@ -5,26 +5,38 @@ package imagecustomizerapi
 
 import (
 	"fmt"
+	"path"
 	"strings"
 )
 
 type Overlay struct {
-	LowerDir  string               `yaml:"lowerDir"`
-	UpperDir  string               `yaml:"upperDir"`
-	WorkDir   string               `yaml:"workDir"`
-	Partition *IdentifiedPartition `yaml:"partition"`
+	LowerDir        string  `yaml:"lowerDir"`
+	UpperDir        string  `yaml:"upperDir"`
+	WorkDir         string  `yaml:"workDir"`
+	MountPoint      string  `yaml:"mountPoint"`
+	IsRootfsOverlay bool    `yaml:"isRootfsOverlay"`
+	MountDependency *string `yaml:"mountDependency"`
+	MountOptions    *string `yaml:"mountOptions"`
 }
 
 func (o *Overlay) IsValid() error {
 	// Validate paths for UpperDir, WorkDir, and LowerDir
+	if err := validatePath(o.LowerDir); err != nil {
+		return fmt.Errorf("invalid lowerDir (%s):\n%w", o.LowerDir, err)
+	}
 	if err := validatePath(o.UpperDir); err != nil {
 		return fmt.Errorf("invalid upperDir (%s):\n%w", o.UpperDir, err)
 	}
 	if err := validatePath(o.WorkDir); err != nil {
 		return fmt.Errorf("invalid workDir (%s):\n%w", o.WorkDir, err)
 	}
-	if err := validatePath(o.LowerDir); err != nil {
-		return fmt.Errorf("invalid lowerDir (%s):\n%w", o.LowerDir, err)
+	if err := validatePath(o.MountPoint); err != nil {
+		return fmt.Errorf("invalid mountPoint (%s):\n%w", o.MountPoint, err)
+	}
+	if o.MountDependency != nil {
+		if err := validatePath(*o.MountDependency); err != nil {
+			return fmt.Errorf("invalid mountDependency (%s):\n%w", *o.MountDependency, err)
+		}
 	}
 
 	// Check if UpperDir and WorkDir are identical
@@ -40,24 +52,23 @@ func (o *Overlay) IsValid() error {
 		return fmt.Errorf("workDir (%s) should not be a subdirectory of upperDir (%s)", o.WorkDir, o.UpperDir)
 	}
 
-	if o.Partition != nil {
-		if err := o.Partition.IsValid(); err != nil {
-			return fmt.Errorf("invalid partition:\n%w", err)
-		}
-	}
-
 	return nil
 }
 
-func validatePath(path string) error {
-	// Check if the path is empty
-	if path == "" {
+func validatePath(p string) error {
+	// Check if the path is empty.
+	if p == "" {
 		return fmt.Errorf("path cannot be empty")
 	}
 
-	// Check if the path contains spaces
-	if strings.Contains(path, " ") {
-		return fmt.Errorf("path (%s) contains spaces and is invalid", path)
+	// Check if the path contains spaces.
+	if strings.Contains(p, " ") {
+		return fmt.Errorf("path (%s) contains spaces and is invalid", p)
+	}
+
+	// Check if the path is an absolute path.
+	if !path.IsAbs(p) {
+		return fmt.Errorf("invalid path (%s): must be an absolute path", p)
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -80,7 +80,7 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 		return err
 	}
 
-	verityUpdated, err := enableVerityPartition(buildDir, config.OS.Verity, imageChroot)
+	verityUpdated, err := enableVerityPartition(config.OS.Verity, imageChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlay.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlay.go
@@ -5,9 +5,13 @@ package imagecustomizerlib
 
 import (
 	"fmt"
-	"strings"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 )
@@ -21,68 +25,128 @@ func enableOverlays(overlays *[]imagecustomizerapi.Overlay, imageChroot *safechr
 
 	logger.Log.Infof("Enable filesystem overlays")
 
-	// Integrate overlay dracut module and overlay driver into initramfs img.
-	overlayDracutModule := "overlayfs"
-	overlayDracutDriver := "overlay"
-	err = addDracutModule(overlayDracutModule, overlayDracutDriver, imageChroot)
+	// Integrate overlay driver into the initramfs img.
+	overlayDriver := "overlay"
+	err = addDracutDriver(overlayDriver, imageChroot)
 	if err != nil {
 		return false, err
 	}
 
 	// Dereference the pointer to get the slice
 	overlaysDereference := *overlays
-	err = updateGrubConfigForOverlay(imageChroot, overlaysDereference)
+	err = updateFstabForOverlays(imageChroot, overlaysDereference)
 	if err != nil {
-		return false, fmt.Errorf("failed to update grub config for filesystem overlays:\n%w", err)
+		return false, fmt.Errorf("failed to update fstab file for overlays:\n%w", err)
+	}
+
+	// Create necessary directories for overlays
+	err = createOverlayDirectories(imageChroot, overlaysDereference)
+	if err != nil {
+		return false, fmt.Errorf("failed to create overlay directories:\n%w", err)
+	}
+
+	// Add equivalency rules for each overlay
+	for _, overlay := range overlaysDereference {
+		err = addEquivalencyRule(filepath.Join(imageChroot.RootDir(), overlay.UpperDir), filepath.Join(imageChroot.RootDir(), overlay.LowerDir))
+		if err != nil {
+			return false, fmt.Errorf("failed to add equivalency rule for overlay:\n%w", err)
+		}
 	}
 
 	return true, nil
 }
 
-func updateGrubConfigForOverlay(imageChroot *safechroot.Chroot, overlays []imagecustomizerapi.Overlay) error {
+func updateFstabForOverlays(imageChroot *safechroot.Chroot, overlays []imagecustomizerapi.Overlay) error {
 	var err error
-	var overlayConfigs []string
-	var formattedPartition string
 
-	// Iterate over each Overlay configuration
+	fstabFile := filepath.Join(imageChroot.RootDir(), "etc", "fstab")
+	fstabEntries, err := diskutils.ReadFstabFile(fstabFile)
+	if err != nil {
+		return fmt.Errorf("failed to read fstab file: %v", err)
+	}
+
+	var updatedEntries []diskutils.FstabEntry
+	for _, entry := range fstabEntries {
+		updatedEntries = append(updatedEntries, entry)
+	}
+
 	for _, overlay := range overlays {
-		formattedPartition = ""
-		if overlay.Partition != nil {
-			formattedPartition, err = systemdFormatPartitionId(overlay.Partition.IdType, overlay.Partition.Id)
-			if err != nil {
-				return err
+		lowerDir := overlay.LowerDir
+		upperDir := overlay.UpperDir
+		workDir := overlay.WorkDir
+		mountDependency := overlay.MountDependency
+
+		if overlay.IsRootfsOverlay {
+			lowerDir = path.Join("/sysroot", overlay.LowerDir)
+			upperDir = path.Join("/sysroot", overlay.UpperDir)
+			workDir = path.Join("/sysroot", overlay.WorkDir)
+			if mountDependency != nil {
+				dep := path.Join("/sysroot", *mountDependency)
+				mountDependency = &dep
 			}
 		}
-		// Construct the argument for each Overlay
-		overlayConfig := fmt.Sprintf(
-			"%s,%s,%s,%s",
-			overlay.LowerDir, overlay.UpperDir, overlay.WorkDir, formattedPartition,
-		)
-		overlayConfigs = append(overlayConfigs, overlayConfig)
+
+		options := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDir, upperDir, workDir)
+
+		// Add any additional options if needed (e.g., x-initrd.mount, x-systemd.requires)
+		if mountDependency != nil {
+			options = fmt.Sprintf("%s,x-systemd.requires=%s", options, *mountDependency)
+		}
+		if overlay.IsRootfsOverlay {
+			options = fmt.Sprintf("%s,x-initrd.mount", options)
+		}
+		if overlay.MountOptions != nil && *overlay.MountOptions != "" {
+			options = fmt.Sprintf("%s,%s", options, *overlay.MountOptions)
+		}
+
+		// Create the FstabEntry based on the overlay.
+		newEntry := diskutils.FstabEntry{
+			Source:  "overlay",
+			Target:  overlay.MountPoint,
+			FsType:  "overlay",
+			Options: options,
+			Freq:    0,
+			PassNo:  0,
+		}
+
+		updatedEntries = append(updatedEntries, newEntry)
 	}
 
-	// Concatenate all overlay configurations with spaces
-	concatenatedOverlays := strings.Join(overlayConfigs, " ")
-
-	// Construct the final cmdline argument
-	newArgs := []string{
-		fmt.Sprintf("rd.overlayfs=%s", concatenatedOverlays),
-	}
-
-	bootCustomizer, err := NewBootCustomizer(imageChroot)
+	err = diskutils.WriteFstabFile(updatedEntries, fstabFile)
 	if err != nil {
 		return err
 	}
 
-	err = bootCustomizer.UpdateKernelCommandLineArgs(defaultGrubFileVarNameCmdlineLinux, []string{"rd.overlayfs"},
-		newArgs)
-	if err != nil {
-		return err
+	return nil
+}
+
+func createOverlayDirectories(imageChroot *safechroot.Chroot, overlays []imagecustomizerapi.Overlay) error {
+	for _, overlay := range overlays {
+		dirsToCreate := []string{
+			filepath.Join(imageChroot.RootDir(), overlay.MountPoint),
+			filepath.Join(imageChroot.RootDir(), overlay.UpperDir),
+			filepath.Join(imageChroot.RootDir(), overlay.WorkDir),
+		}
+
+		// Iterate over each directory and create it if it doesn't exist.
+		for _, dir := range dirsToCreate {
+			if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+				return fmt.Errorf("failed to create directory (%s): %w", dir, err)
+			}
+		}
 	}
 
-	err = bootCustomizer.WriteToFile(imageChroot)
+	return nil
+}
+
+func addEquivalencyRule(upperDir string, lowerDir string) error {
+	// Construct the semanage command
+	cmd := exec.Command("semanage", "fcontext", "-a", "-e", upperDir, lowerDir)
+
+	// Execute the command
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to add equivalency rule between %s and %s: %v\nOutput: %s", upperDir, lowerDir, err, string(output))
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -15,7 +15,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 )
 
-func enableVerityPartition(buildDir string, verity *imagecustomizerapi.Verity, imageChroot *safechroot.Chroot,
+func enableVerityPartition(verity *imagecustomizerapi.Verity, imageChroot *safechroot.Chroot,
 ) (bool, error) {
 	var err error
 
@@ -28,12 +28,12 @@ func enableVerityPartition(buildDir string, verity *imagecustomizerapi.Verity, i
 	// Integrate systemd veritysetup dracut module into initramfs img.
 	systemdVerityDracutModule := "systemd-veritysetup"
 	dmVerityDracutDriver := "dm-verity"
-	err = addDracutModule(systemdVerityDracutModule, dmVerityDracutDriver, imageChroot)
+	err = addDracutModuleAndDriver(systemdVerityDracutModule, dmVerityDracutDriver, imageChroot)
 	if err != nil {
 		return false, fmt.Errorf("failed to add dracut modules for verity:\n%w", err)
 	}
 
-	err = updateFstabForVerity(buildDir, imageChroot)
+	err = updateFstabForVerity(imageChroot)
 	if err != nil {
 		return false, fmt.Errorf("failed to update fstab file for verity:\n%w", err)
 	}
@@ -46,7 +46,7 @@ func enableVerityPartition(buildDir string, verity *imagecustomizerapi.Verity, i
 	return true, nil
 }
 
-func addDracutModule(dracutModuleName string, dracutDriverName string, imageChroot *safechroot.Chroot) error {
+func addDracutModuleAndDriver(dracutModuleName string, dracutDriverName string, imageChroot *safechroot.Chroot) error {
 	dracutConfigFile := filepath.Join(imageChroot.RootDir(), "etc", "dracut.conf.d", dracutModuleName+".conf")
 
 	// Check if the dracut module configuration file already exists.
@@ -60,12 +60,57 @@ func addDracutModule(dracutModuleName string, dracutDriverName string, imageChro
 		if err != nil {
 			return fmt.Errorf("failed to write to dracut module config file (%s): %w", dracutConfigFile, err)
 		}
+	} else {
+		// If the file already exists, return an error.
+		return fmt.Errorf("dracut module config file (%s) already exists", dracutConfigFile)
 	}
 
 	return nil
 }
 
-func updateFstabForVerity(buildDir string, imageChroot *safechroot.Chroot) error {
+func addDracutModule(dracutModuleName string, imageChroot *safechroot.Chroot) error {
+	dracutConfigFile := filepath.Join(imageChroot.RootDir(), "etc", "dracut.conf.d", dracutModuleName+".conf")
+
+	// Check if the dracut module configuration file already exists.
+	if _, err := os.Stat(dracutConfigFile); os.IsNotExist(err) {
+		lines := []string{
+			// Add white spaces on both sides for dracut config syntax.
+			"add_dracutmodules+=\" " + dracutModuleName + " \"",
+		}
+		err = file.WriteLines(lines, dracutConfigFile)
+		if err != nil {
+			return fmt.Errorf("failed to write to dracut module config file (%s): %w", dracutConfigFile, err)
+		}
+	} else {
+		// If the file already exists, return an error.
+		return fmt.Errorf("dracut module config file (%s) already exists", dracutConfigFile)
+	}
+
+	return nil
+}
+
+func addDracutDriver(dracutDriverName string, imageChroot *safechroot.Chroot) error {
+	dracutConfigFile := filepath.Join(imageChroot.RootDir(), "etc", "dracut.conf.d", dracutDriverName+".conf")
+
+	// Check if the dracut driver configuration file already exists.
+	if _, err := os.Stat(dracutConfigFile); os.IsNotExist(err) {
+		lines := []string{
+			// Add white spaces on both sides for dracut config syntax.
+			"add_drivers+=\" " + dracutDriverName + " \"",
+		}
+		err = file.WriteLines(lines, dracutConfigFile)
+		if err != nil {
+			return fmt.Errorf("failed to write to dracut driver config file (%s): %w", dracutConfigFile, err)
+		}
+	} else {
+		// If the file already exists, return an error.
+		return fmt.Errorf("dracut driver config file (%s) already exists", dracutConfigFile)
+	}
+
+	return nil
+}
+
+func updateFstabForVerity(imageChroot *safechroot.Chroot) error {
 	var err error
 
 	fstabFile := filepath.Join(imageChroot.RootDir(), "etc", "fstab")


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

This PR restructures the MIC Overlays APIs, optimizing the process by transitioning from relying on the initrd module script for enabling overlays to leveraging the fstab file. The changes streamline the Overlay feature, making it more generic and easier for users to configure and use.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Internal User Story Tracking](https://dev.azure.com/mariner-org/ECF/_sprints/taskboard/Mariner%20Operator%20Edge/ECF/2408?workitem=8297)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build:
- Used `overlays` field from the config file:
```
  overlays:
    - lowerDir: /etc
      upperDir: /var/overlays/etc/upper
      workDir: /var/overlays/etc/work
      mountPoint: /var/chocolate
      isRootfsOverlay: true
      mountDependency: /var
```
- Print of `df -h`:
```
test [ /var ]$ df -h
Filesystem        Size  Used Avail Use% Mounted on
/dev/mapper/root  2.0G  408M  1.4G  23% /
/dev/sda5         974M  153M  754M  17% /var
overlay           974M  153M  754M  17% /var/chocolate
devtmpfs          4.0M     0  4.0M   0% /dev
tmpfs             851M     0  851M   0% /dev/shm
tmpfs             4.0M     0  4.0M   0% /sys/fs/cgroup
tmpfs             341M  544K  340M   1% /run
tmpfs             851M     0  851M   0% /tmp
/dev/sda2         981M   33M  881M   4% /boot
tmpfs             171M  4.0K  171M   1% /run/user/1001
```
- Print of `fstab`:
```
test [ /var ]$ cat /etc/fstab
/dev/mapper/root / ext4 ro,defaults 0 1
PARTUUID=b4d9e3ba-2f30-48a2-a331-bf95cfeb1815 /boot ext4 defaults 0 2
PARTUUID=65be09e4-cfdc-4f78-9901-431eb9288979 /boot/efi vfat umask=0077 0 2
PARTUUID=2654f0f3-6de4-4e69-a11c-edb221b6754a /var ext4 defaults,x-initrd.mount 0 2
overlay /var/chocolate overlay lowerdir=/sysroot/etc,upperdir=/sysroot/var/overlays/etc/upper,workdir=/sysroot/var/overlays/etc/work,x-systemd.requires=/sysroot/var,x-initrd.mount 0 0
```
