### PR TITLE
Patch CVE-2024-3651 for python-pip

### DIFF
--- a/SPECS/python-pip/CVE-2024-3651.patch
+++ b/SPECS/python-pip/CVE-2024-3651.patch
@@ -1,0 +1,3858 @@
+From 9cdb89916b56c99ddd55c80a30ce1e7513ffc111 Mon Sep 17 00:00:00 2001
+From: Rachel Menge <rachelmenge@microsoft.com>
+Date: Wed, 28 Aug 2024 16:57:08 -0400
+Subject: [PATCH] Update vendor idna to 3.7
+
+CVE-2024-3651 requires python-idna 3.7. Therefore update to this
+version.
+
+This commit is a combination of 2 upstream commits:
+[d83c9e3] Upgrade idna to 3.6
+[cba5b13] Upgrade idna to 3.7
+---
+ news/idna.vendor.rst                 |    1 +
+ src/pip/_vendor/idna/LICENSE.md      |   36 +-
+ src/pip/_vendor/idna/codec.py        |   34 +-
+ src/pip/_vendor/idna/core.py         |   33 +-
+ src/pip/_vendor/idna/idnadata.py     | 2206 +++++++++++++++++++++++++-
+ src/pip/_vendor/idna/package_data.py |    2 +-
+ src/pip/_vendor/idna/uts46data.py    |  454 +++---
+ src/pip/_vendor/vendor.txt           |    2 +-
+ 8 files changed, 2432 insertions(+), 336 deletions(-)
+ create mode 100644 news/idna.vendor.rst
+
+diff --git a/news/idna.vendor.rst b/news/idna.vendor.rst
+new file mode 100644
+index 0000000..1b8f743
+--- /dev/null
++++ b/news/idna.vendor.rst
+@@ -0,0 +1 @@
++Upgrade idna to 3.7
+diff --git a/src/pip/_vendor/idna/LICENSE.md b/src/pip/_vendor/idna/LICENSE.md
+index b6f8732..19b6b45 100644
+--- a/src/pip/_vendor/idna/LICENSE.md
++++ b/src/pip/_vendor/idna/LICENSE.md
+@@ -1,29 +1,31 @@
+ BSD 3-Clause License
+ 
+-Copyright (c) 2013-2021, Kim Davies
++Copyright (c) 2013-2024, Kim Davies and contributors.
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
++modification, are permitted provided that the following conditions are
++met:
+ 
+-1. Redistributions of source code must retain the above copyright notice, this
+-   list of conditions and the following disclaimer.
++1. Redistributions of source code must retain the above copyright
++   notice, this list of conditions and the following disclaimer.
+ 
+-2. Redistributions in binary form must reproduce the above copyright notice,
+-   this list of conditions and the following disclaimer in the documentation
+-   and/or other materials provided with the distribution.
++2. Redistributions in binary form must reproduce the above copyright
++   notice, this list of conditions and the following disclaimer in the
++   documentation and/or other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+ 
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
++TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
++LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
++NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/src/pip/_vendor/idna/codec.py b/src/pip/_vendor/idna/codec.py
+index 1ca9ba6..c855a4d 100644
+--- a/src/pip/_vendor/idna/codec.py
++++ b/src/pip/_vendor/idna/codec.py
+@@ -1,7 +1,7 @@
+ from .core import encode, decode, alabel, ulabel, IDNAError
+ import codecs
+ import re
+-from typing import Tuple, Optional
++from typing import Any, Tuple, Optional
+ 
+ _unicode_dots_re = re.compile('[\u002e\u3002\uff0e\uff61]')
+ 
+@@ -26,24 +26,24 @@ class Codec(codecs.Codec):
+         return decode(data), len(data)
+ 
+ class IncrementalEncoder(codecs.BufferedIncrementalEncoder):
+-    def _buffer_encode(self, data: str, errors: str, final: bool) -> Tuple[str, int]:  # type: ignore
++    def _buffer_encode(self, data: str, errors: str, final: bool) -> Tuple[bytes, int]:
+         if errors != 'strict':
+             raise IDNAError('Unsupported error handling \"{}\"'.format(errors))
+ 
+         if not data:
+-            return "", 0
++            return b'', 0
+ 
+         labels = _unicode_dots_re.split(data)
+-        trailing_dot = ''
++        trailing_dot = b''
+         if labels:
+             if not labels[-1]:
+-                trailing_dot = '.'
++                trailing_dot = b'.'
+                 del labels[-1]
+             elif not final:
+                 # Keep potentially unfinished label until the next call
+                 del labels[-1]
+                 if labels:
+-                    trailing_dot = '.'
++                    trailing_dot = b'.'
+ 
+         result = []
+         size = 0
+@@ -54,18 +54,21 @@ class IncrementalEncoder(codecs.BufferedIncrementalEncoder):
+             size += len(label)
+ 
+         # Join with U+002E
+-        result_str = '.'.join(result) + trailing_dot  # type: ignore
++        result_bytes = b'.'.join(result) + trailing_dot
+         size += len(trailing_dot)
+-        return result_str, size
++        return result_bytes, size
+ 
+ class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
+-    def _buffer_decode(self, data: str, errors: str, final: bool) -> Tuple[str, int]:  # type: ignore
++    def _buffer_decode(self, data: Any, errors: str, final: bool) -> Tuple[str, int]:
+         if errors != 'strict':
+             raise IDNAError('Unsupported error handling \"{}\"'.format(errors))
+ 
+         if not data:
+             return ('', 0)
+ 
++        if not isinstance(data, str):
++            data = str(data, 'ascii')
++
+         labels = _unicode_dots_re.split(data)
+         trailing_dot = ''
+         if labels:
+@@ -99,14 +102,17 @@ class StreamReader(Codec, codecs.StreamReader):
+     pass
+ 
+ 
+-def getregentry() -> codecs.CodecInfo:
+-    # Compatibility as a search_function for codecs.register()
++def search_function(name: str) -> Optional[codecs.CodecInfo]:
++    if name != 'idna2008':
++        return None
+     return codecs.CodecInfo(
+-        name='idna',
+-        encode=Codec().encode,  # type: ignore
+-        decode=Codec().decode,  # type: ignore
++        name=name,
++        encode=Codec().encode,
++        decode=Codec().decode,
+         incrementalencoder=IncrementalEncoder,
+         incrementaldecoder=IncrementalDecoder,
+         streamwriter=StreamWriter,
+         streamreader=StreamReader,
+     )
++
++codecs.register(search_function)
+diff --git a/src/pip/_vendor/idna/core.py b/src/pip/_vendor/idna/core.py
+index 4f30037..0dae61a 100644
+--- a/src/pip/_vendor/idna/core.py
++++ b/src/pip/_vendor/idna/core.py
+@@ -150,9 +150,11 @@ def valid_contextj(label: str, pos: int) -> bool:
+             joining_type = idnadata.joining_types.get(ord(label[i]))
+             if joining_type == ord('T'):
+                 continue
+-            if joining_type in [ord('L'), ord('D')]:
++            elif joining_type in [ord('L'), ord('D')]:
+                 ok = True
+                 break
++            else:
++                break
+ 
+         if not ok:
+             return False
+@@ -162,9 +164,11 @@ def valid_contextj(label: str, pos: int) -> bool:
+             joining_type = idnadata.joining_types.get(ord(label[i]))
+             if joining_type == ord('T'):
+                 continue
+-            if joining_type in [ord('R'), ord('D')]:
++            elif joining_type in [ord('R'), ord('D')]:
+                 ok = True
+                 break
++            else:
++                break
+         return ok
+ 
+     if cp_value == 0x200d:
+@@ -236,12 +240,8 @@ def check_label(label: Union[str, bytes, bytearray]) -> None:
+         if intranges_contain(cp_value, idnadata.codepoint_classes['PVALID']):
+             continue
+         elif intranges_contain(cp_value, idnadata.codepoint_classes['CONTEXTJ']):
+-            try:
+-                if not valid_contextj(label, pos):
+-                    raise InvalidCodepointContext('Joiner {} not allowed at position {} in {}'.format(
+-                        _unot(cp_value), pos+1, repr(label)))
+-            except ValueError:
+-                raise IDNAError('Unknown codepoint adjacent to joiner {} at position {} in {}'.format(
++            if not valid_contextj(label, pos):
++                raise InvalidCodepointContext('Joiner {} not allowed at position {} in {}'.format(
+                     _unot(cp_value), pos+1, repr(label)))
+         elif intranges_contain(cp_value, idnadata.codepoint_classes['CONTEXTO']):
+             if not valid_contexto(label, pos):
+@@ -262,13 +262,8 @@ def alabel(label: str) -> bytes:
+     except UnicodeEncodeError:
+         pass
+ 
+-    if not label:
+-        raise IDNAError('No Input')
+-
+-    label = str(label)
+     check_label(label)
+-    label_bytes = _punycode(label)
+-    label_bytes = _alabel_prefix + label_bytes
++    label_bytes = _alabel_prefix + _punycode(label)
+ 
+     if not valid_label_length(label_bytes):
+         raise IDNAError('Label too long')
+@@ -318,7 +313,7 @@ def uts46_remap(domain: str, std3_rules: bool = True, transitional: bool = False
+             status = uts46row[1]
+             replacement = None  # type: Optional[str]
+             if len(uts46row) == 3:
+-                replacement = uts46row[2]  # type: ignore
++                replacement = uts46row[2]
+             if (status == 'V' or
+                     (status == 'D' and not transitional) or
+                     (status == '3' and not std3_rules and replacement is None)):
+@@ -338,9 +333,9 @@ def uts46_remap(domain: str, std3_rules: bool = True, transitional: bool = False
+ 
+ 
+ def encode(s: Union[str, bytes, bytearray], strict: bool = False, uts46: bool = False, std3_rules: bool = False, transitional: bool = False) -> bytes:
+-    if isinstance(s, (bytes, bytearray)):
++    if not isinstance(s, str):
+         try:
+-            s = s.decode('ascii')
++            s = str(s, 'ascii')
+         except UnicodeDecodeError:
+             raise IDNAError('should pass a unicode string to the function rather than a byte string.')
+     if uts46:
+@@ -372,8 +367,8 @@ def encode(s: Union[str, bytes, bytearray], strict: bool = False, uts46: bool =
+ 
+ def decode(s: Union[str, bytes, bytearray], strict: bool = False, uts46: bool = False, std3_rules: bool = False) -> str:
+     try:
+-        if isinstance(s, (bytes, bytearray)):
+-            s = s.decode('ascii')
++        if not isinstance(s, str):
++            s = str(s, 'ascii')
+     except UnicodeDecodeError:
+         raise IDNAError('Invalid ASCII in A-label')
+     if uts46:
+diff --git a/src/pip/_vendor/idna/idnadata.py b/src/pip/_vendor/idna/idnadata.py
+index 67db462..c61dcf9 100644
+--- a/src/pip/_vendor/idna/idnadata.py
++++ b/src/pip/_vendor/idna/idnadata.py
+@@ -1,6 +1,6 @@
+ # This file is automatically generated by tools/idna-data
+ 
+-__version__ = '15.0.0'
++__version__ = '15.1.0'
+ scripts = {
+     'Greek': (
+         0x37000000374,
+@@ -59,6 +59,7 @@ scripts = {
+         0x2b7400002b81e,
+         0x2b8200002cea2,
+         0x2ceb00002ebe1,
++        0x2ebf00002ee5e,
+         0x2f8000002fa1e,
+         0x300000003134b,
+         0x31350000323b0,
+@@ -100,16 +101,190 @@ scripts = {
+     ),
+ }
+ joining_types = {
+-    0x600: 85,
+-    0x601: 85,
+-    0x602: 85,
+-    0x603: 85,
+-    0x604: 85,
+-    0x605: 85,
+-    0x608: 85,
+-    0x60b: 85,
++    0xad: 84,
++    0x300: 84,
++    0x301: 84,
++    0x302: 84,
++    0x303: 84,
++    0x304: 84,
++    0x305: 84,
++    0x306: 84,
++    0x307: 84,
++    0x308: 84,
++    0x309: 84,
++    0x30a: 84,
++    0x30b: 84,
++    0x30c: 84,
++    0x30d: 84,
++    0x30e: 84,
++    0x30f: 84,
++    0x310: 84,
++    0x311: 84,
++    0x312: 84,
++    0x313: 84,
++    0x314: 84,
++    0x315: 84,
++    0x316: 84,
++    0x317: 84,
++    0x318: 84,
++    0x319: 84,
++    0x31a: 84,
++    0x31b: 84,
++    0x31c: 84,
++    0x31d: 84,
++    0x31e: 84,
++    0x31f: 84,
++    0x320: 84,
++    0x321: 84,
++    0x322: 84,
++    0x323: 84,
++    0x324: 84,
++    0x325: 84,
++    0x326: 84,
++    0x327: 84,
++    0x328: 84,
++    0x329: 84,
++    0x32a: 84,
++    0x32b: 84,
++    0x32c: 84,
++    0x32d: 84,
++    0x32e: 84,
++    0x32f: 84,
++    0x330: 84,
++    0x331: 84,
++    0x332: 84,
++    0x333: 84,
++    0x334: 84,
++    0x335: 84,
++    0x336: 84,
++    0x337: 84,
++    0x338: 84,
++    0x339: 84,
++    0x33a: 84,
++    0x33b: 84,
++    0x33c: 84,
++    0x33d: 84,
++    0x33e: 84,
++    0x33f: 84,
++    0x340: 84,
++    0x341: 84,
++    0x342: 84,
++    0x343: 84,
++    0x344: 84,
++    0x345: 84,
++    0x346: 84,
++    0x347: 84,
++    0x348: 84,
++    0x349: 84,
++    0x34a: 84,
++    0x34b: 84,
++    0x34c: 84,
++    0x34d: 84,
++    0x34e: 84,
++    0x34f: 84,
++    0x350: 84,
++    0x351: 84,
++    0x352: 84,
++    0x353: 84,
++    0x354: 84,
++    0x355: 84,
++    0x356: 84,
++    0x357: 84,
++    0x358: 84,
++    0x359: 84,
++    0x35a: 84,
++    0x35b: 84,
++    0x35c: 84,
++    0x35d: 84,
++    0x35e: 84,
++    0x35f: 84,
++    0x360: 84,
++    0x361: 84,
++    0x362: 84,
++    0x363: 84,
++    0x364: 84,
++    0x365: 84,
++    0x366: 84,
++    0x367: 84,
++    0x368: 84,
++    0x369: 84,
++    0x36a: 84,
++    0x36b: 84,
++    0x36c: 84,
++    0x36d: 84,
++    0x36e: 84,
++    0x36f: 84,
++    0x483: 84,
++    0x484: 84,
++    0x485: 84,
++    0x486: 84,
++    0x487: 84,
++    0x488: 84,
++    0x489: 84,
++    0x591: 84,
++    0x592: 84,
++    0x593: 84,
++    0x594: 84,
++    0x595: 84,
++    0x596: 84,
++    0x597: 84,
++    0x598: 84,
++    0x599: 84,
++    0x59a: 84,
++    0x59b: 84,
++    0x59c: 84,
++    0x59d: 84,
++    0x59e: 84,
++    0x59f: 84,
++    0x5a0: 84,
++    0x5a1: 84,
++    0x5a2: 84,
++    0x5a3: 84,
++    0x5a4: 84,
++    0x5a5: 84,
++    0x5a6: 84,
++    0x5a7: 84,
++    0x5a8: 84,
++    0x5a9: 84,
++    0x5aa: 84,
++    0x5ab: 84,
++    0x5ac: 84,
++    0x5ad: 84,
++    0x5ae: 84,
++    0x5af: 84,
++    0x5b0: 84,
++    0x5b1: 84,
++    0x5b2: 84,
++    0x5b3: 84,
++    0x5b4: 84,
++    0x5b5: 84,
++    0x5b6: 84,
++    0x5b7: 84,
++    0x5b8: 84,
++    0x5b9: 84,
++    0x5ba: 84,
++    0x5bb: 84,
++    0x5bc: 84,
++    0x5bd: 84,
++    0x5bf: 84,
++    0x5c1: 84,
++    0x5c2: 84,
++    0x5c4: 84,
++    0x5c5: 84,
++    0x5c7: 84,
++    0x610: 84,
++    0x611: 84,
++    0x612: 84,
++    0x613: 84,
++    0x614: 84,
++    0x615: 84,
++    0x616: 84,
++    0x617: 84,
++    0x618: 84,
++    0x619: 84,
++    0x61a: 84,
++    0x61c: 84,
+     0x620: 68,
+-    0x621: 85,
+     0x622: 82,
+     0x623: 82,
+     0x624: 82,
+@@ -151,12 +326,33 @@ joining_types = {
+     0x648: 82,
+     0x649: 68,
+     0x64a: 68,
++    0x64b: 84,
++    0x64c: 84,
++    0x64d: 84,
++    0x64e: 84,
++    0x64f: 84,
++    0x650: 84,
++    0x651: 84,
++    0x652: 84,
++    0x653: 84,
++    0x654: 84,
++    0x655: 84,
++    0x656: 84,
++    0x657: 84,
++    0x658: 84,
++    0x659: 84,
++    0x65a: 84,
++    0x65b: 84,
++    0x65c: 84,
++    0x65d: 84,
++    0x65e: 84,
++    0x65f: 84,
+     0x66e: 68,
+     0x66f: 68,
++    0x670: 84,
+     0x671: 82,
+     0x672: 82,
+     0x673: 82,
+-    0x674: 85,
+     0x675: 82,
+     0x676: 82,
+     0x677: 82,
+@@ -253,7 +449,25 @@ joining_types = {
+     0x6d2: 82,
+     0x6d3: 82,
+     0x6d5: 82,
+-    0x6dd: 85,
++    0x6d6: 84,
++    0x6d7: 84,
++    0x6d8: 84,
++    0x6d9: 84,
++    0x6da: 84,
++    0x6db: 84,
++    0x6dc: 84,
++    0x6df: 84,
++    0x6e0: 84,
++    0x6e1: 84,
++    0x6e2: 84,
++    0x6e3: 84,
++    0x6e4: 84,
++    0x6e7: 84,
++    0x6e8: 84,
++    0x6ea: 84,
++    0x6eb: 84,
++    0x6ec: 84,
++    0x6ed: 84,
+     0x6ee: 82,
+     0x6ef: 82,
+     0x6fa: 68,
+@@ -262,6 +476,7 @@ joining_types = {
+     0x6ff: 68,
+     0x70f: 84,
+     0x710: 82,
++    0x711: 84,
+     0x712: 68,
+     0x713: 68,
+     0x714: 68,
+@@ -292,6 +507,33 @@ joining_types = {
+     0x72d: 68,
+     0x72e: 68,
+     0x72f: 82,
++    0x730: 84,
++    0x731: 84,
++    0x732: 84,
++    0x733: 84,
++    0x734: 84,
++    0x735: 84,
++    0x736: 84,
++    0x737: 84,
++    0x738: 84,
++    0x739: 84,
++    0x73a: 84,
++    0x73b: 84,
++    0x73c: 84,
++    0x73d: 84,
++    0x73e: 84,
++    0x73f: 84,
++    0x740: 84,
++    0x741: 84,
++    0x742: 84,
++    0x743: 84,
++    0x744: 84,
++    0x745: 84,
++    0x746: 84,
++    0x747: 84,
++    0x748: 84,
++    0x749: 84,
++    0x74a: 84,
+     0x74d: 82,
+     0x74e: 68,
+     0x74f: 68,
+@@ -343,6 +585,17 @@ joining_types = {
+     0x77d: 68,
+     0x77e: 68,
+     0x77f: 68,
++    0x7a6: 84,
++    0x7a7: 84,
++    0x7a8: 84,
++    0x7a9: 84,
++    0x7aa: 84,
++    0x7ab: 84,
++    0x7ac: 84,
++    0x7ad: 84,
++    0x7ae: 84,
++    0x7af: 84,
++    0x7b0: 84,
+     0x7ca: 68,
+     0x7cb: 68,
+     0x7cc: 68,
+@@ -376,7 +629,38 @@ joining_types = {
+     0x7e8: 68,
+     0x7e9: 68,
+     0x7ea: 68,
++    0x7eb: 84,
++    0x7ec: 84,
++    0x7ed: 84,
++    0x7ee: 84,
++    0x7ef: 84,
++    0x7f0: 84,
++    0x7f1: 84,
++    0x7f2: 84,
++    0x7f3: 84,
+     0x7fa: 67,
++    0x7fd: 84,
++    0x816: 84,
++    0x817: 84,
++    0x818: 84,
++    0x819: 84,
++    0x81b: 84,
++    0x81c: 84,
++    0x81d: 84,
++    0x81e: 84,
++    0x81f: 84,
++    0x820: 84,
++    0x821: 84,
++    0x822: 84,
++    0x823: 84,
++    0x825: 84,
++    0x826: 84,
++    0x827: 84,
++    0x829: 84,
++    0x82a: 84,
++    0x82b: 84,
++    0x82c: 84,
++    0x82d: 84,
+     0x840: 82,
+     0x841: 68,
+     0x842: 68,
+@@ -402,13 +686,14 @@ joining_types = {
+     0x856: 82,
+     0x857: 82,
+     0x858: 82,
++    0x859: 84,
++    0x85a: 84,
++    0x85b: 84,
+     0x860: 68,
+-    0x861: 85,
+     0x862: 68,
+     0x863: 68,
+     0x864: 68,
+     0x865: 68,
+-    0x866: 85,
+     0x867: 82,
+     0x868: 68,
+     0x869: 82,
+@@ -436,16 +721,20 @@ joining_types = {
+     0x884: 67,
+     0x885: 67,
+     0x886: 68,
+-    0x887: 85,
+-    0x888: 85,
+     0x889: 68,
+     0x88a: 68,
+     0x88b: 68,
+     0x88c: 68,
+     0x88d: 68,
+     0x88e: 82,
+-    0x890: 85,
+-    0x891: 85,
++    0x898: 84,
++    0x899: 84,
++    0x89a: 84,
++    0x89b: 84,
++    0x89c: 84,
++    0x89d: 84,
++    0x89e: 84,
++    0x89f: 84,
+     0x8a0: 68,
+     0x8a1: 68,
+     0x8a2: 68,
+@@ -459,7 +748,6 @@ joining_types = {
+     0x8aa: 82,
+     0x8ab: 82,
+     0x8ac: 82,
+-    0x8ad: 85,
+     0x8ae: 82,
+     0x8af: 68,
+     0x8b0: 68,
+@@ -487,11 +775,357 @@ joining_types = {
+     0x8c6: 68,
+     0x8c7: 68,
+     0x8c8: 68,
+-    0x8e2: 85,
+-    0x1806: 85,
++    0x8ca: 84,
++    0x8cb: 84,
++    0x8cc: 84,
++    0x8cd: 84,
++    0x8ce: 84,
++    0x8cf: 84,
++    0x8d0: 84,
++    0x8d1: 84,
++    0x8d2: 84,
++    0x8d3: 84,
++    0x8d4: 84,
++    0x8d5: 84,
++    0x8d6: 84,
++    0x8d7: 84,
++    0x8d8: 84,
++    0x8d9: 84,
++    0x8da: 84,
++    0x8db: 84,
++    0x8dc: 84,
++    0x8dd: 84,
++    0x8de: 84,
++    0x8df: 84,
++    0x8e0: 84,
++    0x8e1: 84,
++    0x8e3: 84,
++    0x8e4: 84,
++    0x8e5: 84,
++    0x8e6: 84,
++    0x8e7: 84,
++    0x8e8: 84,
++    0x8e9: 84,
++    0x8ea: 84,
++    0x8eb: 84,
++    0x8ec: 84,
++    0x8ed: 84,
++    0x8ee: 84,
++    0x8ef: 84,
++    0x8f0: 84,
++    0x8f1: 84,
++    0x8f2: 84,
++    0x8f3: 84,
++    0x8f4: 84,
++    0x8f5: 84,
++    0x8f6: 84,
++    0x8f7: 84,
++    0x8f8: 84,
++    0x8f9: 84,
++    0x8fa: 84,
++    0x8fb: 84,
++    0x8fc: 84,
++    0x8fd: 84,
++    0x8fe: 84,
++    0x8ff: 84,
++    0x900: 84,
++    0x901: 84,
++    0x902: 84,
++    0x93a: 84,
++    0x93c: 84,
++    0x941: 84,
++    0x942: 84,
++    0x943: 84,
++    0x944: 84,
++    0x945: 84,
++    0x946: 84,
++    0x947: 84,
++    0x948: 84,
++    0x94d: 84,
++    0x951: 84,
++    0x952: 84,
++    0x953: 84,
++    0x954: 84,
++    0x955: 84,
++    0x956: 84,
++    0x957: 84,
++    0x962: 84,
++    0x963: 84,
++    0x981: 84,
++    0x9bc: 84,
++    0x9c1: 84,
++    0x9c2: 84,
++    0x9c3: 84,
++    0x9c4: 84,
++    0x9cd: 84,
++    0x9e2: 84,
++    0x9e3: 84,
++    0x9fe: 84,
++    0xa01: 84,
++    0xa02: 84,
++    0xa3c: 84,
++    0xa41: 84,
++    0xa42: 84,
++    0xa47: 84,
++    0xa48: 84,
++    0xa4b: 84,
++    0xa4c: 84,
++    0xa4d: 84,
++    0xa51: 84,
++    0xa70: 84,
++    0xa71: 84,
++    0xa75: 84,
++    0xa81: 84,
++    0xa82: 84,
++    0xabc: 84,
++    0xac1: 84,
++    0xac2: 84,
++    0xac3: 84,
++    0xac4: 84,
++    0xac5: 84,
++    0xac7: 84,
++    0xac8: 84,
++    0xacd: 84,
++    0xae2: 84,
++    0xae3: 84,
++    0xafa: 84,
++    0xafb: 84,
++    0xafc: 84,
++    0xafd: 84,
++    0xafe: 84,
++    0xaff: 84,
++    0xb01: 84,
++    0xb3c: 84,
++    0xb3f: 84,
++    0xb41: 84,
++    0xb42: 84,
++    0xb43: 84,
++    0xb44: 84,
++    0xb4d: 84,
++    0xb55: 84,
++    0xb56: 84,
++    0xb62: 84,
++    0xb63: 84,
++    0xb82: 84,
++    0xbc0: 84,
++    0xbcd: 84,
++    0xc00: 84,
++    0xc04: 84,
++    0xc3c: 84,
++    0xc3e: 84,
++    0xc3f: 84,
++    0xc40: 84,
++    0xc46: 84,
++    0xc47: 84,
++    0xc48: 84,
++    0xc4a: 84,
++    0xc4b: 84,
++    0xc4c: 84,
++    0xc4d: 84,
++    0xc55: 84,
++    0xc56: 84,
++    0xc62: 84,
++    0xc63: 84,
++    0xc81: 84,
++    0xcbc: 84,
++    0xcbf: 84,
++    0xcc6: 84,
++    0xccc: 84,
++    0xccd: 84,
++    0xce2: 84,
++    0xce3: 84,
++    0xd00: 84,
++    0xd01: 84,
++    0xd3b: 84,
++    0xd3c: 84,
++    0xd41: 84,
++    0xd42: 84,
++    0xd43: 84,
++    0xd44: 84,
++    0xd4d: 84,
++    0xd62: 84,
++    0xd63: 84,
++    0xd81: 84,
++    0xdca: 84,
++    0xdd2: 84,
++    0xdd3: 84,
++    0xdd4: 84,
++    0xdd6: 84,
++    0xe31: 84,
++    0xe34: 84,
++    0xe35: 84,
++    0xe36: 84,
++    0xe37: 84,
++    0xe38: 84,
++    0xe39: 84,
++    0xe3a: 84,
++    0xe47: 84,
++    0xe48: 84,
++    0xe49: 84,
++    0xe4a: 84,
++    0xe4b: 84,
++    0xe4c: 84,
++    0xe4d: 84,
++    0xe4e: 84,
++    0xeb1: 84,
++    0xeb4: 84,
++    0xeb5: 84,
++    0xeb6: 84,
++    0xeb7: 84,
++    0xeb8: 84,
++    0xeb9: 84,
++    0xeba: 84,
++    0xebb: 84,
++    0xebc: 84,
++    0xec8: 84,
++    0xec9: 84,
++    0xeca: 84,
++    0xecb: 84,
++    0xecc: 84,
++    0xecd: 84,
++    0xece: 84,
++    0xf18: 84,
++    0xf19: 84,
++    0xf35: 84,
++    0xf37: 84,
++    0xf39: 84,
++    0xf71: 84,
++    0xf72: 84,
++    0xf73: 84,
++    0xf74: 84,
++    0xf75: 84,
++    0xf76: 84,
++    0xf77: 84,
++    0xf78: 84,
++    0xf79: 84,
++    0xf7a: 84,
++    0xf7b: 84,
++    0xf7c: 84,
++    0xf7d: 84,
++    0xf7e: 84,
++    0xf80: 84,
++    0xf81: 84,
++    0xf82: 84,
++    0xf83: 84,
++    0xf84: 84,
++    0xf86: 84,
++    0xf87: 84,
++    0xf8d: 84,
++    0xf8e: 84,
++    0xf8f: 84,
++    0xf90: 84,
++    0xf91: 84,
++    0xf92: 84,
++    0xf93: 84,
++    0xf94: 84,
++    0xf95: 84,
++    0xf96: 84,
++    0xf97: 84,
++    0xf99: 84,
++    0xf9a: 84,
++    0xf9b: 84,
++    0xf9c: 84,
++    0xf9d: 84,
++    0xf9e: 84,
++    0xf9f: 84,
++    0xfa0: 84,
++    0xfa1: 84,
++    0xfa2: 84,
++    0xfa3: 84,
++    0xfa4: 84,
++    0xfa5: 84,
++    0xfa6: 84,
++    0xfa7: 84,
++    0xfa8: 84,
++    0xfa9: 84,
++    0xfaa: 84,
++    0xfab: 84,
++    0xfac: 84,
++    0xfad: 84,
++    0xfae: 84,
++    0xfaf: 84,
++    0xfb0: 84,
++    0xfb1: 84,
++    0xfb2: 84,
++    0xfb3: 84,
++    0xfb4: 84,
++    0xfb5: 84,
++    0xfb6: 84,
++    0xfb7: 84,
++    0xfb8: 84,
++    0xfb9: 84,
++    0xfba: 84,
++    0xfbb: 84,
++    0xfbc: 84,
++    0xfc6: 84,
++    0x102d: 84,
++    0x102e: 84,
++    0x102f: 84,
++    0x1030: 84,
++    0x1032: 84,
++    0x1033: 84,
++    0x1034: 84,
++    0x1035: 84,
++    0x1036: 84,
++    0x1037: 84,
++    0x1039: 84,
++    0x103a: 84,
++    0x103d: 84,
++    0x103e: 84,
++    0x1058: 84,
++    0x1059: 84,
++    0x105e: 84,
++    0x105f: 84,
++    0x1060: 84,
++    0x1071: 84,
++    0x1072: 84,
++    0x1073: 84,
++    0x1074: 84,
++    0x1082: 84,
++    0x1085: 84,
++    0x1086: 84,
++    0x108d: 84,
++    0x109d: 84,
++    0x135d: 84,
++    0x135e: 84,
++    0x135f: 84,
++    0x1712: 84,
++    0x1713: 84,
++    0x1714: 84,
++    0x1732: 84,
++    0x1733: 84,
++    0x1752: 84,
++    0x1753: 84,
++    0x1772: 84,
++    0x1773: 84,
++    0x17b4: 84,
++    0x17b5: 84,
++    0x17b7: 84,
++    0x17b8: 84,
++    0x17b9: 84,
++    0x17ba: 84,
++    0x17bb: 84,
++    0x17bc: 84,
++    0x17bd: 84,
++    0x17c6: 84,
++    0x17c9: 84,
++    0x17ca: 84,
++    0x17cb: 84,
++    0x17cc: 84,
++    0x17cd: 84,
++    0x17ce: 84,
++    0x17cf: 84,
++    0x17d0: 84,
++    0x17d1: 84,
++    0x17d2: 84,
++    0x17d3: 84,
++    0x17dd: 84,
+     0x1807: 68,
+     0x180a: 67,
+-    0x180e: 85,
++    0x180b: 84,
++    0x180c: 84,
++    0x180d: 84,
++    0x180f: 84,
+     0x1820: 68,
+     0x1821: 68,
+     0x1822: 68,
+@@ -581,11 +1215,6 @@ joining_types = {
+     0x1876: 68,
+     0x1877: 68,
+     0x1878: 68,
+-    0x1880: 85,
+-    0x1881: 85,
+-    0x1882: 85,
+-    0x1883: 85,
+-    0x1884: 85,
+     0x1885: 84,
+     0x1886: 84,
+     0x1887: 68,
+@@ -622,14 +1251,339 @@ joining_types = {
+     0x18a6: 68,
+     0x18a7: 68,
+     0x18a8: 68,
++    0x18a9: 84,
+     0x18aa: 68,
+-    0x200c: 85,
++    0x1920: 84,
++    0x1921: 84,
++    0x1922: 84,
++    0x1927: 84,
++    0x1928: 84,
++    0x1932: 84,
++    0x1939: 84,
++    0x193a: 84,
++    0x193b: 84,
++    0x1a17: 84,
++    0x1a18: 84,
++    0x1a1b: 84,
++    0x1a56: 84,
++    0x1a58: 84,
++    0x1a59: 84,
++    0x1a5a: 84,
++    0x1a5b: 84,
++    0x1a5c: 84,
++    0x1a5d: 84,
++    0x1a5e: 84,
++    0x1a60: 84,
++    0x1a62: 84,
++    0x1a65: 84,
++    0x1a66: 84,
++    0x1a67: 84,
++    0x1a68: 84,
++    0x1a69: 84,
++    0x1a6a: 84,
++    0x1a6b: 84,
++    0x1a6c: 84,
++    0x1a73: 84,
++    0x1a74: 84,
++    0x1a75: 84,
++    0x1a76: 84,
++    0x1a77: 84,
++    0x1a78: 84,
++    0x1a79: 84,
++    0x1a7a: 84,
++    0x1a7b: 84,
++    0x1a7c: 84,
++    0x1a7f: 84,
++    0x1ab0: 84,
++    0x1ab1: 84,
++    0x1ab2: 84,
++    0x1ab3: 84,
++    0x1ab4: 84,
++    0x1ab5: 84,
++    0x1ab6: 84,
++    0x1ab7: 84,
++    0x1ab8: 84,
++    0x1ab9: 84,
++    0x1aba: 84,
++    0x1abb: 84,
++    0x1abc: 84,
++    0x1abd: 84,
++    0x1abe: 84,
++    0x1abf: 84,
++    0x1ac0: 84,
++    0x1ac1: 84,
++    0x1ac2: 84,
++    0x1ac3: 84,
++    0x1ac4: 84,
++    0x1ac5: 84,
++    0x1ac6: 84,
++    0x1ac7: 84,
++    0x1ac8: 84,
++    0x1ac9: 84,
++    0x1aca: 84,
++    0x1acb: 84,
++    0x1acc: 84,
++    0x1acd: 84,
++    0x1ace: 84,
++    0x1b00: 84,
++    0x1b01: 84,
++    0x1b02: 84,
++    0x1b03: 84,
++    0x1b34: 84,
++    0x1b36: 84,
++    0x1b37: 84,
++    0x1b38: 84,
++    0x1b39: 84,
++    0x1b3a: 84,
++    0x1b3c: 84,
++    0x1b42: 84,
++    0x1b6b: 84,
++    0x1b6c: 84,
++    0x1b6d: 84,
++    0x1b6e: 84,
++    0x1b6f: 84,
++    0x1b70: 84,
++    0x1b71: 84,
++    0x1b72: 84,
++    0x1b73: 84,
++    0x1b80: 84,
++    0x1b81: 84,
++    0x1ba2: 84,
++    0x1ba3: 84,
++    0x1ba4: 84,
++    0x1ba5: 84,
++    0x1ba8: 84,
++    0x1ba9: 84,
++    0x1bab: 84,
++    0x1bac: 84,
++    0x1bad: 84,
++    0x1be6: 84,
++    0x1be8: 84,
++    0x1be9: 84,
++    0x1bed: 84,
++    0x1bef: 84,
++    0x1bf0: 84,
++    0x1bf1: 84,
++    0x1c2c: 84,
++    0x1c2d: 84,
++    0x1c2e: 84,
++    0x1c2f: 84,
++    0x1c30: 84,
++    0x1c31: 84,
++    0x1c32: 84,
++    0x1c33: 84,
++    0x1c36: 84,
++    0x1c37: 84,
++    0x1cd0: 84,
++    0x1cd1: 84,
++    0x1cd2: 84,
++    0x1cd4: 84,
++    0x1cd5: 84,
++    0x1cd6: 84,
++    0x1cd7: 84,
++    0x1cd8: 84,
++    0x1cd9: 84,
++    0x1cda: 84,
++    0x1cdb: 84,
++    0x1cdc: 84,
++    0x1cdd: 84,
++    0x1cde: 84,
++    0x1cdf: 84,
++    0x1ce0: 84,
++    0x1ce2: 84,
++    0x1ce3: 84,
++    0x1ce4: 84,
++    0x1ce5: 84,
++    0x1ce6: 84,
++    0x1ce7: 84,
++    0x1ce8: 84,
++    0x1ced: 84,
++    0x1cf4: 84,
++    0x1cf8: 84,
++    0x1cf9: 84,
++    0x1dc0: 84,
++    0x1dc1: 84,
++    0x1dc2: 84,
++    0x1dc3: 84,
++    0x1dc4: 84,
++    0x1dc5: 84,
++    0x1dc6: 84,
++    0x1dc7: 84,
++    0x1dc8: 84,
++    0x1dc9: 84,
++    0x1dca: 84,
++    0x1dcb: 84,
++    0x1dcc: 84,
++    0x1dcd: 84,
++    0x1dce: 84,
++    0x1dcf: 84,
++    0x1dd0: 84,
++    0x1dd1: 84,
++    0x1dd2: 84,
++    0x1dd3: 84,
++    0x1dd4: 84,
++    0x1dd5: 84,
++    0x1dd6: 84,
++    0x1dd7: 84,
++    0x1dd8: 84,
++    0x1dd9: 84,
++    0x1dda: 84,
++    0x1ddb: 84,
++    0x1ddc: 84,
++    0x1ddd: 84,
++    0x1dde: 84,
++    0x1ddf: 84,
++    0x1de0: 84,
++    0x1de1: 84,
++    0x1de2: 84,
++    0x1de3: 84,
++    0x1de4: 84,
++    0x1de5: 84,
++    0x1de6: 84,
++    0x1de7: 84,
++    0x1de8: 84,
++    0x1de9: 84,
++    0x1dea: 84,
++    0x1deb: 84,
++    0x1dec: 84,
++    0x1ded: 84,
++    0x1dee: 84,
++    0x1def: 84,
++    0x1df0: 84,
++    0x1df1: 84,
++    0x1df2: 84,
++    0x1df3: 84,
++    0x1df4: 84,
++    0x1df5: 84,
++    0x1df6: 84,
++    0x1df7: 84,
++    0x1df8: 84,
++    0x1df9: 84,
++    0x1dfa: 84,
++    0x1dfb: 84,
++    0x1dfc: 84,
++    0x1dfd: 84,
++    0x1dfe: 84,
++    0x1dff: 84,
++    0x200b: 84,
+     0x200d: 67,
+-    0x202f: 85,
+-    0x2066: 85,
+-    0x2067: 85,
+-    0x2068: 85,
+-    0x2069: 85,
++    0x200e: 84,
++    0x200f: 84,
++    0x202a: 84,
++    0x202b: 84,
++    0x202c: 84,
++    0x202d: 84,
++    0x202e: 84,
++    0x2060: 84,
++    0x2061: 84,
++    0x2062: 84,
++    0x2063: 84,
++    0x2064: 84,
++    0x206a: 84,
++    0x206b: 84,
++    0x206c: 84,
++    0x206d: 84,
++    0x206e: 84,
++    0x206f: 84,
++    0x20d0: 84,
++    0x20d1: 84,
++    0x20d2: 84,
++    0x20d3: 84,
++    0x20d4: 84,
++    0x20d5: 84,
++    0x20d6: 84,
++    0x20d7: 84,
++    0x20d8: 84,
++    0x20d9: 84,
++    0x20da: 84,
++    0x20db: 84,
++    0x20dc: 84,
++    0x20dd: 84,
++    0x20de: 84,
++    0x20df: 84,
++    0x20e0: 84,
++    0x20e1: 84,
++    0x20e2: 84,
++    0x20e3: 84,
++    0x20e4: 84,
++    0x20e5: 84,
++    0x20e6: 84,
++    0x20e7: 84,
++    0x20e8: 84,
++    0x20e9: 84,
++    0x20ea: 84,
++    0x20eb: 84,
++    0x20ec: 84,
++    0x20ed: 84,
++    0x20ee: 84,
++    0x20ef: 84,
++    0x20f0: 84,
++    0x2cef: 84,
++    0x2cf0: 84,
++    0x2cf1: 84,
++    0x2d7f: 84,
++    0x2de0: 84,
++    0x2de1: 84,
++    0x2de2: 84,
++    0x2de3: 84,
++    0x2de4: 84,
++    0x2de5: 84,
++    0x2de6: 84,
++    0x2de7: 84,
++    0x2de8: 84,
++    0x2de9: 84,
++    0x2dea: 84,
++    0x2deb: 84,
++    0x2dec: 84,
++    0x2ded: 84,
++    0x2dee: 84,
++    0x2def: 84,
++    0x2df0: 84,
++    0x2df1: 84,
++    0x2df2: 84,
++    0x2df3: 84,
++    0x2df4: 84,
++    0x2df5: 84,
++    0x2df6: 84,
++    0x2df7: 84,
++    0x2df8: 84,
++    0x2df9: 84,
++    0x2dfa: 84,
++    0x2dfb: 84,
++    0x2dfc: 84,
++    0x2dfd: 84,
++    0x2dfe: 84,
++    0x2dff: 84,
++    0x302a: 84,
++    0x302b: 84,
++    0x302c: 84,
++    0x302d: 84,
++    0x3099: 84,
++    0x309a: 84,
++    0xa66f: 84,
++    0xa670: 84,
++    0xa671: 84,
++    0xa672: 84,
++    0xa674: 84,
++    0xa675: 84,
++    0xa676: 84,
++    0xa677: 84,
++    0xa678: 84,
++    0xa679: 84,
++    0xa67a: 84,
++    0xa67b: 84,
++    0xa67c: 84,
++    0xa67d: 84,
++    0xa69e: 84,
++    0xa69f: 84,
++    0xa6f0: 84,
++    0xa6f1: 84,
++    0xa802: 84,
++    0xa806: 84,
++    0xa80b: 84,
++    0xa825: 84,
++    0xa826: 84,
++    0xa82c: 84,
+     0xa840: 68,
+     0xa841: 68,
+     0xa842: 68,
+@@ -681,20 +1635,151 @@ joining_types = {
+     0xa870: 68,
+     0xa871: 68,
+     0xa872: 76,
+-    0xa873: 85,
++    0xa8c4: 84,
++    0xa8c5: 84,
++    0xa8e0: 84,
++    0xa8e1: 84,
++    0xa8e2: 84,
++    0xa8e3: 84,
++    0xa8e4: 84,
++    0xa8e5: 84,
++    0xa8e6: 84,
++    0xa8e7: 84,
++    0xa8e8: 84,
++    0xa8e9: 84,
++    0xa8ea: 84,
++    0xa8eb: 84,
++    0xa8ec: 84,
++    0xa8ed: 84,
++    0xa8ee: 84,
++    0xa8ef: 84,
++    0xa8f0: 84,
++    0xa8f1: 84,
++    0xa8ff: 84,
++    0xa926: 84,
++    0xa927: 84,
++    0xa928: 84,
++    0xa929: 84,
++    0xa92a: 84,
++    0xa92b: 84,
++    0xa92c: 84,
++    0xa92d: 84,
++    0xa947: 84,
++    0xa948: 84,
++    0xa949: 84,
++    0xa94a: 84,
++    0xa94b: 84,
++    0xa94c: 84,
++    0xa94d: 84,
++    0xa94e: 84,
++    0xa94f: 84,
++    0xa950: 84,
++    0xa951: 84,
++    0xa980: 84,
++    0xa981: 84,
++    0xa982: 84,
++    0xa9b3: 84,
++    0xa9b6: 84,
++    0xa9b7: 84,
++    0xa9b8: 84,
++    0xa9b9: 84,
++    0xa9bc: 84,
++    0xa9bd: 84,
++    0xa9e5: 84,
++    0xaa29: 84,
++    0xaa2a: 84,
++    0xaa2b: 84,
++    0xaa2c: 84,
++    0xaa2d: 84,
++    0xaa2e: 84,
++    0xaa31: 84,
++    0xaa32: 84,
++    0xaa35: 84,
++    0xaa36: 84,
++    0xaa43: 84,
++    0xaa4c: 84,
++    0xaa7c: 84,
++    0xaab0: 84,
++    0xaab2: 84,
++    0xaab3: 84,
++    0xaab4: 84,
++    0xaab7: 84,
++    0xaab8: 84,
++    0xaabe: 84,
++    0xaabf: 84,
++    0xaac1: 84,
++    0xaaec: 84,
++    0xaaed: 84,
++    0xaaf6: 84,
++    0xabe5: 84,
++    0xabe8: 84,
++    0xabed: 84,
++    0xfb1e: 84,
++    0xfe00: 84,
++    0xfe01: 84,
++    0xfe02: 84,
++    0xfe03: 84,
++    0xfe04: 84,
++    0xfe05: 84,
++    0xfe06: 84,
++    0xfe07: 84,
++    0xfe08: 84,
++    0xfe09: 84,
++    0xfe0a: 84,
++    0xfe0b: 84,
++    0xfe0c: 84,
++    0xfe0d: 84,
++    0xfe0e: 84,
++    0xfe0f: 84,
++    0xfe20: 84,
++    0xfe21: 84,
++    0xfe22: 84,
++    0xfe23: 84,
++    0xfe24: 84,
++    0xfe25: 84,
++    0xfe26: 84,
++    0xfe27: 84,
++    0xfe28: 84,
++    0xfe29: 84,
++    0xfe2a: 84,
++    0xfe2b: 84,
++    0xfe2c: 84,
++    0xfe2d: 84,
++    0xfe2e: 84,
++    0xfe2f: 84,
++    0xfeff: 84,
++    0xfff9: 84,
++    0xfffa: 84,
++    0xfffb: 84,
++    0x101fd: 84,
++    0x102e0: 84,
++    0x10376: 84,
++    0x10377: 84,
++    0x10378: 84,
++    0x10379: 84,
++    0x1037a: 84,
++    0x10a01: 84,
++    0x10a02: 84,
++    0x10a03: 84,
++    0x10a05: 84,
++    0x10a06: 84,
++    0x10a0c: 84,
++    0x10a0d: 84,
++    0x10a0e: 84,
++    0x10a0f: 84,
++    0x10a38: 84,
++    0x10a39: 84,
++    0x10a3a: 84,
++    0x10a3f: 84,
+     0x10ac0: 68,
+     0x10ac1: 68,
+     0x10ac2: 68,
+     0x10ac3: 68,
+     0x10ac4: 68,
+     0x10ac5: 82,
+-    0x10ac6: 85,
+     0x10ac7: 82,
+-    0x10ac8: 85,
+     0x10ac9: 82,
+     0x10aca: 82,
+-    0x10acb: 85,
+-    0x10acc: 85,
+     0x10acd: 76,
+     0x10ace: 82,
+     0x10acf: 82,
+@@ -716,9 +1801,9 @@ joining_types = {
+     0x10adf: 68,
+     0x10ae0: 68,
+     0x10ae1: 82,
+-    0x10ae2: 85,
+-    0x10ae3: 85,
+     0x10ae4: 82,
++    0x10ae5: 84,
++    0x10ae6: 84,
+     0x10aeb: 68,
+     0x10aec: 68,
+     0x10aed: 68,
+@@ -748,7 +1833,6 @@ joining_types = {
+     0x10bac: 82,
+     0x10bad: 68,
+     0x10bae: 68,
+-    0x10baf: 85,
+     0x10d00: 76,
+     0x10d01: 68,
+     0x10d02: 68,
+@@ -785,6 +1869,15 @@ joining_types = {
+     0x10d21: 68,
+     0x10d22: 82,
+     0x10d23: 68,
++    0x10d24: 84,
++    0x10d25: 84,
++    0x10d26: 84,
++    0x10d27: 84,
++    0x10eab: 84,
++    0x10eac: 84,
++    0x10efd: 84,
++    0x10efe: 84,
++    0x10eff: 84,
+     0x10f30: 68,
+     0x10f31: 68,
+     0x10f32: 68,
+@@ -806,7 +1899,17 @@ joining_types = {
+     0x10f42: 68,
+     0x10f43: 68,
+     0x10f44: 68,
+-    0x10f45: 85,
++    0x10f46: 84,
++    0x10f47: 84,
++    0x10f48: 84,
++    0x10f49: 84,
++    0x10f4a: 84,
++    0x10f4b: 84,
++    0x10f4c: 84,
++    0x10f4d: 84,
++    0x10f4e: 84,
++    0x10f4f: 84,
++    0x10f50: 84,
+     0x10f51: 68,
+     0x10f52: 68,
+     0x10f53: 68,
+@@ -829,14 +1932,16 @@ joining_types = {
+     0x10f7f: 68,
+     0x10f80: 68,
+     0x10f81: 68,
++    0x10f82: 84,
++    0x10f83: 84,
++    0x10f84: 84,
++    0x10f85: 84,
+     0x10fb0: 68,
+-    0x10fb1: 85,
+     0x10fb2: 68,
+     0x10fb3: 68,
+     0x10fb4: 82,
+     0x10fb5: 82,
+     0x10fb6: 82,
+-    0x10fb7: 85,
+     0x10fb8: 68,
+     0x10fb9: 82,
+     0x10fba: 82,
+@@ -845,20 +1950,668 @@ joining_types = {
+     0x10fbd: 82,
+     0x10fbe: 68,
+     0x10fbf: 68,
+-    0x10fc0: 85,
+     0x10fc1: 68,
+     0x10fc2: 82,
+     0x10fc3: 82,
+     0x10fc4: 68,
+-    0x10fc5: 85,
+-    0x10fc6: 85,
+-    0x10fc7: 85,
+-    0x10fc8: 85,
+     0x10fc9: 82,
+     0x10fca: 68,
+     0x10fcb: 76,
+-    0x110bd: 85,
+-    0x110cd: 85,
++    0x11001: 84,
++    0x11038: 84,
++    0x11039: 84,
++    0x1103a: 84,
++    0x1103b: 84,
++    0x1103c: 84,
++    0x1103d: 84,
++    0x1103e: 84,
++    0x1103f: 84,
++    0x11040: 84,
++    0x11041: 84,
++    0x11042: 84,
++    0x11043: 84,
++    0x11044: 84,
++    0x11045: 84,
++    0x11046: 84,
++    0x11070: 84,
++    0x11073: 84,
++    0x11074: 84,
++    0x1107f: 84,
++    0x11080: 84,
++    0x11081: 84,
++    0x110b3: 84,
++    0x110b4: 84,
++    0x110b5: 84,
++    0x110b6: 84,
++    0x110b9: 84,
++    0x110ba: 84,
++    0x110c2: 84,
++    0x11100: 84,
++    0x11101: 84,
++    0x11102: 84,
++    0x11127: 84,
++    0x11128: 84,
++    0x11129: 84,
++    0x1112a: 84,
++    0x1112b: 84,
++    0x1112d: 84,
++    0x1112e: 84,
++    0x1112f: 84,
++    0x11130: 84,
++    0x11131: 84,
++    0x11132: 84,
++    0x11133: 84,
++    0x11134: 84,
++    0x11173: 84,
++    0x11180: 84,
++    0x11181: 84,
++    0x111b6: 84,
++    0x111b7: 84,
++    0x111b8: 84,
++    0x111b9: 84,
++    0x111ba: 84,
++    0x111bb: 84,
++    0x111bc: 84,
++    0x111bd: 84,
++    0x111be: 84,
++    0x111c9: 84,
++    0x111ca: 84,
++    0x111cb: 84,
++    0x111cc: 84,
++    0x111cf: 84,
++    0x1122f: 84,
++    0x11230: 84,
++    0x11231: 84,
++    0x11234: 84,
++    0x11236: 84,
++    0x11237: 84,
++    0x1123e: 84,
++    0x11241: 84,
++    0x112df: 84,
++    0x112e3: 84,
++    0x112e4: 84,
++    0x112e5: 84,
++    0x112e6: 84,
++    0x112e7: 84,
++    0x112e8: 84,
++    0x112e9: 84,
++    0x112ea: 84,
++    0x11300: 84,
++    0x11301: 84,
++    0x1133b: 84,
++    0x1133c: 84,
++    0x11340: 84,
++    0x11366: 84,
++    0x11367: 84,
++    0x11368: 84,
++    0x11369: 84,
++    0x1136a: 84,
++    0x1136b: 84,
++    0x1136c: 84,
++    0x11370: 84,
++    0x11371: 84,
++    0x11372: 84,
++    0x11373: 84,
++    0x11374: 84,
++    0x11438: 84,
++    0x11439: 84,
++    0x1143a: 84,
++    0x1143b: 84,
++    0x1143c: 84,
++    0x1143d: 84,
++    0x1143e: 84,
++    0x1143f: 84,
++    0x11442: 84,
++    0x11443: 84,
++    0x11444: 84,
++    0x11446: 84,
++    0x1145e: 84,
++    0x114b3: 84,
++    0x114b4: 84,
++    0x114b5: 84,
++    0x114b6: 84,
++    0x114b7: 84,
++    0x114b8: 84,
++    0x114ba: 84,
++    0x114bf: 84,
++    0x114c0: 84,
++    0x114c2: 84,
++    0x114c3: 84,
++    0x115b2: 84,
++    0x115b3: 84,
++    0x115b4: 84,
++    0x115b5: 84,
++    0x115bc: 84,
++    0x115bd: 84,
++    0x115bf: 84,
++    0x115c0: 84,
++    0x115dc: 84,
++    0x115dd: 84,
++    0x11633: 84,
++    0x11634: 84,
++    0x11635: 84,
++    0x11636: 84,
++    0x11637: 84,
++    0x11638: 84,
++    0x11639: 84,
++    0x1163a: 84,
++    0x1163d: 84,
++    0x1163f: 84,
++    0x11640: 84,
++    0x116ab: 84,
++    0x116ad: 84,
++    0x116b0: 84,
++    0x116b1: 84,
++    0x116b2: 84,
++    0x116b3: 84,
++    0x116b4: 84,
++    0x116b5: 84,
++    0x116b7: 84,
++    0x1171d: 84,
++    0x1171e: 84,
++    0x1171f: 84,
++    0x11722: 84,
++    0x11723: 84,
++    0x11724: 84,
++    0x11725: 84,
++    0x11727: 84,
++    0x11728: 84,
++    0x11729: 84,
++    0x1172a: 84,
++    0x1172b: 84,
++    0x1182f: 84,
++    0x11830: 84,
++    0x11831: 84,
++    0x11832: 84,
++    0x11833: 84,
++    0x11834: 84,
++    0x11835: 84,
++    0x11836: 84,
++    0x11837: 84,
++    0x11839: 84,
++    0x1183a: 84,
++    0x1193b: 84,
++    0x1193c: 84,
++    0x1193e: 84,
++    0x11943: 84,
++    0x119d4: 84,
++    0x119d5: 84,
++    0x119d6: 84,
++    0x119d7: 84,
++    0x119da: 84,
++    0x119db: 84,
++    0x119e0: 84,
++    0x11a01: 84,
++    0x11a02: 84,
++    0x11a03: 84,
++    0x11a04: 84,
++    0x11a05: 84,
++    0x11a06: 84,
++    0x11a07: 84,
++    0x11a08: 84,
++    0x11a09: 84,
++    0x11a0a: 84,
++    0x11a33: 84,
++    0x11a34: 84,
++    0x11a35: 84,
++    0x11a36: 84,
++    0x11a37: 84,
++    0x11a38: 84,
++    0x11a3b: 84,
++    0x11a3c: 84,
++    0x11a3d: 84,
++    0x11a3e: 84,
++    0x11a47: 84,
++    0x11a51: 84,
++    0x11a52: 84,
++    0x11a53: 84,
++    0x11a54: 84,
++    0x11a55: 84,
++    0x11a56: 84,
++    0x11a59: 84,
++    0x11a5a: 84,
++    0x11a5b: 84,
++    0x11a8a: 84,
++    0x11a8b: 84,
++    0x11a8c: 84,
++    0x11a8d: 84,
++    0x11a8e: 84,
++    0x11a8f: 84,
++    0x11a90: 84,
++    0x11a91: 84,
++    0x11a92: 84,
++    0x11a93: 84,
++    0x11a94: 84,
++    0x11a95: 84,
++    0x11a96: 84,
++    0x11a98: 84,
++    0x11a99: 84,
++    0x11c30: 84,
++    0x11c31: 84,
++    0x11c32: 84,
++    0x11c33: 84,
++    0x11c34: 84,
++    0x11c35: 84,
++    0x11c36: 84,
++    0x11c38: 84,
++    0x11c39: 84,
++    0x11c3a: 84,
++    0x11c3b: 84,
++    0x11c3c: 84,
++    0x11c3d: 84,
++    0x11c3f: 84,
++    0x11c92: 84,
++    0x11c93: 84,
++    0x11c94: 84,
++    0x11c95: 84,
++    0x11c96: 84,
++    0x11c97: 84,
++    0x11c98: 84,
++    0x11c99: 84,
++    0x11c9a: 84,
++    0x11c9b: 84,
++    0x11c9c: 84,
++    0x11c9d: 84,
++    0x11c9e: 84,
++    0x11c9f: 84,
++    0x11ca0: 84,
++    0x11ca1: 84,
++    0x11ca2: 84,
++    0x11ca3: 84,
++    0x11ca4: 84,
++    0x11ca5: 84,
++    0x11ca6: 84,
++    0x11ca7: 84,
++    0x11caa: 84,
++    0x11cab: 84,
++    0x11cac: 84,
++    0x11cad: 84,
++    0x11cae: 84,
++    0x11caf: 84,
++    0x11cb0: 84,
++    0x11cb2: 84,
++    0x11cb3: 84,
++    0x11cb5: 84,
++    0x11cb6: 84,
++    0x11d31: 84,
++    0x11d32: 84,
++    0x11d33: 84,
++    0x11d34: 84,
++    0x11d35: 84,
++    0x11d36: 84,
++    0x11d3a: 84,
++    0x11d3c: 84,
++    0x11d3d: 84,
++    0x11d3f: 84,
++    0x11d40: 84,
++    0x11d41: 84,
++    0x11d42: 84,
++    0x11d43: 84,
++    0x11d44: 84,
++    0x11d45: 84,
++    0x11d47: 84,
++    0x11d90: 84,
++    0x11d91: 84,
++    0x11d95: 84,
++    0x11d97: 84,
++    0x11ef3: 84,
++    0x11ef4: 84,
++    0x11f00: 84,
++    0x11f01: 84,
++    0x11f36: 84,
++    0x11f37: 84,
++    0x11f38: 84,
++    0x11f39: 84,
++    0x11f3a: 84,
++    0x11f40: 84,
++    0x11f42: 84,
++    0x13430: 84,
++    0x13431: 84,
++    0x13432: 84,
++    0x13433: 84,
++    0x13434: 84,
++    0x13435: 84,
++    0x13436: 84,
++    0x13437: 84,
++    0x13438: 84,
++    0x13439: 84,
++    0x1343a: 84,
++    0x1343b: 84,
++    0x1343c: 84,
++    0x1343d: 84,
++    0x1343e: 84,
++    0x1343f: 84,
++    0x13440: 84,
++    0x13447: 84,
++    0x13448: 84,
++    0x13449: 84,
++    0x1344a: 84,
++    0x1344b: 84,
++    0x1344c: 84,
++    0x1344d: 84,
++    0x1344e: 84,
++    0x1344f: 84,
++    0x13450: 84,
++    0x13451: 84,
++    0x13452: 84,
++    0x13453: 84,
++    0x13454: 84,
++    0x13455: 84,
++    0x16af0: 84,
++    0x16af1: 84,
++    0x16af2: 84,
++    0x16af3: 84,
++    0x16af4: 84,
++    0x16b30: 84,
++    0x16b31: 84,
++    0x16b32: 84,
++    0x16b33: 84,
++    0x16b34: 84,
++    0x16b35: 84,
++    0x16b36: 84,
++    0x16f4f: 84,
++    0x16f8f: 84,
++    0x16f90: 84,
++    0x16f91: 84,
++    0x16f92: 84,
++    0x16fe4: 84,
++    0x1bc9d: 84,
++    0x1bc9e: 84,
++    0x1bca0: 84,
++    0x1bca1: 84,
++    0x1bca2: 84,
++    0x1bca3: 84,
++    0x1cf00: 84,
++    0x1cf01: 84,
++    0x1cf02: 84,
++    0x1cf03: 84,
++    0x1cf04: 84,
++    0x1cf05: 84,
++    0x1cf06: 84,
++    0x1cf07: 84,
++    0x1cf08: 84,
++    0x1cf09: 84,
++    0x1cf0a: 84,
++    0x1cf0b: 84,
++    0x1cf0c: 84,
++    0x1cf0d: 84,
++    0x1cf0e: 84,
++    0x1cf0f: 84,
++    0x1cf10: 84,
++    0x1cf11: 84,
++    0x1cf12: 84,
++    0x1cf13: 84,
++    0x1cf14: 84,
++    0x1cf15: 84,
++    0x1cf16: 84,
++    0x1cf17: 84,
++    0x1cf18: 84,
++    0x1cf19: 84,
++    0x1cf1a: 84,
++    0x1cf1b: 84,
++    0x1cf1c: 84,
++    0x1cf1d: 84,
++    0x1cf1e: 84,
++    0x1cf1f: 84,
++    0x1cf20: 84,
++    0x1cf21: 84,
++    0x1cf22: 84,
++    0x1cf23: 84,
++    0x1cf24: 84,
++    0x1cf25: 84,
++    0x1cf26: 84,
++    0x1cf27: 84,
++    0x1cf28: 84,
++    0x1cf29: 84,
++    0x1cf2a: 84,
++    0x1cf2b: 84,
++    0x1cf2c: 84,
++    0x1cf2d: 84,
++    0x1cf30: 84,
++    0x1cf31: 84,
++    0x1cf32: 84,
++    0x1cf33: 84,
++    0x1cf34: 84,
++    0x1cf35: 84,
++    0x1cf36: 84,
++    0x1cf37: 84,
++    0x1cf38: 84,
++    0x1cf39: 84,
++    0x1cf3a: 84,
++    0x1cf3b: 84,
++    0x1cf3c: 84,
++    0x1cf3d: 84,
++    0x1cf3e: 84,
++    0x1cf3f: 84,
++    0x1cf40: 84,
++    0x1cf41: 84,
++    0x1cf42: 84,
++    0x1cf43: 84,
++    0x1cf44: 84,
++    0x1cf45: 84,
++    0x1cf46: 84,
++    0x1d167: 84,
++    0x1d168: 84,
++    0x1d169: 84,
++    0x1d173: 84,
++    0x1d174: 84,
++    0x1d175: 84,
++    0x1d176: 84,
++    0x1d177: 84,
++    0x1d178: 84,
++    0x1d179: 84,
++    0x1d17a: 84,
++    0x1d17b: 84,
++    0x1d17c: 84,
++    0x1d17d: 84,
++    0x1d17e: 84,
++    0x1d17f: 84,
++    0x1d180: 84,
++    0x1d181: 84,
++    0x1d182: 84,
++    0x1d185: 84,
++    0x1d186: 84,
++    0x1d187: 84,
++    0x1d188: 84,
++    0x1d189: 84,
++    0x1d18a: 84,
++    0x1d18b: 84,
++    0x1d1aa: 84,
++    0x1d1ab: 84,
++    0x1d1ac: 84,
++    0x1d1ad: 84,
++    0x1d242: 84,
++    0x1d243: 84,
++    0x1d244: 84,
++    0x1da00: 84,
++    0x1da01: 84,
++    0x1da02: 84,
++    0x1da03: 84,
++    0x1da04: 84,
++    0x1da05: 84,
++    0x1da06: 84,
++    0x1da07: 84,
++    0x1da08: 84,
++    0x1da09: 84,
++    0x1da0a: 84,
++    0x1da0b: 84,
++    0x1da0c: 84,
++    0x1da0d: 84,
++    0x1da0e: 84,
++    0x1da0f: 84,
++    0x1da10: 84,
++    0x1da11: 84,
++    0x1da12: 84,
++    0x1da13: 84,
++    0x1da14: 84,
++    0x1da15: 84,
++    0x1da16: 84,
++    0x1da17: 84,
++    0x1da18: 84,
++    0x1da19: 84,
++    0x1da1a: 84,
++    0x1da1b: 84,
++    0x1da1c: 84,
++    0x1da1d: 84,
++    0x1da1e: 84,
++    0x1da1f: 84,
++    0x1da20: 84,
++    0x1da21: 84,
++    0x1da22: 84,
++    0x1da23: 84,
++    0x1da24: 84,
++    0x1da25: 84,
++    0x1da26: 84,
++    0x1da27: 84,
++    0x1da28: 84,
++    0x1da29: 84,
++    0x1da2a: 84,
++    0x1da2b: 84,
++    0x1da2c: 84,
++    0x1da2d: 84,
++    0x1da2e: 84,
++    0x1da2f: 84,
++    0x1da30: 84,
++    0x1da31: 84,
++    0x1da32: 84,
++    0x1da33: 84,
++    0x1da34: 84,
++    0x1da35: 84,
++    0x1da36: 84,
++    0x1da3b: 84,
++    0x1da3c: 84,
++    0x1da3d: 84,
++    0x1da3e: 84,
++    0x1da3f: 84,
++    0x1da40: 84,
++    0x1da41: 84,
++    0x1da42: 84,
++    0x1da43: 84,
++    0x1da44: 84,
++    0x1da45: 84,
++    0x1da46: 84,
++    0x1da47: 84,
++    0x1da48: 84,
++    0x1da49: 84,
++    0x1da4a: 84,
++    0x1da4b: 84,
++    0x1da4c: 84,
++    0x1da4d: 84,
++    0x1da4e: 84,
++    0x1da4f: 84,
++    0x1da50: 84,
++    0x1da51: 84,
++    0x1da52: 84,
++    0x1da53: 84,
++    0x1da54: 84,
++    0x1da55: 84,
++    0x1da56: 84,
++    0x1da57: 84,
++    0x1da58: 84,
++    0x1da59: 84,
++    0x1da5a: 84,
++    0x1da5b: 84,
++    0x1da5c: 84,
++    0x1da5d: 84,
++    0x1da5e: 84,
++    0x1da5f: 84,
++    0x1da60: 84,
++    0x1da61: 84,
++    0x1da62: 84,
++    0x1da63: 84,
++    0x1da64: 84,
++    0x1da65: 84,
++    0x1da66: 84,
++    0x1da67: 84,
++    0x1da68: 84,
++    0x1da69: 84,
++    0x1da6a: 84,
++    0x1da6b: 84,
++    0x1da6c: 84,
++    0x1da75: 84,
++    0x1da84: 84,
++    0x1da9b: 84,
++    0x1da9c: 84,
++    0x1da9d: 84,
++    0x1da9e: 84,
++    0x1da9f: 84,
++    0x1daa1: 84,
++    0x1daa2: 84,
++    0x1daa3: 84,
++    0x1daa4: 84,
++    0x1daa5: 84,
++    0x1daa6: 84,
++    0x1daa7: 84,
++    0x1daa8: 84,
++    0x1daa9: 84,
++    0x1daaa: 84,
++    0x1daab: 84,
++    0x1daac: 84,
++    0x1daad: 84,
++    0x1daae: 84,
++    0x1daaf: 84,
++    0x1e000: 84,
++    0x1e001: 84,
++    0x1e002: 84,
++    0x1e003: 84,
++    0x1e004: 84,
++    0x1e005: 84,
++    0x1e006: 84,
++    0x1e008: 84,
++    0x1e009: 84,
++    0x1e00a: 84,
++    0x1e00b: 84,
++    0x1e00c: 84,
++    0x1e00d: 84,
++    0x1e00e: 84,
++    0x1e00f: 84,
++    0x1e010: 84,
++    0x1e011: 84,
++    0x1e012: 84,
++    0x1e013: 84,
++    0x1e014: 84,
++    0x1e015: 84,
++    0x1e016: 84,
++    0x1e017: 84,
++    0x1e018: 84,
++    0x1e01b: 84,
++    0x1e01c: 84,
++    0x1e01d: 84,
++    0x1e01e: 84,
++    0x1e01f: 84,
++    0x1e020: 84,
++    0x1e021: 84,
++    0x1e023: 84,
++    0x1e024: 84,
++    0x1e026: 84,
++    0x1e027: 84,
++    0x1e028: 84,
++    0x1e029: 84,
++    0x1e02a: 84,
++    0x1e08f: 84,
++    0x1e130: 84,
++    0x1e131: 84,
++    0x1e132: 84,
++    0x1e133: 84,
++    0x1e134: 84,
++    0x1e135: 84,
++    0x1e136: 84,
++    0x1e2ae: 84,
++    0x1e2ec: 84,
++    0x1e2ed: 84,
++    0x1e2ee: 84,
++    0x1e2ef: 84,
++    0x1e4ec: 84,
++    0x1e4ed: 84,
++    0x1e4ee: 84,
++    0x1e4ef: 84,
++    0x1e8d0: 84,
++    0x1e8d1: 84,
++    0x1e8d2: 84,
++    0x1e8d3: 84,
++    0x1e8d4: 84,
++    0x1e8d5: 84,
++    0x1e8d6: 84,
+     0x1e900: 68,
+     0x1e901: 68,
+     0x1e902: 68,
+@@ -927,7 +2680,351 @@ joining_types = {
+     0x1e941: 68,
+     0x1e942: 68,
+     0x1e943: 68,
++    0x1e944: 84,
++    0x1e945: 84,
++    0x1e946: 84,
++    0x1e947: 84,
++    0x1e948: 84,
++    0x1e949: 84,
++    0x1e94a: 84,
+     0x1e94b: 84,
++    0xe0001: 84,
++    0xe0020: 84,
++    0xe0021: 84,
++    0xe0022: 84,
++    0xe0023: 84,
++    0xe0024: 84,
++    0xe0025: 84,
++    0xe0026: 84,
++    0xe0027: 84,
++    0xe0028: 84,
++    0xe0029: 84,
++    0xe002a: 84,
++    0xe002b: 84,
++    0xe002c: 84,
++    0xe002d: 84,
++    0xe002e: 84,
++    0xe002f: 84,
++    0xe0030: 84,
++    0xe0031: 84,
++    0xe0032: 84,
++    0xe0033: 84,
++    0xe0034: 84,
++    0xe0035: 84,
++    0xe0036: 84,
++    0xe0037: 84,
++    0xe0038: 84,
++    0xe0039: 84,
++    0xe003a: 84,
++    0xe003b: 84,
++    0xe003c: 84,
++    0xe003d: 84,
++    0xe003e: 84,
++    0xe003f: 84,
++    0xe0040: 84,
++    0xe0041: 84,
++    0xe0042: 84,
++    0xe0043: 84,
++    0xe0044: 84,
++    0xe0045: 84,
++    0xe0046: 84,
++    0xe0047: 84,
++    0xe0048: 84,
++    0xe0049: 84,
++    0xe004a: 84,
++    0xe004b: 84,
++    0xe004c: 84,
++    0xe004d: 84,
++    0xe004e: 84,
++    0xe004f: 84,
++    0xe0050: 84,
++    0xe0051: 84,
++    0xe0052: 84,
++    0xe0053: 84,
++    0xe0054: 84,
++    0xe0055: 84,
++    0xe0056: 84,
++    0xe0057: 84,
++    0xe0058: 84,
++    0xe0059: 84,
++    0xe005a: 84,
++    0xe005b: 84,
++    0xe005c: 84,
++    0xe005d: 84,
++    0xe005e: 84,
++    0xe005f: 84,
++    0xe0060: 84,
++    0xe0061: 84,
++    0xe0062: 84,
++    0xe0063: 84,
++    0xe0064: 84,
++    0xe0065: 84,
++    0xe0066: 84,
++    0xe0067: 84,
++    0xe0068: 84,
++    0xe0069: 84,
++    0xe006a: 84,
++    0xe006b: 84,
++    0xe006c: 84,
++    0xe006d: 84,
++    0xe006e: 84,
++    0xe006f: 84,
++    0xe0070: 84,
++    0xe0071: 84,
++    0xe0072: 84,
++    0xe0073: 84,
++    0xe0074: 84,
++    0xe0075: 84,
++    0xe0076: 84,
++    0xe0077: 84,
++    0xe0078: 84,
++    0xe0079: 84,
++    0xe007a: 84,
++    0xe007b: 84,
++    0xe007c: 84,
++    0xe007d: 84,
++    0xe007e: 84,
++    0xe007f: 84,
++    0xe0100: 84,
++    0xe0101: 84,
++    0xe0102: 84,
++    0xe0103: 84,
++    0xe0104: 84,
++    0xe0105: 84,
++    0xe0106: 84,
++    0xe0107: 84,
++    0xe0108: 84,
++    0xe0109: 84,
++    0xe010a: 84,
++    0xe010b: 84,
++    0xe010c: 84,
++    0xe010d: 84,
++    0xe010e: 84,
++    0xe010f: 84,
++    0xe0110: 84,
++    0xe0111: 84,
++    0xe0112: 84,
++    0xe0113: 84,
++    0xe0114: 84,
++    0xe0115: 84,
++    0xe0116: 84,
++    0xe0117: 84,
++    0xe0118: 84,
++    0xe0119: 84,
++    0xe011a: 84,
++    0xe011b: 84,
++    0xe011c: 84,
++    0xe011d: 84,
++    0xe011e: 84,
++    0xe011f: 84,
++    0xe0120: 84,
++    0xe0121: 84,
++    0xe0122: 84,
++    0xe0123: 84,
++    0xe0124: 84,
++    0xe0125: 84,
++    0xe0126: 84,
++    0xe0127: 84,
++    0xe0128: 84,
++    0xe0129: 84,
++    0xe012a: 84,
++    0xe012b: 84,
++    0xe012c: 84,
++    0xe012d: 84,
++    0xe012e: 84,
++    0xe012f: 84,
++    0xe0130: 84,
++    0xe0131: 84,
++    0xe0132: 84,
++    0xe0133: 84,
++    0xe0134: 84,
++    0xe0135: 84,
++    0xe0136: 84,
++    0xe0137: 84,
++    0xe0138: 84,
++    0xe0139: 84,
++    0xe013a: 84,
++    0xe013b: 84,
++    0xe013c: 84,
++    0xe013d: 84,
++    0xe013e: 84,
++    0xe013f: 84,
++    0xe0140: 84,
++    0xe0141: 84,
++    0xe0142: 84,
++    0xe0143: 84,
++    0xe0144: 84,
++    0xe0145: 84,
++    0xe0146: 84,
++    0xe0147: 84,
++    0xe0148: 84,
++    0xe0149: 84,
++    0xe014a: 84,
++    0xe014b: 84,
++    0xe014c: 84,
++    0xe014d: 84,
++    0xe014e: 84,
++    0xe014f: 84,
++    0xe0150: 84,
++    0xe0151: 84,
++    0xe0152: 84,
++    0xe0153: 84,
++    0xe0154: 84,
++    0xe0155: 84,
++    0xe0156: 84,
++    0xe0157: 84,
++    0xe0158: 84,
++    0xe0159: 84,
++    0xe015a: 84,
++    0xe015b: 84,
++    0xe015c: 84,
++    0xe015d: 84,
++    0xe015e: 84,
++    0xe015f: 84,
++    0xe0160: 84,
++    0xe0161: 84,
++    0xe0162: 84,
++    0xe0163: 84,
++    0xe0164: 84,
++    0xe0165: 84,
++    0xe0166: 84,
++    0xe0167: 84,
++    0xe0168: 84,
++    0xe0169: 84,
++    0xe016a: 84,
++    0xe016b: 84,
++    0xe016c: 84,
++    0xe016d: 84,
++    0xe016e: 84,
++    0xe016f: 84,
++    0xe0170: 84,
++    0xe0171: 84,
++    0xe0172: 84,
++    0xe0173: 84,
++    0xe0174: 84,
++    0xe0175: 84,
++    0xe0176: 84,
++    0xe0177: 84,
++    0xe0178: 84,
++    0xe0179: 84,
++    0xe017a: 84,
++    0xe017b: 84,
++    0xe017c: 84,
++    0xe017d: 84,
++    0xe017e: 84,
++    0xe017f: 84,
++    0xe0180: 84,
++    0xe0181: 84,
++    0xe0182: 84,
++    0xe0183: 84,
++    0xe0184: 84,
++    0xe0185: 84,
++    0xe0186: 84,
++    0xe0187: 84,
++    0xe0188: 84,
++    0xe0189: 84,
++    0xe018a: 84,
++    0xe018b: 84,
++    0xe018c: 84,
++    0xe018d: 84,
++    0xe018e: 84,
++    0xe018f: 84,
++    0xe0190: 84,
++    0xe0191: 84,
++    0xe0192: 84,
++    0xe0193: 84,
++    0xe0194: 84,
++    0xe0195: 84,
++    0xe0196: 84,
++    0xe0197: 84,
++    0xe0198: 84,
++    0xe0199: 84,
++    0xe019a: 84,
++    0xe019b: 84,
++    0xe019c: 84,
++    0xe019d: 84,
++    0xe019e: 84,
++    0xe019f: 84,
++    0xe01a0: 84,
++    0xe01a1: 84,
++    0xe01a2: 84,
++    0xe01a3: 84,
++    0xe01a4: 84,
++    0xe01a5: 84,
++    0xe01a6: 84,
++    0xe01a7: 84,
++    0xe01a8: 84,
++    0xe01a9: 84,
++    0xe01aa: 84,
++    0xe01ab: 84,
++    0xe01ac: 84,
++    0xe01ad: 84,
++    0xe01ae: 84,
++    0xe01af: 84,
++    0xe01b0: 84,
++    0xe01b1: 84,
++    0xe01b2: 84,
++    0xe01b3: 84,
++    0xe01b4: 84,
++    0xe01b5: 84,
++    0xe01b6: 84,
++    0xe01b7: 84,
++    0xe01b8: 84,
++    0xe01b9: 84,
++    0xe01ba: 84,
++    0xe01bb: 84,
++    0xe01bc: 84,
++    0xe01bd: 84,
++    0xe01be: 84,
++    0xe01bf: 84,
++    0xe01c0: 84,
++    0xe01c1: 84,
++    0xe01c2: 84,
++    0xe01c3: 84,
++    0xe01c4: 84,
++    0xe01c5: 84,
++    0xe01c6: 84,
++    0xe01c7: 84,
++    0xe01c8: 84,
++    0xe01c9: 84,
++    0xe01ca: 84,
++    0xe01cb: 84,
++    0xe01cc: 84,
++    0xe01cd: 84,
++    0xe01ce: 84,
++    0xe01cf: 84,
++    0xe01d0: 84,
++    0xe01d1: 84,
++    0xe01d2: 84,
++    0xe01d3: 84,
++    0xe01d4: 84,
++    0xe01d5: 84,
++    0xe01d6: 84,
++    0xe01d7: 84,
++    0xe01d8: 84,
++    0xe01d9: 84,
++    0xe01da: 84,
++    0xe01db: 84,
++    0xe01dc: 84,
++    0xe01dd: 84,
++    0xe01de: 84,
++    0xe01df: 84,
++    0xe01e0: 84,
++    0xe01e1: 84,
++    0xe01e2: 84,
++    0xe01e3: 84,
++    0xe01e4: 84,
++    0xe01e5: 84,
++    0xe01e6: 84,
++    0xe01e7: 84,
++    0xe01e8: 84,
++    0xe01e9: 84,
++    0xe01ea: 84,
++    0xe01eb: 84,
++    0xe01ec: 84,
++    0xe01ed: 84,
++    0xe01ee: 84,
++    0xe01ef: 84,
+ }
+ codepoint_classes = {
+     'PVALID': (
+@@ -1834,7 +3931,6 @@ codepoint_classes = {
+         0xa7d50000a7d6,
+         0xa7d70000a7d8,
+         0xa7d90000a7da,
+-        0xa7f20000a7f5,
+         0xa7f60000a7f8,
+         0xa7fa0000a828,
+         0xa82c0000a82d,
+@@ -1907,9 +4003,7 @@ codepoint_classes = {
+         0x1060000010737,
+         0x1074000010756,
+         0x1076000010768,
+-        0x1078000010786,
+-        0x10787000107b1,
+-        0x107b2000107bb,
++        0x1078000010781,
+         0x1080000010806,
+         0x1080800010809,
+         0x1080a00010836,
+@@ -2112,7 +4206,6 @@ codepoint_classes = {
+         0x1e01b0001e022,
+         0x1e0230001e025,
+         0x1e0260001e02b,
+-        0x1e0300001e06e,
+         0x1e08f0001e090,
+         0x1e1000001e12d,
+         0x1e1300001e13e,
+@@ -2134,6 +4227,7 @@ codepoint_classes = {
+         0x2b7400002b81e,
+         0x2b8200002cea2,
+         0x2ceb00002ebe1,
++        0x2ebf00002ee5e,
+         0x300000003134b,
+         0x31350000323b0,
+     ),
+diff --git a/src/pip/_vendor/idna/package_data.py b/src/pip/_vendor/idna/package_data.py
+index 8501893..ed81113 100644
+--- a/src/pip/_vendor/idna/package_data.py
++++ b/src/pip/_vendor/idna/package_data.py
+@@ -1,2 +1,2 @@
+-__version__ = '3.4'
++__version__ = '3.7'
+ 
+diff --git a/src/pip/_vendor/idna/uts46data.py b/src/pip/_vendor/idna/uts46data.py
+index 186796c..6a1eddb 100644
+--- a/src/pip/_vendor/idna/uts46data.py
++++ b/src/pip/_vendor/idna/uts46data.py
+@@ -7,7 +7,7 @@ from typing import List, Tuple, Union
+ """IDNA Mapping Table from UTS46."""
+ 
+ 
+-__version__ = '15.0.0'
++__version__ = '15.1.0'
+ def _seg_0() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     return [
+     (0x0, '3'),
+@@ -1899,7 +1899,7 @@ def _seg_18() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1E9A, 'M', 'aʾ'),
+     (0x1E9B, 'M', 'ṡ'),
+     (0x1E9C, 'V'),
+-    (0x1E9E, 'M', 'ss'),
++    (0x1E9E, 'M', 'ß'),
+     (0x1E9F, 'V'),
+     (0x1EA0, 'M', 'ạ'),
+     (0x1EA1, 'V'),
+@@ -2418,10 +2418,6 @@ def _seg_23() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x222F, 'M', '∮∮'),
+     (0x2230, 'M', '∮∮∮'),
+     (0x2231, 'V'),
+-    (0x2260, '3'),
+-    (0x2261, 'V'),
+-    (0x226E, '3'),
+-    (0x2270, 'V'),
+     (0x2329, 'M', '〈'),
+     (0x232A, 'M', '〉'),
+     (0x232B, 'V'),
+@@ -2502,14 +2498,14 @@ def _seg_23() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x24BA, 'M', 'e'),
+     (0x24BB, 'M', 'f'),
+     (0x24BC, 'M', 'g'),
+-    ]
+-
+-def _seg_24() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x24BD, 'M', 'h'),
+     (0x24BE, 'M', 'i'),
+     (0x24BF, 'M', 'j'),
+     (0x24C0, 'M', 'k'),
++    ]
++
++def _seg_24() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x24C1, 'M', 'l'),
+     (0x24C2, 'M', 'm'),
+     (0x24C3, 'M', 'n'),
+@@ -2606,14 +2602,14 @@ def _seg_24() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2C26, 'M', 'ⱖ'),
+     (0x2C27, 'M', 'ⱗ'),
+     (0x2C28, 'M', 'ⱘ'),
+-    ]
+-
+-def _seg_25() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x2C29, 'M', 'ⱙ'),
+     (0x2C2A, 'M', 'ⱚ'),
+     (0x2C2B, 'M', 'ⱛ'),
+     (0x2C2C, 'M', 'ⱜ'),
++    ]
++
++def _seg_25() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x2C2D, 'M', 'ⱝ'),
+     (0x2C2E, 'M', 'ⱞ'),
+     (0x2C2F, 'M', 'ⱟ'),
+@@ -2710,14 +2706,14 @@ def _seg_25() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2CC0, 'M', 'ⳁ'),
+     (0x2CC1, 'V'),
+     (0x2CC2, 'M', 'ⳃ'),
+-    ]
+-
+-def _seg_26() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x2CC3, 'V'),
+     (0x2CC4, 'M', 'ⳅ'),
+     (0x2CC5, 'V'),
+     (0x2CC6, 'M', 'ⳇ'),
++    ]
++
++def _seg_26() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x2CC7, 'V'),
+     (0x2CC8, 'M', 'ⳉ'),
+     (0x2CC9, 'V'),
+@@ -2814,14 +2810,14 @@ def _seg_26() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2F13, 'M', '勹'),
+     (0x2F14, 'M', '匕'),
+     (0x2F15, 'M', '匚'),
+-    ]
+-
+-def _seg_27() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x2F16, 'M', '匸'),
+     (0x2F17, 'M', '十'),
+     (0x2F18, 'M', '卜'),
+     (0x2F19, 'M', '卩'),
++    ]
++
++def _seg_27() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x2F1A, 'M', '厂'),
+     (0x2F1B, 'M', '厶'),
+     (0x2F1C, 'M', '又'),
+@@ -2918,14 +2914,14 @@ def _seg_27() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2F77, 'M', '糸'),
+     (0x2F78, 'M', '缶'),
+     (0x2F79, 'M', '网'),
+-    ]
+-
+-def _seg_28() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x2F7A, 'M', '羊'),
+     (0x2F7B, 'M', '羽'),
+     (0x2F7C, 'M', '老'),
+     (0x2F7D, 'M', '而'),
++    ]
++
++def _seg_28() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x2F7E, 'M', '耒'),
+     (0x2F7F, 'M', '耳'),
+     (0x2F80, 'M', '聿'),
+@@ -3022,14 +3018,14 @@ def _seg_28() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x3036, 'M', '〒'),
+     (0x3037, 'V'),
+     (0x3038, 'M', '十'),
+-    ]
+-
+-def _seg_29() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x3039, 'M', '卄'),
+     (0x303A, 'M', '卅'),
+     (0x303B, 'V'),
+     (0x3040, 'X'),
++    ]
++
++def _seg_29() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x3041, 'V'),
+     (0x3097, 'X'),
+     (0x3099, 'V'),
+@@ -3126,14 +3122,14 @@ def _seg_29() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x3182, 'M', 'ᇱ'),
+     (0x3183, 'M', 'ᇲ'),
+     (0x3184, 'M', 'ᅗ'),
+-    ]
+-
+-def _seg_30() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x3185, 'M', 'ᅘ'),
+     (0x3186, 'M', 'ᅙ'),
+     (0x3187, 'M', 'ᆄ'),
+     (0x3188, 'M', 'ᆅ'),
++    ]
++
++def _seg_30() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x3189, 'M', 'ᆈ'),
+     (0x318A, 'M', 'ᆑ'),
+     (0x318B, 'M', 'ᆒ'),
+@@ -3230,14 +3226,14 @@ def _seg_30() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x3244, 'M', '問'),
+     (0x3245, 'M', '幼'),
+     (0x3246, 'M', '文'),
+-    ]
+-
+-def _seg_31() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x3247, 'M', '箏'),
+     (0x3248, 'V'),
+     (0x3250, 'M', 'pte'),
+     (0x3251, 'M', '21'),
++    ]
++
++def _seg_31() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x3252, 'M', '22'),
+     (0x3253, 'M', '23'),
+     (0x3254, 'M', '24'),
+@@ -3334,14 +3330,14 @@ def _seg_31() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x32AF, 'M', '協'),
+     (0x32B0, 'M', '夜'),
+     (0x32B1, 'M', '36'),
+-    ]
+-
+-def _seg_32() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x32B2, 'M', '37'),
+     (0x32B3, 'M', '38'),
+     (0x32B4, 'M', '39'),
+     (0x32B5, 'M', '40'),
++    ]
++
++def _seg_32() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x32B6, 'M', '41'),
+     (0x32B7, 'M', '42'),
+     (0x32B8, 'M', '43'),
+@@ -3438,14 +3434,14 @@ def _seg_32() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x3313, 'M', 'ギルダー'),
+     (0x3314, 'M', 'キロ'),
+     (0x3315, 'M', 'キログラム'),
+-    ]
+-
+-def _seg_33() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x3316, 'M', 'キロメートル'),
+     (0x3317, 'M', 'キロワット'),
+     (0x3318, 'M', 'グラム'),
+     (0x3319, 'M', 'グラムトン'),
++    ]
++
++def _seg_33() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x331A, 'M', 'クルゼイロ'),
+     (0x331B, 'M', 'クローネ'),
+     (0x331C, 'M', 'ケース'),
+@@ -3542,14 +3538,14 @@ def _seg_33() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x3377, 'M', 'dm'),
+     (0x3378, 'M', 'dm2'),
+     (0x3379, 'M', 'dm3'),
+-    ]
+-
+-def _seg_34() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x337A, 'M', 'iu'),
+     (0x337B, 'M', '平成'),
+     (0x337C, 'M', '昭和'),
+     (0x337D, 'M', '大正'),
++    ]
++
++def _seg_34() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x337E, 'M', '明治'),
+     (0x337F, 'M', '株式会社'),
+     (0x3380, 'M', 'pa'),
+@@ -3646,14 +3642,14 @@ def _seg_34() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x33DB, 'M', 'sr'),
+     (0x33DC, 'M', 'sv'),
+     (0x33DD, 'M', 'wb'),
+-    ]
+-
+-def _seg_35() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x33DE, 'M', 'v∕m'),
+     (0x33DF, 'M', 'a∕m'),
+     (0x33E0, 'M', '1日'),
+     (0x33E1, 'M', '2日'),
++    ]
++
++def _seg_35() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x33E2, 'M', '3日'),
+     (0x33E3, 'M', '4日'),
+     (0x33E4, 'M', '5日'),
+@@ -3750,14 +3746,14 @@ def _seg_35() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xA68B, 'V'),
+     (0xA68C, 'M', 'ꚍ'),
+     (0xA68D, 'V'),
+-    ]
+-
+-def _seg_36() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xA68E, 'M', 'ꚏ'),
+     (0xA68F, 'V'),
+     (0xA690, 'M', 'ꚑ'),
+     (0xA691, 'V'),
++    ]
++
++def _seg_36() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xA692, 'M', 'ꚓ'),
+     (0xA693, 'V'),
+     (0xA694, 'M', 'ꚕ'),
+@@ -3854,14 +3850,14 @@ def _seg_36() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xA779, 'M', 'ꝺ'),
+     (0xA77A, 'V'),
+     (0xA77B, 'M', 'ꝼ'),
+-    ]
+-
+-def _seg_37() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xA77C, 'V'),
+     (0xA77D, 'M', 'ᵹ'),
+     (0xA77E, 'M', 'ꝿ'),
+     (0xA77F, 'V'),
++    ]
++
++def _seg_37() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xA780, 'M', 'ꞁ'),
+     (0xA781, 'V'),
+     (0xA782, 'M', 'ꞃ'),
+@@ -3958,14 +3954,14 @@ def _seg_37() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xA878, 'X'),
+     (0xA880, 'V'),
+     (0xA8C6, 'X'),
+-    ]
+-
+-def _seg_38() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xA8CE, 'V'),
+     (0xA8DA, 'X'),
+     (0xA8E0, 'V'),
+     (0xA954, 'X'),
++    ]
++
++def _seg_38() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xA95F, 'V'),
+     (0xA97D, 'X'),
+     (0xA980, 'V'),
+@@ -4062,14 +4058,14 @@ def _seg_38() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xABA8, 'M', 'Ꮨ'),
+     (0xABA9, 'M', 'Ꮩ'),
+     (0xABAA, 'M', 'Ꮪ'),
+-    ]
+-
+-def _seg_39() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xABAB, 'M', 'Ꮫ'),
+     (0xABAC, 'M', 'Ꮬ'),
+     (0xABAD, 'M', 'Ꮭ'),
+     (0xABAE, 'M', 'Ꮮ'),
++    ]
++
++def _seg_39() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xABAF, 'M', 'Ꮯ'),
+     (0xABB0, 'M', 'Ꮰ'),
+     (0xABB1, 'M', 'Ꮱ'),
+@@ -4166,14 +4162,14 @@ def _seg_39() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xF943, 'M', '弄'),
+     (0xF944, 'M', '籠'),
+     (0xF945, 'M', '聾'),
+-    ]
+-
+-def _seg_40() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xF946, 'M', '牢'),
+     (0xF947, 'M', '磊'),
+     (0xF948, 'M', '賂'),
+     (0xF949, 'M', '雷'),
++    ]
++
++def _seg_40() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xF94A, 'M', '壘'),
+     (0xF94B, 'M', '屢'),
+     (0xF94C, 'M', '樓'),
+@@ -4270,14 +4266,14 @@ def _seg_40() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xF9A7, 'M', '獵'),
+     (0xF9A8, 'M', '令'),
+     (0xF9A9, 'M', '囹'),
+-    ]
+-
+-def _seg_41() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xF9AA, 'M', '寧'),
+     (0xF9AB, 'M', '嶺'),
+     (0xF9AC, 'M', '怜'),
+     (0xF9AD, 'M', '玲'),
++    ]
++
++def _seg_41() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xF9AE, 'M', '瑩'),
+     (0xF9AF, 'M', '羚'),
+     (0xF9B0, 'M', '聆'),
+@@ -4374,14 +4370,14 @@ def _seg_41() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFA0B, 'M', '廓'),
+     (0xFA0C, 'M', '兀'),
+     (0xFA0D, 'M', '嗀'),
+-    ]
+-
+-def _seg_42() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFA0E, 'V'),
+     (0xFA10, 'M', '塚'),
+     (0xFA11, 'V'),
+     (0xFA12, 'M', '晴'),
++    ]
++
++def _seg_42() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFA13, 'V'),
+     (0xFA15, 'M', '凞'),
+     (0xFA16, 'M', '猪'),
+@@ -4478,14 +4474,14 @@ def _seg_42() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFA76, 'M', '勇'),
+     (0xFA77, 'M', '勺'),
+     (0xFA78, 'M', '喝'),
+-    ]
+-
+-def _seg_43() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFA79, 'M', '啕'),
+     (0xFA7A, 'M', '喙'),
+     (0xFA7B, 'M', '嗢'),
+     (0xFA7C, 'M', '塚'),
++    ]
++
++def _seg_43() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFA7D, 'M', '墳'),
+     (0xFA7E, 'M', '奄'),
+     (0xFA7F, 'M', '奔'),
+@@ -4582,14 +4578,14 @@ def _seg_43() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFADA, 'X'),
+     (0xFB00, 'M', 'ff'),
+     (0xFB01, 'M', 'fi'),
+-    ]
+-
+-def _seg_44() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFB02, 'M', 'fl'),
+     (0xFB03, 'M', 'ffi'),
+     (0xFB04, 'M', 'ffl'),
+     (0xFB05, 'M', 'st'),
++    ]
++
++def _seg_44() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFB07, 'X'),
+     (0xFB13, 'M', 'մն'),
+     (0xFB14, 'M', 'մե'),
+@@ -4686,14 +4682,14 @@ def _seg_44() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFBDB, 'M', 'ۈ'),
+     (0xFBDD, 'M', 'ۇٴ'),
+     (0xFBDE, 'M', 'ۋ'),
+-    ]
+-
+-def _seg_45() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFBE0, 'M', 'ۅ'),
+     (0xFBE2, 'M', 'ۉ'),
+     (0xFBE4, 'M', 'ې'),
+     (0xFBE8, 'M', 'ى'),
++    ]
++
++def _seg_45() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFBEA, 'M', 'ئا'),
+     (0xFBEC, 'M', 'ئە'),
+     (0xFBEE, 'M', 'ئو'),
+@@ -4790,14 +4786,14 @@ def _seg_45() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFC54, 'M', 'هي'),
+     (0xFC55, 'M', 'يج'),
+     (0xFC56, 'M', 'يح'),
+-    ]
+-
+-def _seg_46() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFC57, 'M', 'يخ'),
+     (0xFC58, 'M', 'يم'),
+     (0xFC59, 'M', 'يى'),
+     (0xFC5A, 'M', 'يي'),
++    ]
++
++def _seg_46() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFC5B, 'M', 'ذٰ'),
+     (0xFC5C, 'M', 'رٰ'),
+     (0xFC5D, 'M', 'ىٰ'),
+@@ -4894,14 +4890,14 @@ def _seg_46() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFCB8, 'M', 'طح'),
+     (0xFCB9, 'M', 'ظم'),
+     (0xFCBA, 'M', 'عج'),
+-    ]
+-
+-def _seg_47() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFCBB, 'M', 'عم'),
+     (0xFCBC, 'M', 'غج'),
+     (0xFCBD, 'M', 'غم'),
+     (0xFCBE, 'M', 'فج'),
++    ]
++
++def _seg_47() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFCBF, 'M', 'فح'),
+     (0xFCC0, 'M', 'فخ'),
+     (0xFCC1, 'M', 'فم'),
+@@ -4998,14 +4994,14 @@ def _seg_47() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFD1C, 'M', 'حي'),
+     (0xFD1D, 'M', 'جى'),
+     (0xFD1E, 'M', 'جي'),
+-    ]
+-
+-def _seg_48() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFD1F, 'M', 'خى'),
+     (0xFD20, 'M', 'خي'),
+     (0xFD21, 'M', 'صى'),
+     (0xFD22, 'M', 'صي'),
++    ]
++
++def _seg_48() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFD23, 'M', 'ضى'),
+     (0xFD24, 'M', 'ضي'),
+     (0xFD25, 'M', 'شج'),
+@@ -5102,14 +5098,14 @@ def _seg_48() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFDA4, 'M', 'تمى'),
+     (0xFDA5, 'M', 'جمي'),
+     (0xFDA6, 'M', 'جحى'),
+-    ]
+-
+-def _seg_49() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFDA7, 'M', 'جمى'),
+     (0xFDA8, 'M', 'سخى'),
+     (0xFDA9, 'M', 'صحي'),
+     (0xFDAA, 'M', 'شحي'),
++    ]
++
++def _seg_49() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFDAB, 'M', 'ضحي'),
+     (0xFDAC, 'M', 'لجي'),
+     (0xFDAD, 'M', 'لمي'),
+@@ -5206,14 +5202,14 @@ def _seg_49() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFE5B, '3', '{'),
+     (0xFE5C, '3', '}'),
+     (0xFE5D, 'M', '〔'),
+-    ]
+-
+-def _seg_50() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFE5E, 'M', '〕'),
+     (0xFE5F, '3', '#'),
+     (0xFE60, '3', '&'),
+     (0xFE61, '3', '*'),
++    ]
++
++def _seg_50() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFE62, '3', '+'),
+     (0xFE63, 'M', '-'),
+     (0xFE64, '3', '<'),
+@@ -5310,14 +5306,14 @@ def _seg_50() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFF18, 'M', '8'),
+     (0xFF19, 'M', '9'),
+     (0xFF1A, '3', ':'),
+-    ]
+-
+-def _seg_51() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFF1B, '3', ';'),
+     (0xFF1C, '3', '<'),
+     (0xFF1D, '3', '='),
+     (0xFF1E, '3', '>'),
++    ]
++
++def _seg_51() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFF1F, '3', '?'),
+     (0xFF20, '3', '@'),
+     (0xFF21, 'M', 'a'),
+@@ -5414,14 +5410,14 @@ def _seg_51() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFF7C, 'M', 'シ'),
+     (0xFF7D, 'M', 'ス'),
+     (0xFF7E, 'M', 'セ'),
+-    ]
+-
+-def _seg_52() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFF7F, 'M', 'ソ'),
+     (0xFF80, 'M', 'タ'),
+     (0xFF81, 'M', 'チ'),
+     (0xFF82, 'M', 'ツ'),
++    ]
++
++def _seg_52() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFF83, 'M', 'テ'),
+     (0xFF84, 'M', 'ト'),
+     (0xFF85, 'M', 'ナ'),
+@@ -5518,14 +5514,14 @@ def _seg_52() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0xFFE7, 'X'),
+     (0xFFE8, 'M', '│'),
+     (0xFFE9, 'M', '←'),
+-    ]
+-
+-def _seg_53() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0xFFEA, 'M', '↑'),
+     (0xFFEB, 'M', '→'),
+     (0xFFEC, 'M', '↓'),
+     (0xFFED, 'M', '■'),
++    ]
++
++def _seg_53() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0xFFEE, 'M', '○'),
+     (0xFFEF, 'X'),
+     (0x10000, 'V'),
+@@ -5622,14 +5618,14 @@ def _seg_53() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x104B3, 'M', '𐓛'),
+     (0x104B4, 'M', '𐓜'),
+     (0x104B5, 'M', '𐓝'),
+-    ]
+-
+-def _seg_54() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x104B6, 'M', '𐓞'),
+     (0x104B7, 'M', '𐓟'),
+     (0x104B8, 'M', '𐓠'),
+     (0x104B9, 'M', '𐓡'),
++    ]
++
++def _seg_54() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x104BA, 'M', '𐓢'),
+     (0x104BB, 'M', '𐓣'),
+     (0x104BC, 'M', '𐓤'),
+@@ -5726,14 +5722,14 @@ def _seg_54() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x10786, 'X'),
+     (0x10787, 'M', 'ʣ'),
+     (0x10788, 'M', 'ꭦ'),
+-    ]
+-
+-def _seg_55() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x10789, 'M', 'ʥ'),
+     (0x1078A, 'M', 'ʤ'),
+     (0x1078B, 'M', 'ɖ'),
+     (0x1078C, 'M', 'ɗ'),
++    ]
++
++def _seg_55() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1078D, 'M', 'ᶑ'),
+     (0x1078E, 'M', 'ɘ'),
+     (0x1078F, 'M', 'ɞ'),
+@@ -5830,14 +5826,14 @@ def _seg_55() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x10A60, 'V'),
+     (0x10AA0, 'X'),
+     (0x10AC0, 'V'),
+-    ]
+-
+-def _seg_56() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x10AE7, 'X'),
+     (0x10AEB, 'V'),
+     (0x10AF7, 'X'),
+     (0x10B00, 'V'),
++    ]
++
++def _seg_56() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x10B36, 'X'),
+     (0x10B39, 'V'),
+     (0x10B56, 'X'),
+@@ -5934,14 +5930,14 @@ def _seg_56() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1107F, 'V'),
+     (0x110BD, 'X'),
+     (0x110BE, 'V'),
+-    ]
+-
+-def _seg_57() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x110C3, 'X'),
+     (0x110D0, 'V'),
+     (0x110E9, 'X'),
+     (0x110F0, 'V'),
++    ]
++
++def _seg_57() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x110FA, 'X'),
+     (0x11100, 'V'),
+     (0x11135, 'X'),
+@@ -6038,14 +6034,14 @@ def _seg_57() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x118A4, 'M', '𑣄'),
+     (0x118A5, 'M', '𑣅'),
+     (0x118A6, 'M', '𑣆'),
+-    ]
+-
+-def _seg_58() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x118A7, 'M', '𑣇'),
+     (0x118A8, 'M', '𑣈'),
+     (0x118A9, 'M', '𑣉'),
+     (0x118AA, 'M', '𑣊'),
++    ]
++
++def _seg_58() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x118AB, 'M', '𑣋'),
+     (0x118AC, 'M', '𑣌'),
+     (0x118AD, 'M', '𑣍'),
+@@ -6142,14 +6138,14 @@ def _seg_58() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x11EE0, 'V'),
+     (0x11EF9, 'X'),
+     (0x11F00, 'V'),
+-    ]
+-
+-def _seg_59() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x11F11, 'X'),
+     (0x11F12, 'V'),
+     (0x11F3B, 'X'),
+     (0x11F3E, 'V'),
++    ]
++
++def _seg_59() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x11F5A, 'X'),
+     (0x11FB0, 'V'),
+     (0x11FB1, 'X'),
+@@ -6246,14 +6242,14 @@ def _seg_59() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x18D00, 'V'),
+     (0x18D09, 'X'),
+     (0x1AFF0, 'V'),
+-    ]
+-
+-def _seg_60() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1AFF4, 'X'),
+     (0x1AFF5, 'V'),
+     (0x1AFFC, 'X'),
+     (0x1AFFD, 'V'),
++    ]
++
++def _seg_60() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1AFFF, 'X'),
+     (0x1B000, 'V'),
+     (0x1B123, 'X'),
+@@ -6350,14 +6346,14 @@ def _seg_60() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D41E, 'M', 'e'),
+     (0x1D41F, 'M', 'f'),
+     (0x1D420, 'M', 'g'),
+-    ]
+-
+-def _seg_61() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D421, 'M', 'h'),
+     (0x1D422, 'M', 'i'),
+     (0x1D423, 'M', 'j'),
+     (0x1D424, 'M', 'k'),
++    ]
++
++def _seg_61() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D425, 'M', 'l'),
+     (0x1D426, 'M', 'm'),
+     (0x1D427, 'M', 'n'),
+@@ -6454,14 +6450,14 @@ def _seg_61() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D482, 'M', 'a'),
+     (0x1D483, 'M', 'b'),
+     (0x1D484, 'M', 'c'),
+-    ]
+-
+-def _seg_62() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D485, 'M', 'd'),
+     (0x1D486, 'M', 'e'),
+     (0x1D487, 'M', 'f'),
+     (0x1D488, 'M', 'g'),
++    ]
++
++def _seg_62() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D489, 'M', 'h'),
+     (0x1D48A, 'M', 'i'),
+     (0x1D48B, 'M', 'j'),
+@@ -6558,14 +6554,14 @@ def _seg_62() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D4E9, 'M', 'z'),
+     (0x1D4EA, 'M', 'a'),
+     (0x1D4EB, 'M', 'b'),
+-    ]
+-
+-def _seg_63() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D4EC, 'M', 'c'),
+     (0x1D4ED, 'M', 'd'),
+     (0x1D4EE, 'M', 'e'),
+     (0x1D4EF, 'M', 'f'),
++    ]
++
++def _seg_63() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D4F0, 'M', 'g'),
+     (0x1D4F1, 'M', 'h'),
+     (0x1D4F2, 'M', 'i'),
+@@ -6662,14 +6658,14 @@ def _seg_63() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D550, 'M', 'y'),
+     (0x1D551, 'X'),
+     (0x1D552, 'M', 'a'),
+-    ]
+-
+-def _seg_64() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D553, 'M', 'b'),
+     (0x1D554, 'M', 'c'),
+     (0x1D555, 'M', 'd'),
+     (0x1D556, 'M', 'e'),
++    ]
++
++def _seg_64() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D557, 'M', 'f'),
+     (0x1D558, 'M', 'g'),
+     (0x1D559, 'M', 'h'),
+@@ -6766,14 +6762,14 @@ def _seg_64() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D5B4, 'M', 'u'),
+     (0x1D5B5, 'M', 'v'),
+     (0x1D5B6, 'M', 'w'),
+-    ]
+-
+-def _seg_65() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D5B7, 'M', 'x'),
+     (0x1D5B8, 'M', 'y'),
+     (0x1D5B9, 'M', 'z'),
+     (0x1D5BA, 'M', 'a'),
++    ]
++
++def _seg_65() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D5BB, 'M', 'b'),
+     (0x1D5BC, 'M', 'c'),
+     (0x1D5BD, 'M', 'd'),
+@@ -6870,14 +6866,14 @@ def _seg_65() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D618, 'M', 'q'),
+     (0x1D619, 'M', 'r'),
+     (0x1D61A, 'M', 's'),
+-    ]
+-
+-def _seg_66() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D61B, 'M', 't'),
+     (0x1D61C, 'M', 'u'),
+     (0x1D61D, 'M', 'v'),
+     (0x1D61E, 'M', 'w'),
++    ]
++
++def _seg_66() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D61F, 'M', 'x'),
+     (0x1D620, 'M', 'y'),
+     (0x1D621, 'M', 'z'),
+@@ -6974,14 +6970,14 @@ def _seg_66() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D67C, 'M', 'm'),
+     (0x1D67D, 'M', 'n'),
+     (0x1D67E, 'M', 'o'),
+-    ]
+-
+-def _seg_67() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D67F, 'M', 'p'),
+     (0x1D680, 'M', 'q'),
+     (0x1D681, 'M', 'r'),
+     (0x1D682, 'M', 's'),
++    ]
++
++def _seg_67() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D683, 'M', 't'),
+     (0x1D684, 'M', 'u'),
+     (0x1D685, 'M', 'v'),
+@@ -7078,14 +7074,14 @@ def _seg_67() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D6E2, 'M', 'α'),
+     (0x1D6E3, 'M', 'β'),
+     (0x1D6E4, 'M', 'γ'),
+-    ]
+-
+-def _seg_68() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D6E5, 'M', 'δ'),
+     (0x1D6E6, 'M', 'ε'),
+     (0x1D6E7, 'M', 'ζ'),
+     (0x1D6E8, 'M', 'η'),
++    ]
++
++def _seg_68() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D6E9, 'M', 'θ'),
+     (0x1D6EA, 'M', 'ι'),
+     (0x1D6EB, 'M', 'κ'),
+@@ -7182,14 +7178,14 @@ def _seg_68() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D747, 'M', 'σ'),
+     (0x1D749, 'M', 'τ'),
+     (0x1D74A, 'M', 'υ'),
+-    ]
+-
+-def _seg_69() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D74B, 'M', 'φ'),
+     (0x1D74C, 'M', 'χ'),
+     (0x1D74D, 'M', 'ψ'),
+     (0x1D74E, 'M', 'ω'),
++    ]
++
++def _seg_69() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D74F, 'M', '∂'),
+     (0x1D750, 'M', 'ε'),
+     (0x1D751, 'M', 'θ'),
+@@ -7286,14 +7282,14 @@ def _seg_69() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1D7AD, 'M', 'δ'),
+     (0x1D7AE, 'M', 'ε'),
+     (0x1D7AF, 'M', 'ζ'),
+-    ]
+-
+-def _seg_70() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1D7B0, 'M', 'η'),
+     (0x1D7B1, 'M', 'θ'),
+     (0x1D7B2, 'M', 'ι'),
+     (0x1D7B3, 'M', 'κ'),
++    ]
++
++def _seg_70() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1D7B4, 'M', 'λ'),
+     (0x1D7B5, 'M', 'μ'),
+     (0x1D7B6, 'M', 'ν'),
+@@ -7390,14 +7386,14 @@ def _seg_70() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1E030, 'M', 'а'),
+     (0x1E031, 'M', 'б'),
+     (0x1E032, 'M', 'в'),
+-    ]
+-
+-def _seg_71() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1E033, 'M', 'г'),
+     (0x1E034, 'M', 'д'),
+     (0x1E035, 'M', 'е'),
+     (0x1E036, 'M', 'ж'),
++    ]
++
++def _seg_71() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1E037, 'M', 'з'),
+     (0x1E038, 'M', 'и'),
+     (0x1E039, 'M', 'к'),
+@@ -7494,14 +7490,14 @@ def _seg_71() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1E907, 'M', '𞤩'),
+     (0x1E908, 'M', '𞤪'),
+     (0x1E909, 'M', '𞤫'),
+-    ]
+-
+-def _seg_72() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1E90A, 'M', '𞤬'),
+     (0x1E90B, 'M', '𞤭'),
+     (0x1E90C, 'M', '𞤮'),
+     (0x1E90D, 'M', '𞤯'),
++    ]
++
++def _seg_72() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1E90E, 'M', '𞤰'),
+     (0x1E90F, 'M', '𞤱'),
+     (0x1E910, 'M', '𞤲'),
+@@ -7598,14 +7594,14 @@ def _seg_72() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1EE48, 'X'),
+     (0x1EE49, 'M', 'ي'),
+     (0x1EE4A, 'X'),
+-    ]
+-
+-def _seg_73() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1EE4B, 'M', 'ل'),
+     (0x1EE4C, 'X'),
+     (0x1EE4D, 'M', 'ن'),
+     (0x1EE4E, 'M', 'س'),
++    ]
++
++def _seg_73() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1EE4F, 'M', 'ع'),
+     (0x1EE50, 'X'),
+     (0x1EE51, 'M', 'ص'),
+@@ -7702,14 +7698,14 @@ def _seg_73() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1EEB2, 'M', 'ق'),
+     (0x1EEB3, 'M', 'ر'),
+     (0x1EEB4, 'M', 'ش'),
+-    ]
+-
+-def _seg_74() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1EEB5, 'M', 'ت'),
+     (0x1EEB6, 'M', 'ث'),
+     (0x1EEB7, 'M', 'خ'),
+     (0x1EEB8, 'M', 'ذ'),
++    ]
++
++def _seg_74() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1EEB9, 'M', 'ض'),
+     (0x1EEBA, 'M', 'ظ'),
+     (0x1EEBB, 'M', 'غ'),
+@@ -7806,14 +7802,14 @@ def _seg_74() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1F150, 'V'),
+     (0x1F16A, 'M', 'mc'),
+     (0x1F16B, 'M', 'md'),
+-    ]
+-
+-def _seg_75() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1F16C, 'M', 'mr'),
+     (0x1F16D, 'V'),
+     (0x1F190, 'M', 'dj'),
+     (0x1F191, 'V'),
++    ]
++
++def _seg_75() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1F1AE, 'X'),
+     (0x1F1E6, 'V'),
+     (0x1F200, 'M', 'ほか'),
+@@ -7910,14 +7906,14 @@ def _seg_75() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x1FA54, 'X'),
+     (0x1FA60, 'V'),
+     (0x1FA6E, 'X'),
+-    ]
+-
+-def _seg_76() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+-    return [
+     (0x1FA70, 'V'),
+     (0x1FA7D, 'X'),
+     (0x1FA80, 'V'),
+     (0x1FA89, 'X'),
++    ]
++
++def _seg_76() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
++    return [
+     (0x1FA90, 'V'),
+     (0x1FABE, 'X'),
+     (0x1FABF, 'V'),
+@@ -7953,6 +7949,8 @@ def _seg_76() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2CEA2, 'X'),
+     (0x2CEB0, 'V'),
+     (0x2EBE1, 'X'),
++    (0x2EBF0, 'V'),
++    (0x2EE5E, 'X'),
+     (0x2F800, 'M', '丽'),
+     (0x2F801, 'M', '丸'),
+     (0x2F802, 'M', '乁'),
+@@ -8014,12 +8012,12 @@ def _seg_76() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2F83C, 'M', '咞'),
+     (0x2F83D, 'M', '吸'),
+     (0x2F83E, 'M', '呈'),
++    (0x2F83F, 'M', '周'),
++    (0x2F840, 'M', '咢'),
+     ]
+ 
+ def _seg_77() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     return [
+-    (0x2F83F, 'M', '周'),
+-    (0x2F840, 'M', '咢'),
+     (0x2F841, 'M', '哶'),
+     (0x2F842, 'M', '唐'),
+     (0x2F843, 'M', '啓'),
+@@ -8118,12 +8116,12 @@ def _seg_77() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2F8A4, 'M', '𢛔'),
+     (0x2F8A5, 'M', '惇'),
+     (0x2F8A6, 'M', '慈'),
++    (0x2F8A7, 'M', '慌'),
++    (0x2F8A8, 'M', '慎'),
+     ]
+ 
+ def _seg_78() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     return [
+-    (0x2F8A7, 'M', '慌'),
+-    (0x2F8A8, 'M', '慎'),
+     (0x2F8A9, 'M', '慌'),
+     (0x2F8AA, 'M', '慺'),
+     (0x2F8AB, 'M', '憎'),
+@@ -8222,12 +8220,12 @@ def _seg_78() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2F908, 'M', '港'),
+     (0x2F909, 'M', '湮'),
+     (0x2F90A, 'M', '㴳'),
++    (0x2F90B, 'M', '滋'),
++    (0x2F90C, 'M', '滇'),
+     ]
+ 
+ def _seg_79() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     return [
+-    (0x2F90B, 'M', '滋'),
+-    (0x2F90C, 'M', '滇'),
+     (0x2F90D, 'M', '𣻑'),
+     (0x2F90E, 'M', '淹'),
+     (0x2F90F, 'M', '潮'),
+@@ -8326,12 +8324,12 @@ def _seg_79() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2F96F, 'M', '縂'),
+     (0x2F970, 'M', '繅'),
+     (0x2F971, 'M', '䌴'),
++    (0x2F972, 'M', '𦈨'),
++    (0x2F973, 'M', '𦉇'),
+     ]
+ 
+ def _seg_80() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     return [
+-    (0x2F972, 'M', '𦈨'),
+-    (0x2F973, 'M', '𦉇'),
+     (0x2F974, 'M', '䍙'),
+     (0x2F975, 'M', '𦋙'),
+     (0x2F976, 'M', '罺'),
+@@ -8430,12 +8428,12 @@ def _seg_80() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     (0x2F9D3, 'M', '𧲨'),
+     (0x2F9D4, 'M', '貫'),
+     (0x2F9D5, 'M', '賁'),
++    (0x2F9D6, 'M', '贛'),
++    (0x2F9D7, 'M', '起'),
+     ]
+ 
+ def _seg_81() -> List[Union[Tuple[int, str], Tuple[int, str, str]]]:
+     return [
+-    (0x2F9D6, 'M', '贛'),
+-    (0x2F9D7, 'M', '起'),
+     (0x2F9D8, 'M', '𧼯'),
+     (0x2F9D9, 'M', '𠠄'),
+     (0x2F9DA, 'M', '跋'),
+diff --git a/src/pip/_vendor/vendor.txt b/src/pip/_vendor/vendor.txt
+index 5554c38..c5a8eba 100644
+--- a/src/pip/_vendor/vendor.txt
++++ b/src/pip/_vendor/vendor.txt
+@@ -10,7 +10,7 @@ pyproject-hooks==1.0.0
+ requests==2.31.0
+     certifi==2023.7.22
+     chardet==5.1.0
+-    idna==3.4
++    idna==3.7
+     urllib3==1.26.17
+ rich==13.4.2
+     pygments==2.15.1
+-- 
+2.34.1
+

--- a/SPECS/python-pip/python-pip.spec
+++ b/SPECS/python-pip/python-pip.spec
@@ -5,13 +5,14 @@ A tool for installing and managing Python packages}
 Summary:        A tool for installing and managing Python packages
 Name:           python-pip
 Version:        24.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT AND Python-2.0.1 AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND LGPL-2.1-only AND MPL-2.0 AND (Apache-2.0 OR BSD-2-Clause)
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Development/Tools
 URL:            https://pip.pypa.io/
 Source0:        https://github.com/pypa/pip/archive/%{version}/%{srcname}-%{version}.tar.gz
