### PR TITLE
Patch CVE-2024-7006 in libtiff

### DIFF
--- a/SPECS/libtiff/CVE-2024-7006.patch
+++ b/SPECS/libtiff/CVE-2024-7006.patch
@@ -1,0 +1,60 @@
+From 818fb8ce881cf839fbc710f6690aadb992aa0f9e Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 1 Dec 2023 20:12:25 +0100
+Subject: [PATCH] Check return value of _TIFFCreateAnonField().
+
+Fixes #624
+---
+ libtiff/tif_dirinfo.c |  2 +-
+ libtiff/tif_dirread.c | 16 ++++++----------
+ 2 files changed, 7 insertions(+), 11 deletions(-)
+
+diff --git a/libtiff/tif_dirinfo.c b/libtiff/tif_dirinfo.c
+index 0e705e8..4cfdaad 100644
+--- a/libtiff/tif_dirinfo.c
++++ b/libtiff/tif_dirinfo.c
+@@ -887,7 +887,7 @@ const TIFFField *_TIFFFindOrRegisterField(TIFF *tif, uint32_t tag,
+     if (fld == NULL)
+     {
+         fld = _TIFFCreateAnonField(tif, tag, dt);
+-        if (!_TIFFMergeFields(tif, fld, 1))
++        if (fld == NULL || !_TIFFMergeFields(tif, fld, 1))
+             return NULL;
+     }
+ 
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 58a4276..738df9f 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -4275,11 +4275,9 @@ int TIFFReadDirectory(TIFF *tif)
+                                 dp->tdir_tag, dp->tdir_tag);
+                 /* the following knowingly leaks the
+                    anonymous field structure */
+-                if (!_TIFFMergeFields(
+-                        tif,
+-                        _TIFFCreateAnonField(tif, dp->tdir_tag,
+-                                             (TIFFDataType)dp->tdir_type),
+-                        1))
++                const TIFFField *fld = _TIFFCreateAnonField(
++                    tif, dp->tdir_tag, (TIFFDataType)dp->tdir_type);
++                if (fld == NULL || !_TIFFMergeFields(tif, fld, 1))
+                 {
+                     TIFFWarningExtR(
+                         tif, module,
+@@ -5153,11 +5151,9 @@ int TIFFReadCustomDirectory(TIFF *tif, toff_t diroff,
+                             "Unknown field with tag %" PRIu16 " (0x%" PRIx16
+                             ") encountered",
+                             dp->tdir_tag, dp->tdir_tag);
+-            if (!_TIFFMergeFields(
+-                    tif,
+-                    _TIFFCreateAnonField(tif, dp->tdir_tag,
+-                                         (TIFFDataType)dp->tdir_type),
+-                    1))
++            const TIFFField *fld = _TIFFCreateAnonField(
++                tif, dp->tdir_tag, (TIFFDataType)dp->tdir_type);
++            if (fld == NULL || !_TIFFMergeFields(tif, fld, 1))
+             {
+                 TIFFWarningExtR(tif, module,
+                                 "Registering anonymous field with tag %" PRIu16
+-- 
+2.34.1

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,7 +1,7 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.6.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        libtiff
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -10,6 +10,7 @@ URL:            https://gitlab.com/libtiff/libtiff
 Source0:        https://gitlab.com/libtiff/libtiff/-/archive/v%{version}/libtiff-v%{version}.tar.gz
 Patch0:         CVE-2023-52356.patch
 Patch1:         CVE-2023-6277.patch
+Patch2:         CVE-2024-7006.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -63,6 +64,9 @@ make %{?_smp_mflags} -k check
 %{_docdir}/*
 
 %changelog
+* Tue Aug 13 2024 Aadhar Agarwal <aadagarwal@microsoft.com> - 4.6.0-4
+- Add patch for CVE-2024-7006
+
 * Wed Aug 07 2024 Sumedh Sharma <sumsharma@microsoft.com> - 4.6.0-3
 - Add patch to resolve CVE-2023-6277
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- This PR addresses CVE-2024-7006 in libtiff by patching the vulnerable code in the `tif_dirinfo.c` and `tif_dirread.c` files. The patch checks the return value of `_TIFFCreateAnonField()` to prevent a NULL pointer dereference and ensure the function is called correctly.
- https://gitlab.com/libtiff/libtiff/-/issues/624
- https://gitlab.com/libtiff/libtiff/-/merge_requests/560

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2024-7006

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://gitlab.com/libtiff/libtiff/-/issues/624

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-7006

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=621287&view=results
