### PR TITLE
[cherry-pick] vim: CVE-2024-43374 (mariner 2) (#10192)

### DIFF
--- a/SPECS/vim/CVE-2024-43374.patch
+++ b/SPECS/vim/CVE-2024-43374.patch
@@ -1,0 +1,282 @@
+From 0a6e57b09bc8c76691b367a5babfb79b31b770e8 Mon Sep 17 00:00:00 2001
+From: Christian Brabandt <cb@256bit.org>
+Date: Thu, 15 Aug 2024 22:15:28 +0200
+Subject: [PATCH] patch 9.1.0678: [security]: use-after-free in alist_add()
+
+Problem:  [security]: use-after-free in alist_add()
+          (SuyueGuo)
+Solution: Lock the current window, so that the reference to
+          the argument list remains valid.
+
+This fixes CVE-2024-43374
+
+Signed-off-by: Christian Brabandt <cb@256bit.org>
+---
+ src/arglist.c                |  6 ++++++
+ src/buffer.c                 |  4 ++--
+ src/ex_cmds.c                |  4 ++--
+ src/proto/window.pro         |  1 +
+ src/structs.h                |  2 +-
+ src/terminal.c               |  4 ++--
+ src/testdir/test_arglist.vim | 23 +++++++++++++++++++++++
+ src/version.c                |  2 ++
+ src/window.c                 | 29 +++++++++++++++++++----------
+ 9 files changed, 58 insertions(+), 17 deletions(-)
+
+diff --git a/src/arglist.c b/src/arglist.c
+index 187e16e8354b1..8825c8e252ccc 100644
+--- a/src/arglist.c
++++ b/src/arglist.c
+@@ -184,6 +184,8 @@ alist_set(
+ /*
+  * Add file "fname" to argument list "al".
+  * "fname" must have been allocated and "al" must have been checked for room.
++ *
++ * May trigger Buf* autocommands
+  */
+     void
+ alist_add(
+@@ -196,6 +198,7 @@ alist_add(
+     if (check_arglist_locked() == FAIL)
+ 	return;
+     arglist_locked = TRUE;
++    curwin->w_locked = TRUE;
+ 
+ #ifdef BACKSLASH_IN_FILENAME
+     slash_adjust(fname);
+@@ -207,6 +210,7 @@ alist_add(
+     ++al->al_ga.ga_len;
+ 
+     arglist_locked = FALSE;
++    curwin->w_locked = FALSE;
+ }
+ 
+ #if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
+@@ -365,6 +369,7 @@ alist_add_list(
+ 	    mch_memmove(&(ARGLIST[after + count]), &(ARGLIST[after]),
+ 				       (ARGCOUNT - after) * sizeof(aentry_T));
+ 	arglist_locked = TRUE;
++	curwin->w_locked = TRUE;
+ 	for (i = 0; i < count; ++i)
+ 	{
+ 	    int flags = BLN_LISTED | (will_edit ? BLN_CURBUF : 0);
+@@ -373,6 +378,7 @@ alist_add_list(
+ 	    ARGLIST[after + i].ae_fnum = buflist_add(files[i], flags);
+ 	}
+ 	arglist_locked = FALSE;
++	curwin->w_locked = FALSE;
+ 	ALIST(curwin)->al_ga.ga_len += count;
+ 	if (old_argcount > 0 && curwin->w_arg_idx >= after)
+ 	    curwin->w_arg_idx += count;
+diff --git a/src/buffer.c b/src/buffer.c
+index 447ce76d49a32..34500e4abc282 100644
+--- a/src/buffer.c
++++ b/src/buffer.c
+@@ -1484,7 +1484,7 @@ do_buffer_ext(
+ 	// (unless it's the only window).  Repeat this so long as we end up in
+ 	// a window with this buffer.
+ 	while (buf == curbuf
+-		   && !(curwin->w_closing || curwin->w_buffer->b_locked > 0)
++		   && !(win_locked(curwin) || curwin->w_buffer->b_locked > 0)
+ 		   && (!ONE_WINDOW || first_tabpage->tp_next != NULL))
+ 	{
+ 	    if (win_close(curwin, FALSE) == FAIL)
+@@ -5470,7 +5470,7 @@ ex_buffer_all(exarg_T *eap)
+ 			    : wp->w_width != Columns)
+ 			|| (had_tab > 0 && wp != firstwin))
+ 		    && !ONE_WINDOW
+-		    && !(wp->w_closing || wp->w_buffer->b_locked > 0)
++		    && !(win_locked(wp) || wp->w_buffer->b_locked > 0)
+ 		    && !win_unlisted(wp))
+ 	    {
+ 		if (win_close(wp, FALSE) == FAIL)
+diff --git a/src/ex_cmds.c b/src/ex_cmds.c
+index 05778c8fd8b9c..349269a2bb8b6 100644
+--- a/src/ex_cmds.c
++++ b/src/ex_cmds.c
+@@ -2840,7 +2840,7 @@ do_ecmd(
+ 
+ 		// Set the w_closing flag to avoid that autocommands close the
+ 		// window.  And set b_locked for the same reason.
+-		the_curwin->w_closing = TRUE;
++		the_curwin->w_locked = TRUE;
+ 		++buf->b_locked;
+ 
+ 		if (curbuf == old_curbuf.br_buf)
+@@ -2854,7 +2854,7 @@ do_ecmd(
+ 
+ 		// Autocommands may have closed the window.
+ 		if (win_valid(the_curwin))
+-		    the_curwin->w_closing = FALSE;
++		    the_curwin->w_locked = FALSE;
+ 		--buf->b_locked;
+ 
+ #ifdef FEAT_EVAL
+diff --git a/src/proto/window.pro b/src/proto/window.pro
+index 26c7040b8a1b4..441070ebfcb8e 100644
+--- a/src/proto/window.pro
++++ b/src/proto/window.pro
+@@ -93,3 +93,4 @@ int get_win_number(win_T *wp, win_T *first_win);
+ int get_tab_number(tabpage_T *tp);
+ char *check_colorcolumn(win_T *wp);
++int win_locked(win_T *wp);
+ /* vim: set ft=c : */
+diff --git a/src/structs.h b/src/structs.h
+index fe4704a367949..abda3a0c38b4e 100644
+--- a/src/structs.h
++++ b/src/structs.h
+@@ -3785,7 +3785,7 @@ struct window_S
+     synblock_T	*w_s;		    // for :ownsyntax
+ #endif
+ 
+-    int		w_closing;	    // window is being closed, don't let
++    int		w_locked;	    // window is being closed, don't let
+ 				    // autocommands close it too.
+ 
+     frame_T	*w_frame;	    // frame containing this window
+diff --git a/src/terminal.c b/src/terminal.c
+index 1fc0ef96881f9..f80196096df49 100644
+--- a/src/terminal.c
++++ b/src/terminal.c
+@@ -3680,10 +3680,10 @@ term_after_channel_closed(term_T *term)
+ 		if (is_aucmd_win(curwin))
+ 		    do_set_w_closing = TRUE;
+ 		if (do_set_w_closing)
+-		    curwin->w_closing = TRUE;
++		    curwin->w_locked = TRUE;
+ 		do_bufdel(DOBUF_WIPE, (char_u *)"", 1, fnum, fnum, FALSE);
+ 		if (do_set_w_closing)
+-		    curwin->w_closing = FALSE;
++		    curwin->w_locked = FALSE;
+ 		aucmd_restbuf(&aco);
+ 	    }
+ #ifdef FEAT_PROP_POPUP
+diff --git a/src/testdir/test_arglist.vim b/src/testdir/test_arglist.vim
+index edc8b77429e20..8d81a828b3e03 100644
+--- a/src/testdir/test_arglist.vim
++++ b/src/testdir/test_arglist.vim
+@@ -359,6 +359,7 @@ func Test_argv()
+   call assert_equal('', argv(1, 100))
+   call assert_equal([], argv(-1, 100))
+   call assert_equal('', argv(10, -1))
++  %argdelete
+ endfunc
+ 
+ " Test for the :argedit command
+@@ -744,4 +745,26 @@ func Test_all_command()
+   %bw!
+ endfunc
+ 
++" Test for deleting buffer when creating an arglist. This was accessing freed
++" memory
++func Test_crash_arglist_uaf()
++  "%argdelete
++  new one
++  au BufAdd XUAFlocal :bw
++  "call assert_fails(':arglocal XUAFlocal', 'E163:')
++  arglocal XUAFlocal
++  au! BufAdd
++  bw! XUAFlocal
++
++  au BufAdd XUAFlocal2 :bw
++  new two
++  new three
++  arglocal
++  argadd XUAFlocal2 Xfoobar
++  bw! XUAFlocal2
++  bw! two
++
++  au! BufAdd
++endfunc
++
+ " vim: shiftwidth=2 sts=2 expandtab
+diff --git a/src/window.c b/src/window.c
+index 43a15e0561f2c..b2c90c7d64114 100644
+--- a/src/window.c
++++ b/src/window.c
+@@ -2511,7 +2511,7 @@ close_windows(
+     for (wp = firstwin; wp != NULL && !ONE_WINDOW; )
+     {
+ 	if (wp->w_buffer == buf && (!keep_curwin || wp != curwin)
+-		&& !(wp->w_closing || wp->w_buffer->b_locked > 0))
++		&& !(win_locked(wp) || wp->w_buffer->b_locked > 0))
+ 	{
+ 	    if (win_close(wp, FALSE) == FAIL)
+ 		// If closing the window fails give up, to avoid looping
+@@ -2532,7 +2532,7 @@ close_windows(
+ 	if (tp != curtab)
+ 	    FOR_ALL_WINDOWS_IN_TAB(tp, wp)
+ 		if (wp->w_buffer == buf
+-		    && !(wp->w_closing || wp->w_buffer->b_locked > 0))
++		    && !(win_locked(wp) || wp->w_buffer->b_locked > 0))
+ 		{
+ 		    win_close_othertab(wp, FALSE, tp);
+ 
+@@ -2654,10 +2654,10 @@ win_close_buffer(win_T *win, int action, int abort_if_last)
+ 	bufref_T    bufref;
+ 
+ 	set_bufref(&bufref, curbuf);
+-	win->w_closing = TRUE;
++	win->w_locked = TRUE;
+ 	close_buffer(win, win->w_buffer, action, abort_if_last, TRUE);
+ 	if (win_valid_any_tab(win))
+-	    win->w_closing = FALSE;
++	    win->w_locked = FALSE;
+ 	// Make sure curbuf is valid. It can become invalid if 'bufhidden' is
+ 	// "wipe".
+ 	if (!bufref_valid(&bufref))
+@@ -2705,7 +2705,7 @@ win_close(win_T *win, int free_buf)
+     if (window_layout_locked(CMD_close))
+ 	return FAIL;
+ 
+-    if (win->w_closing || (win->w_buffer != NULL
++    if (win_locked(win) || (win->w_buffer != NULL
+ 					       && win->w_buffer->b_locked > 0))
+ 	return FAIL; // window is already being closed
+     if (win_unlisted(win))
+@@ -2754,19 +2754,19 @@ win_close(win_T *win, int free_buf)
+ 	    other_buffer = TRUE;
+ 	    if (!win_valid(win))
+ 		return FAIL;
+-	    win->w_closing = TRUE;
++	    win->w_locked = TRUE;
+ 	    apply_autocmds(EVENT_BUFLEAVE, NULL, NULL, FALSE, curbuf);
+ 	    if (!win_valid(win))
+ 		return FAIL;
+-	    win->w_closing = FALSE;
++	    win->w_locked = FALSE;
+ 	    if (last_window())
+ 		return FAIL;
+ 	}
+-	win->w_closing = TRUE;
++	win->w_locked = TRUE;
+ 	apply_autocmds(EVENT_WINLEAVE, NULL, NULL, FALSE, curbuf);
+ 	if (!win_valid(win))
+ 	    return FAIL;
+-	win->w_closing = FALSE;
++	win->w_locked = FALSE;
+ 	if (last_window())
+ 	    return FAIL;
+ #ifdef FEAT_EVAL
+@@ -3346,7 +3346,7 @@ win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
+ 
+     // Get here with win->w_buffer == NULL when win_close() detects the tab
+     // page changed.
+-    if (win->w_closing || (win->w_buffer != NULL
++    if (win_locked(win) || (win->w_buffer != NULL
+ 					       && win->w_buffer->b_locked > 0))
+ 	return; // window is already being closed
+ 
+@@ -7808,3 +7808,12 @@ skip:
+     return NULL;  // no error
+ }
+ #endif
++
++/*
++ * Don't let autocommands close the given window
++ */
++   int
++win_locked(win_T *wp)
++{
++    return wp->w_locked;
++}

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -2,7 +2,7 @@
 Summary:        Text editor
 Name:           vim
 Version:        9.0.2121
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ Group:          Applications/Editors
 URL:            https://www.vim.org
 Source0:        https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Patch0:         CVE-2024-22667.patch
+Patch1:         CVE-2024-43374.patch
 BuildRequires:  ncurses-devel
 BuildRequires:  python3-devel
 Requires(post): sed
@@ -197,6 +198,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Tue Aug 20 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 9.0.2121-3
+- Patch CVE-2024-43374
+
 * Tue Feb 20 2024 Suresh Thelkar <sthelkar@microsoft.com> - 9.0.2121-2
 - Patch CVE-2024-22667
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
The Cherry-pick bot did not create the PR for the main merge. Hence the manual cherry-pick PR.
Fix for CVE-2024-43374

CP for #10192.

###### Change Log  <!-- REQUIRED -->
- Create patch to fix CVE-2024-43374
- Update spec version

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-43374

###### Test Methodology
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=625113&view=results
- fasttrack/2.0: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=633992&view=results
