### PR TITLE
Image Customizer: Add tests for users API.

### DIFF
--- a/toolkit/tools/internal/userutils/groupfile.go
+++ b/toolkit/tools/internal/userutils/groupfile.go
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package userutils
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
+)
+
+type GroupEntry struct {
+	Name     string
+	Password string
+	GID      int
+	UserList []string
+}
+
+func ReadGroupFile(rootDir string) ([]GroupEntry, error) {
+	lines, err := file.ReadLines(filepath.Join(rootDir, GroupFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s file:\n%w", GroupFile, err)
+	}
+
+	entries, err := parseGroupFile(lines)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s file:\n%w", GroupFile, err)
+	}
+
+	return entries, nil
+}
+
+func parseGroupFile(lines []string) ([]GroupEntry, error) {
+	entries := []GroupEntry(nil)
+	for i, line := range lines {
+		entry, err := parseGroupFileEntry(line)
+		if err != nil {
+			return nil, fmt.Errorf("invalid line %d", i)
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func parseGroupFileEntry(line string) (GroupEntry, error) {
+	const (
+		numFields = 4
+	)
+
+	fields := strings.Split(line, ":")
+	if len(fields) != numFields {
+		return GroupEntry{}, fmt.Errorf("%d fields instead of %d", len(fields), numFields)
+	}
+
+	gidStr := fields[2]
+	gid, err := strconv.Atoi(gidStr)
+	if err != nil {
+		return GroupEntry{}, fmt.Errorf("invalid GID:\n%w", err)
+	}
+
+	usersStr := fields[3]
+	users := strings.Split(usersStr, ",")
+
+	entry := GroupEntry{
+		Name:     fields[0],
+		Password: fields[1],
+		GID:      gid,
+		UserList: users,
+	}
+	return entry, nil
+}
+
+func GetUserGroups(rootDir string, username string) ([]string, error) {
+	systemGroups, err := ReadGroupFile(rootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	userGroups := []string(nil)
+	for _, group := range systemGroups {
+		userInGroup := sliceutils.ContainsValue(group.UserList, username)
+		if userInGroup {
+			userGroups = append(userGroups, group.Name)
+		}
+	}
+
+	return userGroups, nil
+}

--- a/toolkit/tools/internal/userutils/shadowfile.go
+++ b/toolkit/tools/internal/userutils/shadowfile.go
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package userutils
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
+)
+
+type ShadowEntry struct {
+	Name                     string
+	EncryptedPassword        string
+	LastPasswordChange       *int
+	MinPasswordAge           *int
+	MaxPasswordAge           *int
+	PasswordWarningPeriod    *int
+	PasswordInactivityPeriod *int
+	AccountExpirationDate    *int
+}
+
+func ReadShadowFile(rootDir string) ([]ShadowEntry, error) {
+	lines, err := file.ReadLines(filepath.Join(rootDir, ShadowFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s file:\n%w", ShadowFile, err)
+	}
+
+	entries, err := parseShadowFile(lines)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s file:\n%w", ShadowFile, err)
+	}
+
+	return entries, nil
+}
+
+func parseShadowFile(lines []string) ([]ShadowEntry, error) {
+	entries := []ShadowEntry(nil)
+	for i, line := range lines {
+		entry, err := parseShadowFileEntry(line)
+		if err != nil {
+			return nil, fmt.Errorf("invalid line %d", i)
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func parseShadowFileEntry(line string) (ShadowEntry, error) {
+	const (
+		numFields = 9
+	)
+
+	fields := strings.Split(line, ":")
+	if len(fields) != numFields {
+		return ShadowEntry{}, fmt.Errorf("%d fields instead of %d", len(fields), numFields)
+	}
+
+	lastPasswordChange, err := parseOptionalInt(fields[2])
+	if err != nil {
+		return ShadowEntry{}, fmt.Errorf("invalid date of last password change:\n%w", err)
+	}
+
+	minPasswordAge, err := parseOptionalInt(fields[3])
+	if err != nil {
+		return ShadowEntry{}, fmt.Errorf("invalid minimum password age:\n%w", err)
+	}
+
+	maxPasswordAge, err := parseOptionalInt(fields[4])
+	if err != nil {
+		return ShadowEntry{}, fmt.Errorf("invalid maximum password age:\n%w", err)
+	}
+
+	passwordWarningPeriod, err := parseOptionalInt(fields[5])
+	if err != nil {
+		return ShadowEntry{}, fmt.Errorf("invalid password warning period:\n%w", err)
+	}
+
+	passwordInactivityPeriod, err := parseOptionalInt(fields[6])
+	if err != nil {
+		return ShadowEntry{}, fmt.Errorf("invalid password inactivity period:\n%w", err)
+	}
+
+	accountExpirationDate, err := parseOptionalInt(fields[7])
+	if err != nil {
+		return ShadowEntry{}, fmt.Errorf("invalid account expiration date:\n%w", err)
+	}
+
+	entry := ShadowEntry{
+		Name:                     fields[0],
+		EncryptedPassword:        fields[1],
+		LastPasswordChange:       lastPasswordChange,
+		MinPasswordAge:           minPasswordAge,
+		MaxPasswordAge:           maxPasswordAge,
+		PasswordWarningPeriod:    passwordWarningPeriod,
+		PasswordInactivityPeriod: passwordInactivityPeriod,
+		AccountExpirationDate:    accountExpirationDate,
+	}
+	return entry, nil
+}
+
+func parseOptionalInt(value string) (*int, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	a, err := strconv.Atoi(value)
+	return &a, err
+}
+
+func GetShadowFileEntryForUser(rootDir string, user string) (ShadowEntry, error) {
+	entries, err := ReadShadowFile(rootDir)
+	if err != nil {
+		return ShadowEntry{}, err
+	}
+
+	entry, found := sliceutils.FindValueFunc(entries, func(entry ShadowEntry) bool {
+		return entry.Name == user
+	})
+	if !found {
+		return ShadowEntry{}, fmt.Errorf("failed to find user (%s) in %s file", user, ShadowFile)
+	}
+
+	return entry, nil
+}

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -24,6 +24,7 @@ const (
 
 	ShadowFile                = "/etc/shadow"
 	PasswdFile                = "/etc/passwd"
+	GroupFile                 = "/etc/group"
 	SSHDirectoryName          = ".ssh"
 	SSHAuthorizedKeysFileName = "authorized_keys"
 )
@@ -93,7 +94,7 @@ func AddUser(username string, homeDir string, primaryGroup string, hashedPasswor
 	}
 
 	err := installChroot.UnsafeRun(func() error {
-		return shell.ExecuteLive(false /*squashErrors*/, "useradd", args...)
+		return shell.ExecuteLiveWithErr(1, "useradd", args...)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to add user (%s):\n%w", username, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
@@ -28,9 +28,17 @@ func AddOrUpdateUsers(users []imagecustomizerapi.User, baseConfigPath string, im
 }
 
 func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageChroot safechroot.ChrootInterface) error {
-	var err error
+	// Check if the user already exists.
+	userExists, err := userutils.UserExists(user.Name, imageChroot)
+	if err != nil {
+		return err
+	}
 
-	logger.Log.Infof("Adding/updating user (%s)", user.Name)
+	if userExists {
+		logger.Log.Infof("Updating user (%s)", user.Name)
+	} else {
+		logger.Log.Infof("Adding user (%s)", user.Name)
+	}
 
 	hashedPassword := ""
 	if user.Password != nil {
@@ -61,12 +69,6 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 				return err
 			}
 		}
-	}
-
-	// Check if the user already exists.
-	userExists, err := userutils.UserExists(user.Name, imageChroot)
-	if err != nil {
-		return err
 	}
 
 	if userExists {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/installutils"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/userutils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	// Parses the password field in the /etc/shadow file, extracting the rounds count and the salt.
+	shadowPasswordRegexp = regexp.MustCompile(`^\$([a-zA-Z0-9]*)\$((rounds=[0-9]+\$)?[a-zA-Z0-9./]*)\$[a-zA-Z0-9./]*$`)
+)
+
+func TestCustomizeImageUsers(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
+	buildDir := filepath.Join(testTmpDir, "build")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	rootSshPublicKey := "fake-root-public-key"
+
+	test2Uid := 10042
+	test2SshPublicKey := "fake-test-public-key"
+	test2SshPublicKeyPath := "files/a.txt"
+	test2PlainText := "cat"
+	test2HomeDirectory := "/home/10042"
+	test2StartupCommand := "/sbin/nologin"
+	test2PasswordExpiresDays := int64(10)
+
+	config := imagecustomizerapi.Config{
+		OS: &imagecustomizerapi.OS{
+			Users: []imagecustomizerapi.User{
+				{
+					Name: "root",
+					SSHPublicKeys: []string{
+						rootSshPublicKey,
+					},
+				},
+				{
+					Name: "test1",
+				},
+				{
+					Name: "test2",
+					UID:  &test2Uid,
+					Password: &imagecustomizerapi.Password{
+						Type:  "plain-text",
+						Value: test2PlainText,
+					},
+					PasswordExpiresDays: &test2PasswordExpiresDays,
+					SSHPublicKeys: []string{
+						test2SshPublicKey,
+					},
+					SSHPublicKeyPaths: []string{
+						test2SshPublicKeyPath,
+					},
+					SecondaryGroups: []string{
+						"sudo",
+					},
+					StartupCommand: test2StartupCommand,
+					HomeDirectory:  test2HomeDirectory,
+				},
+			},
+		},
+	}
+
+	// Customize image.
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
+		false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imageConnection, err := connectToCoreEfiImage(buildDir, outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Verify root user.
+	verifySshAuthorizedKeys(t, imageConnection.Chroot().RootDir(), "/root", []string{rootSshPublicKey})
+
+	rootPasswdEntry, err := userutils.GetPasswdFileEntryForUser(imageConnection.Chroot().RootDir(), "root")
+	if assert.NoError(t, err) {
+		assert.Equal(t, 0, rootPasswdEntry.Uid)
+		assert.Equal(t, 0, rootPasswdEntry.Gid)
+		assert.Equal(t, "/root", rootPasswdEntry.HomeDirectory)
+		assert.Equal(t, "/bin/bash", rootPasswdEntry.Shell)
+	}
+
+	rootUserGroups, err := userutils.GetUserGroups(imageConnection.Chroot().RootDir(), "root")
+	if assert.NoError(t, err) {
+		assert.ElementsMatch(t, rootUserGroups, []string{})
+	}
+
+	// Verify test1 user.
+	test1PasswdEntry, err := userutils.GetPasswdFileEntryForUser(imageConnection.Chroot().RootDir(), "test1")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "/home/test1", test1PasswdEntry.HomeDirectory)
+		assert.Equal(t, "/bin/bash", test1PasswdEntry.Shell)
+	}
+
+	test1UserGroups, err := userutils.GetUserGroups(imageConnection.Chroot().RootDir(), "test1")
+	if assert.NoError(t, err) {
+		assert.ElementsMatch(t, test1UserGroups, []string{})
+	}
+
+	// Verify test2 user.
+	verifySshAuthorizedKeys(t, imageConnection.Chroot().RootDir(), test2HomeDirectory,
+		[]string{test2SshPublicKey, "abcdefg"})
+
+	test2PasswdEntry, err := userutils.GetPasswdFileEntryForUser(imageConnection.Chroot().RootDir(), "test2")
+	if assert.NoError(t, err) {
+		assert.Equal(t, test2Uid, test2PasswdEntry.Uid)
+		assert.Equal(t, test2HomeDirectory, test2PasswdEntry.HomeDirectory)
+		assert.Equal(t, test2StartupCommand, test2PasswdEntry.Shell)
+	}
+
+	test2ShadowEntry, err := userutils.GetShadowFileEntryForUser(imageConnection.Chroot().RootDir(), "test2")
+	if assert.NoError(t, err) {
+		verifyPassword(t, test2ShadowEntry.EncryptedPassword, test2PlainText)
+
+		currentDay := installutils.DaysSinceUnixEpoch()
+		assert.Equal(t, currentDay+test2PasswordExpiresDays, int64(*test2ShadowEntry.AccountExpirationDate))
+	}
+
+	test2UserGroups, err := userutils.GetUserGroups(imageConnection.Chroot().RootDir(), "test2")
+	if assert.NoError(t, err) {
+		assert.ElementsMatch(t, test2UserGroups, []string{"sudo"})
+	}
+}
+
+func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
+	buildDir := filepath.Join(testTmpDir, "build")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	config := imagecustomizerapi.Config{
+		OS: &imagecustomizerapi.OS{
+			Users: []imagecustomizerapi.User{
+				{
+					Name:          "root",
+					HomeDirectory: "/home/root",
+				},
+			},
+		},
+	}
+
+	// Customize image.
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
+		false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	assert.ErrorContains(t, err, "cannot set home directory (/home/root) on a user (root) that already exists")
+}
+
+func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
+	buildDir := filepath.Join(testTmpDir, "build")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	config := imagecustomizerapi.Config{
+		OS: &imagecustomizerapi.OS{
+			Users: []imagecustomizerapi.User{
+				{
+					Name: "root",
+					UID:  ptrutils.PtrTo(1),
+				},
+			},
+		},
+	}
+
+	// Customize image.
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
+		false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	assert.ErrorContains(t, err, "cannot set UID (1) on a user (root) that already exists")
+}
+
+func verifySshAuthorizedKeys(t *testing.T, rootDir string, homeDirectory string, sshPublicKeys []string) bool {
+	authorizedKeysPath := filepath.Join(rootDir, homeDirectory, userutils.SSHDirectoryName,
+		userutils.SSHAuthorizedKeysFileName)
+	authorizedKeys, err := file.ReadLines(authorizedKeysPath)
+	if !assert.NoError(t, err) {
+		return false
+	}
+
+	success := true
+	for _, sshPublicKey := range sshPublicKeys {
+		success = assert.Contains(t, authorizedKeys, sshPublicKey) && success
+	}
+
+	return success
+}
+
+func verifyPassword(t *testing.T, encryptedPassword string, plainTextPassword string) bool {
+	match := shadowPasswordRegexp.FindStringSubmatch(encryptedPassword)
+	if !assert.NotNilf(t, match, "parse shadow password field (%s)", encryptedPassword) {
+		return false
+	}
+
+	id := match[1]
+
+	// 'openssl passwd' allows the number of rounds to be added to the start of the salt arg.
+	roundsAndSalt := match[2]
+
+	if !assert.Equal(t, "6", id) {
+		return false
+	}
+
+	reencryptedPassword, _, err := shell.NewExecBuilder("openssl", "passwd", "-6", "-salt", roundsAndSalt, "-stdin").
+		Stdin(plainTextPassword).
+		LogLevel(shell.LogDisabledLevel, logrus.DebugLevel).
+		ExecuteCaptureOuput()
+	if !assert.NoError(t, err) {
+		return false
+	}
+
+	return assert.Equal(t, encryptedPassword, strings.TrimSpace(reencryptedPassword))
+}


### PR DESCRIPTION
Add tests for installing and updating users.

This change include parsers for the /etc/group and /etc/shadow files, so that it is easier for the tests to verify the contents of these files.

In addition, this change includes some minor cleanup to error messages and logging.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added UT.

