### PR TITLE
Resolve CVE-2024-41946

### DIFF
--- a/SPECS/ruby/ruby.signatures.json
+++ b/SPECS/ruby/ruby.signatures.json
@@ -7,6 +7,6 @@
     "rubygems.con": "eb804c6b50eeafdb2172285265bc487a80acaa9846233cd5f1d20a25f1dac2ea",
     "rubygems.prov": "b79c1f5873dd20d251e100b276a5e584c1fb677f3e1b92534fc09130fabe8ee5",
     "rubygems.req": "e85681d8fa45d214055f3b26a8c1829b3a4bd67b26a5ef3c1f6426e7eff83ad0",
-    "ruby-3.3.3.tar.gz": "83c05b2177ee9c335b631b29b8c077b4770166d02fa527f3a9f6a40d13f3cce2"
+    "ruby-3.3.3.tar.gz": "3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196"
   }
 }

--- a/SPECS/ruby/ruby.signatures.json
+++ b/SPECS/ruby/ruby.signatures.json
@@ -7,6 +7,6 @@
     "rubygems.con": "eb804c6b50eeafdb2172285265bc487a80acaa9846233cd5f1d20a25f1dac2ea",
     "rubygems.prov": "b79c1f5873dd20d251e100b276a5e584c1fb677f3e1b92534fc09130fabe8ee5",
     "rubygems.req": "e85681d8fa45d214055f3b26a8c1829b3a4bd67b26a5ef3c1f6426e7eff83ad0",
-    "ruby-3.3.3.tar.gz": "3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196"
+    "ruby-3.3.5.tar.gz": "3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196"
   }
 }

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -88,7 +88,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        %{ruby_version}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -407,6 +407,9 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
+* Tue Sep 10 2024 Harshit Gupta <guptaharshit@microsoft.com> - 3.3.3-2
+- Bump release to build with new rubygem-rexml to fix CVE-2024-41946
+
 * Wed Aug 07 2024 Alejandro Martinez Torres <alejandroma@microsoft.com> - 3.3.3-1
 - Upgrade ruby to 3.3.3 to resolve CVE-2024-41946
 

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -4,7 +4,7 @@
 %global gem_dir %{_datadir}/ruby/gems
 
 # Default package version defined separately, because the %%version macro gets overwritten by 'Version' tags of the subpackages.
-%global ruby_version            3.3.3
+%global ruby_version            3.3.5
 %define ruby_version_majmin     %(echo %{ruby_version} | cut -d. -f1-2)
 
 %global rubygems_version        3.5.3
@@ -88,7 +88,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        %{ruby_version}
-Release:        2%{?dist}
+Release:        1%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -389,8 +389,8 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
-* Tue Sep 10 2024 Harshit Gupta <guptaharshit@microsoft.com> - 3.3.3-2
-- Bump release to build with new rubygem-rexml to fix CVE-2024-41946
+* Thu Sep 12 2024 Harshit Gupta <guptaharshit@microsoft.com> - 3.3.5-1
+- Upgrade ruby to 3.3.5 to fix CVE-2024-41946 by including bundled gem rexml v3.3.6
 
 * Wed Aug 07 2024 Alejandro Martinez Torres <alejandroma@microsoft.com> - 3.3.3-1
 - Upgrade ruby to 3.3.3 to resolve CVE-2024-41946

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -7,8 +7,10 @@
 %global ruby_version            3.3.5
 %define ruby_version_majmin     %(echo %{ruby_version} | cut -d. -f1-2)
 
+# Version of default rubygem gem. Please update when upgrading ruby.
+# A helpful one-liner script to check the current default version is available via RUBY_VER=%%{ruby_version_majmin} ./get_gem_versions.sh
 %global rubygems_version        3.5.16
-# Add version for default gems from https://stdgems.org/
+# Add version for default gems from https://stdgems.org/. Please update when upgrading ruby.
 # A helpful one-liner script to check the current default versions is available via RUBY_VER=%%{ruby_version_majmin} ./get_gem_versions.sh
 %global abbrev_version          0.1.2
 %global base64_version          0.2.0

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -4,7 +4,7 @@
 %global gem_dir %{_datadir}/ruby/gems
 
 # Default package version defined separately, because the %%version macro gets overwritten by 'Version' tags of the subpackages.
-%global ruby_version            3.3.5
+%global ruby_version            3.3.3
 %define ruby_version_majmin     %(echo %{ruby_version} | cut -d. -f1-2)
 
 %global rubygems_version        3.5.3
@@ -19,6 +19,8 @@
 %global csv_version             3.2.8
 %global date_version            3.3.4
 %global delegate_version        0.3.1
