### PR TITLE
Fix nfs-utils to build rsc.svcgssd and provide the missing rpc-gssd

### DIFF
--- a/SPECS/nfs-utils/nfs-utils.spec
+++ b/SPECS/nfs-utils/nfs-utils.spec
@@ -1,7 +1,7 @@
 Summary:        NFS client utils
 Name:           nfs-utils
 Version:        2.6.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT and GPLv2 and GPLv2+ and BSD
 URL:            https://linux-nfs.org/
 Group:          Applications/Nfs-utils-client
@@ -82,6 +82,7 @@ sed -i 's/RPCGEN_PATH" =/rpcgen_path" =/' configure
             --enable-libmount-mount     \
             --without-tcp-wrappers      \
             --enable-gss                \
+            --enable-svcgss             \
             --enable-nfsv4              \
             --with-rpcgen=internal      \
             --disable-static
@@ -113,6 +114,8 @@ install -m644 systemd/nfs-idmapd.service %{buildroot}/lib/systemd/system/
 install -m644 systemd/rpc_pipefs.target  %{buildroot}/lib/systemd/system/
 install -m644 systemd/var-lib-nfs-rpc_pipefs.mount  %{buildroot}/lib/systemd/system/
 install -m644 systemd/rpc-svcgssd.service %{buildroot}/lib/systemd/system/
+install -m644 systemd/rpc-gssd.service %{buildroot}/lib/systemd/system/
+
 find %{buildroot}/%{_libdir} -name '*.la' -delete
 
 install -vdm755 %{buildroot}/usr/lib/systemd/system-preset
@@ -170,6 +173,10 @@ fi
 %{_libdir}/libnfsidmap.so
 
 %changelog
+* Mon Aug 26 2024 Suresh Thelkar <sthelkar@microsoft.com> - 2.6.4-3
+- Build nfs-utils to provide rsc.svcgssd service
+- Add rsc-gssd.service file to nfs-utils package
+
 * Tue Mar 12 2024 Rachel Menge <rachelmenge@microsoft.com> - 2.6.4-2
 - Cherry-pick fix post-install script to create nobody user instead of named user
 


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix nfs-utils to build rsc.svcgssd and provide the missing rpc-gssd
In NFS rpc.svcgssd and rpc.gssd play crucial roles in providing security through the RPCSEC_GSS protocol.

**rpc.svcgssd**
Role: This is the server-side daemon responsible for handling security context establishment on the NFS server.
Function: It communicates with the Linux kernel to manage security contexts for incoming RPC requests. This ensures that the server can authenticate and authorize clients securely.

**rpc.gssd**
Role: This is the client-side daemon that manages security contexts for the NFS client.
Function: It interacts with the NFS server on behalf of a Kerberos-authenticated user, initializing security contexts using the user’s credentials. This allows the client to securely communicate with the server3

These daemons work together to provide secure communication between NFS clients and servers, ensuring that data is protected during transmission.

1. In Mariner even after installing the package nfs-utils rpc.svcgssd is not getting installed. We have a service file rpc-svcgssd.serice but the executable rpc.svcgssd itself is missing.
2. The other issue is that we have a rpc.gssd executable but we do not have a corresponding service file rpc-gssd.service.

The current PR addresses the above bugs.
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- NA

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Uniform Buddy build with tests: [628465](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=628465&view=results)
