### PR TITLE
fix: remove libssp files to fix avahi hang

### DIFF
--- a/SPECS/avahi/avahi.spec
+++ b/SPECS/avahi/avahi.spec
@@ -3,7 +3,7 @@
 Summary:        Local network service discovery
 Name:           avahi
 Version:        0.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -175,6 +175,16 @@ rm -fv docs/INSTALL
 %build
 # Use autogen to kill rpaths
 rm -fv missing
+
+# AZL: avahi-daemon hangs in libssp's fail() routine when built with libssp support enabled.
+# This support is dynamically set when avahi's configure scans the current build environment
+# for the presence of the standalone libssp built by gcc. 
+# This standalone implementation of libssp is generally obsoleted in most modern systems,
+# and instead the libc's implementation of SSP is used.
+# So we will remove the libssp files from here if we find they are present. Avahi's configure
+# will instead use glibc's ssp implementation which does not hang and is proper.
+rm -fv /usr/lib64/libssp.*
+
 NOCONFIGURE=1 ./autogen.sh
 
 # Note that "--with-distro=none" is necessary to prevent initscripts from being installed
@@ -405,6 +415,9 @@ exit 0
 %endif
 
 %changelog
+* Wed Aug 14 2024 Chris Co <chrco@microsoft.com> - 0.8-2
+- Remove libssp from build environment to fix avahi-daemon hang
+
 * Wed Apr 20 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.8-1
 - Upgrade to latest upstream version to fix CVE-2017-6519
 - Add upstream patch to fix CVE-2021-3502


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
avahi-daemon hangs in libssp when built with libssp support enabled. SSP support is dynamically set when avahi's configure scans the current build environment for the presence of the standalone libssp built by gcc.

This standalone implementation of libssp is generally obsoleted in most modern systems, and instead the libc's implementation of SSP is used.

So we will remove the libssp files from here if we find they are present. Avahi's configure will instead use glibc's ssp implementation which does not hang and is proper.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #10013
-  https://dev.azure.com/mariner-org/ECF/_workitems/edit/7073

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [624801](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=624801&view=results)