+%global did_you_mean_version    1.6.3
+%global digest_version          3.1.1
 %global drb_version             2.2.0
 %global english_version         0.8.0
 %global erb_version             4.0.3
@@ -28,6 +30,7 @@
 %global fiddle_version          1.1.2
 %global fileutils_version       1.7.2
 %global find_version            0.2.0
+%global forwardable_version     1.3.3
 %global getoptlong_version      0.2.1
 %global io_console_version      0.7.1
 %global io_nonblock_version     0.3.0
@@ -47,6 +50,7 @@
 %global optparse_version        0.4.0
 %global ostruct_version         0.6.0
 %global pathname_version        0.3.0
+%global prism_version           0.19.0
 %global pp_version              0.5.0
 %global prettyprint_version     0.2.0
 %global pstore_version          0.1.3
@@ -55,7 +59,9 @@
 %global readline_version        0.0.4
 %global reline_version          0.4.1
 %global resolv_version          0.3.0
+%global resolv_replace_version  0.1.1
 %global rinda_version           0.2.0
+%global ruby2_keywords_version  0.0.5
 %global securerandom_version    0.3.1
 %global set_version             1.1.0
 %global shellwords_version      0.2.0
@@ -82,7 +88,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        %{ruby_version}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -137,6 +143,10 @@ Provides:       rubygem-date = %{date_version}-%{release}
 Provides:       rubygem(date) = %{date_version}-%{release}
 Provides:       rubygem(delegate) = %{delegate_version}-%{release}
 Provides:       rubygem-delegate = %{delegate_version}-%{release}
+Provides:       rubygem(did_you_mean) = %{did_you_mean_version}-%{release}
+Provides:       rubygem-did_you_mean = %{did_you_mean_version}-%{release}
+Provides:       rubygem(digest) = %{digest_version}-%{release}
+Provides:       rubygem-digest = %{digest_version}-%{release}
 Provides:       rubygem(drb) = %{drb_version}-%{release}
 Provides:       rubygem-drb = %{drb_version}-%{release}
 Provides:       rubygem(english) = %{english_version}-%{release}
@@ -155,6 +165,8 @@ Provides:       rubygem-fileutils = %{fileutils_version}-%{release}
 Provides:       rubygem(fileutils) = %{fileutils_version}-%{release}
 Provides:       rubygem-find = %{find_version}-%{release}
 Provides:       rubygem(find) = %{find_version}-%{release}
+Provides:       rubygem-forwardable = %{forwardable_version}-%{release}
+Provides:       rubygem(forwardable) = %{forwardable_version}-%{release}
 Provides:       rubygem-getoptlong = %{getoptlong_version}-%{release}
 Provides:       rubygem(getoptlong) = %{getoptlong_version}-%{release}
 Provides:       rubygem-io-console = %{io_console_version}-%{release}
@@ -197,6 +209,8 @@ Provides:       rubygem-pp = %{pp_version}-%{release}
 Provides:       rubygem(pp) = %{pp_version}-%{release}
 Provides:       rubygem-prettyprint = %{prettyprint_version}-%{release}
 Provides:       rubygem(prettyprint) = %{prettyprint_version}-%{release}
+Provides:       rubygem-prism = %{prism_version}-%{release}
+Provides:       rubygem(prism) = %{prism_version}-%{release}
 Provides:       rubygem-pstore = %{pstore_version}-%{release}
 Provides:       rubygem(pstore) = %{pstore_version}-%{release}
 Provides:       rubygem-psych = %{psych_version}-%{release}
@@ -209,8 +223,12 @@ Provides:       rubygem-reline = %{reline_version}-%{release}
 Provides:       rubygem(reline) = %{reline_version}-%{release}
 Provides:       rubygem-resolv = %{resolv_version}-%{release}
 Provides:       rubygem(resolv) = %{resolv_version}-%{release}
+Provides:       rubygem-resolv-replace = %{resolv_replace_version}-%{release}
+Provides:       rubygem(resolv-replace) = %{resolv_replace_version}-%{release}
 Provides:       rubygem-rinda = %{rinda_version}-%{release}
 Provides:       rubygem(rinda) = %{rinda_version}-%{release}
+Provides:       rubygem-ruby2_keywords = %{ruby2_keywords_version}-%{release}
+Provides:       rubygem(ruby2_keywords) = %{ruby2_keywords_version}-%{release}
 Provides:       rubygem-rubygems = %{rubygems_version}-%{release}
 Provides:       rubygem(rubygems) = %{rubygems_version}-%{release}
 Provides:       rubygem-securerandom = %{securerandom_version}-%{release}

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -7,14 +7,14 @@
 %global ruby_version            3.3.5
 %define ruby_version_majmin     %(echo %{ruby_version} | cut -d. -f1-2)
 
