### PR TITLE
Bump Go Version to 1.22.7-2

### DIFF
--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -2,7 +2,7 @@
   "Signatures": {
     "go.20230802.5.src.tar.gz": "56b9e0e0c3c13ca95d5efa6de4e7d49a9d190eca77919beff99d33cd3fa74e95",
     "go.20240206.2.src.tar.gz": "7982e0011aa9ab95fd0530404060410af4ba57326d26818690f334fdcb6451cd",
-    "go1.22.7-20240905.3.src.tar.gz": "4c2601d9fe6b4692b6bb4487751dec149c30bd76ad9383331a84971a66bdd0bc",
+    "go1.22.7-20240910.4.src.tar.gz": "175a47ee43c7e56eabc7620b5621edad4f5024cc8ad319b8936172ad88fbabb2",
     "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
   }
 }

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -1,7 +1,7 @@
 %global goroot          %{_libdir}/golang
 %global gopath          %{_datadir}/gocode
-%global ms_go_filename  go1.22.7-20240905.3.src.tar.gz
-%global ms_go_revision  1
+%global ms_go_filename  go1.22.7-20240910.4.src.tar.gz
+%global ms_go_revision  2
 %ifarch aarch64
 %global gohostarch      arm64
 %else
@@ -15,7 +15,7 @@
 Summary:        Go
 Name:           golang
 Version:        1.22.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -153,6 +153,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Sep 10 2024 Microsoft Golang Bot <microsoft-golang-bot@users.noreply.github.com> - 1.22.7-2
+- Bump version to 1.22.7-2
+
 * Fri Sep 06 2024 Microsoft Golang Bot <microsoft-golang-bot@users.noreply.github.com> - 1.22.7-1
 - Bump version to 1.22.7-1
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4581,7 +4581,7 @@
         "other": {
           "name": "golang",
           "version": "1.22.7",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.7-1/go1.22.7-20240905.3.src.tar.gz"
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.7-2/go1.22.7-20240910.4.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Bump Go Version to 1.22.7-2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump Go Version to 1.22.7-2
- https://github.com/microsoft/go/releases/tag/v1.22.7-2
  * [microsoft/release-branch.go1.22] Update openssl to ms-go1.22-support, 889cd907e03c by @dagood in https://github.com/microsoft/go/pull/1312
    * This fixes https://github.com/microsoft/go/issues/1290, "With 1.x OpenSSL versions, TripleDES does not panic when expected in some cases"

###### Does this affect the toolchain?  <!-- REQUIRED -->
No

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=637839&view=results
  - Failed, but after the build. I think because I hit the "retry" button: an artifact already existed with the same name.
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=638236&view=results
  - Success.
