### PR TITLE
Toolkit: Fix readdirent toolchain errors for reusable chroots

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -89,9 +89,11 @@ clean-toolchain-rpms:
 
 # We need to clear the toolchain if we are using a daily build, or we change validation state. The filenames will all be
 # the same, but the actual .rpm files may be fundamentally different.
+# We leave the directory structure in place since docker based builds using re-usable chroots will have mounted the
+# toolchain subdirectories into the chroots. Removing the directories would break the mounts.
 $(STATUS_FLAGS_DIR)/toolchain_auto_cleanup.flag: $(STATUS_FLAGS_DIR)/daily_build_id.flag $(depend_VALIDATE_TOOLCHAIN_GPG)
 	@echo "Daily build ID or validation mode changed, sanitizing toolchain"
-	rm -rf $(TOOLCHAIN_RPMS_DIR)
+	find $(TOOLCHAIN_RPMS_DIR) -type f -name '*.rpm' -exec rm -f {} +
 	touch $@
 
 copy-toolchain-rpms:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When using the Docker compatible reusable chroots (`CHROOT_DIR=...`), a number of mount points need to be established external to the toolkit. One set is `./build/toolchain_rpms{x86_64,aarch64,noarch}:chroot-1/toolchainrpms/{x86_64,aarch64,noarch}` (and similar for other chroots).

As part of #9899 and #9963 the `$(STATUS_FLAGS_DIR)/toolchain_auto_cleanup.flag` was added which removes all toolchain rpms from the repo folder `./build/toolchain_rpms` (to remove the chance of unexpected conflicts with signatures or validation state). It simply removed the outer `./build/toolchain_rpms` directory, breaking the mountpoints in the docker environment.

Oddly, as the build runs, it re-creates the toolchain folder, and the mount points contained in it reappear, but are broken.
![image](https://github.com/user-attachments/assets/1ead6cb3-d252-469b-a05c-39b9e2ba3765)

The `pkgworker` tool has a function `removeLibArchivesFromSystem()` which walks the entirety of the chroot's filesystem looking for `*.la` files and removing them. The broken mount points are sufficiently "real" that `filepath.Walk()` will detect them and try to recursively walk them, but then hits `readdirent /toolchainrpms/aarch64: no such file or directory` (this is not unique to aarch64, it occurs on all three mounts).

We can resolve this by preserving the directory structure of the toolchain folder when running the sanitization step, so the mounts will remain intact.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use `find ... -exec rm ...` in `$(STATUS_FLAGS_DIR)/toolchain_auto_cleanup.flag` instead of a simple `rm` to avoid breaking docker chroot mounts.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/53339865/?triage=true

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Locally reproduced version of the pipeline VMs which use Docker + reusable chroots, running build commands manually.
