### PR TITLE
kernel-rt: Add kernel conflicts and produce specialized versions of b…

### DIFF
--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -76,7 +76,6 @@ Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
 ExclusiveArch:  x86_64
-Conflicts:      kernel
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -146,7 +145,7 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf
+%package        python3-perf-%{short_name}
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Requires:       %{name} = %{version}-%{release}
@@ -155,7 +154,7 @@ Provides:       python3-perf-%{short_name}
 %description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
-%package        bpftool
+%package        bpftool-%{short_name}
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Requires:       %{name} = %{version}-%{release}
 Provides:       bpftool-%{short_name}

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -145,7 +145,7 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf-%{short_name}
+%package -n     python3-perf-%{short_name}
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Requires:       %{name} = %{version}-%{release}
@@ -154,7 +154,7 @@ Provides:       python3-perf-%{short_name}
 %description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
-%package        bpftool-%{short_name}
+%package -n     bpftool-%{short_name}
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Requires:       %{name} = %{version}-%{release}
 Provides:       bpftool-%{short_name}

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -4,6 +4,7 @@
 %define uname_r %{version}-%{rt_version}-%{release}
 %define mariner_version 3
 %define version_upstream %(echo %{version} | rev | cut -d'.' -f2- | rev)
+%define short_name rt
 
 # find_debuginfo.sh arguments are set by default in rpm's macros.
 # The default arguments regenerate the build-id for vmlinux in the
@@ -24,7 +25,7 @@
 Summary:        Realtime Linux Kernel
 Name:           kernel-rt
 Version:        6.6.43.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +76,7 @@ Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
 ExclusiveArch:  x86_64
+Conflicts:      kernel
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -144,17 +146,21 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Requires:       %{name} = %{version}-%{release}
+Provides:       python3-perf-%{short_name}
 
-%description -n python3-perf
+%description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     bpftool
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Requires:       %{name} = %{version}-%{release}
+Provides:       bpftool-%{short_name}
 
-%description -n bpftool
+%description    bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -406,14 +412,19 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_unitdir}/cpupower.service
 %config(noreplace) %{_sysconfdir}/sysconfig/cpupower
 
-%files -n python3-perf
+%files python3-perf
 %{python3_sitearch}/*
 
-%files -n bpftool
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Aug 19 2024 Harshit Gupta <guptaharshit@microsoft.com> - 6.6.43.1-2
+- Rename bpftool and python3-perf to be kernel specific
+- Add new requires for bpftool and python3-perf for specfic kernel
+- Add kernel conflicts
+
 * Tue Jul 30 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.43.1-1
 - Auto-upgrade to 6.6.43.1
 

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -151,7 +151,7 @@ Requires:       python3
 Requires:       %{name} = %{version}-%{release}
 Provides:       python3-perf-%{short_name}
 
-%description    python3-perf
+%description -n python3-perf-%{short_name}
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package -n     bpftool-%{short_name}
@@ -159,7 +159,7 @@ Summary:        Inspection and simple manipulation of eBPF programs and maps
 Requires:       %{name} = %{version}-%{release}
 Provides:       bpftool-%{short_name}
 
-%description    bpftool
+%description -n bpftool-%{short_name}
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -411,10 +411,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_unitdir}/cpupower.service
 %config(noreplace) %{_sysconfdir}/sysconfig/cpupower
 
-%files python3-perf
+%files -n python3-perf-%{short_name}
 %{python3_sitearch}/*
 
-%files bpftool
+%files -n bpftool-%{short_name}
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
@@ -422,7 +422,6 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 * Mon Aug 19 2024 Harshit Gupta <guptaharshit@microsoft.com> - 6.6.43.1-2
 - Rename bpftool and python3-perf to be kernel specific
 - Add new requires for bpftool and python3-perf for specfic kernel
-- Add kernel conflicts
 
 * Tue Jul 30 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.43.1-1
 - Auto-upgrade to 6.6.43.1

--- a/SPECS/tuned/tuned.spec
+++ b/SPECS/tuned/tuned.spec
@@ -35,7 +35,7 @@ Requires: python3-configobj
 Requires: python3-dbus 
 Requires: python3-decorator
 Requires: python3-linux-procfs
-Requires: python3-perf
+Requires: python3-perf-rt
 Requires: python3-gobject
 Requires: python3-pyudev
 Requires: python3-schedutils

--- a/SPECS/tuned/tuned.spec
+++ b/SPECS/tuned/tuned.spec
@@ -35,7 +35,7 @@ Requires: python3-configobj
 Requires: python3-dbus 
 Requires: python3-decorator
 Requires: python3-linux-procfs
-Requires: python3-perf-rt
+Requires: (python3-perf or python3-perf-rt)
 Requires: python3-gobject
 Requires: python3-pyudev
 Requires: python3-schedutils
@@ -429,7 +429,7 @@ fi
 
 %changelog
 * Fri Aug 30 2024 Harshit gupta <guptaharshit@microsoft.com> 2.21.0-2
-- Change dependency on python3-perf to python3-perf-rt
+- Require either python3-perf or python3-perf-rt dependency.
 
 * Tue Jan 16 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> 2.21.0-1
 - Upgrade package version to 2.21.0

--- a/SPECS/tuned/tuned.spec
+++ b/SPECS/tuned/tuned.spec
@@ -7,7 +7,7 @@
 Summary:      A dynamic adaptive system tuning daemon
 Name:         tuned
 Version:      2.21.0
-Release:      1%{?dist}
+Release:      2%{?dist}
 License:      GPLv2+
 Vendor:       Microsoft Corporation
 Distribution:   Azure Linux
@@ -428,6 +428,9 @@ fi
 %{_mandir}/man7/tuned-profiles-openshift.7*
 
 %changelog
+* Fri Aug 30 2024 Harshit gupta <guptaharshit@microsoft.com> 2.21.0-2
+- Change dependency on python3-perf to python3-perf-rt
+
 * Tue Jan 16 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> 2.21.0-1
 - Upgrade package version to 2.21.0
 - Modifying SPEC file to reflect upstream changes (https://github.com/redhat-performance/tuned/blob/v2.21.0/tuned.spec)


### PR DESCRIPTION
…pftool and python3-perf

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Both SPECS/kernel and SPECS-EXTENDED/kernel-rt packages contain sub-packages named `python3-perf` and `bpftool`. Therefore, the RPMs those subpackages that were built against `kernel-rt` were replacing the RPMs built against `kernel` in PMC.
This PR disambiguates the RPMs built against the mainline `kernel` from those built against the RT kernel `kernel-rt` by adding a suffix `-rt` to those pkgs.
 
###### Change Log  <!-- REQUIRED -->
- Rename `bpftool` and `python3-perf` to be kernel specific in the `kernel-rt` spec
- Add new requires for `bpftool-rt` and `python3-perf-rt` for `kernel-rt`
- Update dependency in `tuned` from `python3-perf` to `python3-perf-rt`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Test Methodology
- Buddy Build Pipeline build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=631511&view=results
