### PR TITLE
fix: add patch in WALinuxAgent to update setup.py to support azurelinux

### DIFF
--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -1,7 +1,7 @@
 Summary:        The Windows Azure Linux Agent
 Name:           WALinuxAgent
 Version:        2.11.1.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -23,6 +23,9 @@ Patch1:         0002-fix-bump-version-to-2.11.8.8.patch
 # This patch fixes a failure to assign IP address for infiband interfaces.
 # It should be removed in an upcoming release.
 Patch2:         fix-argument-to-goalstate.patch
+# This patch adds azurelinux support into the setup.py. This patch should be
+# removed in the next 2.12 release/
+Patch3:         update-setup.patch
 BuildRequires:  python3-distro
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-xml
@@ -109,6 +112,9 @@ python3 setup.py check && python3 setup.py test
 
 
 %changelog
+* Thu Aug 15 2024 Chris Co <chrco@microsoft.com> - 2.11.1.4-3
+- Add patch to update setup.py with azurelinux support
+
 * Fri Aug 09 2024 Cameron Baird <cameronbaird@microsoft.com> - 2.11.1.4-2
 - Package dracut setup script with WALinuxAgent
 

--- a/SPECS/WALinuxAgent/update-setup.patch
+++ b/SPECS/WALinuxAgent/update-setup.patch
@@ -1,0 +1,22 @@
+From 187f0d694626cf11e24aa45b2ff6789c4b739fc1 Mon Sep 17 00:00:00 2001
+From: "narrieta@microsoft" <narrieta>
+Date: Wed, 14 Aug 2024 21:19:57 -0700
+Subject: [PATCH] Update setup.py
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 2d51fae8c2..0bb053d4c2 100755
+--- a/setup.py
++++ b/setup.py
+@@ -147,7 +147,7 @@ def get_data_files(name, version, fullname):  # pylint: disable=R0912
+                        src=["config/clearlinux/waagent.conf"])
+         set_systemd_files(data_files, dest=systemd_dir_path,
+                           src=["init/clearlinux/waagent.service"])
+-    elif name == 'mariner':
++    elif name in ["mariner", "azurelinux"]:
+         set_bin_files(data_files, dest=agent_bin_path)
+         set_conf_files(data_files, dest="/etc",
+                        src=["config/mariner/waagent.conf"])


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add patch to update WALinuxAgent's setup.py to support azurelinux

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [622170](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=622170&view=results)
