### PR TITLE
e2fsprogs: fix ptest

### DIFF
--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -63,6 +63,8 @@ rm -rf %{buildroot}%{_infodir}
 
 %check
 # This test is known to fail; remove it
+# See upstream issue: https://github.com/tytso/e2fsprogs/issues/134
+# See also LFS: https://www.linuxfromscratch.org/lfs/downloads/stable/LFS-BOOK-12.1-NOCHUNKS.html#ch-system-e2fsprogs
 rm -rvf tests/m_assume_storage_prezeroed
 
 # Multi-threaded runs are flaky.

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -1,7 +1,7 @@
 Summary:        Contains the utilities for the ext2 file system
 Name:           e2fsprogs
 Version:        1.47.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2 AND LGPLv2 AND BSD AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -62,6 +62,9 @@ rm -rf %{buildroot}%{_infodir}
 %find_lang %{name}
 
 %check
+# This test is known to fail; remove it
+rm -rvf tests/m_assume_storage_prezeroed
+
 # Multi-threaded runs are flaky.
 make -j1 check
 test_status=$?
@@ -143,6 +146,9 @@ done
 %defattr(-,root,root)
 
 %changelog
+* Mon Aug 19 2024 Andrew Phelps <anphel@microsoft.com> - 1.47.0-2
+- Remove known bad package test
+
 * Tue Nov 28 2023 Andrew Phelps <anphel@microsoft.com> - 1.47.0-1
 - Upgrade to 1.47.0
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -188,7 +188,7 @@ rpm-lang-4.18.2-1.azl3.aarch64.rpm
 rpm-libs-4.18.2-1.azl3.aarch64.rpm
 cpio-2.14-1.azl3.aarch64.rpm
 cpio-lang-2.14-1.azl3.aarch64.rpm
-e2fsprogs-libs-1.47.0-1.azl3.aarch64.rpm
+e2fsprogs-libs-1.47.0-2.azl3.aarch64.rpm
 libsolv-0.7.28-1.azl3.aarch64.rpm
 libsolv-devel-0.7.28-1.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -188,7 +188,7 @@ rpm-lang-4.18.2-1.azl3.x86_64.rpm
 rpm-libs-4.18.2-1.azl3.x86_64.rpm
 cpio-2.14-1.azl3.x86_64.rpm
 cpio-lang-2.14-1.azl3.x86_64.rpm
-e2fsprogs-libs-1.47.0-1.azl3.x86_64.rpm
+e2fsprogs-libs-1.47.0-2.azl3.x86_64.rpm
 libsolv-0.7.28-1.azl3.x86_64.rpm
 libsolv-devel-0.7.28-1.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -78,11 +78,11 @@ docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-13.azl3.noarch.rpm
 dwz-0.14-2.azl3.aarch64.rpm
 dwz-debuginfo-0.14-2.azl3.aarch64.rpm
-e2fsprogs-1.47.0-1.azl3.aarch64.rpm
-e2fsprogs-debuginfo-1.47.0-1.azl3.aarch64.rpm
-e2fsprogs-devel-1.47.0-1.azl3.aarch64.rpm
-e2fsprogs-lang-1.47.0-1.azl3.aarch64.rpm
-e2fsprogs-libs-1.47.0-1.azl3.aarch64.rpm
+e2fsprogs-1.47.0-2.azl3.aarch64.rpm
+e2fsprogs-debuginfo-1.47.0-2.azl3.aarch64.rpm
+e2fsprogs-devel-1.47.0-2.azl3.aarch64.rpm
+e2fsprogs-lang-1.47.0-2.azl3.aarch64.rpm
+e2fsprogs-libs-1.47.0-2.azl3.aarch64.rpm
 elfutils-0.189-3.azl3.aarch64.rpm
 elfutils-debuginfo-0.189-3.azl3.aarch64.rpm
 elfutils-default-yama-scope-0.189-3.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -81,11 +81,11 @@ docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-13.azl3.noarch.rpm
 dwz-0.14-2.azl3.x86_64.rpm
 dwz-debuginfo-0.14-2.azl3.x86_64.rpm
-e2fsprogs-1.47.0-1.azl3.x86_64.rpm
-e2fsprogs-debuginfo-1.47.0-1.azl3.x86_64.rpm
-e2fsprogs-devel-1.47.0-1.azl3.x86_64.rpm
-e2fsprogs-lang-1.47.0-1.azl3.x86_64.rpm
-e2fsprogs-libs-1.47.0-1.azl3.x86_64.rpm
+e2fsprogs-1.47.0-2.azl3.x86_64.rpm
+e2fsprogs-debuginfo-1.47.0-2.azl3.x86_64.rpm
+e2fsprogs-devel-1.47.0-2.azl3.x86_64.rpm
+e2fsprogs-lang-1.47.0-2.azl3.x86_64.rpm
+e2fsprogs-libs-1.47.0-2.azl3.x86_64.rpm
 elfutils-0.189-3.azl3.x86_64.rpm
 elfutils-debuginfo-0.189-3.azl3.x86_64.rpm
 elfutils-default-yama-scope-0.189-3.azl3.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix `e2fsprogs` package tests by removing a known failing test. According to [Linux from Scratch](https://www.linuxfromscratch.org/lfs/downloads/stable/LFS-BOOK-12.1-NOCHUNKS.html#ch-system-e2fsprogs), the `m_assume_storage_prezeroed` test is bad:
```
"One test named m_assume_storage_prezeroed is known to fail."
```
See also:
https://lfs.fsf.org.cn/lfs/errata/11.3/
https://github.com/tytso/e2fsprogs/issues/134


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- remove known-bad ptest in e2fsprogs

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=624595&view=results
