### PR TITLE
Image Customizer: Add tests for Azure Linux 3.0.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -65,7 +65,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalFiles(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalFiles")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -100,7 +100,7 @@ func TestCustomizeImageAdditionalFiles(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalFilesInfiniteFile(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalFilesInfiniteFile")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -176,7 +176,7 @@ func TestCopyAdditionalDirs(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalDirs(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalDirs")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -205,7 +205,7 @@ func TestCustomizeImageAdditionalDirs(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalDirsInfiniteFile")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
@@ -39,7 +39,7 @@ func TestUpdateHostname(t *testing.T) {
 }
 
 func TestCustomizeImageHostname(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageHostname")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -19,7 +19,7 @@ import (
 func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesAddOfflineDir")
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 	downloadedRpmsDir := getDownloadedRpmsDir(t, "2.0")
 
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -134,7 +134,7 @@ func copyRpms(sourceDir string, targetDir string, excludePrefixes []string) erro
 func TestCustomizeImagePackagesAddOfflineLocalRepo(t *testing.T) {
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesAddOfflineLocalRepo")
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	downloadedRpmsRepoFile := getDownloadedRpmsRepoFile(t, "2.0")
 	rpmSources := []string{downloadedRpmsRepoFile}
@@ -164,7 +164,7 @@ func TestCustomizeImagePackagesAddOfflineLocalRepo(t *testing.T) {
 }
 
 func TestCustomizeImagePackagesUpdate(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesUpdate")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -197,7 +197,7 @@ func TestCustomizeImagePackagesUpdate(t *testing.T) {
 }
 
 func TestCustomizeImagePackagesDiskSpace(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesDiskSpace")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -14,9 +14,20 @@ import (
 )
 
 func TestCustomizeImageSELinux(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	for _, version := range supportedAzureLinuxVersions {
+		t.Run(string(version), func(t *testing.T) {
+			testCustomizeImageSELinuxHelper(t, "TestCustomizeImageSELinux"+string(version), baseImageTypeCoreEfi,
+				version)
+		})
+	}
+}
 
-	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageSELinux")
+func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType baseImageType,
+	imageVersion baseImageVersion,
+) {
+	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+
+	testTmpDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -100,9 +111,20 @@ func TestCustomizeImageSELinux(t *testing.T) {
 }
 
 func TestCustomizeImageSELinuxAndPartitions(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	for _, version := range supportedAzureLinuxVersions {
+		t.Run(string(version), func(t *testing.T) {
+			testCustomizeImageSELinuxAndPartitionsHelper(t, "TestCustomizeImageSELinuxAndPartitions"+string(version),
+				baseImageTypeCoreEfi, version)
+		})
+	}
+}
 
-	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageSELinuxAndPartitions")
+func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string, imageType baseImageType,
+	imageVersion baseImageVersion,
+) {
+	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+
+	testTmpDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -150,7 +172,7 @@ func TestCustomizeImageSELinuxAndPartitions(t *testing.T) {
 }
 
 func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageSELinuxNoPolicy")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCustomizeImageServicesEnableDisable(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesEnableDisable")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -45,7 +45,7 @@ func TestCustomizeImageServicesEnableDisable(t *testing.T) {
 }
 
 func TestCustomizeImageServicesEnableUnknown(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesEnableUnknown")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -69,7 +69,7 @@ func TestCustomizeImageServicesEnableUnknown(t *testing.T) {
 }
 
 func TestCustomizeImageServicesDisableUnknown(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesDisableUnknown")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -25,7 +25,7 @@ var (
 )
 
 func TestCustomizeImageUsers(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -144,7 +144,7 @@ func TestCustomizeImageUsers(t *testing.T) {
 }
 
 func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -168,7 +168,7 @@ func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
 }
 
 func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -19,9 +19,20 @@ import (
 )
 
 func TestCustomizeImageVerity(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	for _, version := range supportedAzureLinuxVersions {
+		t.Run(string(version), func(t *testing.T) {
+			testCustomizeImageVerityHelper(t, "TestCustomizeImageVerity"+string(version), baseImageTypeCoreEfi,
+				version)
+		})
+	}
+}
 
-	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageVerity")
+func testCustomizeImageVerityHelper(t *testing.T, testName string, imageType baseImageType,
+	imageVersion baseImageVersion,
+) {
+	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+
+	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-config.yaml")
@@ -71,9 +82,20 @@ func TestCustomizeImageVerity(t *testing.T) {
 }
 
 func TestCustomizeImageVerityShrinkExtract(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	for _, version := range supportedAzureLinuxVersions {
+		t.Run(string(version), func(t *testing.T) {
+			testCustomizeImageVerityShrinkExtractHelper(t, "TestCustomizeImageVerityShrinkExtract"+string(version),
+				baseImageTypeCoreEfi, version)
+		})
+	}
+}
 
-	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageVerityShrinkExtract")
+func testCustomizeImageVerityShrinkExtractHelper(t *testing.T, testName string, imageType baseImageType,
+	imageVersion baseImageVersion,
+) {
+	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+
+	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-config.yaml")
@@ -141,13 +163,13 @@ func verifyVerity(t *testing.T, bootPath string, rootDevice string, hashDevice s
 		return
 	}
 
-	assert.Regexp(t, "linux.* rd.systemd.verity=1 ", grubCfgContents)
-	assert.Regexp(t, "linux.* systemd.verity_root_data=PARTLABEL=root ", grubCfgContents)
-	assert.Regexp(t, "linux.* systemd.verity_root_hash=PARTLABEL=root-hash ", grubCfgContents)
-	assert.Regexp(t, "linux.* systemd.verity_root_options=panic-on-corruption ", grubCfgContents)
+	assert.Regexp(t, `(?m)linux.* rd.systemd.verity=1 `, grubCfgContents)
+	assert.Regexp(t, `(?m)linux.* systemd.verity_root_data=PARTLABEL=root `, grubCfgContents)
+	assert.Regexp(t, `(?m)linux.* systemd.verity_root_hash=PARTLABEL=root-hash `, grubCfgContents)
+	assert.Regexp(t, `(?m)linux.* systemd.verity_root_options=panic-on-corruption `, grubCfgContents)
 
 	// Read root hash from grub.cfg file.
-	roothashRegexp, err := regexp.Compile("linux.* roothash=([a-fA-F0-9]*) ")
+	roothashRegexp, err := regexp.Compile(`(?m)linux.* roothash=([a-fA-F0-9]*) `)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -146,7 +146,7 @@ func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber 
 func TestCustomizeImageNopShrink(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageNopShrink")
 	configFile := filepath.Join(testDir, "consume-space.yaml")

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -48,7 +48,7 @@ var (
 func TestCustomizeImageEmptyConfig(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")
@@ -67,7 +67,7 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 func TestCustomizeImageCopyFiles(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageCopyFiles")
 	configFile := filepath.Join(testDir, "addfiles-config.yaml")
@@ -206,7 +206,7 @@ func TestValidateConfigScriptNonLocalFile(t *testing.T) {
 func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageKernelCommandLine")
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCustomizeImageMissingKernel(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageMissingKernel")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -22,7 +22,7 @@ import (
 // - Kernel command-line arg append.
 // - .iso.additionalFiles
 func TestCustomizeImageLiveCd1(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCd1")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -139,7 +139,7 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 // - vhdx to ISO, with no OS changes.
 // - ISO to ISO, with OS changes.
 func TestCustomizeImageLiveCd2(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCd2")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -201,7 +201,7 @@ func TestCustomizeImageLiveCd2(t *testing.T) {
 }
 
 func TestCustomizeImageLiveCdIsoNoShimEfi(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCdIso")
 	outImageFilePath := filepath.Join(buildDir, "image.iso")
@@ -223,7 +223,7 @@ func TestCustomizeImageLiveCdIsoNoShimEfi(t *testing.T) {
 }
 
 func TestCustomizeImageLiveCdIsoNoGrubEfi(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageLiveCdIso")
 	outImageFilePath := filepath.Join(buildDir, "image.iso")

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -23,15 +23,33 @@ const (
 	baseImageTypeCoreLegacy baseImageType = "core-legacy"
 )
 
+type baseImageVersion string
+
+const (
+	baseImageVersion20 baseImageVersion = "2.0"
+	baseImageVersion30 baseImageVersion = "3.0"
+
+	// Most features don't have version Azure Linux version specific behavior.
+	// So, there is only minimal value in duplicating the tests across versions for such features.
+	baseImageVersionDefault = baseImageVersion20
+)
+
 var (
-	baseImageCoreEfi    = flag.String("base-image-core-efi", "", "A core-efi image to use as a base image.")
-	baseImageCoreLegacy = flag.String("base-image-core-legacy", "", "A core-legacy image to use as a base image.")
+	baseImageCoreEfi20    = flag.String("base-image-core-efi-20", "", "A core-efi 2.0 image to use as a base image.")
+	baseImageCoreEfi30    = flag.String("base-image-core-efi-30", "", "A core-efi 3.0 image to use as a base image.")
+	baseImageCoreLegacy20 = flag.String("base-image-core-legacy-20", "", "A core-legacy 2.0 image to use as a base image.")
+	baseImageCoreLegacy30 = flag.String("base-image-core-legacy-30", "", "A core-legacy 3.0 image to use as a base image.")
 )
 
 var (
 	testDir    string
 	tmpDir     string
 	workingDir string
+
+	supportedAzureLinuxVersions = []baseImageVersion{
+		baseImageVersion20,
+		baseImageVersion30,
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -65,7 +83,7 @@ func TestMain(m *testing.M) {
 }
 
 // Skip the test if requirements for testing CustomizeImage() are not met.
-func checkSkipForCustomizeImage(t *testing.T, baseImageType baseImageType) string {
+func checkSkipForCustomizeImage(t *testing.T, baseImageType baseImageType, baseImageVersion baseImageVersion) string {
 	if !buildpipeline.IsRegularBuild() {
 		t.Skip("loopback block device not available")
 	}
@@ -74,21 +92,36 @@ func checkSkipForCustomizeImage(t *testing.T, baseImageType baseImageType) strin
 		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
-	switch baseImageType {
-	case baseImageTypeCoreEfi:
-		if baseImageCoreEfi == nil || *baseImageCoreEfi == "" {
-			t.Skip("--base-image-core-efi is required for this test")
-		}
-		return *baseImageCoreEfi
-
-	case baseImageTypeCoreLegacy:
-		if baseImageCoreLegacy == nil || *baseImageCoreLegacy == "" {
-			t.Skip("--base-image-core-legacy is required for this test")
-		}
-		return *baseImageCoreLegacy
+	param, paramName := getImageParamAndName(baseImageType, baseImageVersion)
+	if param == nil || *param == "" {
+		t.Skipf("--%s is required for this test", paramName)
 	}
 
-	return ""
+	return *param
+}
+
+func getImageParamAndName(baseImageType baseImageType, baseImageVersion baseImageVersion) (*string, string) {
+	switch baseImageType {
+	case baseImageTypeCoreEfi:
+		switch baseImageVersion {
+		case baseImageVersion20:
+			return baseImageCoreEfi20, "base-image-core-efi-20"
+
+		case baseImageVersion30:
+			return baseImageCoreEfi30, "base-image-core-efi-30"
+		}
+
+	case baseImageTypeCoreLegacy:
+		switch baseImageVersion {
+		case baseImageVersion20:
+			return baseImageCoreLegacy20, "base-image-core-legacy-20"
+
+		case baseImageVersion30:
+			return baseImageCoreLegacy30, "base-image-core-legacy-30"
+		}
+	}
+
+	return nil, ""
 }
 
 func getDownloadedRpmsDir(t *testing.T, azureLinuxVersion string) string {

--- a/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCustomizeImageResolvConfDelete(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfDelete")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -51,7 +51,7 @@ func TestCustomizeImageResolvConfDelete(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreFile")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -122,7 +122,7 @@ func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreSymlink")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -185,7 +185,7 @@ func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfNewSymlink(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfNewSymlink")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -14,7 +14,7 @@ import (
 func TestCustomizeImageRunScripts(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi)
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageRunScripts")
 	buildDir := filepath.Join(testTmpDir, "build")


### PR DESCRIPTION
Allow the functional tests to accept both Azure Linux 2.0 and 3.0 image versions as input. Then, for the features that have different behavior based on the image version, ensure the tests for those features cover both image versions.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran new UTs.

