### PR TITLE
krb5: Add patch for fixing CVE-2024-26458 and CVE-2024-26461

### DIFF
--- a/SPECS/krb5/CVE-2024-26461.patch
+++ b/SPECS/krb5/CVE-2024-26461.patch
@@ -1,0 +1,195 @@
+From c929e7d18bdd47b9e9316de173359efc76810b29 Mon Sep 17 00:00:00 2001
+From: ankita <ankitapareek@microsoft.com>
+Date: Mon, 2 Sep 2024 12:34:38 +0530
+Subject: [PATCH] krb5: Fix CVE-2024-26458 and CVE-2024-26461
+
+---
+ src/lib/gssapi/krb5/k5sealv3.c | 56 +++++++++++++++-------------------
+ src/lib/rpc/pmap_rmt.c         |  9 +++---
+ 2 files changed, 29 insertions(+), 36 deletions(-)
+
+diff --git a/src/lib/gssapi/krb5/k5sealv3.c b/src/lib/gssapi/krb5/k5sealv3.c
+index 1fcbdfb..d3210c1 100644
+--- a/src/lib/gssapi/krb5/k5sealv3.c
++++ b/src/lib/gssapi/krb5/k5sealv3.c
+@@ -65,7 +65,7 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+                                 int conf_req_flag, int toktype)
+ {
+     size_t bufsize = 16;
+-    unsigned char *outbuf = 0;
++    unsigned char *outbuf = NULL;
+     krb5_error_code err;
+     int key_usage;
+     unsigned char acceptor_flag;
+@@ -75,9 +75,13 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ #endif
+     size_t ec;
+     unsigned short tok_id;
+-    krb5_checksum sum;
++    krb5_checksum sum = { 0 };
+     krb5_key key;
+     krb5_cksumtype cksumtype;
++    krb5_data plain = empty_data();
++
++    token->value = NULL;
++    token->length = 0;
+ 
+     acceptor_flag = ctx->initiate ? 0 : FLAG_SENDER_IS_ACCEPTOR;
+     key_usage = (toktype == KG_TOK_WRAP_MSG
+@@ -107,14 +111,15 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ #endif
+ 
+     if (toktype == KG_TOK_WRAP_MSG && conf_req_flag) {
+-        krb5_data plain;
+         krb5_enc_data cipher;
+         size_t ec_max;
+         size_t encrypt_size;
+ 
+         /* 300: Adds some slop.  */
+-        if (SIZE_MAX - 300 < message->length)
+-            return ENOMEM;
++        if (SIZE_MAX - 300 < message->length) {
++            err = ENOMEM;
++            goto cleanup;
++        }
+         ec_max = SIZE_MAX - message->length - 300;
+         if (ec_max > 0xffff)
+             ec_max = 0xffff;
+@@ -126,20 +131,20 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ #endif
+         err = alloc_data(&plain, message->length + 16 + ec);
+         if (err)
+-            return err;
++            goto cleanup;
+ 
+         /* Get size of ciphertext.  */
+         encrypt_size = krb5_encrypt_size(plain.length, key->keyblock.enctype);
+         if (encrypt_size > SIZE_MAX / 2) {
+             err = ENOMEM;
+-            goto error;
++            goto cleanup;
+         }
+         bufsize = 16 + encrypt_size;
+         /* Allocate space for header plus encrypted data.  */
+         outbuf = gssalloc_malloc(bufsize);
+         if (outbuf == NULL) {
+-            free(plain.data);
+-            return ENOMEM;
++            err = ENOMEM;
++            goto cleanup;
+         }
+ 
+         /* TOK_ID */
+@@ -164,11 +169,8 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+         cipher.ciphertext.length = bufsize - 16;
+         cipher.enctype = key->keyblock.enctype;
+         err = krb5_k_encrypt(context, key, key_usage, 0, &plain, &cipher);
+-        zap(plain.data, plain.length);
+-        free(plain.data);
+-        plain.data = 0;
+         if (err)
+-            goto error;
++            goto cleanup;
+ 
+         /* Now that we know we're returning a valid token....  */
+         ctx->seq_send++;
+@@ -181,7 +183,6 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+         /* If the rotate fails, don't worry about it.  */
+ #endif
+     } else if (toktype == KG_TOK_WRAP_MSG && !conf_req_flag) {
+-        krb5_data plain;
+         size_t cksumsize;
+ 
+         /* Here, message is the application-supplied data; message2 is
+@@ -193,21 +194,19 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+     wrap_with_checksum:
+         err = alloc_data(&plain, message->length + 16);
+         if (err)
+-            return err;
++            goto cleanup;
+ 
+         err = krb5_c_checksum_length(context, cksumtype, &cksumsize);
+         if (err)
+-            goto error;
++            goto cleanup;
+ 
+         assert(cksumsize <= 0xffff);
+ 
+         bufsize = 16 + message2->length + cksumsize;
+         outbuf = gssalloc_malloc(bufsize);
+         if (outbuf == NULL) {
+-            free(plain.data);
+-            plain.data = 0;
+             err = ENOMEM;
+-            goto error;
++            goto cleanup;
+         }
+ 
+         /* TOK_ID */
+@@ -239,23 +238,15 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+         if (message2->length)
+             memcpy(outbuf + 16, message2->value, message2->length);
+ 
+-        sum.contents = outbuf + 16 + message2->length;
+-        sum.length = cksumsize;
+-
+         err = krb5_k_make_checksum(context, cksumtype, key,
+                                    key_usage, &plain, &sum);
+-        zap(plain.data, plain.length);
+-        free(plain.data);
+-        plain.data = 0;
+         if (err) {
+             zap(outbuf,bufsize);
+-            goto error;
++            goto cleanup;
+         }
+         if (sum.length != cksumsize)
+             abort();
+         memcpy(outbuf + 16 + message2->length, sum.contents, cksumsize);
+-        krb5_free_checksum_contents(context, &sum);
+-        sum.contents = 0;
+         /* Now that we know we're actually generating the token...  */
+         ctx->seq_send++;
+ 
+@@ -285,12 +276,13 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ 
+     token->value = outbuf;
+     token->length = bufsize;
+-    return 0;
++    outbuf = NULL;
++    err = 0;
+ 
+-error:
++cleanup:
++    krb5_free_checksum_contents(context, &sum);
++    zapfree(plain.data, plain.length);
+     gssalloc_free(outbuf);
+-    token->value = NULL;
+-    token->length = 0;
+     return err;
+ }
+ 
+diff --git a/src/lib/rpc/pmap_rmt.c b/src/lib/rpc/pmap_rmt.c
+index 8c7e30c..115a55a 100644
+--- a/src/lib/rpc/pmap_rmt.c
++++ b/src/lib/rpc/pmap_rmt.c
+@@ -160,11 +160,12 @@ xdr_rmtcallres(
+ 	caddr_t port_ptr;
+ 
+ 	port_ptr = (caddr_t)(void *)crp->port_ptr;
+-	if (xdr_reference(xdrs, &port_ptr, sizeof (uint32_t),
+-	    xdr_u_int32) && xdr_u_int32(xdrs, &crp->resultslen)) {
+-		crp->port_ptr = (uint32_t *)(void *)port_ptr;
++	if (!xdr_reference(xdrs, &port_ptr, sizeof (uint32_t),
++	    xdr_u_int32))
++		return (FALSE);
++	crp->port_ptr = (uint32_t *)(void *)port_ptr;
++	if (xdr_u_int32(xdrs, &crp->resultslen))
+ 		return ((*(crp->xdr_results))(xdrs, crp->results_ptr));
+-	}
+ 	return (FALSE);
+ }
+ 
+-- 
+2.34.1
+

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -4,14 +4,15 @@
 Summary:        The Kerberos newtork authentication system
 Name:           krb5
 Version:        1.21.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System Environment/Security
 URL:            https://web.mit.edu/kerberos/
 Source0:        https://kerberos.org/dist/%{name}/%{maj_version}/%{name}-%{version}.tar.gz
-Source1:        krb5.conf
+Source1:        krb5.
+Patch0:         CVE-2024-26461.patch
 BuildRequires:  e2fsprogs-devel
 BuildRequires:  openssl-devel
 Requires:       e2fsprogs-libs
@@ -125,6 +126,9 @@ make check
 %{_datarootdir}/locale/*
 
 %changelog
+* Mon Sep 2 2024 Ankita Pareek <ankitapareek@microsoft.com> - 1.21.3-2
+- Add patch for CVE-2024-26458 and CVE-2024-26461
+
 * Wed Jul 24 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.21.3-1
 - Auto-upgrade to 1.21.3 - CVE-2024-37371, CVE-2024-37370
 

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -11,7 +11,7 @@ Distribution:   Azure Linux
 Group:          System Environment/Security
 URL:            https://web.mit.edu/kerberos/
 Source0:        https://kerberos.org/dist/%{name}/%{maj_version}/%{name}-%{version}.tar.gz
-Source1:        krb5.
+Source1:        krb5.conf
 Patch0:         CVE-2024-26461.patch
 BuildRequires:  e2fsprogs-devel
 BuildRequires:  openssl-devel

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -193,7 +193,7 @@ libsolv-0.7.28-1.azl3.aarch64.rpm
 libsolv-devel-0.7.28-1.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm
 libssh2-devel-1.11.0-1.azl3.aarch64.rpm
-krb5-1.21.3-1.azl3.aarch64.rpm
+krb5-1.21.3-2.azl3.aarch64.rpm
 nghttp2-1.61.0-2.azl3.aarch64.rpm
 curl-8.8.0-1.azl3.aarch64.rpm
 curl-devel-8.8.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -193,7 +193,7 @@ libsolv-0.7.28-1.azl3.x86_64.rpm
 libsolv-devel-0.7.28-1.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm
 libssh2-devel-1.11.0-1.azl3.x86_64.rpm
-krb5-1.21.3-1.azl3.x86_64.rpm
+krb5-1.21.3-2.azl3.x86_64.rpm
 nghttp2-1.61.0-2.azl3.x86_64.rpm
 curl-8.8.0-1.azl3.x86_64.rpm
 curl-devel-8.8.0-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -160,10 +160,10 @@ kernel-headers-6.6.47.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm
-krb5-1.21.3-1.azl3.aarch64.rpm
-krb5-debuginfo-1.21.3-1.azl3.aarch64.rpm
-krb5-devel-1.21.3-1.azl3.aarch64.rpm
-krb5-lang-1.21.3-1.azl3.aarch64.rpm
+krb5-1.21.3-2.azl3.aarch64.rpm
+krb5-debuginfo-1.21.3-2.azl3.aarch64.rpm
+krb5-devel-1.21.3-2.azl3.aarch64.rpm
+krb5-lang-1.21.3-2.azl3.aarch64.rpm
 libacl-2.3.1-2.azl3.aarch64.rpm
 libacl-devel-2.3.1-2.azl3.aarch64.rpm
 libarchive-3.7.1-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -166,10 +166,10 @@ kernel-headers-6.6.47.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm
-krb5-1.21.3-1.azl3.x86_64.rpm
-krb5-debuginfo-1.21.3-1.azl3.x86_64.rpm
-krb5-devel-1.21.3-1.azl3.x86_64.rpm
-krb5-lang-1.21.3-1.azl3.x86_64.rpm
+krb5-1.21.3-2.azl3.x86_64.rpm
+krb5-debuginfo-1.21.3-2.azl3.x86_64.rpm
+krb5-devel-1.21.3-2.azl3.x86_64.rpm
+krb5-lang-1.21.3-2.azl3.x86_64.rpm
 libacl-2.3.1-2.azl3.x86_64.rpm
 libacl-devel-2.3.1-2.azl3.x86_64.rpm
 libarchive-3.7.1-2.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fixes CVE-2024-26458 and CVE-2024-26461 in krb5 package

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2024-26458 and CVE-2024-26461

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-26458
- https://nvd.nist.gov/vuln/detail/CVE-2024-26461

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [632804](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=632804&view=results) (The tests fail here because it uninstalls some packages like curl, openssl, etc which have a dependency on krb5 and at the end tdnf as well. This is an expected behaviour)