### PR TITLE
Fixed `openssh` ptests.

### DIFF
--- a/SPECS/openssh/openssh-8.2p1-visibility.patch
+++ b/SPECS/openssh/openssh-8.2p1-visibility.patch
@@ -1,0 +1,40 @@
+diff --git a/regress/misc/sk-dummy/sk-dummy.c b/regress/misc/sk-dummy/sk-dummy.c
+index dca158de..afdcb1d2 100644
+--- a/regress/misc/sk-dummy/sk-dummy.c
++++ b/regress/misc/sk-dummy/sk-dummy.c
+@@ -71,7 +71,7 @@ skdebug(const char *func, const char *fmt, ...)
+ #endif
+ }
+ 
+-uint32_t
++uint32_t __attribute__((visibility("default")))
+ sk_api_version(void)
+ {
+ 	return SSH_SK_VERSION_MAJOR;
+@@ -220,7 +220,7 @@ check_options(struct sk_option **options)
+ 	return 0;
+ }
+ 
+-int
++int __attribute__((visibility("default")))
+ sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
+     const char *application, uint8_t flags, const char *pin,
+     struct sk_option **options, struct sk_enroll_response **enroll_response)
+@@ -467,7 +467,7 @@ sig_ed25519(const uint8_t *message, size_t message_len,
+ 	return ret;
+ }
+ 
+-int
++int __attribute__((visibility("default")))
+ sk_sign(uint32_t alg, const uint8_t *data, size_t datalen,
+     const char *application, const uint8_t *key_handle, size_t key_handle_len,
+     uint8_t flags, const char *pin, struct sk_option **options,
+@@ -518,7 +518,7 @@ sk_sign(uint32_t alg, const uint8_t *message, size_t message_len,
+ 	return ret;
+ }
+ 
+-int
++int __attribute__((visibility("default")))
+ sk_load_resident_keys(const char *pin, struct sk_option **options,
+     struct sk_resident_key ***rks, size_t *nrks)
+ {

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -3,7 +3,7 @@
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh
 Version:        %{openssh_ver}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -32,6 +32,10 @@ Patch306:       pam_ssh_agent_auth-0.10.2-compat.patch
 # Fix NULL dereference from getpwuid() return value
 # https://sourceforge.net/p/pamsshagentauth/bugs/22/
 Patch307:       pam_ssh_agent_auth-0.10.2-dereference.patch
+# sk-dummy.so built with -fvisibility=hidden does not work
+# The tests fail with the following error:
+#   dlsym(sk_api_version) failed: (...)/sk-dummy.so: undefined symbol: sk_api_version
+Patch965: openssh-8.2p1-visibility.patch
 BuildRequires:  audit-devel
 BuildRequires:  autoconf
 BuildRequires:  e2fsprogs-devel
@@ -104,6 +108,8 @@ pushd pam_ssh_agent_auth-%{pam_ssh_agent_ver}
 rm -f $(cat %{SOURCE4})
 autoreconf
 popd
+
+%patch -P 965 -p1 -b .visibility
 
 %build
 # The -fvisibility=hidden is needed for clean build of the pam_ssh_agent_auth.
@@ -262,6 +268,9 @@ fi
 %{_mandir}/man8/ssh-sk-helper.8.gz
 
 %changelog
+* Fri Aug 16 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 9.8p1-2
+- Fixed 'openssh' ptests.
+
 * Mon Jul 01 2024 Jon Slobodzian <joslobo@microsoft.com> - 9.8p1-1
 - Upgrade to version 9.8p1. This fixes CVE-2024-6387 (a regression to CVE-2006-5051) in OpenSSH's server.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Fixing the ptests for `openssh`. Switching to building with `-fvisibility=hidden` caused issues building a dummy test library.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=623239&view=results).