### PR TITLE
Update SymCrypt-OpenSSL to 1.5.0

### DIFF
--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "SymCrypt-OpenSSL-1.4.3.tar.gz": "9225dd28ff03ecface28df77617f22344e144817a9556d3df909484f5661004b"
+  "SymCrypt-OpenSSL-1.5.0.tar.gz": "843e1fd23be215832a62df34caf51d791c4e8c7a185e0d7c1a059ac77a1ffa75"
  }
 }

--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
@@ -1,6 +1,6 @@
 Summary:        The SymCrypt engine for OpenSSL (SCOSSL) allows the use of OpenSSL with SymCrypt as the provider for core cryptographic operations
 Name:           SymCrypt-OpenSSL
-Version:        1.4.3
+Version:        1.5.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -67,6 +67,10 @@ install SymCryptProvider/symcrypt_prov.cnf %{buildroot}%{_sysconfdir}/pki/tls/sy
 %{_sysconfdir}/pki/tls/symcrypt_prov.cnf
 
 %changelog
+* Thu Aug 15 2024 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.5.0-1
+- Fix AES-CFB to match expected OpenSSL calling patterns
+- Support ECC key X and Y coordinate export
+
 * Thu May 16 2024 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.4.3-1
 - Additional bugfixes for TLS connections
 - Add variable length GCM IV support to the SymCrypt engine

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -28106,8 +28106,8 @@
         "type": "other",
         "other": {
           "name": "SymCrypt-OpenSSL",
-          "version": "1.4.3",
-          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.4.3.tar.gz"
+          "version": "1.5.0",
+          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.5.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
Updates SymCrypt-OpenSSL to 1.5.0 with bugfixes for TPM2 libraries.

###### Change Log
- Fixes bugs found when using the SymCrypt provider for TPM2 operations
  - Allow export of ECC key X and Y coordinates, which tpm2-tss needs
  - Fix the AES-CFB interface to behave the same as the OpenSSL default provider

###### Does this affect the toolchain?
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build, tested on AZL3 Hyper-V VM
