### PR TITLE
Set ptest retries to 1 for PR package build check. (CP: #10133)

### DIFF
--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -102,6 +102,7 @@ extends:
                 steps:
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
+                      checkBuildRetries: "1"
                       customToolchainArtifactName: $(toolchainArtifactNameBase)_${{ configuration.name }}
                       isCheckBuild: true
                       isQuickRebuildPackages: true
@@ -109,8 +110,8 @@ extends:
                       maxCPU: "${{ configuration.maxCPUs }}"
                       pipArtifactFeeds: "mariner/Mariner-Pypi-Feed"
                       selfRepoName: self
-                      testSuiteName: "[${{ configuration.name }}] Package test"
                       testRerunList: "$(testListFromToolchain)"
+                      testSuiteName: "[${{ configuration.name }}] Package test"
 
                   - task: PublishPipelineArtifact@1
                     inputs:

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -6,6 +6,10 @@ parameters:
     type: string
     default: "$(Build.SourcesDirectory)"
 
+  - name: checkBuildRetries
+    type: string
+    default: ""
+
   - name: concurrentPackageBuilds
     type: number
     default: 12
@@ -19,10 +23,6 @@ parameters:
     default: "toolchain_built_rpms_all.tar.gz"
 
   - name: extraPackageRepos
-    type: string
-    default: ""
-
-  - name: testRerunList
     type: string
     default: ""
 
@@ -125,6 +125,10 @@ parameters:
     type: string
     default: ""
 
+  - name: testRerunList
+    type: string
+    default: ""
+
   - name: testSuiteName
     type: string
     default: "Package test"
@@ -176,6 +180,10 @@ steps:
         displayName: "Populate cache RPMs"
 
   - script: |
+      if [[ -n "${{ parameters.checkBuildRetries }}" ]]; then
+        check_build_retries_arg="CHECK_BUILD_RETRIES=${{ parameters.checkBuildRetries }}"
+      fi
+
       if [[ ${{ parameters.isDeltaBuild }} == "true" ]]; then
         delta_fetch_arg="DELTA_FETCH=y"
       elif [[ ${{ parameters.isDeltaBuild }} == "false" ]]; then
@@ -217,6 +225,7 @@ steps:
         SPECS_DIR="${{ parameters.buildRepoRoot }}/${{ parameters.specsFolderPath }}" \
         SRPM_PACK_LIST="${{ parameters.srpmPackList }}" \
         TEST_RERUN_LIST="${{ parameters.testRerunList }}" \
+        $check_build_retries_arg \
         $delta_fetch_arg \
         $max_cascading_rebuilds_arg \
         $quick_rebuild_packages_arg \

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -53,8 +53,8 @@ PACKAGE_CACHE_SUMMARY                ?=
 IMAGE_CACHE_SUMMARY                  ?=
 INITRD_CACHE_SUMMARY                 ?=
 PACKAGE_ARCHIVE                      ?=
-PACKAGE_BUILD_RETRIES                ?= 1
-CHECK_BUILD_RETRIES                  ?= 1
+PACKAGE_BUILD_RETRIES                ?= 0
+CHECK_BUILD_RETRIES                  ?= 0
 EXTRA_BUILD_LAYERS                   ?= 0
 REFRESH_WORKER_CHROOT                ?= y
 # Set to 0 to use the number of logical CPUs.

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -287,8 +287,8 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(no_repo_acl) $(preprocessed_file) $(chroo
 		--distro-release-version="$(RELEASE_VERSION)" \
 		--distro-build-number="$(BUILD_NUMBER)" \
 		--rpmmacros-file="$(TOOLCHAIN_MANIFESTS_DIR)/macros.override" \
-		--build-attempts="$(PACKAGE_BUILD_RETRIES)" \
-		--check-attempts="$(CHECK_BUILD_RETRIES)" \
+		--build-attempts="$$(($(PACKAGE_BUILD_RETRIES)+1))" \
+		--check-attempts="$$(($(CHECK_BUILD_RETRIES)+1))" \
 		$(if $(MAX_CASCADING_REBUILDS),--max-cascading-rebuilds="$(MAX_CASCADING_REBUILDS)") \
 		--extra-layers="$(EXTRA_BUILD_LAYERS)" \
 		--build-agent="chroot-agent" \

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -314,7 +314,7 @@ func testSRPMFile(agent buildagents.BuildAgent, checkAttempts int, basePackageNa
 	}, checkAttempts, retryDuration)
 
 	if checkFailed {
-		logger.Log.Debugf("Tests failed for '%s' after %d retries.", basePackageName, checkAttempts)
+		logger.Log.Debugf("Tests failed for '%s' after %d attempt(s).", basePackageName, checkAttempts)
 		err = nil
 	}
 	return


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

### Cherry-pick of #10133.

We have some flaky ptests in our set of packages. During daily builds we re-run them once in an attempt to separate most of such tests from constantly failing ones. This change aligns the PR check with the behaviour of the daily builds.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Original PR checks.