### PR TITLE
Adding swtpmtools to list of required packages for kubevirt

### DIFF
--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -20,7 +20,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        1.2.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -32,6 +32,7 @@ Source0:        https://github.com/kubevirt/kubevirt/archive/refs/tags/v%{versio
 # correctly.
 Patch0:         Cleanup-housekeeping-cgroup-on-vm-del.patch
 %global debug_package %{nil}
+BuildRequires:  swtpm-tools
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.38-8%{?dist}
 BuildRequires:  golang >= 1.21
@@ -270,6 +271,9 @@ install -p -m 0644 cmd/virt-launcher/qemu.conf %{buildroot}%{_datadir}/kube-virt
 %{_bindir}/virt-tests
 
 %changelog
+* Mon Aug 26 2024 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 1.2.0-8
+- Adding swtpm tools for building kubevirt RPM.
+
 * Fri Aug 30 2024 Harshit Gupta <guptaharshit@microsoft.com> - 1.2.0-7
 - Update installation path of virt_launcher.cil in virt-handler container.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

The PR looks to address [Bug 8599](https://dev.azure.com/mariner-org/ECF/_workitems/edit/8599?src=WorkItemMention&src-action=artifact_link) raised by Nexus - 

```
When attempting to use launch a kubevirt vm the requires tpm, virt-handler/virt-launcher fails to start with the following error:

spec snippet:

    devices:
      tpm: {}
    features:
      smm: {}
    firmware:
      bootloader:
        efi:
          secureBoot: true

Results in:

Warning  SyncFailed        2s (x12 over 7s)  virt-handler               server error. command SyncVMI failed: "LibvirtError(Code=38, Domain=70, Message='Unable to find 'swtpm' binary in $PATH: No such file or directory')"


It seems the mariner2/azurelinux3 build of kubevirt does not include swtpm:
https://github.com/microsoft/azurelinux/blob/9fccce321e0275a7c9c3c1c2efb2090f9afffbf8/SPECS/kubevirt/kubevirt.spec#L35


While the upstream community bazel based build does:
https://github.com/kubevirt/kubevirt/blob/735f25dde4ac7e75a11fefb4bf2c1acb10b5e925/rpm/BUILD.bazel#L790
https://github.com/kubevirt/kubevirt/blob/735f25dde4ac7e75a11fefb4bf2c1acb10b5e925/hack/rpm-deps.sh#L17


We need to be able to launch kubevirt virtualmachines that require TPM (windows11/windowsserver2025).
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adding swtpm-tools to BuildRequires Package


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=635428&view=results
