### PR TITLE
Fixed `nghttp2` test-time dependency on `CUnit`.

### DIFF
--- a/SPECS/nghttp2/nghttp2.spec
+++ b/SPECS/nghttp2/nghttp2.spec
@@ -1,7 +1,7 @@
 Summary:        nghttp2 is an implementation of HTTP/2 and its header compression algorithm, HPACK.
 Name:           nghttp2
 Version:        1.61.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,7 +11,7 @@ Source0:        https://github.com/nghttp2/nghttp2/releases/download/v%{version}
 BuildRequires:  gcc
 BuildRequires:  make
 %if 0%{?with_check}
-BuildRequires:  cunit
+BuildRequires:  CUnit
 %endif
 Provides:       libnghttp2 = %{version}-%{release}
 
@@ -59,6 +59,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Thu Aug 29 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.61.0-2
+- Fix test-time dependency on CUnit.
+
 * Thu Aug 08 2024 Muhammad Falak <mwani@microsoft.com> - 1.61.0-1
 - Upgrade version to 1.61.0 to address CVE-2024-28182
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -194,7 +194,7 @@ libsolv-devel-0.7.28-1.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm
 libssh2-devel-1.11.0-1.azl3.aarch64.rpm
 krb5-1.21.3-1.azl3.aarch64.rpm
-nghttp2-1.61.0-1.azl3.aarch64.rpm
+nghttp2-1.61.0-2.azl3.aarch64.rpm
 curl-8.8.0-1.azl3.aarch64.rpm
 curl-devel-8.8.0-1.azl3.aarch64.rpm
 curl-libs-8.8.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -194,7 +194,7 @@ libsolv-devel-0.7.28-1.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm
 libssh2-devel-1.11.0-1.azl3.x86_64.rpm
 krb5-1.21.3-1.azl3.x86_64.rpm
-nghttp2-1.61.0-1.azl3.x86_64.rpm
+nghttp2-1.61.0-2.azl3.x86_64.rpm
 curl-8.8.0-1.azl3.x86_64.rpm
 curl-devel-8.8.0-1.azl3.x86_64.rpm
 curl-libs-8.8.0-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -275,9 +275,9 @@ newt-0.52.23-1.azl3.aarch64.rpm
 newt-debuginfo-0.52.23-1.azl3.aarch64.rpm
 newt-devel-0.52.23-1.azl3.aarch64.rpm
 newt-lang-0.52.23-1.azl3.aarch64.rpm
-nghttp2-1.61.0-1.azl3.aarch64.rpm
-nghttp2-debuginfo-1.61.0-1.azl3.aarch64.rpm
-nghttp2-devel-1.61.0-1.azl3.aarch64.rpm
+nghttp2-1.61.0-2.azl3.aarch64.rpm
+nghttp2-debuginfo-1.61.0-2.azl3.aarch64.rpm
+nghttp2-devel-1.61.0-2.azl3.aarch64.rpm
 ninja-build-1.11.1-1.azl3.aarch64.rpm
 ninja-build-debuginfo-1.11.1-1.azl3.aarch64.rpm
 npth-1.6-4.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -281,9 +281,9 @@ newt-0.52.23-1.azl3.x86_64.rpm
 newt-debuginfo-0.52.23-1.azl3.x86_64.rpm
 newt-devel-0.52.23-1.azl3.x86_64.rpm
 newt-lang-0.52.23-1.azl3.x86_64.rpm
-nghttp2-1.61.0-1.azl3.x86_64.rpm
-nghttp2-debuginfo-1.61.0-1.azl3.x86_64.rpm
-nghttp2-devel-1.61.0-1.azl3.x86_64.rpm
+nghttp2-1.61.0-2.azl3.x86_64.rpm
+nghttp2-debuginfo-1.61.0-2.azl3.x86_64.rpm
+nghttp2-devel-1.61.0-2.azl3.x86_64.rpm
 ninja-build-1.11.1-1.azl3.x86_64.rpm
 ninja-build-debuginfo-1.11.1-1.azl3.x86_64.rpm
 npth-1.6-4.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In 3.0 we've modified the toolkit to not ignore the casing of the package dependencies. This is by design and it broke test builds for `nghttp2`, which declares a dependency on `cunit`, where in reality the package is called `CUnit`. Fixing this here.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=630875&view=results).
- Local build.