### PR TITLE
cdi:  CVE-2022-41717, CVE-2022-32149, CVE-2024-28180

### DIFF
--- a/SPECS/containerized-data-importer/CVE-2022-32149.patch
+++ b/SPECS/containerized-data-importer/CVE-2022-32149.patch
@@ -1,0 +1,59 @@
+From 434eadcdbc3b0256971992e8c70027278364c72c Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <bracewell@google.com>
+Date: Fri, 2 Sep 2022 09:35:37 -0700
+Subject: [PATCH] language: reject excessively large Accept-Language strings
+
+The BCP 47 tag parser has quadratic time complexity due to inherent
+aspects of its design. Since the parser is, by design, exposed to
+untrusted user input, this can be leveraged to force a program to
+consume significant time parsing Accept-Language headers.
+
+The parser cannot be easily rewritten to fix this behavior for
+various reasons. Instead the solution implemented in this CL is to
+limit the total complexity of tags passed into ParseAcceptLanguage
+by limiting the number of dashes in the string to 1000. This should
+be more than enough for the majority of real world use cases, where
+the number of tags being sent is likely to be in the single digits.
+
+Thanks to the OSS-Fuzz project for discovering this issue and to Adam
+Korczynski (ADA Logics) for writing the fuzz case and for reporting the
+issue.
+
+Fixes CVE-2022-32149
+Fixes golang/go#56152
+
+Change-Id: I7bda1d84cee2b945039c203f26869d58ee9374ae
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1565112
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/text/+/442235
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Auto-Submit: Roland Shoemaker <roland@golang.org>
+Run-TryBot: Roland Shoemaker <roland@golang.org>
+---
+ vendor/golang.org/x/text/language/parse.go      |  5 +++++
+ 1 files changed, 5 insertions(+)
+
+diff --git a/vendor/golang.org/x/text/language/parse.go b/vendor/golang.org/x/text/language/parse.go
+index 59b04100..b982d9e4 100644
+--- a/vendor/golang.org/x/text/language/parse.go
++++ b/vendor/golang.org/x/text/language/parse.go
+@@ -147,6 +147,7 @@ func update(b *language.Builder, part ...interface{}) (err error) {
+ }
+ 
+ var errInvalidWeight = errors.New("ParseAcceptLanguage: invalid weight")
++var errTagListTooLarge = errors.New("tag list exceeds max length")
+ 
+ // ParseAcceptLanguage parses the contents of an Accept-Language header as
+ // defined in http://www.ietf.org/rfc/rfc2616.txt and returns a list of Tags and
+@@ -164,6 +165,10 @@ func ParseAcceptLanguage(s string) (tag []Tag, q []float32, err error) {
+ 		}
+ 	}()
+ 
++	if strings.Count(s, "-") > 1000 {
++		return nil, nil, errTagListTooLarge
++	}
++
+ 	var entry string
+ 	for s != "" {
+ 		if entry, s = split(s, ','); entry == "" {

--- a/SPECS/containerized-data-importer/CVE-2022-41717.patch
+++ b/SPECS/containerized-data-importer/CVE-2022-41717.patch
@@ -1,0 +1,70 @@
+From 1e63c2f08a10a150fa02c50ece89b340ae64efe4 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Tue, 06 Dec 2022 11:57:53 -0800
+Subject: [PATCH] http2: limit canonical header cache by bytes, not entries
+
+The canonical header cache is a per-connection cache mapping header
+keys to their canonicalized form. (For example, "foo-bar" => "Foo-Bar").
+We limit the number of entries in the cache to prevent an attacker
+from consuming unbounded amounts of memory by sending many unique
+keys, but a small number of very large keys can still consume an
+unreasonable amount of memory.
+
+Track the amount of memory consumed by the cache and limit it based
+on memory rather than number of entries.
+
+Thanks to Josselin Costanzi for reporting this issue.
+
+For golang/go#56350
+
+Change-Id: I41db4c9823ed5bf371a9881accddff1268489b16
+Reviewed-on: https://go-review.googlesource.com/c/net/+/455635
+Reviewed-by: Jenny Rakoczy <jenny@golang.org>
+Run-TryBot: Damien Neil <dneil@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+---
+
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index e35a76c..4eb7617 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -527,6 +527,7 @@
+ 	headerTableSize             uint32
+ 	peerMaxHeaderListSize       uint32            // zero means unknown (default)
+ 	canonHeader                 map[string]string // http2-lower-case -> Go-Canonical-Case
++	canonHeaderKeysSize         int               // canonHeader keys size in bytes
+ 	writingFrame                bool              // started writing a frame (on serve goroutine or separate)
+ 	writingFrameAsync           bool              // started a frame on its own goroutine but haven't heard back on wroteFrameCh
+ 	needsFrameFlush             bool              // last frame write wasn't a flush
+@@ -766,6 +767,13 @@
+ 	}
+ }
+ 
++// maxCachedCanonicalHeadersKeysSize is an arbitrarily-chosen limit on the size
++// of the entries in the canonHeader cache.
++// This should be larger than the size of unique, uncommon header keys likely to
++// be sent by the peer, while not so high as to permit unreasonable memory usage
++// if the peer sends an unbounded number of unique header keys.
++const maxCachedCanonicalHeadersKeysSize = 2048
++
+ func (sc *serverConn) canonicalHeader(v string) string {
+ 	sc.serveG.check()
+ 	buildCommonHeaderMapsOnce()
+@@ -781,14 +789,10 @@
+ 		sc.canonHeader = make(map[string]string)
+ 	}
+ 	cv = http.CanonicalHeaderKey(v)
+-	// maxCachedCanonicalHeaders is an arbitrarily-chosen limit on the number of
+-	// entries in the canonHeader cache. This should be larger than the number
+-	// of unique, uncommon header keys likely to be sent by the peer, while not
+-	// so high as to permit unreasonable memory usage if the peer sends an unbounded
+-	// number of unique header keys.
+-	const maxCachedCanonicalHeaders = 32
+-	if len(sc.canonHeader) < maxCachedCanonicalHeaders {
++	size := 100 + len(v)*2 // 100 bytes of map overhead + key + value
++	if sc.canonHeaderKeysSize+size <= maxCachedCanonicalHeadersKeysSize {
+ 		sc.canonHeader[v] = cv
++		sc.canonHeaderKeysSize += size
+ 	}
+ 	return cv
+ }

