### PR TITLE
Filter out debuginfo packages when running sodiff (#6698)

### DIFF
--- a/.pipelines/templatesWithCheckout/SodiffCheck.yml
+++ b/.pipelines/templatesWithCheckout/SodiffCheck.yml
@@ -13,6 +13,14 @@ parameters:
     type: string
     default: "rpms.tar.gz"
 
+  - name: sodiffRepoCommand
+    type: string
+    default: "sodiff-repo"
+
+  - name: sodiffRepoFile
+    type: string
+    default: "sodiff.repo"
+
   - name: sourcesWorkspace
     type: string
     default: "$(Agent.TempDirectory)/SourcesWorkspace"
@@ -52,8 +60,8 @@ steps:
       sodiff_out_dir="${{ parameters.buildRepoRoot }}/out/sodiff"
       mkdir -p $sodiff_out_dir
 
-      echo "Generate sodiff.repo file"
-      sudo make -sC "$toolkit_dir" sodiff-repo
+      echo "Generate sodiff repo file"
+      sudo make -sC "$toolkit_dir" ${{ parameters.sodiffRepoCommand }}
 
       echo "Generate input file"
       find $sodiff_rpms_dir -type f -name '*.rpm' -exec basename {} \; > ./sodiff-rpms
@@ -61,7 +69,7 @@ steps:
       sodiff_release_ver=`cat ${{ parameters.buildRepoRoot }}/SPECS/azurelinux-release/azurelinux-release.spec | grep "Version:" | cut -d " " -f 1 --complement | xargs`
       echo "sodiff release ver: $sodiff_release_ver"
       
-      $toolkit_dir/scripts/sodiff/mariner-sodiff.sh $sodiff_rpms_dir/ $toolkit_dir/scripts/sodiff/sodiff.repo $sodiff_release_ver $sodiff_out_dir < ./sodiff-rpms
+      $toolkit_dir/scripts/sodiff/mariner-sodiff.sh -r $sodiff_rpms_dir/ -f ${{ parameters.buildRepoRoot }}/build/sodiff/${{ parameters.sodiffRepoFile }} -v $sodiff_release_ver -o $sodiff_out_dir -e true < ./sodiff-rpms
 
 
     displayName: "Sodiff check"

--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -23,11 +23,15 @@ ifneq ($(build_arch),x86_64)
 # Microsoft OSS repository only exists for x86_64 - skip that .repo file;
 # otherwise package manager will signal an error due to being unable to make contact
 SODIFF_REPO_SOURCES="azurelinux-official-base.repo"
+SODIFF_REPO_SOURCES_EXTENDED="azurelinux-official-base.repo azurelinux-extended.repo"
 else
 SODIFF_REPO_SOURCES="azurelinux-official-base.repo azurelinux-ms-oss.repo"
+SODIFF_REPO_SOURCES_EXTENDED="azurelinux-official-base.repo azurelinux-microsoft.repo azurelinux-extended.repo"
 endif
 
-SODIFF_REPO_FILE=$(SCRIPTS_DIR)/sodiff/sodiff.repo
+
+SODIFF_REPO_FILE=$(BUILD_DIR)/sodiff/sodiff.repo
+SODIFF_REPO_FILE_EXTENDED=$(BUILD_DIR)/sodiff/sodiff-extended.repo
 # An artifact containing a list of packages that need to be dash-rolled due to their dependency having a new .so version
 SODIFF_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt
 # A script doing the sodiff work
@@ -72,8 +76,15 @@ fake-built-packages-list: | $(SODIFF_OUTPUT_FOLDER)
 .PHONY: sodiff-repo
 sodiff-repo: $(SODIFF_REPO_FILE)
 
-$(SODIFF_REPO_FILE):
+$(SODIFF_REPO_FILE): $(SODIFF_OUTPUT_FOLDER)
 	echo $(SODIFF_REPO_SOURCES) | sed -E 's:([^ ]+[.]repo):$(SPECS_DIR)/azurelinux-repos/\1:g' | xargs cat > $(SODIFF_REPO_FILE)
+
+# sodiff-repo-extended: Generate just the sodiff.repo file
+.PHONY: sodiff-repo-extended
+sodiff-repo-extended: $(SODIFF_REPO_FILE_EXTENDED)
+
+$(SODIFF_REPO_FILE_EXTENDED): $(SODIFF_OUTPUT_FOLDER)
+	echo $(SODIFF_REPO_SOURCES_EXTENDED) | sed -E 's:([^ ]+[.]repo):$(SPECS_DIR)/azurelinux-repos/\1:g' | xargs cat > $(SODIFF_REPO_FILE_EXTENDED)
 
 # sodiff-setup: populate gpg-keys from SPECS/azurelinux-repos for mariner official repos for ubuntu
 .PHONY: sodiff-setup
@@ -85,7 +96,7 @@ sodiff-setup:
 .SILENT .PHONY: sodiff-check
 
 sodiff-check: $(BUILT_PACKAGES_FILE) | $(SODIFF_REPO_FILE)
-	<$(BUILT_PACKAGES_FILE) $(SODIFF_SCRIPT) $(RPMS_DIR)/ $(SODIFF_REPO_FILE) $(RELEASE_MAJOR_ID) $(SODIFF_OUTPUT_FOLDER)
+	<$(BUILT_PACKAGES_FILE) $(SODIFF_SCRIPT) -r $(RPMS_DIR)/ -f $(SODIFF_REPO_FILE) -v $(RELEASE_MAJOR_ID) -o $(SODIFF_OUTPUT_FOLDER)
 
 package-toolkit: $(SODIFF_REPO_FILE)
 

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -2,13 +2,36 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Required binaries:
-# rpm and dnf
+sodiff_script_error=false
+while getopts "r:f:v:o:e:" opt; do
+    case $opt in
+        r) rpms_folder="$OPTARG";;
+        f) repo_file_path="$OPTARG";;
+        v) mariner_version="$OPTARG";;
+        o) sodiff_out_dir="$OPTARG";;
+        e) sodiff_script_error="$OPTARG";;
+    esac
+done
 