-%global rubygems_version        3.5.3
+%global rubygems_version        3.5.16
 # Add version for default gems from https://stdgems.org/
 # A helpful one-liner script to check the current default versions is available via RUBY_VER=%%{ruby_version_majmin} ./get_gem_versions.sh
 %global abbrev_version          0.1.2
 %global base64_version          0.2.0
 %global benchmark_version       0.3.0
 %global bigdecimal_version      3.1.5
-%global bundler_version         2.5.3
+%global bundler_version         2.5.16
 %global cgi_version             0.4.1
 %global csv_version             3.2.8
 %global date_version            3.3.4
@@ -36,11 +36,11 @@
 %global io_nonblock_version     0.3.0
 %global io_wait_version         0.3.1
 %global ipaddr_version          1.2.6
-%global irb_version             1.11.0
+%global irb_version             1.13.1
 %global json_version            2.7.1
 %global logger_version          1.6.0
 %global mutex_m_version         0.2.0
-%global net_http_version        0.4.0
+%global net_http_version        0.4.1
 %global net_protocol_version    0.2.2
 %global nkf_version             0.1.3
 %global observer_version        0.1.2
@@ -55,9 +55,9 @@
 %global prettyprint_version     0.2.0
 %global pstore_version          0.1.3
 %global psych_version           5.1.2
-%global rdoc_version            6.6.2
+%global rdoc_version            6.6.3.1
 %global readline_version        0.0.4
-%global reline_version          0.4.1
+%global reline_version          0.5.7
 %global resolv_version          0.3.0
 %global resolv_replace_version  0.1.1
 %global rinda_version           0.2.0
@@ -66,8 +66,8 @@
 %global set_version             1.1.0
 %global shellwords_version      0.2.0
 %global singleton_version       0.2.0
-%global stringio_version        3.1.0
-%global strscan_version         3.0.7
+%global stringio_version        3.1.1
+%global strscan_version         3.0.9
 %global syslog_version          0.1.2
 %global syntax_suggest_version  2.0.0
 %global tempfile_version        0.2.1
@@ -76,11 +76,11 @@
 %global tmpdir_version          0.2.0
 %global tsort_version           0.2.0
 %global un_version              0.3.0
-%global uri_version             0.13.0
+%global uri_version             0.13.1
 %global weakref_version         0.1.3
 %global win32ole_version        1.8.10
 %global yaml_version            0.3.0
-%global zlib_version            3.1.0
+%global zlib_version            3.1.1
 
 Summary:        Ruby
 Name:           ruby
@@ -409,6 +409,7 @@ sudo -u test make test TESTS="-v"
 %changelog
 * Thu Sep 12 2024 Harshit Gupta <guptaharshit@microsoft.com> - 3.3.5-1
 - Upgrade ruby to 3.3.5 to fix CVE-2024-41946 by including bundled gem rexml v3.3.6
+- Update versions of default gems
 
 * Wed Aug 07 2024 Alejandro Martinez Torres <alejandroma@microsoft.com> - 3.3.3-1
 - Upgrade ruby to 3.3.3 to resolve CVE-2024-41946

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -4,7 +4,7 @@
 %global gem_dir %{_datadir}/ruby/gems
 
 # Default package version defined separately, because the %%version macro gets overwritten by 'Version' tags of the subpackages.
-%global ruby_version            3.3.3
+%global ruby_version            3.3.5
 %define ruby_version_majmin     %(echo %{ruby_version} | cut -d. -f1-2)
 
 %global rubygems_version        3.5.3
@@ -19,8 +19,6 @@
 %global csv_version             3.2.8
 %global date_version            3.3.4
 %global delegate_version        0.3.1
-%global did_you_mean_version    1.6.3
-%global digest_version          3.1.1
 %global drb_version             2.2.0
 %global english_version         0.8.0
 %global erb_version             4.0.3
@@ -30,7 +28,6 @@
 %global fiddle_version          1.1.2
 %global fileutils_version       1.7.2
 %global find_version            0.2.0
-%global forwardable_version     1.3.3
 %global getoptlong_version      0.2.1
 %global io_console_version      0.7.1
 %global io_nonblock_version     0.3.0
@@ -50,7 +47,6 @@
 %global optparse_version        0.4.0
 %global ostruct_version         0.6.0
 %global pathname_version        0.3.0
-%global prism_version           0.19.0
 %global pp_version              0.5.0
 %global prettyprint_version     0.2.0
 %global pstore_version          0.1.3
@@ -59,9 +55,7 @@
 %global readline_version        0.0.4
 %global reline_version          0.4.1
 %global resolv_version          0.3.0
