### PR TITLE
Toolkit: Respect overridden home directory for .ssh path.

### DIFF
--- a/toolkit/tools/internal/userutils/main_test.go
+++ b/toolkit/tools/internal/userutils/main_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	tmpDir string
+	testDataDir string
+	tmpDir      string
 )
 
 func TestMain(m *testing.M) {
@@ -24,6 +25,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		logger.Log.Panicf("Failed to get working directory, error: %s", err)
 	}
+
+	testDataDir = filepath.Join(workingDir, "testdata")
 
 	tmpDir = filepath.Join(workingDir, "_tmp")
 

--- a/toolkit/tools/internal/userutils/passwdfile.go
+++ b/toolkit/tools/internal/userutils/passwdfile.go
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package userutils
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
+)
+
+type PasswdEntry struct {
+	Name          string
+	Uid           int
+	Gid           int
+	Description   string
+	HomeDirectory string
+	Shell         string
+}
+
+func ReadPasswdFile(rootDir string) ([]PasswdEntry, error) {
+	lines, err := file.ReadLines(filepath.Join(rootDir, PasswdFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s file:\n%w", PasswdFile, err)
+	}
+
+	entries, err := parsePasswdFile(lines)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s file:\n%w", PasswdFile, err)
+	}
+
+	return entries, nil
+}
+
+func parsePasswdFile(lines []string) ([]PasswdEntry, error) {
+	entries := []PasswdEntry(nil)
+	for i, line := range lines {
+		entry, err := parsePasswdFileEntry(line)
+		if err != nil {
+			return nil, fmt.Errorf("invalid line %d:\n%w", i, err)
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func parsePasswdFileEntry(line string) (PasswdEntry, error) {
+	const (
+		numFields = 7
+	)
+
+	fields := strings.Split(line, ":")
+	if len(fields) != numFields {
+		return PasswdEntry{}, fmt.Errorf("%d fields instead of %d", len(fields), numFields)
+	}
+
+	uidStr := fields[2]
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		return PasswdEntry{}, fmt.Errorf("invalid UID (%s):\n%w", uidStr, err)
+	}
+
+	gidStr := fields[3]
+	gid, err := strconv.Atoi(gidStr)
+	if err != nil {
+		return PasswdEntry{}, fmt.Errorf("invalid GID (%s):\n%w", gidStr, err)
+	}
+
+	entry := PasswdEntry{
+		Name:          fields[0],
+		Uid:           uid,
+		Gid:           gid,
+		Description:   fields[4],
+		HomeDirectory: fields[5],
+		Shell:         fields[6],
+	}
+	return entry, nil
+}
+
+func GetPasswdFileEntryForUser(rootDir string, user string) (PasswdEntry, error) {
+	entries, err := ReadPasswdFile(rootDir)
+	if err != nil {
+		return PasswdEntry{}, err
+	}
+
+	entry, found := sliceutils.FindValueFunc(entries, func(entry PasswdEntry) bool {
+		return entry.Name == user
+	})
+	if !found {
+		return PasswdEntry{}, fmt.Errorf("failed to find user (%s) in %s file", user, PasswdFile)
+	}
+
+	return entry, nil
+}

--- a/toolkit/tools/internal/userutils/passwdfile_test.go
+++ b/toolkit/tools/internal/userutils/passwdfile_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package userutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadPasswdFile(t *testing.T) {
+	expected := []PasswdEntry{
+		{
+			Name:          "root",
+			Uid:           0,
+			Gid:           0,
+			Description:   "root",
+			HomeDirectory: "/root",
+			Shell:         "/bin/bash",
+		},
+		{
+			Name:          "test",
+			Uid:           1001,
+			Gid:           100,
+			Description:   "",
+			HomeDirectory: "/home/1001",
+			Shell:         "/bin/sh",
+		},
+	}
+
+	entries, err := ReadPasswdFile(testDataDir)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, entries)
+}
+
+func TestGetPasswdFileEntryForUser(t *testing.T) {
+	expected := PasswdEntry{
+		Name:          "test",
+		Uid:           1001,
+		Gid:           100,
+		Description:   "",
+		HomeDirectory: "/home/1001",
+		Shell:         "/bin/sh",
+	}
+
+	entries, err := GetPasswdFileEntryForUser(testDataDir, "test")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, entries)
+}

--- a/toolkit/tools/internal/userutils/testdata/etc/passwd
+++ b/toolkit/tools/internal/userutils/testdata/etc/passwd
@@ -1,0 +1,2 @@
+root:x:0:0:root:/root:/bin/bash
+test:x:1001:100::/home/1001:/bin/sh

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -23,6 +23,7 @@ const (
 	UserHomeDirPrefix = "/home"
 
 	ShadowFile                = "/etc/shadow"
+	PasswdFile                = "/etc/passwd"
 	SSHDirectoryName          = ".ssh"
 	SSHAuthorizedKeysFileName = "authorized_keys"
 )
@@ -147,19 +148,24 @@ func UpdateUserPassword(installRoot, username, hashedPassword string) error {
 }
 
 // UserHomeDirectory returns the home directory for a user.
-func UserHomeDirectory(username string) string {
-	if username == RootUser {
-		return RootHomeDir
-	} else {
-		return filepath.Join(UserHomeDirPrefix, username)
+func UserHomeDirectory(installRoot string, username string) (string, error) {
+	entry, err := GetPasswdFileEntryForUser(installRoot, username)
+	if err != nil {
+		return "", err
 	}
+
+	return entry.HomeDirectory, nil
 }
 
 // UserSSHDirectory returns the path of the .ssh directory for a user.
-func UserSSHDirectory(username string) string {
-	homeDir := UserHomeDirectory(username)
+func UserSSHDirectory(installRoot string, username string) (string, error) {
+	homeDir, err := UserHomeDirectory(installRoot, username)
+	if err != nil {
+		return "", err
+	}
+
 	userSSHKeyDir := filepath.Join(homeDir, SSHDirectoryName)
-	return userSSHKeyDir
+	return userSSHKeyDir, nil
 }
 
 // NameIsValid returns an error if the User name is empty

--- a/toolkit/tools/internal/userutils/userutils_test.go
+++ b/toolkit/tools/internal/userutils/userutils_test.go
@@ -12,14 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUserHomeDirectoryNormalUser(t *testing.T) {
-	homeDir := UserHomeDirectory("test")
-	assert.Equal(t, "/home/test", homeDir)
-}
-
-func TestUserHomeDirectoryRoot(t *testing.T) {
-	homeDir := UserHomeDirectory("root")
-	assert.Equal(t, "/root", homeDir)
+func TestUserSSHDirectory(t *testing.T) {
+	expected := "/home/1001/.ssh"
+	actual, err := UserSSHDirectory(testDataDir, "test")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }
 
 func TestNameIsValidRoot(t *testing.T) {


### PR DESCRIPTION
When populating the `.ssh/authorized_keys` path, the toolkit currently assumes the standard home directory path is being used. This is particularly unfortunate given that the toolkit supports overridding the home directory when creating a user. This change pulls the home directory from the `/etc/passwd` file.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added UTs.

