### PR TITLE
libsndfile: Add patch to resolve CVE-2022-33065

### DIFF
--- a/SPECS/libsndfile/CVE-2022-33065.patch
+++ b/SPECS/libsndfile/CVE-2022-33065.patch
@@ -1,0 +1,1005 @@
+From db88d0d6878ca9147874443b791254b29d2a9543 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 10:48:49 -0400
+Subject: [PATCH 02/17] ossfuzz: remove extraneous read_buffer pointer
+
+Clang complains about the
+sndfile_fuzz_header.h:sf_init_file():read_buffer pointer being unused
+within its scope. This seems to be true, and a survey of the commit
+which added it didn't indicate that this is intentional.
+
+Remove the unused read_buffer pointer.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ ossfuzz/sndfile_fuzz_header.h | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/ossfuzz/sndfile_fuzz_header.h b/ossfuzz/sndfile_fuzz_header.h
+index 898aec441..e82e9f8c0 100644
+--- a/ossfuzz/sndfile_fuzz_header.h
++++ b/ossfuzz/sndfile_fuzz_header.h
+@@ -88,8 +88,7 @@ int sf_init_file(const uint8_t *data,
+                 SNDFILE **sndfile, 
+                 VIO_DATA *vio_data, 
+                 SF_VIRTUAL_IO *vio, SF_INFO *sndfile_info)
+-{  float* read_buffer = NULL ;
+-
++{
+    // Initialize the virtual IO structure.
+    vio->get_filelen = vfget_filelen ;
+    vio->seek = vfseek ;
+
+From 98fc031b1d65a1a5bfc9ab53fd3dff88ad0b4e11 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 11:10:59 -0400
+Subject: [PATCH 03/17] ossfuzz: fix sometimes undefined default case
+
+When vfseek() is called with a whence that is not SEEK_SET, SEEK_CUR, or
+SEEK_END, it enters a default switch-case that does not set the
+new_offset variable. The function then continues on and uses that unset
+variable.
+
+Linux 3.1+ stdio allows for SEEK_DATA and SEEK_HOLE whence values,
+though they aren't conceptually supported by the vfseek() function.
+
+Handle this case more sanely (and consistently with the lseek()
+function) by setting errno to EINVAL when whence is an unsupported
+value, and immediately returning -1 to flag the error.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ ossfuzz/sndfile_fuzz_header.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/ossfuzz/sndfile_fuzz_header.h b/ossfuzz/sndfile_fuzz_header.h
+index e82e9f8c0..a95b097b6 100644
+--- a/ossfuzz/sndfile_fuzz_header.h
++++ b/ossfuzz/sndfile_fuzz_header.h
+@@ -1,6 +1,8 @@
+ #ifndef SNDFILE_FUZZ_HEADER_H
+ #define SNDFILE_FUZZ_HEADER_H
+ 
++#include <errno.h>
++
+ typedef struct
+ {
+   sf_count_t offset ;
+@@ -32,6 +34,9 @@ static sf_count_t vfseek (sf_count_t offset, int whence, void *user_data)
+         break ;
+ 
+     default :
++        // SEEK_DATA and SEEK_HOLE are not supported by this function.
++        errno = EINVAL ;
++        return -1 ;
+         break ;
+   }
+ 
+
+From 58469844b5fb675e5bbe919fceda2db77ec868a7 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 13:22:06 -0400
+Subject: [PATCH 04/17] Makefile.am: fixup ossfuzz LDADD
+
+Automake cannot properly associate the libstandaloneengine.la target as
+a dependency of the other ossfuzz targets, because it is specified with
+the wrong path - leading to a make error when trying to build with
+`--enable-ossfuzzers`.
+
+Specify the correct path.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 324d76329..55e8cf632 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -456,7 +456,7 @@ if USE_OSSFUZZ_STATIC
+ FUZZ_LDADD = $(LIB_FUZZING_ENGINE)
+ FUZZ_FLAG =
+ else
+-FUZZ_LDADD = libstandaloneengine.la
++FUZZ_LDADD = ossfuzz/libstandaloneengine.la
+ FUZZ_FLAG =
+ endif
+ endif
+
+From 57ad7b69431073d52312a69addd46221029ccb08 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Tue, 10 Oct 2023 16:10:34 -0400
+Subject: [PATCH 05/17] mat4/mat5: fix int overflow in dataend calculation
+
+The clang sanitizer warns of a possible signed integer overflow when
+calculating the `dataend` value in `mat4_read_header()`.
+
+```
+src/mat4.c:323:41: runtime error: signed integer overflow: 205 * -100663296 cannot be represented in type 'int'
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/mat4.c:323:41 in
+src/mat4.c:323:48: runtime error: signed integer overflow: 838860800 * 4 cannot be represented in type 'int'
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/mat4.c:323:48 in
+```
+
+Cast the offending `rows` and `cols` ints to `sf_count_t` (the type of
+`dataend` before performing the calculation, to avoid the issue.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/789
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/mat4.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mat4.c b/src/mat4.c
+index 0b1b414b4..575683ba1 100644
+--- a/src/mat4.c
++++ b/src/mat4.c
+@@ -320,7 +320,7 @@ mat4_read_header (SF_PRIVATE *psf)
+ 				psf->filelength - psf->dataoffset, psf->sf.channels * psf->sf.frames * psf->bytewidth) ;
+ 		}
+ 	else if ((psf->filelength - psf->dataoffset) > psf->sf.channels * psf->sf.frames * psf->bytewidth)
+-		psf->dataend = psf->dataoffset + rows * cols * psf->bytewidth ;
++		psf->dataend = psf->dataoffset + (sf_count_t) rows * (sf_count_t) cols * psf->bytewidth ;
+ 
+ 	psf->datalength = psf->filelength - psf->dataoffset - psf->dataend ;
+ 
+
+From 56e6c5408f1ee6d476b234c105fb28b4998e811b Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 16:36:02 -0400
+Subject: [PATCH 06/17] au: avoid int overflow while calculating data_end
+
+At several points in au_read_header(), we calculate the functional end
+of the data segment by adding the (int)au_fmt.dataoffset and the
+(int)au_fmt.datasize. This can overflow the implicit int_32 return value
+and cause undefined behavior.
+
+Instead, precalculate the value and assign it to a 64-bit
+(sf_count_t)data_end variable.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/au.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/au.c b/src/au.c
+index 62bd691d6..f68f25871 100644
+--- a/src/au.c
++++ b/src/au.c
+@@ -291,6 +291,7 @@ static int
+ au_read_header (SF_PRIVATE *psf)
+ {	AU_FMT	au_fmt ;
+ 	int		marker, dword ;
++	sf_count_t data_end ;
+ 
+ 	memset (&au_fmt, 0, sizeof (au_fmt)) ;
+ 	psf_binheader_readf (psf, "pm", 0, &marker) ;
+@@ -317,14 +318,15 @@ au_read_header (SF_PRIVATE *psf)
+ 		return SFE_AU_EMBED_BAD_LEN ;
+ 		} ;
+ 
++	data_end = (sf_count_t) au_fmt.dataoffset + (sf_count_t) au_fmt.datasize ;
+ 	if (psf->fileoffset > 0)
+-	{	psf->filelength = au_fmt.dataoffset + au_fmt.datasize ;
++	{	psf->filelength = data_end ;
+ 		psf_log_printf (psf, "  Data Size   : %d\n", au_fmt.datasize) ;
+ 		}
+-	else if (au_fmt.datasize == -1 || au_fmt.dataoffset + au_fmt.datasize == psf->filelength)
++	else if (au_fmt.datasize == -1 || data_end == psf->filelength)
+ 		psf_log_printf (psf, "  Data Size   : %d\n", au_fmt.datasize) ;
+-	else if (au_fmt.dataoffset + au_fmt.datasize < psf->filelength)
+-	{	psf->filelength = au_fmt.dataoffset + au_fmt.datasize ;
++	else if (data_end < psf->filelength)
++	{	psf->filelength = data_end ;
+ 		psf_log_printf (psf, "  Data Size   : %d\n", au_fmt.datasize) ;
+ 		}
+ 	else
+
+From 839fa9131820d689b2038c81531b618b2932fbe3 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 16:46:29 -0400
+Subject: [PATCH 07/17] avr: fix int overflow in avr_read_header()
+
+Pre-cast hdr.frames to sf_count_t, to provide the calculation with
+enough numeric space to avoid an int-overflow.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/avr.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/avr.c b/src/avr.c
+index 6c78ff69b..1bc1ffc90 100644
+--- a/src/avr.c
++++ b/src/avr.c
+@@ -162,7 +162,7 @@ avr_read_header (SF_PRIVATE *psf)
+ 	psf->endian = SF_ENDIAN_BIG ;
+ 
+  	psf->dataoffset = AVR_HDR_SIZE ;
+-	psf->datalength = hdr.frames * (hdr.rez / 8) ;
++	psf->datalength = (sf_count_t) hdr.frames * (hdr.rez / 8) ;
+ 
+ 	if (psf->fileoffset > 0)
+ 		psf->filelength = AVR_HDR_SIZE + psf->datalength ;
+
+From 1116fa173ea8785c9d881936b2174be6a58c0055 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 16:54:21 -0400
+Subject: [PATCH 08/17] sds: fix int overflow warning in sample calculations
+
+The sds_*byte_read() functions compose their uint_32 sample buffers by
+shifting 7bit samples into a 32bit wide buffer, and adding them
+together. Because the 7bit samples are stored in 32bit ints, code
+fuzzers become concerned that the addition operation can overflow and
+cause undefined behavior.
+
+Instead, bitwise-OR the bytes together - which should accomplish the
+same arithmetic operation, without risking an int-overflow.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Do the same for the 3byte and 4byte read functions.
+---
+ src/sds.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/sds.c b/src/sds.c
+index 6bc761716..2a0f164c3 100644
+--- a/src/sds.c
++++ b/src/sds.c
+@@ -454,7 +454,7 @@ sds_2byte_read (SF_PRIVATE *psf, SDS_PRIVATE *psds)
+ 
+ 	ucptr = psds->read_data + 5 ;
+ 	for (k = 0 ; k < 120 ; k += 2)
+-	{	sample = arith_shift_left (ucptr [k], 25) + arith_shift_left (ucptr [k + 1], 18) ;
++	{	sample = arith_shift_left (ucptr [k], 25) | arith_shift_left (ucptr [k + 1], 18) ;
+ 		psds->read_samples [k / 2] = (int) (sample - 0x80000000) ;
+ 		} ;
+ 
+@@ -498,7 +498,7 @@ sds_3byte_read (SF_PRIVATE *psf, SDS_PRIVATE *psds)
+ 
+ 	ucptr = psds->read_data + 5 ;
+ 	for (k = 0 ; k < 120 ; k += 3)
+-	{	sample = (((uint32_t) ucptr [k]) << 25) + (ucptr [k + 1] << 18) + (ucptr [k + 2] << 11) ;
++	{	sample = (((uint32_t) ucptr [k]) << 25) | (ucptr [k + 1] << 18) | (ucptr [k + 2] << 11) ;
+ 		psds->read_samples [k / 3] = (int) (sample - 0x80000000) ;
+ 		} ;
+ 
+@@ -542,7 +542,7 @@ sds_4byte_read (SF_PRIVATE *psf, SDS_PRIVATE *psds)
+ 
+ 	ucptr = psds->read_data + 5 ;
+ 	for (k = 0 ; k < 120 ; k += 4)
+-	{	sample = (((uint32_t) ucptr [k]) << 25) + (ucptr [k + 1] << 18) + (ucptr [k + 2] << 11) + (ucptr [k + 3] << 4) ;
++	{	sample = (((uint32_t) ucptr [k]) << 25) | (ucptr [k + 1] << 18) | (ucptr [k + 2] << 11) | (ucptr [k + 3] << 4) ;
+ 		psds->read_samples [k / 4] = (int) (sample - 0x80000000) ;
+ 		} ;
+ 
+
+From 23188c9b1c34f06ca7f17243425d59403e9eb0db Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 17:26:51 -0400
+Subject: [PATCH 09/17] aiff: fix int overflow when counting header elements
+
+aiff_read_basc_chunk() tries to count the AIFF header size by keeping
+track of the bytes returned by psf_binheader_readf(). Though improbable,
+it is technically possible for these added bytes to exceed the int-sized
+`count` accumulator.
+
+Use a 64-bit sf_count_t type for `count`, to ensure that it always has
+enough numeric space.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/aiff.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/aiff.c b/src/aiff.c
+index ac3655e9d..6d8f1bc83 100644
+--- a/src/aiff.c
++++ b/src/aiff.c
+@@ -1702,7 +1702,7 @@ static int
+ aiff_read_basc_chunk (SF_PRIVATE * psf, int datasize)
+ {	const char * type_str ;
+ 	basc_CHUNK bc ;
+-	int count ;
++	sf_count_t count ;
+ 
+ 	count = psf_binheader_readf (psf, "E442", &bc.version, &bc.numBeats, &bc.rootNote) ;
+ 	count += psf_binheader_readf (psf, "E222", &bc.scaleType, &bc.sigNumerator, &bc.sigDenominator) ;
+
+From 00bd0320d895ef5f3027c75a9df26546bc18f8b7 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 17:43:02 -0400
+Subject: [PATCH 10/17] ircam: fix int overflow in ircam_read_header()
+
+When reading the IRCAM header, it is possible for the calculated
+blockwidth to exceed the bounds of a signed int32.
+
+Use a 64bit sf_count_t to store the blockwidth.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/common.h |  2 +-
+ src/ircam.c  | 10 +++++-----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/common.h b/src/common.h
+index cd9ac8b07..01f6ae095 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -439,7 +439,7 @@ typedef struct sf_private_tag
+ 	sf_count_t		datalength ;	/* Length in bytes of the audio data. */
+ 	sf_count_t		dataend ;		/* Offset to file tailer. */
+ 
+-	int				blockwidth ;	/* Size in bytes of one set of interleaved samples. */
++	sf_count_t		blockwidth ;	/* Size in bytes of one set of interleaved samples. */
+ 	int				bytewidth ;		/* Size in bytes of one sample (one channel). */
+ 
+ 	void			*dither ;
+diff --git a/src/ircam.c b/src/ircam.c
+index 8e7cdba81..3d73ba442 100644
+--- a/src/ircam.c
++++ b/src/ircam.c
+@@ -171,35 +171,35 @@ ircam_read_header	(SF_PRIVATE *psf)
+ 	switch (encoding)
+ 	{	case IRCAM_PCM_16 :
+ 				psf->bytewidth = 2 ;
+-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
++				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
+ 
+ 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_PCM_16 ;
+ 				break ;
+ 
+ 		case IRCAM_PCM_32 :
+ 				psf->bytewidth = 4 ;
+-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
++				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
+ 
+ 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_PCM_32 ;
+ 				break ;
+ 
+ 		case IRCAM_FLOAT :
+ 				psf->bytewidth = 4 ;
+-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
++				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
+ 
+ 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_FLOAT ;
+ 				break ;
+ 
+ 		case IRCAM_ALAW :
+ 				psf->bytewidth = 1 ;
+-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
++				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
+ 
+ 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_ALAW ;
+ 				break ;
+ 
+ 		case IRCAM_ULAW :
+ 				psf->bytewidth = 1 ;
+-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
++				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
+ 
+ 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_ULAW ;
+ 				break ;
+
+From 590608bbbded2ca0966dc89c5d9b6bf659f4cb71 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Wed, 11 Oct 2023 16:12:22 -0400
+Subject: [PATCH 11/17] mat4/mat5: fix int overflow when calculating blockwidth
+
+Pre-cast the components of the blockwidth calculation to sf_count_t to
+avoid overflowing integers during calculation.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/mat4.c | 2 +-
+ src/mat5.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/mat4.c b/src/mat4.c
+index 575683ba1..9f046f0c6 100644
+--- a/src/mat4.c
++++ b/src/mat4.c
+@@ -104,7 +104,7 @@ mat4_open	(SF_PRIVATE *psf)
+ 
+ 	psf->container_close = mat4_close ;
+ 
+-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
++	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
+ 
+ 	switch (subformat)
+ 	{	case SF_FORMAT_PCM_16 :
+diff --git a/src/mat5.c b/src/mat5.c
+index da5a6eca0..20f0ea64b 100644
+--- a/src/mat5.c
++++ b/src/mat5.c
+@@ -114,7 +114,7 @@ mat5_open	(SF_PRIVATE *psf)
+ 
+ 	psf->container_close = mat5_close ;
+ 
+-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
++	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
+ 
+ 	switch (subformat)
+ 	{	case SF_FORMAT_PCM_U8 :
+
+From 4ec860910a4ee91ed4fdf1c0a49f2dad96d595c9 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Mon, 16 Oct 2023 12:37:47 -0400
+Subject: [PATCH 12/17] common: fix int overflow in psf_binheader_readf()
+
+The psf_binheader_readf() function attempts to count and return the
+number of bytes traversed in the header. During this accumulation, it is
+possible to overflow the int-sized byte_count variable.
+
+Avoid this overflow by checking that the accumulated bytes do not exceed
+INT_MAX and throwing an error if they do. This implies that files with
+multi-gigabyte headers threaten to produce this error, but I imagine
+those files don't really exist - and this error is better than the
+undefined behavior which would have resulted previously.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/common.c | 36 ++++++++++++++++++++++++------------
+ 1 file changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/src/common.c b/src/common.c
+index b877aa864..8982379a4 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -18,6 +18,7 @@
+ 
+ #include <config.h>
+ 
++#include <limits.h>
+ #include <stdarg.h>
+ #include <string.h>
+ #if HAVE_UNISTD_H
+@@ -990,6 +991,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 	double			*doubleptr ;
+ 	char			c ;
+ 	int				byte_count = 0, count = 0 ;
++	int				read_bytes = 0 ;
+ 
+ 	if (! format)
+ 		return psf_ftell (psf) ;
+@@ -998,6 +1000,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 
+ 	while ((c = *format++))
+ 	{
++		read_bytes = 0 ;
+ 		if (psf->header.indx + 16 >= psf->header.len && psf_bump_header_allocation (psf, 16))
+ 			break ;
+ 
+@@ -1014,7 +1017,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 					intptr = va_arg (argptr, unsigned int*) ;
+ 					*intptr = 0 ;
+ 					ucptr = (unsigned char*) intptr ;
+-					byte_count += header_read (psf, ucptr, sizeof (int)) ;
++					read_bytes = header_read (psf, ucptr, sizeof (int)) ;
+ 					*intptr = GET_MARKER (ucptr) ;
+ 					break ;
+ 
+@@ -1022,7 +1025,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 					intptr = va_arg (argptr, unsigned int*) ;
+ 					*intptr = 0 ;
+ 					ucptr = (unsigned char*) intptr ;
+-					byte_count += header_read (psf, sixteen_bytes, sizeof (sixteen_bytes)) ;
++					read_bytes = header_read (psf, sixteen_bytes, sizeof (sixteen_bytes)) ;
+ 					{	int k ;
+ 						intdata = 0 ;
+ 						for (k = 0 ; k < 16 ; k++)
+@@ -1034,14 +1037,14 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 			case '1' :
+ 					charptr = va_arg (argptr, char*) ;
+ 					*charptr = 0 ;
+-					byte_count += header_read (psf, charptr, sizeof (char)) ;
++					read_bytes = header_read (psf, charptr, sizeof (char)) ;
+ 					break ;
+ 
+ 			case '2' : /* 2 byte value with the current endian-ness */
+ 					shortptr = va_arg (argptr, unsigned short*) ;
+ 					*shortptr = 0 ;
+ 					ucptr = (unsigned char*) shortptr ;
+-					byte_count += header_read (psf, ucptr, sizeof (short)) ;
++					read_bytes = header_read (psf, ucptr, sizeof (short)) ;
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+ 						*shortptr = GET_BE_SHORT (ucptr) ;
+ 					else
+@@ -1051,7 +1054,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 			case '3' : /* 3 byte value with the current endian-ness */
+ 					intptr = va_arg (argptr, unsigned int*) ;
+ 					*intptr = 0 ;
+-					byte_count += header_read (psf, sixteen_bytes, 3) ;
++					read_bytes = header_read (psf, sixteen_bytes, 3) ;
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+ 						*intptr = GET_BE_3BYTE (sixteen_bytes) ;
+ 					else
+@@ -1062,7 +1065,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 					intptr = va_arg (argptr, unsigned int*) ;
+ 					*intptr = 0 ;
+ 					ucptr = (unsigned char*) intptr ;
+-					byte_count += header_read (psf, ucptr, sizeof (int)) ;
++					read_bytes = header_read (psf, ucptr, sizeof (int)) ;
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+ 						*intptr = psf_get_be32 (ucptr, 0) ;
+ 					else
+@@ -1072,7 +1075,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 			case '8' : /* 8 byte value with the current endian-ness */
+ 					countptr = va_arg (argptr, sf_count_t *) ;
+ 					*countptr = 0 ;
+-					byte_count += header_read (psf, sixteen_bytes, 8) ;
++					read_bytes = header_read (psf, sixteen_bytes, 8) ;
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+ 						countdata = psf_get_be64 (sixteen_bytes, 0) ;
+ 					else
+@@ -1083,7 +1086,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 			case 'f' : /* Float conversion */
+ 					floatptr = va_arg (argptr, float *) ;
+ 					*floatptr = 0.0 ;
+-					byte_count += header_read (psf, floatptr, sizeof (float)) ;
++					read_bytes = header_read (psf, floatptr, sizeof (float)) ;
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+ 						*floatptr = float32_be_read ((unsigned char*) floatptr) ;
+ 					else
+@@ -1093,7 +1096,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 			case 'd' : /* double conversion */
+ 					doubleptr = va_arg (argptr, double *) ;
+ 					*doubleptr = 0.0 ;
+-					byte_count += header_read (psf, doubleptr, sizeof (double)) ;
++					read_bytes = header_read (psf, doubleptr, sizeof (double)) ;
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+ 						*doubleptr = double64_be_read ((unsigned char*) doubleptr) ;
+ 					else
+@@ -1117,7 +1120,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 					charptr = va_arg (argptr, char*) ;
+ 					count = va_arg (argptr, size_t) ;
+ 					memset (charptr, 0, count) ;
+-					byte_count += header_read (psf, charptr, count) ;
++					read_bytes = header_read (psf, charptr, count) ;
+ 					break ;
+ 
+ 			case 'G' :
+@@ -1128,7 +1131,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 					if (psf->header.indx + count >= psf->header.len && psf_bump_header_allocation (psf, count))
+ 						break ;
+ 
+-					byte_count += header_gets (psf, charptr, count) ;
++					read_bytes = header_gets (psf, charptr, count) ;
+ 					break ;
+ 
+ 			case 'z' :
+@@ -1152,7 +1155,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 			case 'j' :	/* Seek to position from current position. */
+ 					count = va_arg (argptr, size_t) ;
+ 					header_seek (psf, count, SEEK_CUR) ;
+-					byte_count += count ;
++					read_bytes = count ;
+ 					break ;
+ 
+ 			case '!' : /* Clear buffer, forcing re-read. */
+@@ -1164,8 +1167,17 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
+ 				psf->error = SFE_INTERNAL ;
+ 				break ;
+ 			} ;
++
++		if (read_bytes > 0 && byte_count > (INT_MAX - read_bytes))
++		{	psf_log_printf (psf, "Header size exceeds INT_MAX. Aborting.", c) ;
++			psf->error = SFE_INTERNAL ;
++			break ;
++		} else
++		{	byte_count += read_bytes ;
+ 		} ;
+ 
++		} ;	/*end while*/
++
+ 	va_end (argptr) ;
+ 
+ 	return byte_count ;
+
+From 6e162cb767e81cd15f4dc2a2fa253d2e36adfd70 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Thu, 19 Oct 2023 14:07:19 -0400
+Subject: [PATCH 13/17] nms_adpcm: fix int overflow in signal estimate
+
+It is possible (though functionally incorrect) for the signal estimate
+calculation in nms_adpcm_update() to overflow the int value of s_e,
+resulting in undefined behavior.
+
+Since adpcm state signal values are never practically larger than
+16 bits, use smaller numeric sizes throughout the file to avoid the
+overflow.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Authored-by: Arthur Taylor <art@ified.ca>
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/nms_adpcm.c | 83 ++++++++++++++++++++++++-------------------------
+ 1 file changed, 41 insertions(+), 42 deletions(-)
+
+diff --git a/src/nms_adpcm.c b/src/nms_adpcm.c
+index 1aac375..c164a64 100644
+--- a/src/nms_adpcm.c
++++ b/src/nms_adpcm.c
+@@ -48,36 +48,36 @@
+ /* Variable names from ITU G.726 spec */
+ struct nms_adpcm_state
+ {	/* Log of the step size multiplier. Operated on by codewords. */
+-	int yl ;
++	short yl ;
+ 
+ 	/* Quantizer step size multiplier. Generated from yl. */
+-	int y ;
++	short y ;
+ 
+ 	/* Coefficents of the pole predictor */
+-	int a [2] ;
++	short a [2] ;
+ 
+ 	/* Coefficents of the zero predictor  */
+-	int b [6] ;
++	short b [6] ;
+ 
+ 	/* Previous quantized deltas (multiplied by 2^14) */
+-	int d_q [7] ;
++	short d_q [7] ;
+ 
+ 	/* d_q [x] + s_ez [x], used by the pole-predictor for signs only. */
+-	int p [3] ;
++	short p [3] ;
+ 
+ 	/* Previous reconstructed signal values. */
+-	int s_r [2] ;
++	short s_r [2] ;
+ 
+ 	/* Zero predictor components of the signal estimate. */
+-	int s_ez ;
++	short s_ez ;
+ 
+ 	/* Signal estimate, (including s_ez). */
+-	int s_e ;
++	short s_e ;
+ 
+ 	/* The most recent codeword (enc:generated, dec:inputted) */
+-	int Ik ;
++	char Ik ;
+ 
+-	int parity ;
++	char parity ;
+ 
+ 	/*
+ 	** Offset into code tables for the bitrate.
+@@ -109,7 +109,7 @@ typedef struct
+ } NMS_ADPCM_PRIVATE ;
+ 
+ /* Pre-computed exponential interval used in the antilog approximation. */
+-static unsigned int table_expn [] =
++static unsigned short table_expn [] =
+ {	0x4000, 0x4167, 0x42d5, 0x444c,	0x45cb, 0x4752, 0x48e2, 0x4a7a,
+ 	0x4c1b, 0x4dc7, 0x4f7a, 0x5138,	0x52ff, 0x54d1, 0x56ac, 0x5892,
+ 	0x5a82, 0x5c7e, 0x5e84, 0x6096,	0x62b4, 0x64dd, 0x6712, 0x6954,
+@@ -117,21 +117,21 @@ static unsigned int table_expn [] =
+ } ;
+ 
+ /* Table mapping codewords to scale factor deltas. */
+-static int table_scale_factor_step [] =
++static short table_scale_factor_step [] =
+ {	0x0,	0x0,	0x0,	0x0,	0x4b0,	0x0,	0x0,	0x0,	/* 2-bit */
+ 	-0x3c,	0x0,	0x90,	0x0,	0x2ee,	0x0,	0x898,	0x0,	/* 3-bit */
+ 	-0x30,	0x12,	0x6b,	0xc8,	0x188,	0x2e0,	0x551,	0x1150,	/* 4-bit */
+ } ;
+ 
+ /* Table mapping codewords to quantized delta interval steps. */
+-static unsigned int table_step [] =
++static unsigned short table_step [] =
+ {	0x73F,	0,		0,		0,		0x1829,	0,		0,		0,		/* 2-bit */
+ 	0x3EB,	0,		0xC18,	0,		0x1581,	0,		0x226E,	0,		/* 3-bit */
+ 	0x20C,	0x635,	0xA83,	0xF12,	0x1418,	0x19E3,	0x211A,	0x2BBA,	/* 4-bit */
+ } ;
+ 
+ /* Binary search lookup table for quantizing using table_step. */
+-static int table_step_search [] =
++static short table_step_search [] =
+ {	0,		0x1F6D,	0,		-0x1F6D,	0,		0,			0,			0, /* 2-bit */
+ 	0x1008,	0x1192,	0,		-0x219A,	0x1656,	-0x1656,	0,			0, /* 3-bit */
+ 	0x872,	0x1277,	-0x8E6,	-0x232B,	0xD06,	-0x17D7,	-0x11D3,	0, /* 4-bit */
+@@ -179,23 +179,23 @@ static sf_count_t nms_adpcm_seek (SF_PRIVATE *psf, int mode, sf_count_t offset)
+ ** Maps [1,20480] to [1,1024] in an exponential relationship. This is
+ ** approximately ret = b^exp where b = e^(ln(1024)/ln(20480)) ~= 1.0003385
+ */
+-static inline int
+-nms_adpcm_antilog (int exp)
+-{	int ret ;
++static inline short
++nms_adpcm_antilog (short exp)
++{	int_fast32_t r ;
+ 
+-	ret = 0x1000 ;
+-	ret += (((exp & 0x3f) * 0x166b) >> 12) ;
+-	ret *= table_expn [(exp & 0x7c0) >> 6] ;
+-	ret >>= (26 - (exp >> 11)) ;
++	r = 0x1000 ;
++	r += (((int_fast32_t) (exp & 0x3f) * 0x166b) >> 12) ;
++	r *= table_expn [(exp & 0x7c0) >> 6] ;
++	r >>= (26 - (exp >> 11)) ;
+ 
+-	return ret ;
++	return (short) r ;
+ } /* nms_adpcm_antilog */
+ 
+ static void
+ nms_adpcm_update (struct nms_adpcm_state *s)
+ {	/* Variable names from ITU G.726 spec */
+-	int a1ul ;
+-	int fa1 ;
++	short a1ul, fa1 ;
++	int_fast32_t se ;
+ 	int i ;
+ 
+ 	/* Decay and Modify the scale factor in the log domain based on the codeword. */
+@@ -222,7 +222,7 @@ nms_adpcm_update (struct nms_adpcm_state *s)
+ 	else if (fa1 > 256)
+ 		fa1 = 256 ;
+ 
+-	s->a [0] = (0xff * s->a [0]) >> 8 ;
++	s->a [0] = (s->a [0] * 0xff) >> 8 ;
+ 	if (s->p [0] != 0 && s->p [1] != 0 && ((s->p [0] ^ s->p [1]) < 0))
+ 		s->a [0] -= 192 ;
+ 	else
+@@ -230,7 +230,7 @@ nms_adpcm_update (struct nms_adpcm_state *s)
+ 		fa1 = -fa1 ;
+ 		}
+ 
+-	s->a [1] = fa1 + ((0xfe * s->a [1]) >> 8) ;
++	s->a [1] = fa1 + ((s->a [1] * 0xfe) >> 8) ;
+ 	if (s->p [0] != 0 && s->p [2] != 0 && ((s->p [0] ^ s->p [2]) < 0))
+ 		s->a [1] -= 128 ;
+ 	else
+@@ -250,19 +250,18 @@ nms_adpcm_update (struct nms_adpcm_state *s)
+ 			s->a [0] = a1ul ;
+ 		} ;
+ 
+-	/* Compute the zero predictor estimate. Rotate past deltas too. */
+-	s->s_ez = 0 ;
++	/* Compute the zero predictor estimate and rotate past deltas. */
++	se = 0 ;
+ 	for (i = 5 ; i >= 0 ; i--)
+-	{	s->s_ez += s->d_q [i] * s->b [i] ;
++	{	se += (int_fast32_t) s->d_q [i] * s->b [i] ;
+ 		s->d_q [i + 1] = s->d_q [i] ;
+ 		} ;
+-
+-	/* Compute the signal estimate. */
+-	s->s_e = s->a [0] * s->s_r [0] + s->a [1] * s->s_r [1] + s->s_ez ;
+-
+-	/* Return to scale */
+-	s->s_ez >>= 14 ;
+-	s->s_e >>= 14 ;
++	s->s_ez = se >> 14 ;
++ 
++	/* Complete the signal estimate. */
++	se += (int_fast32_t) s->a [0] * s->s_r [0] ;
++	se += (int_fast32_t) s->a [1] * s->s_r [1] ;
++	s->s_e = se >> 14 ;
+ 
+ 	/* Rotate members to prepare for next iteration. */
+ 	s->s_r [1] = s->s_r [0] ;
+@@ -274,7 +273,7 @@ nms_adpcm_update (struct nms_adpcm_state *s)
+ static int16_t
+ nms_adpcm_reconstruct_sample (struct nms_adpcm_state *s, uint8_t I)
+ {	/* Variable names from ITU G.726 spec */
+-	int dqx ;
++	int_fast32_t dqx ;
+ 
+ 	/*
+ 	** The ordering of the 12-bit right-shift is a precision loss. It agrees
+@@ -308,17 +307,17 @@ nms_adpcm_codec_init (struct nms_adpcm_state *s, enum nms_enc_type type)
+ /*
+ ** nms_adpcm_encode_sample()
+ **
+-** Encode a linear 16-bit pcm sample into a 2,3, or 4 bit NMS-ADPCM codeword
++** Encode a linear 16-bit pcm sample into a 2, 3, or 4 bit NMS-ADPCM codeword
+ ** using and updating the predictor state.
+ */
+ static uint8_t
+ nms_adpcm_encode_sample (struct nms_adpcm_state *s, int16_t sl)
+ {	/* Variable names from ITU G.726 spec */
+-	int d ;
++	int_fast32_t d ;
+ 	uint8_t I ;
+ 
+ 	/* Down scale the sample from 16 => ~14 bits. */
+-	sl = (sl * 0x1fdf) / 0x7fff ;
++	sl = ((int_fast32_t) sl * 0x1fdf) / 0x7fff ;
+ 
+ 	/* Compute estimate, and delta from actual value */
+ 	nms_adpcm_update (s) ;
+@@ -407,7 +406,7 @@ nms_adpcm_encode_sample (struct nms_adpcm_state *s, int16_t sl)
+ */
+ static int16_t
+ nms_adpcm_decode_sample (struct nms_adpcm_state *s, uint8_t I)
+-{	int sl ;
++{	int_fast32_t sl ;
+ 
+ 	nms_adpcm_update (s) ;
+ 	sl = nms_adpcm_reconstruct_sample (s, I) ;
+
+From cd44bfaf3708e778c8670cb7f707a597c3334376 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Tue, 17 Oct 2023 11:50:53 -0400
+Subject: [PATCH 14/17] nms_adpcm: fix int overflow in sf.frames calc
+
+When calculating sf.frames from the blocks_total PNMS variable, it is
+theoretically possible to overflow the blocks_total int boundaries,
+leading to undefined behavior.
+
+Cast blocks_total to a long-sized sf_count_t before the calculation, to
+provide it with enough numeric space and because that is the final
+typing regardless.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/nms_adpcm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/nms_adpcm.c b/src/nms_adpcm.c
+index dca85f0b0..61d171c73 100644
+--- a/src/nms_adpcm.c
++++ b/src/nms_adpcm.c
+@@ -1090,7 +1090,7 @@ nms_adpcm_init (SF_PRIVATE *psf)
+ 	else
+ 		pnms->blocks_total = psf->datalength / (pnms->shortsperblock * sizeof (short)) ;
+ 
+-	psf->sf.frames		= pnms->blocks_total * NMS_SAMPLES_PER_BLOCK ;
++	psf->sf.frames		= (sf_count_t) pnms->blocks_total * NMS_SAMPLES_PER_BLOCK ;
+ 	psf->codec_close	= nms_adpcm_close ;
+ 	psf->seek			= nms_adpcm_seek ;
+ 
+
+From 915e154e2deb327612ca413c838365b7c9bfbf16 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Tue, 17 Oct 2023 11:57:23 -0400
+Subject: [PATCH 15/17] pcm: fix int overflow in pcm_init()
+
+Cast the int-sized bytewidth variable to a long-sized sf_count_t type
+prior to calculating the blockwidth, to provide the calculation with
+enough numeric space and sf_count_t is the final typing regardless.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/pcm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pcm.c b/src/pcm.c
+index bdf461839..a42e48681 100644
+--- a/src/pcm.c
++++ b/src/pcm.c
+@@ -127,7 +127,7 @@ pcm_init (SF_PRIVATE *psf)
+ 		return SFE_INTERNAL ;
+ 		} ;
+ 
+-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
++	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
+ 
+ 	if ((SF_CODEC (psf->sf.format)) == SF_FORMAT_PCM_S8)
+ 		chars = SF_CHARS_SIGNED ;
+
+From ec149a79d457916479489d71b55e4d63015a08ea Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Tue, 17 Oct 2023 12:01:00 -0400
+Subject: [PATCH 16/17] rf64: fix int overflow in rf64_read_header()
+
+When checking for mismatches between the filelength and riff_size, it is
+possible to overflow the temporary riff_size value used in the
+comparison by adding a static offset; which is probably fine, but it is
+offensive to overflow fuzzers.
+
+Since filelength is always a positive value, simply move the offset to
+the other side of the comparison operator as a negative value, avoid the
+possibility of an overflow.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/rf64.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rf64.c b/src/rf64.c
+index 123db445a..c60399fb3 100644
+--- a/src/rf64.c
++++ b/src/rf64.c
+@@ -242,7 +242,7 @@ rf64_read_header (SF_PRIVATE *psf, int *blockalign, int *framesperblock)
+ 							} ;
+ 						} ;
+ 
+-					if (psf->filelength != riff_size + 8)
++					if (psf->filelength - 8 != riff_size)
+ 						psf_log_printf (psf, "  Riff size : %D (should be %D)\n", riff_size, psf->filelength - 8) ;
+ 					else
+ 						psf_log_printf (psf, "  Riff size : %D\n", riff_size) ;
+
+From 9f097e492a07c96e3b250d6ac0044499f64f6cea Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Tue, 17 Oct 2023 12:19:12 -0400
+Subject: [PATCH 17/17] ima_adpcm: fix int overflow in ima_reader_init()
+
+When calculating sf.frames, pre-cast samplesperblock to sf_count_t, to
+provide the calculation with enough numeric space to avoid overflows.
+
+Other changes in this commit are syntactic, and only to satisfy the git
+pre-commit syntax checker.
+
+CVE: CVE-2022-33065
+Fixes: https://github.com/libsndfile/libsndfile/issues/833
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ src/ima_adpcm.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/ima_adpcm.c b/src/ima_adpcm.c
+index bc61f4e5a..7464d1b33 100644
+--- a/src/ima_adpcm.c
++++ b/src/ima_adpcm.c
+@@ -187,7 +187,7 @@ ima_reader_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
+ 	**	to avoid having to branch when pulling apart the nibbles.
+ 	*/
+ 	count = ((samplesperblock - 2) | 7) + 2 ;
+-	pimasize = sizeof (IMA_ADPCM_PRIVATE) + psf->sf.channels * (blockalign + samplesperblock + sizeof(short) * count) ;
++	pimasize = sizeof (IMA_ADPCM_PRIVATE) + psf->sf.channels * (blockalign + samplesperblock + sizeof (short) * count) ;
+ 
+ 	if (! (pima = calloc (1, pimasize)))
+ 		return SFE_MALLOC_FAILED ;
+@@ -238,7 +238,7 @@ ima_reader_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
+ 		case SF_FORMAT_AIFF :
+ 				psf_log_printf (psf, "still need to check block count\n") ;
+ 				pima->decode_block = aiff_ima_decode_block ;
+-				psf->sf.frames = pima->samplesperblock * pima->blocks / pima->channels ;
++				psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blocks / pima->channels ;
+ 				break ;
+ 
+ 		default :
+@@ -391,7 +391,7 @@ aiff_ima_encode_block (SF_PRIVATE *psf, IMA_ADPCM_PRIVATE *pima)
+ static int
+ wavlike_ima_decode_block (SF_PRIVATE *psf, IMA_ADPCM_PRIVATE *pima)
+ {	int		chan, k, predictor, blockindx, indx, indxstart, diff ;
+-	short	step, bytecode, stepindx [2] = { 0 };
++	short	step, bytecode, stepindx [2] = { 0 } ;
+ 
+ 	pima->blockcount ++ ;
+ 	pima->samplecount = 0 ;

--- a/SPECS/libsndfile/libsndfile.spec
+++ b/SPECS/libsndfile/libsndfile.spec
@@ -1,7 +1,7 @@
 Summary:        Library for reading and writing sound files
 Name:           libsndfile
 Version:        1.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD AND GPLv2+ AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -14,6 +14,7 @@ Patch1:         revert.patch
 # CVE disputed by project's owner, no repro.
 # See here for more details: https://github.com/libsndfile/libsndfile/issues/398.
 Patch100:       CVE-2018-13419.nopatch
+Patch101:       CVE-2022-33065.patch
 
 BuildRequires:  alsa-lib-devel
 BuildRequires:  autogen
@@ -138,6 +139,9 @@ LD_LIBRARY_PATH=$PWD/src/.libs make check
 %{_libdir}/pkgconfig/sndfile.pc
 
 %changelog
+* Fri Aug 23 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.2.2-2
+- Add patch to resolve CVE-2022-33065
+
 * Thu Feb 22 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.2.2-1
 - Auto-upgrade to 1.2.2
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch to resolve CVE-2022-33065

###### Change Log  <!-- REQUIRED -->
- Add patch file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-33065

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id:[ Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=626766&view=results)
