### PR TITLE
Fix tests for perl-HTTP-Message, python-pytest-mock, upgrade pyOpenSSL

### DIFF
--- a/SPECS/perl-HTTP-Message/perl-HTTP-Message.spec
+++ b/SPECS/perl-HTTP-Message/perl-HTTP-Message.spec
@@ -1,6 +1,6 @@
 Name:           perl-HTTP-Message
 Version:        6.45
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        HTTP style message
 # CONTRIBUTING.md:  CC0
 # other files:      GPL+ or Artistic
@@ -42,6 +42,8 @@ BuildRequires:  perl(Config)
 BuildRequires:  perl(File::Spec)
 BuildRequires:  perl(PerlIO::encoding)
 BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Test::Needs)
+BuildRequires:  perl(Clone)
 # Testing requires Time::Local on MacOS only
 BuildRequires:  perl(Try::Tiny)
 Requires:       perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
@@ -94,6 +96,9 @@ make test
 %{_mandir}/man3/*
 
 %changelog
+* Fri Aug 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 6.45-2
+- Add missing test requirements
+
 * Mon Dec 18 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.45-1
 - Auto-upgrade to 6.45 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/pyOpenSSL/pyOpenSSL.signatures.json
+++ b/SPECS/pyOpenSSL/pyOpenSSL.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "pyOpenSSL-23.2.0.tar.gz": "276f931f55a452e7dea69c7173e984eb2a4407ce413c918aa34b55f82f9b8bac"
-  }
+ "Signatures": {
+  "pyopenssl-24.2.1.tar.gz": "4247f0dbe3748d560dcbb2ff3ea01af0f9a1a001ef5f7c4c647956ed8cbf0e95"
+ }
 }

--- a/SPECS/pyOpenSSL/pyOpenSSL.spec
+++ b/SPECS/pyOpenSSL/pyOpenSSL.spec
@@ -1,13 +1,15 @@
+%global         srcname     pyopenssl
+
 Summary:        Python wrapper module around the OpenSSL library
 Name:           pyOpenSSL
-Version:        23.2.0
+Version:        24.2.1
 Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Development/Languages/Python
 URL:            https://github.com/pyca/pyopenssl
-Source0:        https://files.pythonhosted.org/packages/be/df/75a6525d8988a89aed2393347e9db27a56cb38a3e864314fac223e905aef/%{name}-%{version}.tar.gz
+Source0:        %{pypi_source %{srcname} %{version}}
 BuildArch:      noarch
 
 %description
@@ -39,7 +41,7 @@ BuildRequires:  python3-six
 High-level wrapper around a subset of the OpenSSL library.
 
 %prep
-%autosetup
+%autosetup -p1 -n %{srcname}-%{version}
 
 %build
 %py3_build
@@ -48,7 +50,7 @@ High-level wrapper around a subset of the OpenSSL library.
 %py3_install
 
 %check
-pip3 install pretend flaky pytest
+pip3 install pretend pytest-rerunfailures pytest
 PATH=%{buildroot}%{_bindir}:${PATH} \
 LANG=en_US.UTF-8  PYTHONPATH=%{buildroot}%{python3_sitelib} \
     pytest
@@ -59,6 +61,10 @@ LANG=en_US.UTF-8  PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %{python3_sitelib}/*
 
 %changelog
+* Fri Aug 16 2023 Daniel McIlvaney <damcilva@microsoft.com> - 24.2.1-1
+- Selectively take upstream changes from F41 to update to 24.2.1 to support our
+    version of python-cryptography.
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 23.2.0-1
 - Auto-upgrade to 23.2.0 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/python-pytest-mock/fix__test_failure_message.patch
+++ b/SPECS/python-pytest-mock/fix__test_failure_message.patch
@@ -1,0 +1,68 @@
+From 8480bb6d0500f933be039cfec65e04157e6ecffe Mon Sep 17 00:00:00 2001
+From: Bruno Oliveira <nicoddemus@gmail.com>
+Date: Tue, 19 Dec 2023 08:24:23 -0300
+Subject: [PATCH] Fix tests for Python 3.11 and 3.12
+
+Fixes #401.
+
+Modified by: damcilva@microsoft.com
+    Include cleanup from:
+        c596504e062be06475b03122c9c0cc732ae87840
+        b8522e73a85441cf4c02c39038a88ac0bab57504
+---
+ tests/test_pytest_mock.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/tests/test_pytest_mock.py b/tests/test_pytest_mock.py
+index 3ee00da..7acb361 100644
+--- a/tests/test_pytest_mock.py
++++ b/tests/test_pytest_mock.py
+@@ -246,9 +246,8 @@ def __test_failure_message(self, mocker: MockerFixture, **kwargs: Any) -> None:
+             msg = "Expected call: {0}()\nNot called"
+         expected_message = msg.format(expected_name)
+         stub = mocker.stub(**kwargs)
+-        with pytest.raises(AssertionError) as exc_info:
++        with pytest.raises(AssertionError, match=re.escape(expected_message)):
+             stub.assert_called_with()
+-        assert str(exc_info.value) == expected_message
+
+     def test_failure_message_with_no_name(self, mocker: MagicMock) -> None:
+         self.__test_failure_message(mocker)
+
+From 6da5b0506d6378a8dbe5ae314d5134e6868aeabd Mon Sep 17 00:00:00 2001
+From: danigm <daniel.garcia@suse.com>
+Date: Wed, 20 Dec 2023 16:02:13 +0100
+Subject: [PATCH] Update expected message to match python 3.11.7 (#404)
+
+https://github.com/python/cpython/issues/111019
+
+Fixes #401.
+Closes #403.
+---
+ tests/test_pytest_mock.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/tests/test_pytest_mock.py b/tests/test_pytest_mock.py
+index c185f2a..01534a4 100644
+--- a/tests/test_pytest_mock.py
++++ b/tests/test_pytest_mock.py
+@@ -25,6 +25,8 @@
+
+ # Python 3.8 changed the output formatting (bpo-35500), which has been ported to mock 3.0
+ NEW_FORMATTING = sys.version_info >= (3, 8)
++# Python 3.11.7 changed the output formatting, https://github.com/python/cpython/issues/111019
++NEWEST_FORMATTING = sys.version_info >= (3, 11, 7)
+
+ if sys.version_info[:2] >= (3, 8):
+     from unittest.mock import AsyncMock
+@@ -240,7 +242,9 @@ def test_repr_with_name(self, mocker: MockerFixture) -> None:
+
+     def __test_failure_message(self, mocker: MockerFixture, **kwargs: Any) -> None:
+         expected_name = kwargs.get("name") or "mock"
+-        if NEW_FORMATTING:
++        if NEWEST_FORMATTING:
++            msg = "expected call not found.\nExpected: {0}()\n  Actual: not called."
++        elif NEW_FORMATTING:
+             msg = "expected call not found.\nExpected: {0}()\nActual: not called."
+         else:
+             msg = "Expected call: {0}()\nNot called"

--- a/SPECS/python-pytest-mock/python-pytest-mock.spec
+++ b/SPECS/python-pytest-mock/python-pytest-mock.spec
@@ -3,7 +3,7 @@
 Summary:        Thin-wrapper around the mock package for easier use with py.test
 Name:           python-%{pypi_name}
 Version:        3.12.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,7 @@ URL:            https://github.com/pytest-dev/pytest-mock/
 Source0:        https://pypi.io/packages/source/p/pytest-mock/%{pypi_name}-%{version}.tar.gz
 # Can be removed once this bug is resolved: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006736
 Patch0:         skip_broken_tests_since_3.6.1.patch
+Patch1:         fix__test_failure_message.patch
 
 BuildArch:      noarch
 
@@ -48,12 +49,12 @@ sed -i 's/\r$//' README.rst
 %py3_install
 
 %check
-pip3 install atomicwrites>=1.3.0 \
-    attrs>=19.1.0 \
-    more-itertools>=7.0.0 \
-    pluggy>=0.11.0 \
-    pytest==7.1.2 \
-    pytest-cov>=2.7.1
+pip3 install 'atomicwrites>=1.3.0' \
+    'attrs>=19.1.0' \
+    'more-itertools>=7.0.0' \
+    'pluggy>=0.11.0' \
+    'pytest==7.1.2' \
+    'pytest-cov>=2.7.1'
 PATH=%{buildroot}%{_bindir}:${PATH} \
 PYTHONPATH=%{buildroot}%{python3_sitelib} \
     python%{python3_version} -m pytest -v tests \
@@ -67,6 +68,10 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %{python3_sitelib}/%{file_name}-%{version}-py%{python3_version}.egg-info/
 
 %changelog
+* Fri Aug 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 3.12.0-2
+- Fix test requirement install command
+- Backport fixes for failing unit test
+
 * Tue Jan 23 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.12.0-1
 - Auto-upgrade to 3.12.0 - Azure Linux 3.0 - package upgrades
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21513,8 +21513,8 @@
         "type": "other",
         "other": {
           "name": "pyOpenSSL",
-          "version": "23.2.0",
-          "downloadUrl": "https://files.pythonhosted.org/packages/be/df/75a6525d8988a89aed2393347e9db27a56cb38a3e864314fac223e905aef/pyOpenSSL-23.2.0.tar.gz"
+          "version": "24.2.1",
+          "downloadUrl": "https://files.pythonhosted.org/packages/source/p/pyopenssl/pyopenssl-24.2.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix several ptest failures.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `perl-HTTP-Message` was missing two `BuildRequires` for the check section
- `python-pytest-mock` relies on the format of messages from `Python`, this message changed in `3.11.7`. Backport the fixes to our version so it works with our version of `Python`.
- `pyOpenSSL` has a dependency on `python-cryptography`, we updated `python-cryptography` beyond what our version of `pyOpenSSL` supports so update to a newer version based on F41.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- ~https://dev.azure.com/mariner-org/mariner/_build/results?buildId=623323&view=results~ https://dev.azure.com/mariner-org/mariner/_build/results?buildId=623347&view=results
