### PR TITLE
Separated toolchain tests from non-toolchain package builds.

### DIFF
--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -159,6 +159,7 @@ extends:
                       outputArtifactsFolder: $(ob_outputDirectory)
                       pipArtifactFeeds: "mariner/Mariner-Pypi-Feed"
                       selfRepoName: self
+                      srpmPackList: "$(testListFromToolchain)"
                       testRerunList: "$(testListFromToolchain)"
                       testSuiteName: "[${{ configuration.name }}] Toolchain test"
 

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -13,13 +13,13 @@ parameters:
       - name: "AMD64"
         agentPool: "$(DEV_AMD64_Managed)"
         maxCPUs: "$(($(nproc) / 2))"
-        rawToolchainCacheURL: "$(rawToolchainCacheURL_AMD64_2.0)"
-        rawToolchainExpectedHash: "$(rawToolchainCacheHash_AMD64_2.0)"
+        rawToolchainCacheURL: "$(rawToolchainCacheURL_AMD64_3.0)"
+        rawToolchainExpectedHash: "$(rawToolchainCacheHash_AMD64_3.0)"
       - name: "ARM64"
         agentPool: "$(DEV_ARM64_Managed)"
         maxCPUs: "$(($(nproc) / 3))"
-        rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64_2.0)"
-        rawToolchainExpectedHash: "$(rawToolchainCacheHash_ARM64_2.0)"
+        rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64_3.0)"
+        rawToolchainExpectedHash: "$(rawToolchainCacheHash_ARM64_3.0)"
   - name: debug
     type: boolean
     default: false
@@ -39,8 +39,10 @@ variables:
     value: RPMs
   - name: toolchainArtifactNameBase
     value: Toolchain
+  - name: toolchainTestsArtifactNameBase
+    value: Toolchain_tests
   - name: system.debug
-    value: '${{ parameters.debug }}'
+    value: "${{ parameters.debug }}"
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
@@ -74,6 +76,9 @@ extends:
                   # Toolchain package tests should be run through the full package build, calculate the list of packages that should be re-tested
                   # and make it available to the next stage via an output variable: 'CalculateToolchainPackageRetestList.toolchainPackageRetestList'
                   - template: .pipelines/templates/ToolchainCalculatePackageRetests.yml@self
+                    parameters:
+                      # GCC fails to build as a regular package.
+                      ignoredSpecs: ["gcc"]
 
                   - script: echo "##vso[task.setvariable variable=toolchainArtifactName;isOutput=true]$(ob_artifactBaseName)"
                     name: "ToolchainArtifactName"
@@ -99,9 +104,8 @@ extends:
                   isCustom: true
                   name: ${{ configuration.agentPool }}
                 variables:
