### PR TITLE
fix: use static search path for toolchain GPG keys during validation

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -155,7 +155,7 @@ VALIDATE_TOOLCHAIN_GPG ?= y
 endif
 endif
 
-TOOLCHAIN_GPG_VALIDATION_KEYS ?= $(wildcard $(SPECS_DIR)/azurelinux-repos/MICROSOFT-*-GPG-KEY) $(wildcard $(toolkit_root)/repos/MICROSOFT-*-GPG-KEY)
+TOOLCHAIN_GPG_VALIDATION_KEYS ?= $(wildcard $(PROJECT_ROOT)/SPECS/azurelinux-repos/MICROSOFT-*-GPG-KEY) $(wildcard $(toolkit_root)/repos/MICROSOFT-*-GPG-KEY)
 
 ######## COMMON MAKEFILE UTILITIES ########
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The new toolchain validation step relies on `$(TOOLCHAIN_GPG_VALIDATION_KEYS)` to check the toolchain rpms against. This variable is by default a list of gpg keys from `./SPECS/azurelinux-repos/`. 

When using `make package-toolkit` these keys are included in `./toolkit/repos`. The search is `$(wildcard $(PROJECT_ROOT)/SPECS/azurelinux-repos/MICROSOFT-*-GPG-KEY) $(wildcard $(toolkit_root)/repos/MICROSOFT-*-GPG-KEY)`.

This works well for common use cases, but if the user selects a custom `SPECS_DIR=...` with the core repo the validation will fail. Instead use `$(PROJECT_ROOT)/SPECS` which is a stable directory (similar to https://github.com/microsoft/azurelinux/blob/9f8d0fad669392e8c53e7334da1f481f5306e673/toolkit/scripts/preview.mk#L16).

The two supported use-cases for the toolkit are via core repo checkout, and `make package-toolkit` -> `tar -xzvf toolkit.tar.gz`. The packaged flow will always include the GPG keys in the toolkit. For the core checkout, we can always assume that the toolkit will be present inside the repo, so it should be safe to assume the GPG keys are also present. Even if the user is not using the `./SPECS` from the repo the keys are still valid.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use GPG keys for toolchain validation from `$(PROJECT_ROOT)/SPECS` instead of `$(SPECS_DIR)`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES** (Only in so much as GPG validation for some less common local build flows was broken)

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/53478906


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
```
mkdir ./SPECS_TEST
cp ./SPECS/words ./SPECS_TEST/ -r
cd toolkit
git checkout 3.0-stable
sudo make clean
sudo make build-packages SPECS_DIR=../SPECS_TEST/ USE_PREVIEW_REPO=n QUICK_REBUILD_PACKAGES=y PRECACHE=n CONFIG_FILE="" REBUILD_TOOLS=y
```
Also
```
make printvar-TOOLCHAIN_GPG_VALIDATION_KEYS SPECS_DIR=not/a/real/dir
# vs
make printvar-TOOLCHAIN_GPG_VALIDATION_KEYS
```