-%global resolv_replace_version  0.1.1
 %global rinda_version           0.2.0
-%global ruby2_keywords_version  0.0.5
 %global securerandom_version    0.3.1
 %global set_version             1.1.0
 %global shellwords_version      0.2.0
@@ -88,7 +82,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        %{ruby_version}
-Release:        2%{?dist}
+Release:        1%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -143,10 +137,6 @@ Provides:       rubygem-date = %{date_version}-%{release}
 Provides:       rubygem(date) = %{date_version}-%{release}
 Provides:       rubygem(delegate) = %{delegate_version}-%{release}
 Provides:       rubygem-delegate = %{delegate_version}-%{release}
-Provides:       rubygem(did_you_mean) = %{did_you_mean_version}-%{release}
-Provides:       rubygem-did_you_mean = %{did_you_mean_version}-%{release}
-Provides:       rubygem(digest) = %{digest_version}-%{release}
-Provides:       rubygem-digest = %{digest_version}-%{release}
 Provides:       rubygem(drb) = %{drb_version}-%{release}
 Provides:       rubygem-drb = %{drb_version}-%{release}
 Provides:       rubygem(english) = %{english_version}-%{release}
@@ -165,8 +155,6 @@ Provides:       rubygem-fileutils = %{fileutils_version}-%{release}
 Provides:       rubygem(fileutils) = %{fileutils_version}-%{release}
 Provides:       rubygem-find = %{find_version}-%{release}
 Provides:       rubygem(find) = %{find_version}-%{release}
-Provides:       rubygem-forwardable = %{forwardable_version}-%{release}
-Provides:       rubygem(forwardable) = %{forwardable_version}-%{release}
 Provides:       rubygem-getoptlong = %{getoptlong_version}-%{release}
 Provides:       rubygem(getoptlong) = %{getoptlong_version}-%{release}
 Provides:       rubygem-io-console = %{io_console_version}-%{release}
@@ -209,8 +197,6 @@ Provides:       rubygem-pp = %{pp_version}-%{release}
 Provides:       rubygem(pp) = %{pp_version}-%{release}
 Provides:       rubygem-prettyprint = %{prettyprint_version}-%{release}
 Provides:       rubygem(prettyprint) = %{prettyprint_version}-%{release}
-Provides:       rubygem-prism = %{prism_version}-%{release}
-Provides:       rubygem(prism) = %{prism_version}-%{release}
 Provides:       rubygem-pstore = %{pstore_version}-%{release}
 Provides:       rubygem(pstore) = %{pstore_version}-%{release}
 Provides:       rubygem-psych = %{psych_version}-%{release}
@@ -223,12 +209,8 @@ Provides:       rubygem-reline = %{reline_version}-%{release}
 Provides:       rubygem(reline) = %{reline_version}-%{release}
 Provides:       rubygem-resolv = %{resolv_version}-%{release}
 Provides:       rubygem(resolv) = %{resolv_version}-%{release}
-Provides:       rubygem-resolv-replace = %{resolv_replace_version}-%{release}
-Provides:       rubygem(resolv-replace) = %{resolv_replace_version}-%{release}
 Provides:       rubygem-rinda = %{rinda_version}-%{release}
 Provides:       rubygem(rinda) = %{rinda_version}-%{release}
-Provides:       rubygem-ruby2_keywords = %{ruby2_keywords_version}-%{release}
-Provides:       rubygem(ruby2_keywords) = %{ruby2_keywords_version}-%{release}
 Provides:       rubygem-rubygems = %{rubygems_version}-%{release}
 Provides:       rubygem(rubygems) = %{rubygems_version}-%{release}
 Provides:       rubygem-securerandom = %{securerandom_version}-%{release}

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -25794,8 +25794,8 @@
         "type": "other",
         "other": {
           "name": "ruby",
-          "version": "3.3.3",
-          "downloadUrl": "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.3.tar.gz"
+          "version": "3.3.5",
+          "downloadUrl": "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.5.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade `ruby` to version 3.3.5 to fix CVE-2024-41946. The current version of Ruby (3.3.3) contains the bundled gem `rexml` version 3.2.8 which is affected by this CVE. Upgrading `ruby` to version `3.3.5` increments the version of the bundled gem `rexml` to `3.3.6`, which has the CVE fixed.

###### Change Log  <!-- REQUIRED -->
- Upgrade ruby to 3.3.5 to fix CVE-2024-41946 by including bundled gem rexml v3.3.6
- Update versions of default gems

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-41946

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build Pipeline build id: [637390](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=637390&view=results)
- Buddy Build Pipeline build id: [641262](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=641262&view=results)
- Manual installation on an Azure Linux 3.0 container.