--- a/SPECS/containerized-data-importer/CVE-2024-28180.patch
+++ b/SPECS/containerized-data-importer/CVE-2024-28180.patch
@@ -1,0 +1,180 @@
+From 0dd4dd541c665fb292d664f77604ba694726f298 Mon Sep 17 00:00:00 2001
+From: Jacob Hoffman-Andrews <github@hoffman-andrews.com>
+Date: Thu, 7 Mar 2024 14:25:21 -0800
+Subject: [PATCH] v2: backport decompression limit fix (#109)
+
+Backport from #107.
+---
+ CHANGELOG.md     | 84 ++++++++++++++++++++++++++++++++++++++++++++++++
+ crypter.go       |  6 ++++
+ encoding.go      | 21 +++++++++---
+ encoding_test.go | 34 ++++++++++++++++++++
+ 4 files changed, 141 insertions(+), 4 deletions(-)
+ create mode 100644 CHANGELOG.md
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+new file mode 100644
+index 0000000..8e6e913
+--- /dev/null
++++ b/CHANGELOG.md
+@@ -0,0 +1,84 @@
++# v4.0.1
++
++## Fixed
++
++ - An attacker could send a JWE containing compressed data that used large
++   amounts of memory and CPU when decompressed by `Decrypt` or `DecryptMulti`.
++   Those functions now return an error if the decompressed data would exceed
++   250kB or 10x the compressed size (whichever is larger). Thanks to
++   Enze Wang@Alioth and Jianjun Chen@Zhongguancun Lab (@zer0yu and @chenjj)
++   for reporting.
++
++# v4.0.0
++
++This release makes some breaking changes in order to more thoroughly
++address the vulnerabilities discussed in [Three New Attacks Against JSON Web
++Tokens][1], "Sign/encrypt confusion", "Billion hash attack", and "Polyglot
++token".
++
++## Changed
++
++ - Limit JWT encryption types (exclude password or public key types) (#78)
++ - Enforce minimum length for HMAC keys (#85)
++ - jwt: match any audience in a list, rather than requiring all audiences (#81)
++ - jwt: accept only Compact Serialization (#75)
++ - jws: Add expected algorithms for signatures (#74)
++ - Require specifying expected algorithms for ParseEncrypted,
++   ParseSigned, ParseDetached, jwt.ParseEncrypted, jwt.ParseSigned,
++   jwt.ParseSignedAndEncrypted (#69, #74)
++   - Usually there is a small, known set of appropriate algorithms for a program
++     to use and it's a mistake to allow unexpected algorithms. For instance the
++     "billion hash attack" relies in part on programs accepting the PBES2
++     encryption algorithm and doing the necessary work even if they weren't
++     specifically configured to allow PBES2.
++ - Revert "Strip padding off base64 strings" (#82)
++  - The specs require base64url encoding without padding.
++ - Minimum supported Go version is now 1.21
++
++## Added
++
++ - ParseSignedCompact, ParseSignedJSON, ParseEncryptedCompact, ParseEncryptedJSON.
++   - These allow parsing a specific serialization, as opposed to ParseSigned and
++     ParseEncrypted, which try to automatically detect which serialization was
++     provided. It's common to require a specific serialization for a specific
++     protocol - for instance JWT requires Compact serialization.
++
++[1]: https://i.blackhat.com/BH-US-23/Presentations/US-23-Tervoort-Three-New-Attacks-Against-JSON-Web-Tokens.pdf
++
++# v3.0.3
++
++## Fixed
++
++ - Limit decompression output size to prevent a DoS. Backport from v4.0.1.
++
++# v3.0.2
++
++## Fixed
++
++ - DecryptMulti: handle decompression error (#19)
++
++## Changed
++
++ - jwe/CompactSerialize: improve performance (#67)
++ - Increase the default number of PBKDF2 iterations to 600k (#48)
++ - Return the proper algorithm for ECDSA keys (#45)
++
++## Added
++
++ - Add Thumbprint support for opaque signers (#38)
++
++# v3.0.1
++
++## Fixed
++
++ - Security issue: an attacker specifying a large "p2c" value can cause
++   JSONWebEncryption.Decrypt and JSONWebEncryption.DecryptMulti to consume large
++   amounts of CPU, causing a DoS. Thanks to Matt Schwager (@mschwager) for the
++   disclosure and to Tom Tervoort for originally publishing the category of attack.
++   https://i.blackhat.com/BH-US-23/Presentations/US-23-Tervoort-Three-New-Attacks-Against-JSON-Web-Tokens.pdf
++
++# v2.6.3
++
++## Fixed
++
++ - Limit decompression output size to prevent a DoS. Backport from v4.0.1.
+diff --git a/vendor/gopkg.in/square/go-jose.v2/crypter.go b/vendor/gopkg.in/square/go-jose.v2/crypter.go
+index 73aab0f..0ae2e5e 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/crypter.go
++++ b/vendor/gopkg.in/square/go-jose.v2/crypter.go
+@@ -406,6 +406,9 @@ func (ctx *genericEncrypter) Options() EncrypterOptions {
+ // Decrypt and validate the object and return the plaintext. Note that this
+ // function does not support multi-recipient, if you desire multi-recipient
+ // decryption use DecryptMulti instead.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >10x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) {
+ 	headers := obj.mergedHeaders(nil)
+ 
+@@ -470,6 +473,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error)
+ // with support for multiple recipients. It returns the index of the recipient
+ // for which the decryption was successful, the merged headers for that recipient,
+ // and the plaintext.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >3x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Header, []byte, error) {
+ 	globalHeaders := obj.mergedHeaders(nil)
+ 
+diff --git a/vendor/gopkg.in/square/go-jose.v2/encoding.go b/vendor/gopkg.in/square/go-jose.v2/encoding.go
+index 40b688b..636f6c8 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/encoding.go
++++ b/vendor/gopkg.in/square/go-jose.v2/encoding.go
+@@ -21,6 +21,7 @@ import (
+ 	"compress/flate"
+ 	"encoding/base64"
+ 	"encoding/binary"
++	"fmt"
+ 	"io"
+ 	"math/big"
+ 	"strings"
+@@ -85,7 +86,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
+ 	}
+ }
+ 
+-// Compress with DEFLATE
++// deflate compresses the input.
+ func deflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 
+@@ -97,15 +98,27 @@ func deflate(input []byte) ([]byte, error) {
+ 	return output.Bytes(), err
+ }
+ 
+-// Decompress with DEFLATE
++// inflate decompresses the input.
++//
++// Errors if the decompressed data would be >250kB or >10x the size of the
++// compressed data, whichever is larger.
+ func inflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 	reader := flate.NewReader(bytes.NewBuffer(input))
+ 
+-	_, err := io.Copy(output, reader)
+-	if err != nil {
++	maxCompressedSize := 10 * int64(len(input))
++	if maxCompressedSize < 250000 {
++		maxCompressedSize = 250000
++	}
++
++	limit := maxCompressedSize + 1
++	n, err := io.CopyN(output, reader, limit)
++	if err != nil && err != io.EOF {
+ 		return nil, err
+ 	}
++	if n == limit {
++		return nil, fmt.Errorf("uncompressed data would be too large (>%d bytes)", maxCompressedSize)
++	}
+ 
+ 	err = reader.Close()
+ 	return output.Bytes(), err

--- a/SPECS/containerized-data-importer/containerized-data-importer.spec
+++ b/SPECS/containerized-data-importer/containerized-data-importer.spec
@@ -18,7 +18,7 @@
 Summary:        Container native virtualization
 Name:           containerized-data-importer
 Version:        1.55.0
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -35,6 +35,9 @@ Provides:       cdi = %{version}-%{release}
 ExclusiveArch:  x86_64 aarch64
 Patch0:         CVE-2023-44487.patch
 Patch1:         CVE-2024-3727.patch
+Patch2:         CVE-2022-41717.patch
+Patch3:         CVE-2022-32149.patch
+Patch4:         CVE-2024-28180.patch
 
 %description
 Containerized-Data-Importer (CDI) is a persistent storage management add-on for Kubernetes
@@ -202,6 +205,11 @@ install -m 0644 _out/manifests/release/cdi-cr.yaml %{buildroot}%{_datadir}/cdi/m
 %{_datadir}/cdi/manifests
 
 %changelog
+* Wed Aug 06 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 1.55.0-20
+- Address CVE-2022-41717
+- Address CVE-2022-32149
+- Address CVE-2024-28180
+
 * Thu Jun 06 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 1.55.0-19
 - Address CVE-2024-3727 by patching vendored github.com/containers/image
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
- Address CVE-2022-41717
- Address CVE-2022-32149
- Address CVE-2024-28180

###### Change Log  <!-- REQUIRED -->
- Create patches from upstream commits
- Adjust patch paths and remove paths that are not vendored

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-41717
- https://nvd.nist.gov/vuln/detail/CVE-2022-32149
- https://nvd.nist.gov/vuln/detail/CVE-2024-28180

###### Test Methodology
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=626235&view=results
- fasttrack/2.0: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=633961&view=results
