### PR TITLE
Image Customizer: Be robust to lsblk and fdisk output ordering.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -44,17 +44,20 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 	var partitionMetadataOutput []outputPartitionMetadata
 
 	// Extract partitions to files
-	for partitionNum := range diskPartitions {
-		partition := diskPartitions[partitionNum]
+	for _, partition := range diskPartitions {
 		if partition.Type != "part" {
 			continue
 		}
 
+		partitionNum, err := getPartitionNum(partition.Path)
+		if err != nil {
+			return err
+		}
+
 		partitionFilename := basename + "_" + strconv.Itoa(partitionNum)
 		rawFilename := partitionFilename + ".raw"
-		partitionLoopDevice := partition.Path
 
-		partitionFilepath, err := copyBlockDeviceToFile(outDir, partitionLoopDevice, rawFilename)
+		partitionFilepath, err := copyBlockDeviceToFile(outDir, partition.Path, rawFilename)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
@@ -22,6 +23,9 @@ import (
 
 var (
 	bootPartitionRegex = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
+
+	// Extract the partition number from the loopback partition path.
+	partitionNumberRegex = regexp.MustCompile(`^/dev/loop\d+p(\d+)$`)
 )
 
 func findPartitions(buildDir string, diskDevice string) ([]*safechroot.MountPoint, error) {
@@ -426,4 +430,22 @@ func getNonSpecialChrootMountPoints(imageChroot *safechroot.Chroot) []*safechroo
 			}
 		},
 	)
+}
+
+// Extract the partition number from the partition path.
+// Ideally, we would use `lsblk --output PARTN` instead of this. But that is only available in util-linux v2.39+.
+func getPartitionNum(partitionLoopDevice string) (int, error) {
+	match := partitionNumberRegex.FindStringSubmatch(partitionLoopDevice)
+	if match == nil {
+		return 0, fmt.Errorf("failed to find partition number in partition dev path (%s)", partitionLoopDevice)
+	}
+
+	numStr := match[1]
+
+	num, err := strconv.Atoi(numStr)
+	if match == nil {
+		return 0, fmt.Errorf("failed to parse partition number (%s):\n%w", numStr, err)
+	}
+
+	return num, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -34,9 +34,8 @@ func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomi
 
 	// Get the start sectors of all partitions
 	startSectors, err := getStartSectors(imageLoopDevice, len(diskPartitions)-1)
-	// Number of partitions is len(diskPartitions)-1 as diskPartitions[0] refers to the loop device for the image itself
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get partitions start sectors:\n%w", err)
 	}
 
 	for _, diskPartition := range diskPartitions {


### PR DESCRIPTION
It seems that in most cases, the lsblk and fdisk commands output partitions in the correct order. But this isn't actually guaranteed and there have been user reports of unusual errors that are the result of assuming this is the case. This change fixes the code so that it is agnostic to the ordering of the partitions.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran UTs.