+Patch0:         CVE-2024-3651.patch
 
 BuildArch:      noarch
 
@@ -20,13 +21,12 @@ BuildArch:      noarch
 %package -n python3-pip
 Summary:        %{summary}
 BuildRequires:  python3-devel
-# TODO: enable python3-wheel BR when this package is added to toolchain to fix non-toolchain builds
-#BuildRequires:  python3-wheel
+BuildRequires:  python3-wheel
 
 %description -n python3-pip %{_description}
 
 %prep
-%autosetup -n %{srcname}-%{version}
+%autosetup -p1 -n %{srcname}-%{version}
 
 %build
 # Bootstrap `pip3` which casues ptest build failure.
@@ -52,6 +52,10 @@ pip3 install --no-cache-dir --no-index --ignore-installed --root %{buildroot} \
 %{python3_sitelib}/pip*
 
 %changelog
-* Tue Feb 13 2024 Andrew Phelps anphel@microsoft.com - 24.0-1
+* Wed Aug 28 2024 Rachel Menge <rachelmenge@microsoft.com> - 24.0-2
+- Patch CVE-2024-3651.patch
+- Add python3-wheel BR to python3-pip subpackage
+
+* Tue Feb 13 2024 Andrew Phelps <anphel@microsoft.com> - 24.0-1
 - License verified
 - Original version for Azure Linux.

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -547,7 +547,7 @@ python3-magic-5.45-1.azl3.noarch.rpm
 python3-markupsafe-2.1.3-1.azl3.aarch64.rpm
 python3-newt-0.52.23-1.azl3.aarch64.rpm
 python3-packaging-23.2-3.azl3.noarch.rpm