-rpms_folder="$1"
-repo_file_path="$2"
-mariner_version="$3"
-sodiff_out_dir="$4"
+if [[ -z "$rpms_folder" ]]; then
+    echo "INVALID ARGUMENT: RPMS_FOLDER is empty. It can be specified via the -r command line option."
+    exit 1
+fi
+
+if [[ -z "$repo_file_path" ]]; then
+    echo "INVALID ARGUMENT: REPO_FILE_PATH is empty. It can be specified via the -f command line option."
+    exit 1
+fi
+
+if [[ -z "$mariner_version" ]]; then
+    echo "INVALID ARGUMENT: MARINER_VERSION is empty. It can be specified via the -v command line option."
+    exit 1
+fi
+
+if [[ -z "$sodiff_out_dir" ]]; then
+    echo "INVALID ARGUMENT: SODIFF_OUT_DIR is empty. It can be specified via the -o command line option."
+    exit 1
+fi
 sodiff_log_file="${sodiff_out_dir}/sodiff.log"
 
 # Setup output dir
@@ -18,22 +41,26 @@ mkdir -p "$sodiff_out_dir"
 
 common_options="-c $repo_file_path --releasever $mariner_version"
 
-DNF_COMMAND=dnf
+dnf_command=dnf
 # Cache RPM metadata
->/dev/null dnf $common_options -y makecache
+>/dev/null $dnf_command $common_options -y makecache
 
 # Get packages from stdin
 pkgs=`cat`
+echo "$pkgs"
 
 for rpmpackage in $pkgs; do
+    package_debuginfo=$(echo "$rpmpackage" | rev | cut -f3 -d'-' | rev)
+    if [[ "$package_debuginfo" == "debuginfo" ]]; then
+        continue
+	fi
     package_path=$(find "$rpms_folder" -name "$rpmpackage" -type f)
     package_provides=`2>/dev/null rpm -qP "$package_path" | grep -E '[.]so[(.]' `
     echo "Processing ${rpmpackage}..."
     echo ".so's provided: $package_provides"
     for sofile in $package_provides; do
         # Query local metadata for provides
-        sos_found=$( 2>/dev/null $DNF_COMMAND repoquery $common_options --whatprovides $sofile | wc -l )
-        echo "Number of .so files found: $sos_found"
+        sos_found=$( 2>/dev/null $dnf_command repoquery $common_options --whatprovides $sofile | wc -l )
         if [ "$sos_found" -eq 0 ] ; then
             # SO file not found, meaning this might be a new .SO
             # or a new version of a preexisting .SO.
@@ -43,14 +70,13 @@ for rpmpackage in $pkgs; do
             sofile_no_ver=$(echo "$sofile" | sed -E 's/[.]so[(.].+/.so/')
 
             # check for generic .so in the repo
-            sos_found=$( 2>/dev/null $DNF_COMMAND repoquery $common_options --whatprovides "${sofile_no_ver}*" | wc -l )
-            echo "Number of non-versioned .so files found: $sos_found"
+            sos_found=$( 2>/dev/null $dnf_command repoquery $common_options --whatprovides "${sofile_no_ver}*" | wc -l )
             if ! [ "$sos_found" -eq 0 ] ; then
                 # Generic version of SO was found.
                 # This means it's a new version of a preexisting SO.
                 # Log which packages depend on this functionality
                 echo "Packages that require $sofile_no_ver:"
-                2>/dev/null $DNF_COMMAND repoquery $common_options -s --whatrequires "${sofile_no_ver}*" | sed -E 's/[.][^.]+[.]src[.]rpm//' | tee "$sodiff_out_dir"/"require_${sofile}"
+                2>/dev/null $dnf_command repoquery $common_options -s --whatrequires "${sofile_no_ver}*" | sed -E 's/[.][^.]+[.]src[.]rpm//' | tee "$sodiff_out_dir"/"require_${sofile}"
             fi
         fi
     done
@@ -60,7 +86,7 @@ done
 # Obtain a list of unique packages to be updated
 2>/dev/null cat "$sodiff_out_dir"/require* | sort -u > "$sodiff_out_dir"/sodiff-intermediate-summary.txt
 
-rm "$sodiff_out_dir"/require*
+rm -f "$sodiff_out_dir"/require*
 touch "$sodiff_out_dir"/sodiff-summary.txt
 
 # Remove packages that have been dash-rolled already.
@@ -88,6 +114,9 @@ echo "######################"
 if [[ $pkgsFound -gt 0 ]]; then
     echo "The Following Packages Are in Need of an Update:"
     cat "$sodiff_out_dir"/sodiff-summary.txt
+    if [[ "$sodiff_script_error" -eq "true" ]]; then
+        exit 1
+    fi 
 else
     echo "No Packages with Conflicting .so Files Found."
 fi


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
sodiff checks were broken for Azure Linux 3.0. This PR ports the fix which was needed for 2.0 that did not originally make it into 3.0.
2.0 PR here: https://github.com/microsoft/azurelinux/pull/6698

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add Sodiff debuginfo filtering and adjustments to 3.0

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full build
- ARM64: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=630778&view=results
- AMD64:  https://dev.azure.com/mariner-org/mariner/_build/results?buildId=630745&view=results
