### PR TITLE
Added systemd unit file to krb5 package for krb5kdc service

### DIFF
--- a/SPECS/krb5/krb5.signatures.json
+++ b/SPECS/krb5/krb5.signatures.json
@@ -1,6 +1,7 @@
 {
   "Signatures": {
     "krb5.conf": "54ce761ea22e55923f4b10b5a8ed306f98c579217b4253163437c33eec243720",
-    "krb5-1.21.3.tar.gz": "b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35"
+    "krb5-1.21.3.tar.gz": "b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35",
+    "krb5kdc.service": "5309bda6d5acb03b8fd1285c9c15aab49a756abbfce80ea378e86cf31723425e"
   }
 }

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -4,7 +4,7 @@
 Summary:        The Kerberos newtork authentication system
 Name:           krb5
 Version:        1.21.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -12,8 +12,10 @@ Group:          System Environment/Security
 URL:            https://web.mit.edu/kerberos/
 Source0:        https://kerberos.org/dist/%{name}/%{maj_version}/%{name}-%{version}.tar.gz
 Source1:        krb5.conf
+Source2:        krb5kdc.service
 BuildRequires:  e2fsprogs-devel
 BuildRequires:  openssl-devel
+BuildRequires:  systemd-rpm-macros
 Requires:       e2fsprogs-libs
 Requires:       openssl
 Provides:       %{name}-libs = %{version}-%{release}
@@ -62,6 +64,8 @@ autoconf &&
 make %{?_smp_mflags}
 
 %install
+mkdir -p %{buildroot}%{_unitdir}/
+cp %{SOURCE2} %{buildroot}%{_unitdir}/
 cd src
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make install DESTDIR=%{buildroot}
@@ -112,6 +116,7 @@ make check
 %{_mandir}/man8/*
 %{_datarootdir}/man/man5/.k5identity.5.gz
 %{_datarootdir}/man/man5/.k5login.5.gz
+%{_unitdir}/%{name}*.service
 
 %files devel
 %defattr(-,root,root)
@@ -125,6 +130,9 @@ make check
 %{_datarootdir}/locale/*
 
 %changelog
+* Wed Aug 21 2024 Andy Zaugg <azaugg@linkedin.com> - 1.21.3-2
+- Adding systemd unit file for krb5kdc service
+
 * Wed Jul 24 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.21.3-1
 - Auto-upgrade to 1.21.3 - CVE-2024-37371, CVE-2024-37370
 

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -15,7 +15,6 @@ Source1:        krb5.conf
 Source2:        krb5kdc.service
 BuildRequires:  e2fsprogs-devel
 BuildRequires:  openssl-devel
-BuildRequires:  systemd-rpm-macros
 Requires:       e2fsprogs-libs
 Requires:       openssl
 Provides:       %{name}-libs = %{version}-%{release}

--- a/SPECS/krb5/krb5kdc.service
+++ b/SPECS/krb5/krb5kdc.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kerberos 5 KDC
+After=syslog.target network.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/krb5kdc.pid
+EnvironmentFile=-/etc/sysconfig/krb5kdc
+ExecStart=/usr/sbin/krb5kdc -P /var/run/krb5kdc.pid $KRB5KDC_ARGS
+ExecReload=/bin/kill -HUP $MAINPID
+LimitNOFILE=32768
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adds a unit file to krb5 package

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adds a unit file to krb5 package, allowing krb5kdc which is the Kerberos Authentication Service and Key Distribution Center to start as a service.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
