### PR TITLE
Toolkit bugfix: update_manifest.sh group name may not allways exist

### DIFF
--- a/toolkit/scripts/update_manifest.sh
+++ b/toolkit/scripts/update_manifest.sh
@@ -100,7 +100,7 @@ update_manifest() {
 
         echo "Manifests are different, updating ${basename}"
         mv "${BUILD_TEMP_MANIFEST_FILENAME}" "${filepath}"
-        chown "$CALLING_USER:$CALLING_USER" "${filepath}"
+        chown "$CALLING_USER:" "${filepath}"
     else
         echo "Manifests are the same, not updating ${basename}"
     fi


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There are situations where the calling username may not have an assotiated group name. Call chown without explicitly setting the group name and leave the group ownership the same.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Leave default group in place


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
-Prior to change
```
Manifests are the same, not updating toolchain_x86_64.txt
Running update_manifest.sh as azaugg
2024-08-21 19:29:47 URL:https://mariner3dailydevrepo.blob.core.windows.net/lkg/2024-08-21-3.0-dev.json [332/332] -> "/home/azaugg/CBL-Mariner/build/daily_build_id/2024-08-21-3.0-dev.json.V87Yhf" [1]
Checking for updates to pkggen_core_x86_64.txt manifest from https://raw.githubusercontent.com/microsoft/CBL-Mariner/ce47a7432e5e86214aa034dbe39fa935f4bbecbf/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
2024-08-21 19:29:48 URL:https://raw.githubusercontent.com/microsoft/CBL-Mariner/ce47a7432e5e86214aa034dbe39fa935f4bbecbf/toolkit/resources/manifests/package/pkggen_core_x86_64.txt [9525/9525] -> "/home/azaugg/CBL-Mariner/build/daily_build_id/pkggen_core_x86_64.txt.GzIGqJ" [1]
Manifests are different, updating pkggen_core_x86_64.txt
chown: invalid group: ‘azaugg:azaugg’
```

after change
```
Manifests are the same, not updating toolchain_x86_64.txt
Running update_manifest.sh as azaugg
2024-08-21 19:30:10 URL:https://mariner3dailydevrepo.blob.core.windows.net/lkg/2024-08-21-3.0-dev.json [332/332] -> "/home/azaugg/CBL-Mariner/build/daily_build_id/2024-08-21-3.0-dev.json.salvwh" [1]
Checking for updates to pkggen_core_x86_64.txt manifest from https://raw.githubusercontent.com/microsoft/CBL-Mariner/ce47a7432e5e86214aa034dbe39fa935f4bbecbf/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
2024-08-21 19:30:10 URL:https://raw.githubusercontent.com/microsoft/CBL-Mariner/ce47a7432e5e86214aa034dbe39fa935f4bbecbf/toolkit/resources/manifests/package/pkggen_core_x86_64.txt [9525/9525] -> "/home/azaugg/CBL-Mariner/build/daily_build_id/pkggen_core_x86_64.txt.GUDURe" [1]
```

https://microsoft.visualstudio.com/OS/_workitems/edit/53390877