### PR TITLE
fix: change bfq patch to select "none" scheduler as default

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -14,7 +14,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -86,6 +86,9 @@ popd
 /usr/share/man/man7/systemd-boot.7.gz
 
 %changelog
+* Fri Aug 23 2024 Chris Co <chrco@microsoft.com> - 255-17
+- Bump release to match systemd spec
+
 * Wed Jul 10 2024 Thien Trung Vuong <tvuong@microsoft.com> - 255-16
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/use-none-scheduler.patch
+++ b/SPECS/systemd/use-none-scheduler.patch
@@ -3,6 +3,14 @@ From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
 Date: Wed, 14 Aug 2019 15:57:42 +0200
 Subject: [PATCH] udev: use bfq as the default scheduler
 
+NOTE change for azurelinux:
+
+This patch from Fedora has been renamed from "bfq" to "none" and adjusted
+to set the udev rule's i/o scheduler from "bfq" to "none" which is the
+preferred default i/o scheduler in Azure VMs and for NVMe drives.
+
+Original Fedora commit message below:
+
 As requested in https://bugzilla.redhat.com/show_bug.cgi?id=1738828.
 Test results are that bfq seems to behave better and more consistently on
 typical hardware. The kernel does not have a configuration option to set
@@ -25,7 +33,7 @@ index 0000000000..850b64540e
 +
 +ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", \
 +  KERNEL=="mmcblk*[0-9]|msblk*[0-9]|mspblk*[0-9]|sd*[!0-9]|sr*", \
-+  ATTR{queue/scheduler}="bfq"
++  ATTR{queue/scheduler}="none"
 diff --git a/rules.d/meson.build b/rules.d/meson.build
 index 20fca222da..94fee9d7c0 100644
 --- a/rules.d/meson.build


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
On Azure, it is recommended to use an i/o scheduler that passes the scheduling decisions to the underlying Hyper-V hypervisor. In our case, we should use the "none" scheduler, which is also ideal for fast random I/O devices like NVMe. So we update Fedora's bfq patch to change the udev rule to select "none" instead of Fedora's default Budget Fair Queuing (bfq) and rename the patch from referencing "bfq" to "none".

https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/best-practices-for-running-linux-on-hyper-v#use-io-scheduler-noopnone-for-better-disk-io-performance

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/53188956
- https://microsoft.visualstudio.com/OS/_workitems/edit/53416283

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [626715](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=626715&view=results)
