### PR TITLE
cloud-hypervisor-cvm: Add upstream patch to prevent crash when SEV-SNP guest queries ext. att. report

### DIFF
--- a/SPECS/cloud-hypervisor-cvm/0001-hypervisor-mshv-Fix-panic-when-rejecting-extended-gu.patch
+++ b/SPECS/cloud-hypervisor-cvm/0001-hypervisor-mshv-Fix-panic-when-rejecting-extended-gu.patch
@@ -1,0 +1,32 @@
+From 234ac402dd04cac78033fb2334cdeb7d96526648 Mon Sep 17 00:00:00 2001
+From: Tom Dohrmann <erbse.13@gmx.de>
+Date: Wed, 14 Aug 2024 16:02:39 +0200
+Subject: [PATCH] hypervisor: mshv: Fix panic when rejecting extended guest
+ report
+
+swei2_rw_gpa_arg.data is an array of size 16 and value.to_le_bytes() is
+only 8 bytes.
+
+Co-authored-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
+Signed-off-by: Tom Dohrmann <erbse.13@gmx.de>
+---
+ hypervisor/src/mshv/mod.rs | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/hypervisor/src/mshv/mod.rs b/hypervisor/src/mshv/mod.rs
+index 62e0dfa5..5d23492f 100644
+--- a/hypervisor/src/mshv/mod.rs
++++ b/hypervisor/src/mshv/mod.rs
+@@ -1012,7 +1012,8 @@ impl cpu::Vcpu for MshvVcpu {
+                                         byte_count: std::mem::size_of::<u64>() as u32,
+                                         ..Default::default()
+                                     };
+-                                    swei2_rw_gpa_arg.data.copy_from_slice(&value.to_le_bytes());
++                                    swei2_rw_gpa_arg.data[0..8]
++                                        .copy_from_slice(&value.to_le_bytes());
+                                     self.fd
+                                         .gpa_write(&mut swei2_rw_gpa_arg)
+                                         .map_err(|e| cpu::HypervisorCpuError::GpaWrite(e.into()))?;
+-- 
+2.39.4
+

--- a/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.spec
+++ b/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.spec
@@ -5,7 +5,7 @@
 Name:           cloud-hypervisor-cvm
 Summary:        Cloud Hypervisor CVM is an open source Virtual Machine Monitor (VMM) that enables running SEV SNP enabled VMs on top of MSHV using the IGVM file format as payload.
 Version:        38.0.72.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -23,6 +23,7 @@ Source0:        https://github.com/microsoft/cloud-hypervisor/archive/refs/tags/
 Source1:        %{name}-%{version}-cargo.tar.gz
 Source2:        config.toml
 %endif
+Patch0:         0001-hypervisor-mshv-Fix-panic-when-rejecting-extended-gu.patch
 
 Conflicts: cloud-hypervisor
 
@@ -71,7 +72,7 @@ Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on to
 
 %prep
 
-%setup -q -n cloud-hypervisor-msft-v%{version}
+%autosetup -p1 -n cloud-hypervisor-msft-v%{version}
 %if 0%{?using_vendored_crates}
 tar xf %{SOURCE1}
 mkdir -p .cargo
@@ -138,6 +139,9 @@ cargo build --release --target=%{rust_musl_target} %{cargo_pkg_feature_opts} %{c
 %license LICENSE-BSD-3-Clause
 
 %changelog
+* Fri Aug 23 2024 Manuel Huber <mahuber@microsoft.com> - 38.0.72.2-2
+- Add upstream patch to prevent crash
+
 * Thu Jul 04 2024 Archana Choudhary <archana1@microsoft.com> - 38.0.72.2-1
 - Upgrade to v38.0.72.2
 - Fixes CVE-2023-45853, CVE-2018-25032, CVE-2023-5363, CVE-2023-5678, CVE-2023-6129, CVE-2023-6237, CVE-2024-0727, CVE-2024-4603


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change adds a patch file for an upstream commit that resolves a CLH crash that occurs when attempting to retrieve the extended attestation report.
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch: [hypervisor: mshv: Fix panic when rejecting extended guest
 report](https://github.com/cloud-hypervisor/cloud-hypervisor/commit/ca88d4449e843ddb69d72a3908e7447d536517e2)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- PR: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/6682

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Internal validation based on e2e tests
- Minimal binary that queries (extended) attestation reports
