### PR TITLE
Image Customizer: Add support for 'vfat' filesystem.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -244,7 +244,7 @@ storage:
 
     - id: rootfs
       start: 9M
-      
+
   filesystems:
   - deviceId: esp
     type: fat32
@@ -660,7 +660,8 @@ The filesystem type of the partition.
 Supported options:
 
 - `ext4`
-- `fat32`
+- `fat32` (alias for `vfat`)
+- `vfat` (will select either FAT12, FAT16, or FAT32 based on the size of the partition)
 - `xfs`
 
 ### mountPoint [[mountPoint](#mountpoint-type)]
@@ -939,7 +940,7 @@ Specifies options for the partition.
 Supported options:
 
 - `esp`: The UEFI System Partition (ESP).
-  The partition must have a `fileSystemType` of `fat32`.
+  The partition must have a `fileSystemType` of `fat32` or `vfat`.
 
 - `bios-grub`: Specifies this partition is the BIOS boot partition.
   This is required for GPT disks that wish to be bootable using legacy BIOS mode.

--- a/toolkit/tools/imagecustomizerapi/filesystemtype.go
+++ b/toolkit/tools/imagecustomizerapi/filesystemtype.go
@@ -3,7 +3,9 @@
 
 package imagecustomizerapi
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // FileSystemType is a type of file system (e.g. ext4, xfs, etc.)
 type FileSystemType string
@@ -12,11 +14,12 @@ const (
 	FileSystemTypeExt4  FileSystemType = "ext4"
 	FileSystemTypeXfs   FileSystemType = "xfs"
 	FileSystemTypeFat32 FileSystemType = "fat32"
+	FileSystemTypeVfat  FileSystemType = "vfat"
 )
 
 func (t FileSystemType) IsValid() error {
 	switch t {
-	case FileSystemTypeExt4, FileSystemTypeXfs, FileSystemTypeFat32:
+	case FileSystemTypeExt4, FileSystemTypeXfs, FileSystemTypeFat32, FileSystemTypeVfat:
 		// All good.
 		return nil
 

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -39,7 +39,7 @@ func (s *Storage) IsValid() error {
 	for i, fileSystem := range s.FileSystems {
 		err = fileSystem.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid filesystems item at index %d: %w", i, err)
+			return fmt.Errorf("invalid filesystems item at index %d:\n%w", i, err)
 		}
 
 		if _, existingName := fileSystemSet[fileSystem.DeviceId]; existingName {
@@ -73,16 +73,16 @@ func (s *Storage) IsValid() error {
 			if partition.IsESP() {
 				espPartitionExists = true
 
-				if fileSystem.Type != FileSystemTypeFat32 {
-					return fmt.Errorf("ESP partition must have 'fat32' filesystem type")
+				if fileSystem.Type != FileSystemTypeFat32 && fileSystem.Type != FileSystemTypeVfat {
+					return fmt.Errorf("ESP partition must have 'fat32' or 'vfat' filesystem type")
 				}
 			}
 
 			if partition.IsBiosBoot() {
 				biosBootPartitionExists = true
 
-				if fileSystem.Type != FileSystemTypeFat32 {
-					return fmt.Errorf("BIOS boot partition must have 'fat32' filesystem type")
+				if fileSystem.Type != FileSystemTypeFat32 && fileSystem.Type != FileSystemTypeVfat {
+					return fmt.Errorf("BIOS boot partition must have 'fat32' or 'vfat' filesystem type")
 				}
 			}
 

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -123,7 +123,7 @@ func TestStorageIsValidBadEspFsType(t *testing.T) {
 
 	err := storage.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "ESP partition must have 'fat32' filesystem type")
+	assert.ErrorContains(t, err, "ESP partition must have 'fat32' or 'vfat' filesystem type")
 }
 
 func TestStorageIsValidBadBiosBootFsType(t *testing.T) {
@@ -151,7 +151,7 @@ func TestStorageIsValidBadBiosBootFsType(t *testing.T) {
 
 	err := storage.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "BIOS boot partition must have 'fat32' filesystem type")
+	assert.ErrorContains(t, err, "BIOS boot partition must have 'fat32' or 'vfat' filesystem type")
 }
 
 func TestStorageIsValidBadBiosBootStart(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -11,6 +11,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStorageIsValidCoreEfi(t *testing.T) {
+	value := Storage{
+		Disks: []Disk{{
+			PartitionTableType: "gpt",
+			MaxSize:            4 * diskutils.GiB,
+			Partitions: []Partition{
+				{
+					Id:    "esp",
+					Start: 1 * diskutils.MiB,
+					End:   ptrutils.PtrTo(DiskSize(9 * diskutils.MiB)),
+					Type:  PartitionTypeESP,
+				},
+				{
+					Id:    "rootfs",
+					Start: 9 * diskutils.MiB,
+				},
+			},
+		}},
+		BootType: "efi",
+		FileSystems: []FileSystem{
+			{
+				DeviceId: "esp",
+				Type:     "vfat",
+				MountPoint: &MountPoint{
+					Path: "/boot/efi",
+				},
+			},
+			{
+				DeviceId: "rootfs",
+				Type:     "ext4",
+				MountPoint: &MountPoint{
+					Path: "/",
+				},
+			},
+		},
+	}
+
+	err := value.IsValid()
+	assert.NoError(t, err)
+}
+
 func TestStorageIsValidDuplicatePartitionID(t *testing.T) {
 	value := Storage{
 		Disks: []Disk{{

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -580,7 +580,13 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		}
 	}
 
-	mkpartArgs = append(mkpartArgs, partition.FsType, fmt.Sprintf(sFmt, start))
+	fsType := partition.FsType
+	if fsType == "vfat" {
+		// 'parted mkpart' requires value of either 'fat16' or 'fat32'.
+		fsType = "fat32"
+	}
+
+	mkpartArgs = append(mkpartArgs, fsType, fmt.Sprintf(sFmt, start))
 
 	if end == 0 {
 		mkpartArgs = append(mkpartArgs, fillToEndOption)

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-selinux-enforcing.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-selinux-enforcing.yaml
@@ -19,7 +19,7 @@ storage:
 
   filesystems:
   - deviceId: esp
-    type: fat32
+    type: vfat
     mountPoint:
       path: /boot/efi
       options: umask=0077


### PR DESCRIPTION
The FAT filesystem is a tad confusing. Technically, FAT12, FAT16, and FAT32 refer to a fat filesystem with 12, 16, and 32 bit addressing respectively. However, you can't just use FAT32 for everything since each variant has different min and max partition sizes. So, instead you have to dynamically select the correct one based on the partition size. However, a lot of partioning tools (including Windows) hide this complexity and just use 'fat32' to mean either FAT12, FAT16, or FAT32.

There is also VFAT which refers to any FAT filesystem variants where long filename support is enabled. Nowadays it is pretty much always enabled. So, it isn't unusual for tools (including the Linux kernel) to use 'vfat' as a generic term to refer to any of the FAT filesystem variants.

The image customizer tool currently supports 'fat32' to mean dynamically selecting between FAT12, FAT16, or FAT32. This change adds 'vfat' to mean the same thing.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran tests.