-python3-pip-24.0-1.azl3.noarch.rpm
+python3-pip-24.0-2.azl3.noarch.rpm
 python3-pygments-2.7.4-2.azl3.noarch.rpm
 python3-rpm-4.18.2-1.azl3.aarch64.rpm
 python3-rpm-generators-14-11.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -553,7 +553,7 @@ python3-magic-5.45-1.azl3.noarch.rpm
 python3-markupsafe-2.1.3-1.azl3.x86_64.rpm
 python3-newt-0.52.23-1.azl3.x86_64.rpm
 python3-packaging-23.2-3.azl3.noarch.rpm
-python3-pip-24.0-1.azl3.noarch.rpm
+python3-pip-24.0-2.azl3.noarch.rpm
 python3-pygments-2.7.4-2.azl3.noarch.rpm
 python3-rpm-4.18.2-1.azl3.x86_64.rpm
 python3-rpm-generators-14-11.azl3.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
CVE-2024-3651 affects idma versions before 3.7. Therefore,
update vendored version of idma in pip to 3.7.

This patch is a combination of 2 upstream commits:
[[d83c9e3](https://github.com/pypa/pip/commit/d83c9e3)] Upgrade idna to 3.6
[[cba5b13](https://github.com/pypa/pip/commit/cba5b13)] Upgrade idna to 3.7

Additionally, python3-wheel and python3-pip are both in the
toolchain so address "TODO" and add python3-wheel as a
BR to fix non-toolchain builds.

Note that python-pip has new versions (such as 24.2) but the 
setup.py script was removed. They removed setup.py here: https://github.com/pypa/pip/commit/0ad4c94be74cc24874c6feb5bb3c2152c398a18e
Therefore, patch CVE directly to avoid changing the build section 
implementation.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2024-3651 for python-pip

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-3651

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
-  [Buddy build pipeline](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=630332&view=results)
- [full pipeline ](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=630338&view=results)(in progress)
- local build
```
INFO[0019][scheduler] 0 currently active build(s): [].             
INFO[0019][scheduler] All packages built                           
INFO[0020][scheduler] ---------------------------                  
INFO[0020][scheduler] --------- Summary ---------                  
INFO[0020][scheduler] ---------------------------                  
INFO[0020][scheduler] Number of prebuilt SRPMs:              0 
INFO[0020][scheduler] Number of prebuilt delta SRPMs:        0 
INFO[0020][scheduler] Number of skipped SRPMs tests:         0 
INFO[0020][scheduler] Number of built SRPMs:                 1 
INFO[0020][scheduler] Number of passed SRPMs tests:          0 
INFO[0020][scheduler] Number of unresolved dependencies:     0 
INFO[0020][scheduler] Number of blocked SRPMs:               0 
INFO[0020][scheduler] Number of blocked SRPMs tests:         0 
INFO[0020][scheduler] Number of failed SRPMs:                0 
INFO[0020][scheduler] Number of failed SRPMs tests:          0 
INFO[0020][scheduler] Number of SRPMs with license errors:   0 
INFO[0020][scheduler] Number of SRPMs with license warnings: 0 
INFO[0020][scheduler] Number of toolchain RPM conflicts:     0 
INFO[0020][scheduler] Number of toolchain SRPM conflicts:    0 
INFO[0020][scheduler] Built SRPMs:                        
INFO[0020][scheduler] --> python-pip-24.0-2.azl3.src.rpm           
INFO[0020][scheduler] ---------------------------                  
INFO[0020][scheduler] --------- Summary ---------                  
INFO[0020][scheduler] ---------------------------                  
INFO[0020][scheduler] Number of prebuilt SRPMs:              0 
INFO[0020][scheduler] Number of prebuilt delta SRPMs:        0 
INFO[0020][scheduler] Number of skipped SRPMs tests:         0 
INFO[0020][scheduler] Number of built SRPMs:                 1 
INFO[0020][scheduler] Number of passed SRPMs tests:          0 
INFO[0020][scheduler] Number of unresolved dependencies:     0 
INFO[0020][scheduler] Number of blocked SRPMs:               0 
INFO[0020][scheduler] Number of blocked SRPMs tests:         0 
INFO[0020][scheduler] Number of failed SRPMs:                0 
INFO[0020][scheduler] Number of failed SRPMs tests:          0 
INFO[0020][scheduler] Number of SRPMs with license errors:   0 
INFO[0020][scheduler] Number of SRPMs with license warnings: 0 
INFO[0020][scheduler] Number of toolchain RPM conflicts:     0 
INFO[0020][scheduler] Number of toolchain SRPM conflicts:    0 
```