### PR TITLE
[cherry-pick] kubevirt: CVE-2022-32149 and CVE-2023-26484 (#10232)

### DIFF
--- a/SPECS/kubevirt/CVE-2022-32149.patch
+++ b/SPECS/kubevirt/CVE-2022-32149.patch
@@ -1,0 +1,59 @@
+From 434eadcdbc3b0256971992e8c70027278364c72c Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <bracewell@google.com>
+Date: Fri, 2 Sep 2022 09:35:37 -0700
+Subject: [PATCH] language: reject excessively large Accept-Language strings
+
+The BCP 47 tag parser has quadratic time complexity due to inherent
+aspects of its design. Since the parser is, by design, exposed to
+untrusted user input, this can be leveraged to force a program to
+consume significant time parsing Accept-Language headers.
+
+The parser cannot be easily rewritten to fix this behavior for
+various reasons. Instead the solution implemented in this CL is to
+limit the total complexity of tags passed into ParseAcceptLanguage
+by limiting the number of dashes in the string to 1000. This should
+be more than enough for the majority of real world use cases, where
+the number of tags being sent is likely to be in the single digits.
+
+Thanks to the OSS-Fuzz project for discovering this issue and to Adam
+Korczynski (ADA Logics) for writing the fuzz case and for reporting the
+issue.
+
+Fixes CVE-2022-32149
+Fixes golang/go#56152
+
+Change-Id: I7bda1d84cee2b945039c203f26869d58ee9374ae
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1565112
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/text/+/442235
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Auto-Submit: Roland Shoemaker <roland@golang.org>
+Run-TryBot: Roland Shoemaker <roland@golang.org>
+---
+ vendor/golang.org/x/text/language/parse.go      |  5 +++++
+ 1 files changed, 5 insertions(+)
+
+diff --git a/vendor/golang.org/x/text/language/parse.go b/vendor/golang.org/x/text/language/parse.go
+index 59b04100..b982d9e4 100644
+--- a/vendor/golang.org/x/text/language/parse.go
++++ b/vendor/golang.org/x/text/language/parse.go
+@@ -147,6 +147,7 @@ func update(b *language.Builder, part ...interface{}) (err error) {
+ }
+ 
+ var errInvalidWeight = errors.New("ParseAcceptLanguage: invalid weight")
++var errTagListTooLarge = errors.New("tag list exceeds max length")
+ 
+ // ParseAcceptLanguage parses the contents of an Accept-Language header as
+ // defined in http://www.ietf.org/rfc/rfc2616.txt and returns a list of Tags and
+@@ -164,6 +165,10 @@ func ParseAcceptLanguage(s string) (tag []Tag, q []float32, err error) {
+ 		}
+ 	}()
+ 
++	if strings.Count(s, "-") > 1000 {
++		return nil, nil, errTagListTooLarge
++	}
++
+ 	var entry string
+ 	for s != "" {
+ 		if entry, s = split(s, ','); entry == "" {

--- a/SPECS/kubevirt/CVE-2023-26484.patch
+++ b/SPECS/kubevirt/CVE-2023-26484.patch
@@ -1,0 +1,389 @@
+From 5fc09595bb88f4e0ae2998dcc1a271cf810d77fc Mon Sep 17 00:00:00 2001
+From: Luboslav Pivarc <lpivarc@redhat.com>
+Date: Thu, 30 May 2024 10:37:24 +0200
+Subject: [PATCH 1/3] Node restiction
+
+Introduce NodeRestriction feature gate. This enables
+us to check if a virt-handler request is authorized to
+modify VMI.
+
+This feature requires following Kubernetes feature gate
+ServiceAccountTokenPodNodeInfo. The feature gate is available
+in 1.30 as Beta.
+
+Signed-off-by: Luboslav Pivarc <lpivarc@redhat.com>
+---
+ pkg/virt-api/webhooks/utils.go                |  18 +-
+ .../validating-webhook/admitters/BUILD.bazel  |   2 +
+ .../admitters/vmi-update-admitter.go          |  43 ++++-
+ .../admitters/vmi-update-admitter_test.go     | 156 ++++++++++++++++++
+ pkg/virt-config/feature-gates.go              |  11 ++
+ tests/decorators/decorators.go                |   3 +
+ 8 files changed, 336 insertions(+), 6 deletions(-)
+ create mode 100644 tests/infrastructure/security.go
+
+diff --git a/pkg/virt-api/webhooks/utils.go b/pkg/virt-api/webhooks/utils.go
+index 1307cb366fdb..e6ee54431f91 100644
+--- a/pkg/virt-api/webhooks/utils.go
++++ b/pkg/virt-api/webhooks/utils.go
+@@ -79,7 +79,11 @@ type Informers struct {
+ 	DataSourceInformer cache.SharedIndexInformer
+ }
+ 
+-func IsKubeVirtServiceAccount(serviceAccount string) bool {
++func IsComponentServiceAccount(serviceAccount, namespace, component string) bool {
++	return serviceAccount == fmt.Sprintf("system:serviceaccount:%s:%s", namespace, component)
++}
++
++func GetNamespace() string {
+ 	ns, err := clientutil.GetNamespace()
+ 	logger := log.DefaultLogger()
+ 
+@@ -87,11 +91,14 @@ func IsKubeVirtServiceAccount(serviceAccount string) bool {
+ 		logger.Info("Failed to get namespace. Fallback to default: 'kubevirt'")
+ 		ns = "kubevirt"
+ 	}
++	return ns
++}
+ 
+-	prefix := fmt.Sprintf("system:serviceaccount:%s", ns)
+-	return serviceAccount == fmt.Sprintf("%s:%s", prefix, rbac.ApiServiceAccountName) ||
+-		serviceAccount == fmt.Sprintf("%s:%s", prefix, rbac.HandlerServiceAccountName) ||
+-		serviceAccount == fmt.Sprintf("%s:%s", prefix, rbac.ControllerServiceAccountName)
++func IsKubeVirtServiceAccount(serviceAccount string) bool {
++	ns := GetNamespace()
++	return IsComponentServiceAccount(serviceAccount, ns, rbac.ApiServiceAccountName) ||
++		IsComponentServiceAccount(serviceAccount, ns, rbac.HandlerServiceAccountName) ||
++		IsComponentServiceAccount(serviceAccount, ns, rbac.ControllerServiceAccountName)
+ }
+ 
+ func IsARM64() bool {
+diff --git a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+index 1a71fdf6eab2..8c507b7d9bc2 100644
+--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
++++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+@@ -43,6 +43,7 @@ go_library(
+         "//pkg/virt-config:go_default_library",
+         "//pkg/virt-handler/node-labeller/util:go_default_library",
+         "//pkg/virt-operator/resource/generate/rbac:go_default_library",
++        "//pkg/virt-operator/resource/generate/components:go_default_library",
+         "//staging/src/kubevirt.io/api/clone:go_default_library",
+         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
+         "//staging/src/kubevirt.io/api/core:go_default_library",
+@@ -135,6 +136,7 @@ go_test(
+         "//vendor/github.com/golang/mock/gomock:go_default_library",
+         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+         "//vendor/github.com/onsi/gomega:go_default_library",
++        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
+         "//vendor/github.com/onsi/gomega/types:go_default_library",
+         "//vendor/k8s.io/api/admission/v1:go_default_library",
+         "//vendor/k8s.io/api/authentication/v1:go_default_library",
+diff --git a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+index b33f167eb37b..2c56c4be80dd 100644
+--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
++++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+@@ -29,18 +29,20 @@ import (
+ 
+ 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+ 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
++	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
+ 
+ 	v1 "kubevirt.io/api/core/v1"
+ 
+ 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
+ )
+ 
++const nodeNameExtraInfo = "authentication.kubernetes.io/node-name"
++
+ type VMIUpdateAdmitter struct {
+ 	ClusterConfig *virtconfig.ClusterConfig
+ }
+ 
+ func (admitter *VMIUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+-
+ 	if resp := webhookutils.ValidateSchema(v1.VirtualMachineInstanceGroupVersionKind, ar.Request.Object.Raw); resp != nil {
+ 		return resp
+ 	}
+@@ -50,6 +52,45 @@ func (admitter *VMIUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admis
+ 		return webhookutils.ToAdmissionResponseError(err)
+ 	}
+ 
++	if admitter.ClusterConfig.NodeRestrictionEnabled() && webhooks.IsComponentServiceAccount(ar.Request.UserInfo.Username, webhooks.GetNamespace(), rbac.HandlerServiceAccountName) {
++		values, exist := ar.Request.UserInfo.Extra[nodeNameExtraInfo]
++		if exist && len(values) > 0 {
++			nodeName := values[0]
++			sourceNode := oldVMI.Status.NodeName
++			targetNode := ""
++			if oldVMI.Status.MigrationState != nil {
++				targetNode = oldVMI.Status.MigrationState.TargetNode
++			}
++
++			// Check that source or target is making this request
++			if nodeName != sourceNode && (targetNode == "" || nodeName != targetNode) {
++				return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
++					{
++						Type:    metav1.CauseTypeFieldValueInvalid,
++						Message: "Node restriction, virt-handler is only allowed to modify VMIs it owns",
++					},
++				})
++			}
++
++			// Check that handler is not setting target
++			if targetNode == "" && newVMI.Status.MigrationState != nil && newVMI.Status.MigrationState.TargetNode != targetNode {
++				return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
++					{
++						Type:    metav1.CauseTypeFieldValueInvalid,
++						Message: "Node restriction, virt-handler is not allowed to set target node",
++					},
++				})
++			}
++		} else {
++			return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
++				{
++					Type:    metav1.CauseTypeFieldValueInvalid,
++					Message: "Node restriction failed, virt-handler service account is missing node name",
++				},
++			})
++		}
++	}
++
+ 	// Reject VMI update if VMI spec changed
+ 	if !equality.Semantic.DeepEqual(newVMI.Spec, oldVMI.Spec) {
+ 		// Only allow the KubeVirt SA to modify the VMI spec, since that means it went through the sub resource.
+diff --git a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+index a12cd35a4207..edfe94022436 100644
+--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
++++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+@@ -25,6 +25,7 @@ import (
+ 
+ 	. "github.com/onsi/ginkgo/v2"
+ 	. "github.com/onsi/gomega"
++	"github.com/onsi/gomega/gstruct"
+ 	"github.com/onsi/gomega/types"
+ 	admissionv1 "k8s.io/api/admission/v1"
+ 	authv1 "k8s.io/api/authentication/v1"
+@@ -76,6 +77,161 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
+ 	config, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
+ 	vmiUpdateAdmitter := &VMIUpdateAdmitter{config}
+ 
++	Context("Node restriction", func() {
++		mustMarshal := func(vmi *v1.VirtualMachineInstance) []byte {
++			b, err := json.Marshal(vmi)
++			Expect(err).To(Not(HaveOccurred()))
++			return b
++		}
++
++		admissionWithCustomUpdate := func(vmi, updatedVMI *v1.VirtualMachineInstance, handlernode string) *admissionv1.AdmissionReview {
++			newVMIBytes := mustMarshal(updatedVMI)
++			oldVMIBytes := mustMarshal(vmi)
++			return &admissionv1.AdmissionReview{
++				Request: &admissionv1.AdmissionRequest{
++					UserInfo: authv1.UserInfo{
++						Username: "system:serviceaccount:kubevirt:kubevirt-handler",
++						Extra: map[string]authv1.ExtraValue{
++							"authentication.kubernetes.io/node-name": {handlernode},
++						},
++					},
++					Resource: webhooks.VirtualMachineInstanceGroupVersionResource,
++					Object: runtime.RawExtension{
++						Raw: newVMIBytes,
++					},
++					OldObject: runtime.RawExtension{
++						Raw: oldVMIBytes,
++					},
++					Operation: admissionv1.Update,
++				},
++			}
++		}
++
++		admission := func(vmi *v1.VirtualMachineInstance, handlernode string) *admissionv1.AdmissionReview {
++			updatedVMI := vmi.DeepCopy()
++			if updatedVMI.Labels == nil {
++				updatedVMI.Labels = map[string]string{}
++			}
++			updatedVMI.Labels["allowed.io"] = "value"
++			return admissionWithCustomUpdate(vmi, updatedVMI, handlernode)
++		}
++
++		Context("with Node Restriction feature gate enabled", func() {
++			BeforeEach(func() { enableFeatureGate(virtconfig.NodeRestrictionGate) })
++
++			shouldNotAllowCrossNodeRequest := And(
++				WithTransform(func(resp *admissionv1.AdmissionResponse) bool { return resp.Allowed },
++					BeFalse(),
++				),
++				WithTransform(func(resp *admissionv1.AdmissionResponse) []metav1.StatusCause { return resp.Result.Details.Causes },
++					ContainElement(
++						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
++							"Message": Equal("Node restriction, virt-handler is only allowed to modify VMIs it owns"),
++						}),
++					),
++				),
++			)
++
++			shouldBeAllowed := WithTransform(func(resp *admissionv1.AdmissionResponse) bool { return resp.Allowed },
++				BeTrue(),
++			)
++
++			DescribeTable("and NodeName set", func(handlernode string, matcher types.GomegaMatcher) {
++				vmi := api.NewMinimalVMI("testvmi")
++				vmi.Status.NodeName = "got"
++
++				resp := vmiUpdateAdmitter.Admit(admission(vmi, handlernode))
++				Expect(resp).To(matcher)
++			},
++				Entry("should deny request if handler is on different node", "diff",
++					shouldNotAllowCrossNodeRequest,
++				),
++				Entry("should allow request if handler is on same node", "got",
++					shouldBeAllowed,
++				),
++			)
++
++			DescribeTable("and TargetNode set", func(handlernode string, matcher types.GomegaMatcher) {
++				vmi := api.NewMinimalVMI("testvmi")
++				vmi.Status.NodeName = "got"
++				vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
++					TargetNode: "git",
++				}
++
++				resp := vmiUpdateAdmitter.Admit(admission(vmi, handlernode))
++				Expect(resp).To(matcher)
++			},
++				Entry("should deny request if handler is on different node", "diff",
++					shouldNotAllowCrossNodeRequest,
++				),
++				Entry("should allow request if handler is on same node", "git",
++					shouldBeAllowed,
++				),
++			)
++
++			DescribeTable("and both NodeName and TargetNode set", func(handlernode string, matcher types.GomegaMatcher) {
++				vmi := api.NewMinimalVMI("testvmi")
++				vmi.Status.NodeName = "got"
++				vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
++					TargetNode: "target",
++				}
++
++				resp := vmiUpdateAdmitter.Admit(admission(vmi, handlernode))
++				Expect(resp).To(matcher)
++			},
++				Entry("should deny request if handler is on different node", "diff",
++					shouldNotAllowCrossNodeRequest,
++				),
++				Entry("should allow request if handler is on source node", "got",
++					shouldBeAllowed,
++				),
++
++				Entry("should allow request if handler is on target node", "target",
++					shouldBeAllowed,
++				),
++			)
++
++			It("should allow finalize migration", func() {
++				vmi := api.NewMinimalVMI("testvmi")
++				vmi.Status.NodeName = "got"
++				vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
++					TargetNode: "target",
++				}
++
++				updatedVMI := vmi.DeepCopy()
++				updatedVMI.Status.NodeName = "target"
++
++				resp := vmiUpdateAdmitter.Admit(admissionWithCustomUpdate(vmi, updatedVMI, "got"))
++				Expect(resp.Allowed).To(BeTrue())
++			})
++
++			It("should not allow to set targetNode to source handler", func() {
++				vmi := api.NewMinimalVMI("testvmi")
++				vmi.Status.NodeName = "got"
++
++				updatedVMI := vmi.DeepCopy()
++				updatedVMI.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
++					TargetNode: "target",
++				}
++				resp := vmiUpdateAdmitter.Admit(admissionWithCustomUpdate(vmi, updatedVMI, "got"))
++				Expect(resp.Allowed).To(BeFalse())
++			})
++		})
++
++		DescribeTable("with Node Restriction feature gate disabled should allow different handler", func(migrationState *v1.VirtualMachineInstanceMigrationState) {
++			vmi := api.NewMinimalVMI("testvmi")
++			vmi.Status.NodeName = "got"
++			vmi.Status.MigrationState = migrationState
++
++			resp := vmiUpdateAdmitter.Admit(admission(vmi, "diff"))
++			Expect(resp.Allowed).To(BeTrue())
++		},
++			Entry("when TargetNode is not set", nil),
++			Entry("when TargetNode is set", &v1.VirtualMachineInstanceMigrationState{TargetNode: "git"}),
++		)
++
++	})
++
+ 	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
+ 		input := map[string]interface{}{}
+ 		json.Unmarshal([]byte(data), &input)
+diff --git a/pkg/virt-config/feature-gates.go b/pkg/virt-config/feature-gates.go
+index f1b7ecfb2ad2..71551da7de7b 100644
+--- a/pkg/virt-config/feature-gates.go
++++ b/pkg/virt-config/feature-gates.go
+@@ -85,6 +85,13 @@ const (
+ 	// KubevirtSeccompProfile indicate that Kubevirt will install its custom profile and
+ 	// user can tell Kubevirt to use it
+ 	KubevirtSeccompProfile = "KubevirtSeccompProfile"
++	// Owner: @xpivarc
++	// Alpha: v1.3.0
++	//
++	// NodeRestriction enables Kubelet's like NodeRestriction but for Kubevirt's virt-handler.
++	// This feature requires following Kubernetes feature gate "ServiceAccountTokenPodNodeInfo". The feature gate is available
++	// in Kubernetes 1.30 as Beta.
++	NodeRestrictionGate = "NodeRestriction"
+ )
+ 
+ var deprecatedFeatureGates = [...]string{
+@@ -256,3 +263,7 @@ func (config *ClusterConfig) VolumesUpdateStrategyEnabled() bool {
+ func (config *ClusterConfig) KubevirtSeccompProfileEnabled() bool {
+ 	return config.isFeatureGateEnabled(KubevirtSeccompProfile)
+ }
++
++func (config *ClusterConfig) NodeRestrictionEnabled() bool {
++	return config.isFeatureGateEnabled(NodeRestrictionGate)
++}
+diff --git a/tests/decorators/decorators.go b/tests/decorators/decorators.go
+index 6f728b176c0e..a39c77f569b7 100644
+--- a/tests/decorators/decorators.go
++++ b/tests/decorators/decorators.go
+@@ -56,4 +56,7 @@ var (
+ 	Upgrade          = []interface{}{Label("Upgrade")}
+ 	CustomSELinux    = []interface{}{Label("CustomSELinux")}
+ 	Istio            = []interface{}{Label("Istio")}
++
++	// Kubernetes versions
++	Kubernetes130 = []interface{}{Label("kubernetes130")}
+ )
+From d1d26f9cba0decb69e3e610971ed70edba53d906 Mon Sep 17 00:00:00 2001
+From: Luboslav Pivarc <lpivarc@redhat.com>
+Date: Tue, 11 Jun 2024 13:47:46 +0200
+Subject: [PATCH 3/3] Run NodeIsolation tests only on 1.30 lane
+
+Signed-off-by: Luboslav Pivarc <lpivarc@redhat.com>
+---
+ automation/test.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/automation/test.sh b/automation/test.sh
+index b3bf13dacc55..4ea306a710bf 100755
+--- a/automation/test.sh
++++ b/automation/test.sh
+@@ -455,6 +455,10 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter}
+   else
+     label_filter='(!(Multus,SRIOV,Macvtap,GPU,VGPU))'
+   fi
++
++  if [[ ! $TARGET =~ k8s-1\.3[0-9].* ]]; then
++    add_to_label_filter "(!kubernetes130)" "&&"
++  fi
+ fi
+ 
+ add_to_label_filter() {

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -19,7 +19,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        0.59.0
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -29,15 +29,17 @@ Source0:        https://github.com/kubevirt/kubevirt/archive/refs/tags/v%{versio
 Source1:        disks-images-provider.yaml
 # Nexus team needs these to-be-upstreamed patches for the operator Edge to work
 # correctly.
-Patch0:         Cleanup-housekeeping-cgroup-on-vm-del.patch
-Patch1:         Allocate-2-cpu-for-the-emulator-thread.patch
-Patch2:         Hotplug_detach_grace_period.patch
-Patch3:         CVE-2023-44487.patch
-Patch4:         CVE-2024-21626.patch
-Patch5:         Hp-volume-pod-should-respect-blockdevices.patch
-Patch6:         CVE-2022-41723.patch
-Patch7:         CVE-2024-24786.patch
-Patch8:         CVE-2023-45288.patch
+Patch00:        Cleanup-housekeeping-cgroup-on-vm-del.patch
+Patch01:        Allocate-2-cpu-for-the-emulator-thread.patch
+Patch02:        Hotplug_detach_grace_period.patch
+Patch03:        CVE-2023-44487.patch
+Patch04:        CVE-2024-21626.patch
+Patch05:        Hp-volume-pod-should-respect-blockdevices.patch
+Patch06:        CVE-2022-41723.patch
+Patch07:        CVE-2024-24786.patch
+Patch08:        CVE-2023-45288.patch
+Patch09:        CVE-2022-32149.patch
+Patch10:        CVE-2023-26484.patch
 %global debug_package %{nil}
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.35-7%{?dist}
@@ -217,6 +219,10 @@ install -p -m 0644 cmd/virt-handler/nsswitch.conf %{buildroot}%{_datadir}/kube-v
 %{_bindir}/virt-tests
 
 %changelog
+* Thu Aug 22 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 0.59.0-20
+- Fix for CVE-2022-32149
+- Fix for CVE-2023-26484
+
 * Thu Jun 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.59.0-19
 - Bump release to rebuild with go 1.21.11
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
The Cherry-pick bot did not create the PR for the main merge. Hence the manual cherry-pick PR.
CVE-2022-32149 and CVE-2023-26484

CP for #10232.

###### Change Log  <!-- REQUIRED -->
- CVE-2022-32149
- CVE-2023-26484: CVE references [kubevirt issue](https://github.com/kubevirt/kubevirt/issues/9109) that refers to 2 independent PRs [11982](https://github.com/kubevirt/kubevirt/pull/11982) and [12009](https://github.com/kubevirt/kubevirt/pull/12009) ... 11982 requires more recent KubeVirt (mariner 2.0 uses 0.59) which uses K8s libraries 0.30 (we use 0.23.5), so only 12009 is used in patch.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-32149
- https://nvd.nist.gov/vuln/detail/CVE-2023-26484

###### Test Methodology
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=626357&view=results
- fasttrack/2.0: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=633960&view=results
