### PR TITLE
jx: Add patch to resolve CVE-2023-45288

### DIFF
--- a/SPECS/jx/CVE-2023-45288.patch
+++ b/SPECS/jx/CVE-2023-45288.patch
@@ -1,0 +1,83 @@
+From 63b4ddd633bde166d2b2800dbc6ad6a64f77b838 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Wed, 10 Jan 2024 13:41:39 -0800
+Subject: [PATCH] http2: close connections when receiving too many headers
+
+Maintaining HPACK state requires that we parse and process
+all HEADERS and CONTINUATION frames on a connection.
+When a request's headers exceed MaxHeaderBytes, we don't
+allocate memory to store the excess headers but we do
+parse them. This permits an attacker to cause an HTTP/2
+endpoint to read arbitrary amounts of data, all associated
+with a request which is going to be rejected.
+
+Set a limit on the amount of excess header frames we
+will process before closing a connection.
+
+Thanks to Bartek Nowotarski for reporting this issue.
+
+Fixes CVE-2023-45288
+Fixes golang/go#65051
+
+Change-Id: I15df097268df13bb5a9e9d3a5c04a8a141d850f6
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/2130527
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/net/+/576155
+Reviewed-by: Dmitri Shuralyov <dmitshur@google.com>
+Auto-Submit: Dmitri Shuralyov <dmitshur@golang.org>
+Reviewed-by: Than McIntosh <thanm@google.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/net/http2/frame.go | 31 ++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90..175c154 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1565,6 +1565,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1578,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the struture of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the struture of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}

--- a/SPECS/jx/jx.spec
+++ b/SPECS/jx/jx.spec
@@ -1,7 +1,7 @@
 Summary:        Command line tool for working with Jenkins X.
 Name:           jx
 Version:        3.10.116
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -27,6 +27,7 @@ Source0:        https://github.com/jenkins-x/jx/archive/v%{version}.tar.gz#/%{na
 #         See: https://reproducible-builds.org/docs/archives/
 #       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
 Source1:        %{name}-%{version}-vendor.tar.gz
+Patch0:         CVE-2023-45288.patch
 
 BuildRequires:  golang >= 1.17.1
 %global debug_package %{nil}
@@ -36,10 +37,12 @@ BuildRequires:  golang >= 1.17.1
 Command line tool for working with Jenkins X.
 
 %prep
-%autosetup -p1
+%autosetup -N
+# Apply vendor before patching
+tar --no-same-owner -xf %{SOURCE1}
+%autopatch -p1
 
 %build
-tar --no-same-owner -xf %{SOURCE1}
 export GOPATH=%{our_gopath}
 # No download use vednor cache locally
 sed -i 's/go mod download/# go mod download/' ./Makefile
@@ -60,6 +63,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./build/jx
 %{_bindir}/jx
 
 %changelog
+* Thu Aug 22 2024 Sumedh Sharma <sumsharma@microsoft.com> - 3.10.116-2
+- Add patch to resolve CVE-2023-45288
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.10.116-1
 - Auto-upgrade to 3.10.116 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch to resolve CVE-2023-45288

###### Change Log  <!-- REQUIRED -->
- Add patch file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-45288

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=626018&view=results)