-                  ob_artifactBaseName: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}_$(System.JobAttempt)
+                  ob_artifactBaseName: $(rpmsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
-                  testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
                   toolchainArtifactName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainArtifactName'] ]
                 steps:
                   - template: .pipelines/templates/PackageBuild.yml@self
@@ -111,12 +115,11 @@ extends:
                       isCheckBuild: true
                       isQuickRebuildPackages: true
                       isUseCCache: true
-                      outputArtifactsFolder: $(ob_outputDirectory)
                       maxCPU: "${{ configuration.maxCPUs }}"
+                      outputArtifactsFolder: $(ob_outputDirectory)
                       pipArtifactFeeds: "mariner/Mariner-Pypi-Feed"
                       selfRepoName: self
                       testSuiteName: "[${{ configuration.name }}] Package test"
-                      testRerunList: "$(testListFromToolchain)"
 
                   - script: echo "##vso[task.setvariable variable=rpmsArtifactName;isOutput=true]$(ob_artifactBaseName)"
                     name: "RPMsArtifactName"
@@ -124,12 +127,49 @@ extends:
 
                   - task: PublishPipelineArtifact@1
                     inputs:
-                      artifact: ${{ variables.rpmsArtifactNameBase }}_${{ configuration.name }}_$(System.JobAttempt)
+                      artifact: $(rpmsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                       targetPath: $(ob_outputDirectory)
                     condition: always()
                     displayName: "Publish packages build artifacts"
 
-          - stage: sodiff_${{ configuration.name }}
+          - stage: Toolchain_tests_${{ configuration.name }}
+            dependsOn: Toolchain_${{ configuration.name }}
+            jobs:
+              - job: TestToolchainPackages
+                condition: stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList']
+                pool:
+                  type: linux
+                  isCustom: true
+                  name: ${{ configuration.agentPool }}
+                variables:
+                  ob_artifactBaseName: $(toolchainTestsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
+                  ob_outputDirectory: $(Build.ArtifactStagingDirectory)
+                  testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
+                  toolchainArtifactName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainArtifactName'] ]
+                steps:
+                  - template: .pipelines/templates/PackageBuild.yml@self
+                    parameters:
+                      checkBuildRetries: "1"
+                      customToolchainArtifactName: $(toolchainArtifactName)
+                      isAllowToolchainRebuilds: true
+                      isCheckBuild: true
+                      isQuickRebuildPackages: true
+                      isUseCCache: true
+                      maxCPU: "${{ configuration.maxCPUs }}"
+                      outputArtifactsFolder: $(ob_outputDirectory)
+                      packageRebuildList: "$(testListFromToolchain)"
+                      pipArtifactFeeds: "mariner/Mariner-Pypi-Feed"
+                      selfRepoName: self
+                      testSuiteName: "[${{ configuration.name }}] Toolchain test"
+
+                  - task: PublishPipelineArtifact@1
+                    inputs:
+                      artifact: $(toolchainTestsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
+                      targetPath: $(ob_outputDirectory)
+                    condition: always()
+                    displayName: "Publish toolchain build artifacts"
+
+          - stage: Sodiff_${{ configuration.name }}
             dependsOn: RPMs_${{ configuration.name }}
             jobs:
               - job: Sodiff_Check

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -13,13 +13,13 @@ parameters:
       - name: "AMD64"
         agentPool: "$(DEV_AMD64_Managed)"
         maxCPUs: "$(($(nproc) / 2))"
-        rawToolchainCacheURL: "$(rawToolchainCacheURL_AMD64_3.0)"
-        rawToolchainExpectedHash: "$(rawToolchainCacheHash_AMD64_3.0)"
+        rawToolchainCacheURL: "$(rawToolchainCacheURL_AMD64_2.0)"
+        rawToolchainExpectedHash: "$(rawToolchainCacheHash_AMD64_2.0)"
       - name: "ARM64"
         agentPool: "$(DEV_ARM64_Managed)"
         maxCPUs: "$(($(nproc) / 3))"
-        rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64_3.0)"
-        rawToolchainExpectedHash: "$(rawToolchainCacheHash_ARM64_3.0)"
+        rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64_2.0)"
+        rawToolchainExpectedHash: "$(rawToolchainCacheHash_ARM64_2.0)"
   - name: debug
     type: boolean
     default: false

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -157,9 +157,9 @@ extends:
                       isUseCCache: true
                       maxCPU: "${{ configuration.maxCPUs }}"
                       outputArtifactsFolder: $(ob_outputDirectory)
-                      packageRebuildList: "$(testListFromToolchain)"
                       pipArtifactFeeds: "mariner/Mariner-Pypi-Feed"
                       selfRepoName: self
+                      testRerunList: "$(testListFromToolchain)"
                       testSuiteName: "[${{ configuration.name }}] Toolchain test"
 
                   - task: PublishPipelineArtifact@1

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -37,6 +37,14 @@ parameters:
     # - name: build-artifacts
     #   rpmsTarball: cache.tar.gz
 
+  - name: isAllowToolchainRebuilds
+    type: string
+    default: "default"
+    values:
+      - "default"
+      - "false"
+      - "true"
+
   - name: isCheckBuild
     type: string
     default: "default"
@@ -104,6 +112,14 @@ parameters:
   - name: outputSRPMsTarballName
     type: string
     default: "srpms.tar.gz"
+
+  - name: packageBuildList
+    type: string
+    default: ""
+
+  - name: packageRebuildList
+    type: string
+    default: ""
 
   - name: pipArtifactFeeds
     type: string
@@ -184,20 +200,14 @@ steps:
         check_build_retries_arg="CHECK_BUILD_RETRIES=${{ parameters.checkBuildRetries }}"
       fi
 
-      if [[ ${{ parameters.isDeltaBuild }} == "true" ]]; then
-        delta_fetch_arg="DELTA_FETCH=y"
-      elif [[ ${{ parameters.isDeltaBuild }} == "false" ]]; then
-        delta_fetch_arg="DELTA_FETCH=n"
+      if [[ -n "${{ parameters.customToolchainArtifactName }}" ]]; then
+        toolchain_archive_arg="TOOLCHAIN_ARCHIVE=$(toolchainArchive)"
       fi
 
-      if [[ -n "${{ parameters.maxCascadingRebuilds }}" ]]; then
-        max_cascading_rebuilds_arg="MAX_CASCADING_REBUILDS=${{ parameters.maxCascadingRebuilds }}"
-      fi
-
-      if [[ ${{ parameters.isQuickRebuildPackages }} == "true" ]]; then
-        quick_rebuild_packages_arg="QUICK_REBUILD_PACKAGES=y"
-      elif [[ ${{ parameters.isQuickRebuildPackages }} == "false" ]]; then
-        quick_rebuild_packages_arg="QUICK_REBUILD_PACKAGES=n"
+      if [[ ${{ parameters.isAllowToolchainRebuilds }} == "true" ]]; then
+        allow_toolchain_rebuilds_arg="ALLOW_TOOLCHAIN_REBUILDS=y"
+      elif [[ ${{ parameters.isAllowToolchainRebuilds }} == "false" ]]; then
+        allow_toolchain_rebuilds_arg="ALLOW_TOOLCHAIN_REBUILDS=n"
       fi
 
       if [[ ${{ parameters.isCheckBuild }} == "true" ]]; then
@@ -206,8 +216,16 @@ steps:
         run_check_arg="RUN_CHECK=n"
       fi
 
-      if [[ -n "${{ parameters.customToolchainArtifactName }}" ]]; then
-        toolchain_archive_arg="TOOLCHAIN_ARCHIVE=$(toolchainArchive)"
+      if [[ ${{ parameters.isDeltaBuild }} == "true" ]]; then
+        delta_fetch_arg="DELTA_FETCH=y"
+      elif [[ ${{ parameters.isDeltaBuild }} == "false" ]]; then
+        delta_fetch_arg="DELTA_FETCH=n"
+      fi
+
+      if [[ ${{ parameters.isQuickRebuildPackages }} == "true" ]]; then
+        quick_rebuild_packages_arg="QUICK_REBUILD_PACKAGES=y"
+      elif [[ ${{ parameters.isQuickRebuildPackages }} == "false" ]]; then
+        quick_rebuild_packages_arg="QUICK_REBUILD_PACKAGES=n"
       fi
 
       if [[ ${{ parameters.isUseCCache }} == "true" ]]; then
@@ -216,15 +234,22 @@ steps:
         use_ccache_arg="USE_CCACHE=n"
       fi
 
+      if [[ -n "${{ parameters.maxCascadingRebuilds }}" ]]; then
+        max_cascading_rebuilds_arg="MAX_CASCADING_REBUILDS=${{ parameters.maxCascadingRebuilds }}"
+      fi
+
       sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" build-packages -j$(nproc) \
         CONCURRENT_PACKAGE_BUILDS=${{ parameters.concurrentPackageBuilds }} \
         CONFIG_FILE="" \
         MAX_CPU="${{ parameters.maxCPU }}" \
+        PACKAGE_BUILD_LIST="${{ parameters.packageBuildList }}" \
+        PACKAGE_REBUILD_LIST="${{ parameters.packageRebuildList }}" \
         REBUILD_TOOLS=y \
         REPO_LIST="${{ parameters.extraPackageRepos }}" \
         SPECS_DIR="${{ parameters.buildRepoRoot }}/${{ parameters.specsFolderPath }}" \
         SRPM_PACK_LIST="${{ parameters.srpmPackList }}" \
         TEST_RERUN_LIST="${{ parameters.testRerunList }}" \
+        $allow_toolchain_rebuilds_arg \
         $check_build_retries_arg \
         $delta_fetch_arg \
         $max_cascading_rebuilds_arg \

--- a/.pipelines/templates/PackageTestResultsAnalysis.yml
+++ b/.pipelines/templates/PackageTestResultsAnalysis.yml
@@ -281,14 +281,16 @@ steps:
 
   - ${{ if parameters.failOnTestFailures }}:
       - bash: |
-            report_path="${{ parameters.testsWorkspace }}/${{ parameters.reportFileName }}"
-            if [[ ! -f "$report_path" ]]; then
-                echo "##[error]Test report not found at '$report_path'."
-                exit 1
-            fi
+          report_path="${{ parameters.testsWorkspace }}/${{ parameters.reportFileName }}"
+          if [[ ! -f "$report_path" ]]; then
+              echo "##[error]Test report not found at '$report_path'."
+              exit 1
+          fi
 
-            if ! grep -q '^<testsuites.*failures="0"' "$report_path"; then
-                echo "##[error]Test report has failing tests. See the 'Tests' tab for details."
-                exit 1
-            fi
+          # The "failures" attribute indicates completed tests where at least one of the test cases failed.
+          # The "errors" attribute indicates tests, which failed to complete for whatever reason.
+          if grep -qP '^<testsuites.*(errors|failures)="(?!0)' "$report_path"; then
+              echo "##[error]Test report has failing tests. See the 'Tests' tab for details."
+              exit 1
+          fi
         displayName: "Verify all tests passed"

--- a/.pipelines/templates/ToolchainCalculatePackageRetests.yml
+++ b/.pipelines/templates/ToolchainCalculatePackageRetests.yml
@@ -1,16 +1,38 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# This template will calculate a list of toolchain packages that might need to be re-tested at a later stage.
+# It assumes a toolchain build has already been performed in the same job.
+
+# Output pipeline variables set by this template:
+# - CalculateToolchainPackageRetestList.toolchainPackageRetestList
+
 parameters:
   - name: buildRepoRoot
     type: string
     default: "$(Build.SourcesDirectory)"
 
+  - name: ignoredSpecs
+    type: object
+    default: []
+
 steps:
-  # This template will calculate a list of toolchain packages that might need to be re-tested at a later stage.
-  # It assumes a toolchain build has already been performed in the same job. The value will be made available as
-  # the variable 'CalculateToolchainPackageRetestList.toolchainPackageRetestList'.
   - bash: |
+      array_contains() {
+          local -n __array=$1
+          local value=$2
+
+          for item in "${__array[@]}"; do
+              if [[ "$item" == "$value" ]]; then
+                  return 0
+              fi
+          done
+
+          return 1
+      }
+
+      ignored_specs=(${{ join(parameters.ignoredSpecs, ' ') }})
+
       # Calculate the list of packages that should be re-tested during full package build.
       #   This list will be the contents of 'built_specs_list.txt' in the toolchain build logs directory, but only for
       #   packages that have a '%check' section in their spec file. The assumption is that all packages will have a 
@@ -24,14 +46,18 @@ steps:
               echo "##[error]ERROR: '${specs_dir}/${spec}/${spec}.spec' does not exist"
               exit 1
           fi
+
           if grep -q '^%check' "${specs_dir}/${spec}/${spec}.spec"; then
-              retest_list+=("${spec}")
+              if ! array_contains ignored_specs "${spec}"; then
+                retest_list+=("${spec}")
+              fi
           fi
         done < "$built_list"
       else
         echo "No file '$built_list' found, so no packages to re-test"
       fi
       # Default will be "", which is fine.
+
       echo "Setting 'CalculateToolchainPackageRetestList.toolchainPackageRetestList' to '${retest_list[*]}'"
       echo "##vso[task.setvariable variable=toolchainPackageRetestList;isOutput=true]${retest_list[*]}"
     name: "CalculateToolchainPackageRetestList"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Backport of #10389.

We have a bug in the PR check where a change to a toolchain package prevents ptest from being run for all non-toolchain packages. This change moves toolchain ptests to a separate job, so the original `BuildAndTest` will build and test only non-toolchain packages.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR check.