### PR TITLE
libsolv: enable zstd support to match createrepo_c

### DIFF
--- a/SPECS/libsolv/libsolv.spec
+++ b/SPECS/libsolv/libsolv.spec
@@ -10,7 +10,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 BuildRequires:  cmake
 BuildRequires:  rpm-devel
-BuildRequires:  libzstd-devel
+BuildRequires:  zstd-devel
 Requires:       expat-libs
 
 %description

--- a/SPECS/libsolv/libsolv.spec
+++ b/SPECS/libsolv/libsolv.spec
@@ -1,7 +1,7 @@
 Summary:        A free package dependency solver
 Name:           libsolv
 Version:        0.7.28
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 URL:            https://github.com/openSUSE/libsolv
 Source0:        https://github.com/openSUSE/libsolv/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
@@ -10,6 +10,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 BuildRequires:  cmake
 BuildRequires:  rpm-devel
+BuildRequires:  libzstd-devel
 Requires:       expat-libs
 
 %description
@@ -47,7 +48,8 @@ Requires:       xz
     -DENABLE_RPMDB_BYRPMHEADER=ON       \
     -DENABLE_RPMDB_LIBRPM=ON            \
     -DENABLE_RPMMD=ON                   \
-    -DENABLE_COMPS=ON
+    -DENABLE_COMPS=ON                   \
+    -DENABLE_ZSTD_COMPRESSION=ON
 %make_build
 
 %install
@@ -77,6 +79,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_mandir}/man1/*
 
 %changelog
+* Wed Sep 04 2024 Reuben Olinsky <reubeno@microsoft.com> - 0.7.28-2
+- Enable zstd support to match createrepo_c.
+
 * Wed Feb 07 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 0.7.28-1
 - Upgrade to version 0.7.28
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -189,8 +189,8 @@ rpm-libs-4.18.2-1.azl3.aarch64.rpm
 cpio-2.14-1.azl3.aarch64.rpm
 cpio-lang-2.14-1.azl3.aarch64.rpm
 e2fsprogs-libs-1.47.0-2.azl3.aarch64.rpm
-libsolv-0.7.28-1.azl3.aarch64.rpm
-libsolv-devel-0.7.28-1.azl3.aarch64.rpm
+libsolv-0.7.28-2.azl3.aarch64.rpm
+libsolv-devel-0.7.28-2.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm
 libssh2-devel-1.11.0-1.azl3.aarch64.rpm
 krb5-1.21.3-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -189,8 +189,8 @@ rpm-libs-4.18.2-1.azl3.x86_64.rpm
 cpio-2.14-1.azl3.x86_64.rpm
 cpio-lang-2.14-1.azl3.x86_64.rpm
 e2fsprogs-libs-1.47.0-2.azl3.x86_64.rpm
-libsolv-0.7.28-1.azl3.x86_64.rpm
-libsolv-devel-0.7.28-1.azl3.x86_64.rpm
+libsolv-0.7.28-2.azl3.x86_64.rpm
+libsolv-devel-0.7.28-2.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm
 libssh2-devel-1.11.0-1.azl3.x86_64.rpm
 krb5-1.21.3-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -223,10 +223,10 @@ libselinux-utils-3.6-3.azl3.aarch64.rpm
 libsepol-3.6-1.azl3.aarch64.rpm
 libsepol-debuginfo-3.6-1.azl3.aarch64.rpm
 libsepol-devel-3.6-1.azl3.aarch64.rpm
-libsolv-0.7.28-1.azl3.aarch64.rpm
-libsolv-debuginfo-0.7.28-1.azl3.aarch64.rpm
-libsolv-devel-0.7.28-1.azl3.aarch64.rpm
-libsolv-tools-0.7.28-1.azl3.aarch64.rpm
+libsolv-0.7.28-2.azl3.aarch64.rpm
+libsolv-debuginfo-0.7.28-2.azl3.aarch64.rpm
+libsolv-devel-0.7.28-2.azl3.aarch64.rpm
+libsolv-tools-0.7.28-2.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm
 libssh2-debuginfo-1.11.0-1.azl3.aarch64.rpm
 libssh2-devel-1.11.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -229,10 +229,10 @@ libselinux-utils-3.6-3.azl3.x86_64.rpm
 libsepol-3.6-1.azl3.x86_64.rpm
 libsepol-debuginfo-3.6-1.azl3.x86_64.rpm
 libsepol-devel-3.6-1.azl3.x86_64.rpm
-libsolv-0.7.28-1.azl3.x86_64.rpm
-libsolv-debuginfo-0.7.28-1.azl3.x86_64.rpm
-libsolv-devel-0.7.28-1.azl3.x86_64.rpm
-libsolv-tools-0.7.28-1.azl3.x86_64.rpm
+libsolv-0.7.28-2.azl3.x86_64.rpm
+libsolv-debuginfo-0.7.28-2.azl3.x86_64.rpm
+libsolv-devel-0.7.28-2.azl3.x86_64.rpm
+libsolv-tools-0.7.28-2.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm
 libssh2-debuginfo-1.11.0-1.azl3.x86_64.rpm
 libssh2-devel-1.11.0-1.azl3.x86_64.rpm

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -541,8 +541,9 @@ build_rpm_in_chroot_no_install libxslt
 chroot_and_install_rpms pam
 build_rpm_in_chroot_no_install docbook-style-xsl
 
-# libsolv needs cmake
+# libsolv needs cmake, zstd-devel
 chroot_and_install_rpms cmake
+chroot_and_install_rpms zstd
 build_rpm_in_chroot_no_install libsolv
 
 # ccache needs cmake


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In 3.0, `createrepo_c`'s default behavior is to create repodata files compressed using zstd; prior to this change, `libsolv` didn't support `zstd`, though, so `tdnf`/`dnf`/et al. couldn't actually handle those repos. As a workaround, the toolkit and manual invocations of `createrepo_c` for 3.0 have needed to use the `--compatibility` flag. Standard OSS tooling doesn't know to do this (nor should it have to), though; the right thing to do is to add support for zstd to `libsolv`, as other distros have done.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Enable zstd support in `libsolv` at compile time.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local build + pipeline build through and including toolchain (phase 1).
