### PR TITLE
nss: Disable DBM backend.

### DIFF
--- a/SPECS/nss/nss.spec
+++ b/SPECS/nss/nss.spec
@@ -8,13 +8,12 @@
     %{buildroot}%{unsupported_tools_directory}/shlibsign -i %{buildroot}%{_libdir}/libsoftokn3.so \
     %{buildroot}%{unsupported_tools_directory}/shlibsign -i %{buildroot}%{_libdir}/libfreeblpriv3.so \
     %{buildroot}%{unsupported_tools_directory}/shlibsign -i %{buildroot}%{_libdir}/libfreebl3.so \
-    %{buildroot}%{unsupported_tools_directory}/shlibsign -i %{buildroot}%{_libdir}/libnssdbm3.so \
     %{nil}
 
 Summary:        Security client
 Name:           nss
 Version:        3.96.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -96,7 +95,8 @@ make VERBOSE=1 BUILD_OPT=1 \
     ZLIB_LIBS=-lz \
     USE_64=1 \
     NSS_ENABLE_WERROR=0 \
-    $([ -f %{_includedir}/sqlite3.h ] && echo NSS_USE_SYSTEM_SQLITE=1)
+    NSS_USE_SYSTEM_SQLITE=1 \
+    NSS_DISABLE_DBM=1
 popd
 
 cat %{SOURCE1} | sed -e "s,%%libdir%%,%{_libdir},g" \
@@ -215,6 +215,9 @@ popd
 %{_bindir}/ssltap
 
 %changelog
+* Tue Aug 27 2024 Chris Gunn <chrisgun@microsoft.com> - 3.96.1-3
+- Disable building DBM backend.
+
 * Fri Jun 07 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.96.1-2
 - Remove dependency on 'libdb'.
 


### PR DESCRIPTION
This change disables building the DBM backend in the NSS library.

For the NSS library and tools, a replacement SQLite database backend has been available since v3.12. The DBM backend has been deprecated since v3.35. Also, the DBM backend code is scheduled for deletion in a future release. As such any found CVEs (e.g. CVE-2017-11695) are being WONTFIXed by upstream.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Change Log  <!-- REQUIRED -->
- nss: Disable DBM backend
- CVE-2017-11695
- CVE-2017-11696
- CVE-2017-11697
- CVE-2017-11698

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Built package and dependencies.
