### PR TITLE
update wget with patches from fedora

### DIFF
--- a/SPECS/wget/0002-normalize-path-in-url.patch
+++ b/SPECS/wget/0002-normalize-path-in-url.patch
@@ -1,0 +1,48 @@
+From 9aeab55d09f9df833bca4467b0a209cea2901ede Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Thu, 28 Mar 2024 18:12:19 +0100
+Subject: [PATCH] Fix --no-parent for denormalized paths
+
+* libwget/iri.c (wget_iri_parse): Normalize path part of URL.
+* unit-tests/test.c (test_iri_parse): Add test with denormalized path.
+---
+ libwget/iri.c     | 3 +++
+ unit-tests/test.c | 1 +
+ 2 files changed, 4 insertions(+)
+
+diff --git a/libwget/iri.c b/libwget/iri.c
+index 8241ea971..13bd5259b 100644
+--- a/libwget/iri.c
++++ b/libwget/iri.c
+@@ -82,6 +82,8 @@ static struct iri_scheme {
+ 	[WGET_IRI_SCHEME_HTTPS] = { 443, "https" },
+ };
+ 
++static size_t WGET_GCC_NONNULL_ALL normalize_path(char *path);
++
+ /**
+  * \param[in] scheme Scheme to get name for
+  * \return Name of \p scheme (e.g. "http" or "https") or NULL is not supported
+@@ -561,6 +563,7 @@ wget_iri *wget_iri_parse(const char *url, const char *encoding)
+ 		c = *s;
+ 		if (c) *s++ = 0;
+ 		wget_iri_unescape_inline((char *)iri->path);
++		normalize_path((char *)iri->path);
+ 	}
+ 
+ 	if (c == '?') {
+diff --git a/unit-tests/test.c b/unit-tests/test.c
+index da8cc728b..80ddeced5 100644
+--- a/unit-tests/test.c
++++ b/unit-tests/test.c
+@@ -584,6 +584,7 @@ static void test_iri_parse(void)
+ 		{ "http://example+.com/pa+th?qu+ery#fr+ag", NULL, WGET_IRI_SCHEME_HTTP, NULL, NULL, "example+.com", 80, "pa+th", "qu ery", "fr+ag"},
+ 		{ "http://example.com#frag?x", NULL, WGET_IRI_SCHEME_HTTP, NULL, NULL, "example.com", 80, NULL, NULL, "frag?x"},
+ 		{ "http://user:pw@example.com", NULL, WGET_IRI_SCHEME_HTTP, "user", "pw", "example.com", 80, NULL, NULL, NULL},
++		{ "http://example.com//path//file", NULL, WGET_IRI_SCHEME_HTTP, NULL, NULL, "example.com", 80, "path/file", NULL, NULL},
+ 	};
+ 	unsigned it;
+ 
+-- 
+GitLab
+

--- a/SPECS/wget/0003-Allow-option-no-tcp-fastopen-to-work-on-Linux-kernel.patch
+++ b/SPECS/wget/0003-Allow-option-no-tcp-fastopen-to-work-on-Linux-kernel.patch
@@ -1,0 +1,35 @@
+From 7929bf887c69ffdcbdfb525825bffba4c9e5d6e8 Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@amadeus.com>
+Date: Fri, 10 May 2024 16:24:57 +0000
+Subject: [PATCH] Allow option --no-tcp-fastopen to work on Linux kernels >=
+ 4.11.
+
+* libwget/net.c (set_socket_options): Add check for tcp->tcp_fastopen.
+
+Copyright-paperwork-exempt: Yes
+---
+ libwget/net.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/libwget/net.c b/libwget/net.c
+index 8fc6d143..836649c0 100644
+--- a/libwget/net.c
++++ b/libwget/net.c
+@@ -640,9 +640,11 @@ static void set_socket_options(const wget_tcp *tcp, int fd)
+ #endif
+ 
+ #ifdef TCP_FASTOPEN_LINUX_411
+-	on = 1;
+-	if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, (void *)&on, sizeof(on)) == -1)
+-		debug_printf("Failed to set socket option TCP_FASTOPEN_CONNECT\n");
++	if (tcp->tcp_fastopen) {
++		on = 1;
++		if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, (void *)&on, sizeof(on)) == -1)
++			debug_printf("Failed to set socket option TCP_FASTOPEN_CONNECT\n");
++	}
+ #endif
+ }
+ 
+-- 
+2.43.0
+

--- a/SPECS/wget/0004-Disable-OCSP-by-default.patch
+++ b/SPECS/wget/0004-Disable-OCSP-by-default.patch
@@ -1,0 +1,627 @@
+Backport of all the OCSP-related commits related to issue https://gitlab.com/gnuwget/wget2/-/issues/664:
+ - 53a8a88e8479fca04fb17f923b0f40781ee6a253
+ - a96f88a054a0dbb31eb23d7f39b0922447177ab3
+ - 715e646642e169a0a4510bdf51a5b4fc512f94d6
+ - 35986bd093676df0b2acd6110620534d41d0ec4d
+ - 0895f9230859207385393a148d6b0a6ec24521b9
+ - c341fcd1dfd57b3cf5a1f5acb84784571fff3a20
+ - c556a3226aca0e99191b52218117b7967889a9bf
+ - 543e1f270821cc7ea562444bfd79ae4d66d5b964
+ - f4e7c46073850af7b5c3d58b9452bdd2124b593c
+ - de294c8ddf27b11e8abc7954856d590d7ce2d4f3
+
+
+commit 53a8a88e8479fca04fb17f923b0f40781ee6a253
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 12 15:14:31 2024 +0200
+
+    Fix OCSP verification of first intermediate certificate.
+    
+    * libwget/ssl_gnutls.c (verify_certificate_callback): Fix off-by-one check.
+    
+    See https://gitlab.com/gnuwget/wget2/-/issues/664#note_1901610438
+
+diff --git a/libwget/ssl_gnutls.c b/libwget/ssl_gnutls.c
+index 35f20279..5524c02c 100644
+--- a/libwget/ssl_gnutls.c
++++ b/libwget/ssl_gnutls.c
+@@ -1153,7 +1153,7 @@ static int verify_certificate_callback(gnutls_session_t session)
+ 		cert_verify_hpkp(cert, hostname, session);
+ 
+ #ifdef WITH_OCSP
+-		if (config.ocsp && it > nvalid) {
++		if (config.ocsp && it >= nvalid) {
+ 			char fingerprint[64 * 2 +1];
+ 			int revoked;
+ 
+commit a96f88a054a0dbb31eb23d7f39b0922447177ab3
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 12 19:51:03 2024 +0200
+
+    -* libwget/ssl_gnutls.c (cert_verify_ocsp): Fix segfault when OCSP response is missing
+
+diff --git a/libwget/ssl_gnutls.c b/libwget/ssl_gnutls.c
+index 5524c02c..1058e50f 100644
+--- a/libwget/ssl_gnutls.c
++++ b/libwget/ssl_gnutls.c
+@@ -860,6 +860,11 @@ static int cert_verify_ocsp(gnutls_x509_crt_t cert, gnutls_x509_crt_t issuer)
+ 		return -1;
+ 	}
+ 
++	if (!resp) {
++		debug_printf("Missing response from OCSP server\n");
++		return -1;
++	}
++
+ 	/* verify and check the response for revoked cert */
+ 	ret = check_ocsp_response(cert, issuer, resp, &nonce);
+ 	wget_buffer_free(&resp);
+commit 715e646642e169a0a4510bdf51a5b4fc512f94d6
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 12 19:51:44 2024 +0200
+
+    Fix tests/test-ocsp-server
+    
+    * tests/libtest.c: Handle > 1 OCSP responses.
+    * tests/libtest.h: Rename WGET_TEST_OCSP_RESP_FILE to WGET_TEST_OCSP_RESP_FILES.
+    * tests/test-ocsp-server.c: Make use of WGET_TEST_OCSP_RESP_FILES.
+
+diff --git a/tests/libtest.c b/tests/libtest.c
+index 533f5d47..e3850bc0 100644
+--- a/tests/libtest.c
++++ b/tests/libtest.c
+@@ -90,9 +90,11 @@ static int
+ 	keep_tmpfiles,
+ 	clean_directory,
+ 	reject_http_connection,
+-	reject_https_connection;
++	reject_https_connection,
++	ocsp_response_pos;
+ static wget_vector
+-	*request_urls;
++	*request_urls,
++	*ocsp_responses;
+ static wget_test_url_t
+ 	*urls;
+ static size_t
+@@ -121,12 +123,12 @@ static struct MHD_Daemon
+ static gnutls_pcert_st *pcrt;
+ static gnutls_privkey_t *privkey;
+ 
+-static struct ocsp_resp_t {
++typedef struct {
+ 	char
+ 		*data;
+ 	size_t
+ 		size;
+-} *ocsp_resp;
++} ocsp_resp_t;
+ #endif
+ 
+ #ifdef WITH_GNUTLS_OCSP
+@@ -311,14 +313,14 @@ static enum MHD_Result _ocsp_ahc(
+ 	} else if (!first && upload_data == NULL) {
+ 		int ret = 0;
+ 
+-		if (ocsp_resp->data) {
++		ocsp_resp_t *ocsp_resp = wget_vector_get(ocsp_responses, ocsp_response_pos++);
++
++		if (ocsp_resp) {
+ 			struct MHD_Response *response = MHD_create_response_from_buffer (ocsp_resp->size, ocsp_resp->data, MHD_RESPMEM_MUST_COPY);
+ 
+ 			ret = MHD_queue_response (connection, MHD_HTTP_OK, response);
+ 
+ 			MHD_destroy_response (response);
+-
+-			wget_xfree(ocsp_resp->data);
+ 		}
+ 
+ 		return ret;
+@@ -715,11 +717,6 @@ static void _http_server_stop(void)
+ 
+ #ifdef WITH_GNUTLS_OCSP
+ 	gnutls_global_deinit();
+-
+-	if(ocsp_resp)
+-		wget_free(ocsp_resp->data);
+-
+-	wget_xfree(ocsp_resp);
+ #endif
+ }
+ 
+@@ -892,8 +889,6 @@ static int _http_server_start(int SERVER_MODE)
+ #endif
+ 			MHD_OPTION_CONNECTION_MEMORY_LIMIT, (size_t) 1*1024*1024,
+ 			MHD_OPTION_END);
+-
+-		ocsp_resp = wget_malloc(sizeof(struct ocsp_resp_t));
+ #endif
+ 
+ 		if (!ocspdaemon)
+@@ -1121,6 +1116,7 @@ void wget_test_stop_server(void)
+ {
+ //	wget_vector_free(&response_headers);
+ 	wget_vector_free(&request_urls);
++	wget_vector_free(&ocsp_responses);
+ 
+ 	for (wget_test_url_t *url = urls; url < urls + nurls; url++) {
+ 		if (url->body_original) {
+@@ -1535,9 +1531,6 @@ void wget_test(int first_key, ...)
+ 		const char
+ 			*request_url,
+ 			*options = "",
+-#ifdef WITH_GNUTLS_OCSP
+-			*ocsp_resp_file = NULL,
+-#endif
+ 			*executable = global_executable;
+ 		const wget_test_file_t
+ 			*expected_files = NULL,
+@@ -1581,6 +1574,10 @@ void wget_test(int first_key, ...)
+ 			wget_vector_set_destructor(request_urls, NULL);
+ 		}
+ 
++		if (!ocsp_responses) {
++			ocsp_responses = wget_vector_create(2, NULL);
++		}
++
+ 		va_start (args, first_key);
+ 		for (key = first_key; key; key = va_arg(args, int)) {
+ 			switch (key) {
+@@ -1633,9 +1630,24 @@ void wget_test(int first_key, ...)
+ #endif
+ 				}
+ 				break;
+-			case WGET_TEST_OCSP_RESP_FILE:
++			case WGET_TEST_OCSP_RESP_FILES:
+ #ifdef WITH_GNUTLS_OCSP
+-				ocsp_resp_file = va_arg(args, const char *);
++			{
++				const char *ocsp_resp_file = NULL;
++				while ((ocsp_resp_file = va_arg(args, const char *))) {
++					if (ocspdaemon) {
++						ocsp_resp_t ocsp_resp = { .data = wget_strdup(""), .size = 0 };
++						if (*ocsp_resp_file) {
++							ocsp_resp.data = wget_read_file(ocsp_resp_file, &ocsp_resp.size);
++							if (ocsp_resp.data == NULL) {
++								wget_error_printf_exit("Couldn't read the response from '%s'.\n", ocsp_resp_file);
++							}
++						}
++						wget_vector_add_memdup(ocsp_responses, &ocsp_resp, sizeof(ocsp_resp));
++					}
++				}
++				ocsp_response_pos = 0;
++			}
+ #endif
+ 				break;
+ 			default:
+@@ -1650,19 +1662,6 @@ void wget_test(int first_key, ...)
+ 			_empty_directory(cmd->data);
+ 		}
+ 
+-#ifdef WITH_GNUTLS_OCSP
+-		if (ocspdaemon) {
+-			if (ocsp_resp_file) {
+-				ocsp_resp->data = wget_read_file(ocsp_resp_file, &(ocsp_resp->size));
+-				if (ocsp_resp->data == NULL) {
+-					wget_error_printf_exit("Couldn't read the response.\n");
+-				}
+-			} else {
+-				wget_error_printf_exit("Need value for option WGET_TEST_OCSP_RESP_FILE.\n");
+-			}
+-		}
+-#endif
+-
+ 		// create files
+ 		if (existing_files) {
+ 			for (it = 0; existing_files[it].name; it++) {
+@@ -1835,6 +1834,11 @@ void wget_test(int first_key, ...)
+ 			wget_free(post_handshake_auth);
+ #endif
+ 
++		for (int i = 0; i < wget_vector_size(ocsp_responses); i++) {
++			ocsp_resp_t *r = wget_vector_get(ocsp_responses, it);
++			wget_xfree(r->data);
++		}
++		wget_vector_clear(ocsp_responses);
+ 		wget_vector_clear(request_urls);
+ 		wget_buffer_free(&cmd);
+ 
+diff --git a/tests/libtest.h b/tests/libtest.h
+index 7aa72088..dfccbe0b 100644
+--- a/tests/libtest.h
++++ b/tests/libtest.h
+@@ -76,7 +76,7 @@ extern "C" {
+ #define WGET_TEST_POST_HANDSHAKE_AUTH 3002
+ 
+ // for OCSP testing
+-#define WGET_TEST_OCSP_RESP_FILE 3003
++#define WGET_TEST_OCSP_RESP_FILES 3003
+ 
+ typedef enum {
+ 	INTERRUPT_RESPONSE_DISABLED = 0,
+diff --git a/tests/test-ocsp-server.c b/tests/test-ocsp-server.c
+index 8b844e18..ebe443a5 100644
+--- a/tests/test-ocsp-server.c
++++ b/tests/test-ocsp-server.c
+@@ -46,7 +46,7 @@ int main(void)
+ 		WGET_TEST_OPTIONS, "--ca-certificate=" SRCDIR "/certs/ocsp/x509-root-cert.pem --no-ocsp-file --no-ocsp-date --no-ocsp-nonce --ocsp --ocsp-server http://localhost:{{ocspport}}",
+ 		WGET_TEST_REQUEST_URL, "https://localhost:{{sslport}}/index.html",
+ 		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+-		WGET_TEST_OCSP_RESP_FILE, SRCDIR "/certs/ocsp/ocsp_resp_ok.der",
++		WGET_TEST_OCSP_RESP_FILES, "", SRCDIR "/certs/ocsp/ocsp_resp_ok.der", NULL,
+ 		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+ 			{urls[0].name + 1, urls[0].body},
+ 			{	NULL} },
+@@ -58,7 +58,7 @@ int main(void)
+ 		WGET_TEST_OPTIONS, "--ca-certificate=" SRCDIR "/certs/ocsp/x509-root-cert.pem --no-ocsp-file --no-ocsp-date --no-ocsp-nonce --ocsp --ocsp-server http://localhost:{{ocspport}}",
+ 		WGET_TEST_REQUEST_URL, "https://localhost:{{sslport}}/index.html",
+ 		WGET_TEST_EXPECTED_ERROR_CODE, 5,
+-		WGET_TEST_OCSP_RESP_FILE, SRCDIR "/certs/ocsp/ocsp_resp_revoked.der",
++		WGET_TEST_OCSP_RESP_FILES, "", SRCDIR "/certs/ocsp/ocsp_resp_revoked.der", NULL,
+ 		0);
+ #endif
+ 
+@@ -67,7 +67,7 @@ int main(void)
+ 		WGET_TEST_OPTIONS, "--ca-certificate=" SRCDIR "/certs/ocsp/x509-root-cert.pem --no-ocsp-file --no-ocsp-date --no-ocsp-nonce --ocsp --ocsp-server http://localhost:{{ocspport}} --no-check-certificate",
+ 		WGET_TEST_REQUEST_URL, "https://localhost:{{sslport}}/index.html",
+ 		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+-		WGET_TEST_OCSP_RESP_FILE, SRCDIR "/certs/ocsp/ocsp_resp_revoked.der",
++		WGET_TEST_OCSP_RESP_FILES, "", SRCDIR "/certs/ocsp/ocsp_resp_revoked.der", NULL,
+ 		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+ 			{urls[0].name + 1, urls[0].body},
+ 			{	NULL} },
+@@ -79,7 +79,7 @@ int main(void)
+ 		WGET_TEST_OPTIONS, "--ca-certificate=" SRCDIR "/certs/ocsp/x509-root-cert.pem --no-ocsp-file --no-ocsp-date --no-ocsp-nonce --ocsp",
+ 		WGET_TEST_REQUEST_URL, "https://localhost:{{sslport}}/index.html",
+ 		WGET_TEST_EXPECTED_ERROR_CODE, 0,
+-		WGET_TEST_OCSP_RESP_FILE, SRCDIR "/certs/ocsp/ocsp_resp_ok.der",
++		WGET_TEST_OCSP_RESP_FILES, "", SRCDIR "/certs/ocsp/ocsp_resp_ok.der", NULL,
+ 		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
+ 			{urls[0].name + 1, urls[0].body},
+ 			{	NULL} },
+commit 35986bd093676df0b2acd6110620534d41d0ec4d
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sat May 18 14:35:45 2024 +0200
+
+    Disable explicit OCSP requests by default
+    
+    * docs/wget2.md: Document --ocsp default value as 'off'.
+    * src/options.c (struct config): Disable .ocsp by default.
+    
+    OCSP validation of the server certificate implies privacy issues:
+      - The OCSP request tells the CA which web service the client tries to reach.
+      - The OCSP requests are sent via unencrypted HTTP, so every "listener in the
+        middle" can see which web service the client tries to connect.
+    Additionally, the OCSP requests slow down operation and may cause unexpected
+    network traffic, which may trigger security alarms unnecessarily.
+    
+    Due to these issues we explicitly disable OCSP by default.
+
+diff --git a/docs/wget2.md b/docs/wget2.md
+index 6e408592..61da3ccb 100644
+--- a/docs/wget2.md
++++ b/docs/wget2.md
+@@ -1569,7 +1569,7 @@ Go to background immediately after startup. If no output file is specified via t
+ 
+ ### `--ocsp`
+ 
+-  Enable OCSP server access to check the possible revocation the HTTPS server certificate(s) (default: on).
++  Enable OCSP server access to check the possible revocation the HTTPS server certificate(s) (default: off).
+ 
+   This procedure is pretty slow (connect to server, HTTP request, response) and thus we support
+   OSCP stapling (server sends OCSP response within TLS handshake) and persistent OCSP caching.
+diff --git a/src/options.c b/src/options.c
+index 54e8cabb..7684b795 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -1302,7 +1302,16 @@ struct config config = {
+ 	.http2 = 1,
+ 	.http2_request_window = 30,
+ #endif
+-	.ocsp = 1,
++	// OCSP validation of the server certificate implies privacy issues:
++	//   - The OCSP request tells the CA which web service the client tries to reach.
++	//   - The OCSP requests are sent via unencrypted HTTP, so every "listener in the middle" can see which web service
++	//     the client tries to connect.
++	// Additionally, the OCSP requests slow down operation and may cause unexpected network traffic, which may trigger
++	// security alarms unnecessarily.
++	// Due to these issues we explicitly disable OCSP by default.
++	//
++	// The upside of enabling OCSP mostly is a "real-time" recognition of certificate revocations.
++	.ocsp = 0,
+ 	.ocsp_date = 1,
+ 	.ocsp_stapling = 1,
+ 	.ocsp_nonce = 1,
+commit 0895f9230859207385393a148d6b0a6ec24521b9
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sat May 18 14:46:07 2024 +0200
+
+    * libwget/ssl_gnutls.c: Improve messages for OCSP stapling
+
+diff --git a/libwget/ssl_gnutls.c b/libwget/ssl_gnutls.c
+index 1058e50f..f12b5e74 100644
+--- a/libwget/ssl_gnutls.c
++++ b/libwget/ssl_gnutls.c
+@@ -1136,7 +1136,7 @@ static int verify_certificate_callback(gnutls_session_t session)
+ 			}
+ #endif
+ 			else if (!config.ocsp)
+-				error_printf_check(_("WARNING: The certificate's (stapled) OCSP status has not been sent\n"));
++				error_printf_check(_("WARNING: OCSP stapling is not supported by '%s'\n"), hostname);
+ #endif
+ 		} else if (ctx->valid)
+ 			debug_printf("OCSP: Host '%s' is valid (from cache)\n", hostname);
+@@ -1728,13 +1728,14 @@ int wget_ssl_open(wget_tcp *tcp)
+ 	// If we know the cert chain for the hostname being valid at the moment,
+ 	// we don't ask for OCSP stapling to avoid unneeded IP traffic.
+ 	// In the unlikely case that the server's certificate chain changed right now,
+-	// we fallback to OCSP responder request later.
++	// we fallback to OCSP responder request later (if enabled).
+ 	if (hostname) {
+ 		if (!(ctx->valid = wget_ocsp_hostname_is_valid(config.ocsp_host_cache, hostname))) {
+ #if GNUTLS_VERSION_NUMBER >= 0x030103
+-			if ((rc = gnutls_ocsp_status_request_enable_client(session, NULL, 0, NULL)) == GNUTLS_E_SUCCESS)
++			if ((rc = gnutls_ocsp_status_request_enable_client(session, NULL, 0, NULL)) == GNUTLS_E_SUCCESS) {
++				debug_printf("OCSP stapling requested for %s\n", hostname);
+ 				ctx->ocsp_stapling = 1;
+-			else
++			} else
+ 				error_printf("GnuTLS: %s\n", gnutls_strerror(rc)); // no translation
+ #endif
+ 		}
+commit c341fcd1dfd57b3cf5a1f5acb84784571fff3a20
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 19 12:41:55 2024 +0200
+
+    Disable explicit OCSP requests by default for TLS library functions
+    
+    * libwget/ssl_openssl: Disable explicit OCSP requests by default.
+    * libwget/ssl_gnutls: Likewise.
+    * libwget/ssl_wolfssl.c: Likewise.
+
+diff --git a/libwget/ssl_gnutls.c b/libwget/ssl_gnutls.c
+index f12b5e74..7dbbde39 100644
+--- a/libwget/ssl_gnutls.c
++++ b/libwget/ssl_gnutls.c
+@@ -116,7 +116,7 @@ static struct config {
+ 	.report_invalid_cert = 1,
+ 	.check_hostname = 1,
+ #ifdef WITH_OCSP
+-	.ocsp = 1,
++	.ocsp = 0,
+ 	.ocsp_stapling = 1,
+ #endif
+ 	.ca_type = WGET_SSL_X509_FMT_PEM,
+diff --git a/libwget/ssl_openssl.c b/libwget/ssl_openssl.c
+index 94da0d3f..2332ec40 100644
+--- a/libwget/ssl_openssl.c
++++ b/libwget/ssl_openssl.c
+@@ -102,7 +102,7 @@ static struct config
+ 	.check_certificate = 1,
+ 	.check_hostname = 1,
+ #ifdef WITH_OCSP
+-	.ocsp = 1,
++	.ocsp = 0,
+ 	.ocsp_stapling = 1,
+ #endif
+ 	.ca_type = WGET_SSL_X509_FMT_PEM,
+diff --git a/libwget/ssl_wolfssl.c b/libwget/ssl_wolfssl.c
+index 47ed9ba9..967e984d 100644
+--- a/libwget/ssl_wolfssl.c
++++ b/libwget/ssl_wolfssl.c
+@@ -108,7 +108,7 @@ static struct config {
+ 	.check_certificate = 1,
+ 	.report_invalid_cert = 1,
+ 	.check_hostname = 1,
+-	.ocsp = 1,
++	.ocsp = 0,
+ 	.ocsp_stapling = 1,
+ 	.ca_type = WGET_SSL_X509_FMT_PEM,
+ 	.cert_type = WGET_SSL_X509_FMT_PEM,
+commit c556a3226aca0e99191b52218117b7967889a9bf
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 19 13:05:11 2024 +0200
+
+    * libwget/ssl_openssl.c (verify_ocsp): Fix segfault when OCSP response is missing
+
+diff --git a/libwget/ssl_openssl.c b/libwget/ssl_openssl.c
+index 2332ec40..6cac6ecb 100644
+--- a/libwget/ssl_openssl.c
++++ b/libwget/ssl_openssl.c
+@@ -1024,9 +1024,7 @@ static int verify_ocsp(const char *ocsp_uri,
+ 	certid = OCSP_cert_to_id(EVP_sha1(), subject_cert, issuer_cert);
+ 
+ 	/* Send OCSP request to server, via HTTP */
+-	if (!(ocspreq = send_ocsp_request(ocsp_uri,
+-			certid,
+-			&resp)))
++	if (!(ocspreq = send_ocsp_request(ocsp_uri, certid, &resp)) || !resp || !resp->body)
+ 		return -1;
+ 
+ 	/* Check server's OCSP response */
+commit 543e1f270821cc7ea562444bfd79ae4d66d5b964
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 19 12:26:29 2024 +0200
+
+    * libwget/ssl_gnutls.c (verify_certificate_callback): Warn about OCSP privacy leak
+
+diff --git a/libwget/ssl_gnutls.c b/libwget/ssl_gnutls.c
+index 7dbbde39..08f95383 100644
+--- a/libwget/ssl_gnutls.c
++++ b/libwget/ssl_gnutls.c
+@@ -1121,6 +1121,8 @@ static int verify_certificate_callback(gnutls_session_t session)
+ 	// At this point, the cert chain has been found valid regarding the locally available CA certificates and CRLs.
+ 	// Now, we are going to check the revocation status via OCSP
+ #ifdef WITH_OCSP
++	bool skip_server_cert_check = false;
++
+ 	if (config.ocsp_stapling) {
+ 		if (!ctx->valid && ctx->ocsp_stapling) {
+ #if GNUTLS_VERSION_NUMBER >= 0x030103
+@@ -1129,14 +1131,20 @@ static int verify_certificate_callback(gnutls_session_t session)
+ //				_get_cert_fingerprint(cert, fingerprint, sizeof(fingerprint)); // calc hexadecimal fingerprint string
+ 				add_cert_to_ocsp_cache(cert, true);
+ 				nvalid = 1;
++				skip_server_cert_check = true;
+ 			}
+ #if GNUTLS_VERSION_NUMBER >= 0x030400
+ 			else if (gnutls_ocsp_status_request_is_checked(session, GNUTLS_OCSP_SR_IS_AVAIL)) {
+ 				error_printf_check(_("WARNING: The certificate's (stapled) OCSP status is invalid\n"));
++				skip_server_cert_check = true;
+ 			}
+ #endif
+-			else if (!config.ocsp)
+-				error_printf_check(_("WARNING: OCSP stapling is not supported by '%s'\n"), hostname);
++			else if (!config.ocsp) {
++				debug_printf(_("OCSP stapling is not supported by '%s'\n"), hostname);
++			} else {
++				error_printf_check(_("WARNING: OCSP stapling is not supported by '%s', but OCSP validation has been requested.\n"), hostname);
++				error_printf_check(_("WARNING: This implies a privacy leak: the client sends the certificate serial ID over HTTP to the CA.\n"));
++			}
+ #endif
+ 		} else if (ctx->valid)
+ 			debug_printf("OCSP: Host '%s' is valid (from cache)\n", hostname);
+@@ -1158,55 +1166,55 @@ static int verify_certificate_callback(gnutls_session_t session)
+ 		cert_verify_hpkp(cert, hostname, session);
+ 
+ #ifdef WITH_OCSP
+-		if (config.ocsp && it >= nvalid) {
+-			char fingerprint[64 * 2 +1];
+-			int revoked;
++		if (!config.ocsp || (skip_server_cert_check && it == 0))
++			continue;
+ 
+-			_get_cert_fingerprint(cert, fingerprint, sizeof(fingerprint)); // calc hexadecimal fingerprint string
++		char fingerprint[64 * 2 +1];
++		_get_cert_fingerprint(cert, fingerprint, sizeof(fingerprint)); // calc hexadecimal fingerprint string
+ 
+-			if (wget_ocsp_fingerprint_in_cache(config.ocsp_cert_cache, fingerprint, &revoked)) {
+-				// found cert's fingerprint in cache
+-				if (revoked) {
+-					debug_printf("Certificate[%u] of '%s' has been revoked (cached)\n", it, hostname);
+-					nrevoked++;
+-				} else {
+-					debug_printf("Certificate[%u] of '%s' is valid (cached)\n", it, hostname);
+-					nvalid++;
+-				}
+-				continue;
++		int revoked;
++		if (wget_ocsp_fingerprint_in_cache(config.ocsp_cert_cache, fingerprint, &revoked)) {
++			// found cert's fingerprint in cache
++			if (revoked) {
++				debug_printf("Certificate[%u] of '%s' has been revoked (cached)\n", it, hostname);
++				nrevoked++;
++			} else {
++				debug_printf("Certificate[%u] of '%s' is valid (cached)\n", it, hostname);
++				nvalid++;
+ 			}
++			continue;
++		}
+ 
+-			if (deinit_issuer) {
+-				gnutls_x509_crt_deinit(issuer);
+-				deinit_issuer = 0;
+-			}
+-			if ((err = gnutls_certificate_get_issuer(credentials, cert, &issuer, 0)) != GNUTLS_E_SUCCESS && it < cert_list_size - 1) {
+-				gnutls_x509_crt_init(&issuer);
+-				deinit_issuer = 1;
+-				if ((err = gnutls_x509_crt_import(issuer, &cert_list[it + 1], GNUTLS_X509_FMT_DER))  != GNUTLS_E_SUCCESS) {
+-					debug_printf("Decoding error: %s\n", gnutls_strerror(err));
+-					continue;
+-				}
+-			} else if (err  != GNUTLS_E_SUCCESS) {
+-				debug_printf("Cannot find issuer: %s\n", gnutls_strerror(err));
++		if (deinit_issuer) {
++			gnutls_x509_crt_deinit(issuer);
++			deinit_issuer = 0;
++		}
++		if ((err = gnutls_certificate_get_issuer(credentials, cert, &issuer, 0)) != GNUTLS_E_SUCCESS && it < cert_list_size - 1) {
++			gnutls_x509_crt_init(&issuer);
++			deinit_issuer = 1;
++			if ((err = gnutls_x509_crt_import(issuer, &cert_list[it + 1], GNUTLS_X509_FMT_DER))  != GNUTLS_E_SUCCESS) {
++				debug_printf("Decoding error: %s\n", gnutls_strerror(err));
+ 				continue;
+ 			}
++		} else if (err  != GNUTLS_E_SUCCESS) {
++			debug_printf("Cannot find issuer: %s\n", gnutls_strerror(err));
++			continue;
++		}
+ 
+-			ocsp_ok = cert_verify_ocsp(cert, issuer);
+-			debug_printf("check_ocsp_response() returned %d\n", ocsp_ok);
+-
+-			if (ocsp_ok == 1) {
+-				debug_printf("Certificate[%u] of '%s' is valid (via OCSP)\n", it, hostname);
+-				wget_ocsp_db_add_fingerprint(config.ocsp_cert_cache, fingerprint, time(NULL) + 3600, true); // 1h valid
+-				nvalid++;
+-			} else if (ocsp_ok == 0) {
+-				debug_printf("%s: Certificate[%u] of '%s' has been revoked (via OCSP)\n", tag, it, hostname);
+-				wget_ocsp_db_add_fingerprint(config.ocsp_cert_cache, fingerprint, time(NULL) + 3600, false);  // cert has been revoked
+-				nrevoked++;
+-			} else {
+-				debug_printf("WARNING: OCSP response not available or ignored\n");
+-				nignored++;
+-			}
++		ocsp_ok = cert_verify_ocsp(cert, issuer);
++		debug_printf("check_ocsp_response() returned %d\n", ocsp_ok);
++
++		if (ocsp_ok == 1) {
++			debug_printf("Certificate[%u] of '%s' is valid (via OCSP)\n", it, hostname);
++			wget_ocsp_db_add_fingerprint(config.ocsp_cert_cache, fingerprint, time(NULL) + 3600, true); // 1h valid
++			nvalid++;
++		} else if (ocsp_ok == 0) {
++			debug_printf("%s: Certificate[%u] of '%s' has been revoked (via OCSP)\n", tag, it, hostname);
++			wget_ocsp_db_add_fingerprint(config.ocsp_cert_cache, fingerprint, time(NULL) + 3600, false);  // cert has been revoked
++			nrevoked++;
++		} else {
++			debug_printf("WARNING: OCSP response not available or ignored\n");
++			nignored++;
+ 		}
+ #endif
+ 	}
+commit f4e7c46073850af7b5c3d58b9452bdd2124b593c
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 19 19:36:59 2024 +0200
+
+    * libwget/ssl_gnutls.c (verify_certificate_callback): Fix 'do not translate debug strings'
+
+diff --git a/libwget/ssl_gnutls.c b/libwget/ssl_gnutls.c
+index 08f95383..a3cf6f5d 100644
+--- a/libwget/ssl_gnutls.c
++++ b/libwget/ssl_gnutls.c
+@@ -1140,7 +1140,7 @@ static int verify_certificate_callback(gnutls_session_t session)
+ 			}
+ #endif
+ 			else if (!config.ocsp) {
+-				debug_printf(_("OCSP stapling is not supported by '%s'\n"), hostname);
++				debug_printf("OCSP stapling is not supported by '%s'\n", hostname);
+ 			} else {
+ 				error_printf_check(_("WARNING: OCSP stapling is not supported by '%s', but OCSP validation has been requested.\n"), hostname);
+ 				error_printf_check(_("WARNING: This implies a privacy leak: the client sends the certificate serial ID over HTTP to the CA.\n"));
+commit de294c8ddf27b11e8abc7954856d590d7ce2d4f3
+Author: Tim Rühsen <tim.ruehsen@gmx.de>
+Date:   Sun May 19 20:02:31 2024 +0200
+
+    * libwget/ssl_gnutls.c (verify_certificate_callback): Fix gcc warning -Wjump-misses-init
+
+diff --git a/libwget/ssl_gnutls.c b/libwget/ssl_gnutls.c
+index a3cf6f5d..6edbcea1 100644
+--- a/libwget/ssl_gnutls.c
++++ b/libwget/ssl_gnutls.c
+@@ -965,6 +965,7 @@ static int verify_certificate_callback(gnutls_session_t session)
+ 	gnutls_x509_crt_t cert = NULL, issuer = NULL;
+ 	const char *tag = config.check_certificate ? _("ERROR") : _("WARNING");
+ #ifdef WITH_OCSP
++	bool skip_server_cert_check = false;
+ 	unsigned nvalid = 0, nrevoked = 0, nignored = 0;
+ #endif
+ 
+@@ -1121,8 +1122,6 @@ static int verify_certificate_callback(gnutls_session_t session)
+ 	// At this point, the cert chain has been found valid regarding the locally available CA certificates and CRLs.
+ 	// Now, we are going to check the revocation status via OCSP
+ #ifdef WITH_OCSP
+-	bool skip_server_cert_check = false;
+-
+ 	if (config.ocsp_stapling) {
+ 		if (!ctx->valid && ctx->ocsp_stapling) {
+ #if GNUTLS_VERSION_NUMBER >= 0x030103

--- a/SPECS/wget/0005-Accept-progress-dot-.-for-backwards-compatibility.patch
+++ b/SPECS/wget/0005-Accept-progress-dot-.-for-backwards-compatibility.patch
@@ -1,0 +1,57 @@
+From e8f1e99c96a8303421e66b0feda1651a11c8b250 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Mon, 20 May 2024 13:19:06 +0200
+Subject: [PATCH] Accept --progress=dot:... for backwards compatibility
+
+* src/options.c (parse_progress_type): Fix checking dot options.
+* tests/test-wget-1.c: Add check for --progress variants.
+---
+ src/options.c       |  6 +++---
+ tests/test-wget-1.c | 10 ++++++++++
+ 2 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/src/options.c b/src/options.c
+index 7684b795..0f7b3f35 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -798,13 +798,13 @@ static int WGET_GCC_PURE WGET_GCC_NONNULL((1)) parse_progress_type(option_t opt,
+ 
+ 	if (!wget_strcasecmp_ascii(val, "none"))
+ 		*((char *)opt->var) = PROGRESS_TYPE_NONE;
+-	else if (!wget_strncasecmp_ascii(val, "bar", 3)) {
++	else if (!wget_strncasecmp_ascii(val, "bar", 3) && (val[3] == ':' || val[3] == 0)) {
+ 		*((char *)opt->var) = PROGRESS_TYPE_BAR;
+ 		// Silent Wget compatibility
+-		if (!wget_strncasecmp_ascii(val+3, ":force", 6) || !wget_strncasecmp_ascii(val+3, ":noscroll:force", 15)) {
++		if (!wget_strncasecmp_ascii(val+4, "force", 5) || !wget_strncasecmp_ascii(val+4, "noscroll:force", 14)) {
+ 			config.force_progress = true;
+ 		}
+-	} else if (!wget_strcasecmp_ascii(val, "dot")) {
++	} else if (!wget_strncasecmp_ascii(val, "dot", 3) && (val[3] == ':' || val[3] == 0)) {
+ 		// Wget compatibility, whether want to support 'dot' depends on user feedback.
+ 		info_printf(_("Progress type '%s' ignored. It is not implemented yet\n"), val);
+ 	} else {
+diff --git a/tests/test-wget-1.c b/tests/test-wget-1.c
+index fdd4f54e..8a08d74d 100644
+--- a/tests/test-wget-1.c
++++ b/tests/test-wget-1.c
+@@ -626,6 +626,16 @@ int main(void)
+ 			{	NULL } },
+ 		0);
+ 
++	// test different --progress options to be accepted
++	wget_test(
++		WGET_TEST_OPTIONS, "--progress=none --progress=bar --progress=bar:force --progress=bar:noscroll:force --progress=dot --progress=dot:giga",
++		WGET_TEST_REQUEST_URL, "dummy.txt",
++		WGET_TEST_EXPECTED_ERROR_CODE, 0,
++		WGET_TEST_EXPECTED_FILES, &(wget_test_file_t []) {
++			{	"dummy.txt", urls[3].body },
++			{	NULL } },
++		0);
++
+ 	// test--https-only
+ 	wget_test(
+ 		WGET_TEST_OPTIONS, "--https-only -r -nH",
+-- 
+2.43.0
+

--- a/SPECS/wget/0006-Disable-TCP-Fast-Open-by-default.patch
+++ b/SPECS/wget/0006-Disable-TCP-Fast-Open-by-default.patch
@@ -1,0 +1,51 @@
+From 7a945d31aeb34fc73cf86a494673ae97e069d84d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Sun, 30 Jun 2024 19:33:01 +0200
+Subject: [PATCH] Disable TCP Fast Open by default
+
+* docs/wget2.md: Amended description of --tcp-fastopen.
+* src/options.c (struct config config): Disabled TFO.
+---
+ docs/wget2.md | 8 +++++++-
+ src/options.c | 1 -
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/docs/wget2.md b/docs/wget2.md
+index 61da3ccb..06828bf8 100644
+--- a/docs/wget2.md
++++ b/docs/wget2.md
+@@ -730,12 +730,18 @@ Go to background immediately after startup. If no output file is specified via t
+ 
+ ### `--tcp-fastopen`
+ 
+-  Enable support for TCP Fast Open (TFO) (default: on).
++  Enable support for TCP Fast Open (TFO) (default: off).
+ 
+   TFO reduces connection latency by 1 RT on "hot" connections (2nd+ connection to the same host in a certain amount of time).
+ 
+   Currently this works on recent Linux and OSX kernels, on HTTP and HTTPS.
+ 
++  The main reasons why TFO is disabled by default are
++    - possible user tracking issues
++    - possible issues with middle boxes that do not support TFO
++
++  This article gives has more details about TFO than fits here: https://candrews.integralblue.com/2019/03/the-sad-story-of-tcp-fast-open/
++
+ ### `--dns-cache-preload=file`
+ 
+   Load a list of IP / Name tuples into the DNS cache.
+diff --git a/src/options.c b/src/options.c
+index 026aa415..f4b5d1a1 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -1235,7 +1235,6 @@ struct config config = {
+ 	.max_redirect = 20,
+ 	.max_threads = 5,
+ 	.dns_caching = 1,
+-	.tcp_fastopen = 1,
+ 	.user_agent = PACKAGE_NAME"/"PACKAGE_VERSION,
+ 	.verbose = 1,
+ 	.check_certificate= CHECK_CERTIFICATE_ENABLED,
+-- 
+2.43.0
+


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Since we upgraded wget for 3.0 with change #7672, upstream Fedora has added several packages that would be useful to us. These include patches that disable `ocsp` and `tcp-fastopen` by default (you can still set them on the command-line). A combination of these two things causes some issues on certain urls when downloading from a local hyper-v vm, and generally we'd rather have them disabled by default.

This change takes all the patches that fedora currently applies to wget.

###### Change Log  <!-- REQUIRED -->
- Applied patches from fedora upstream.
- Cleaned up some build warnings.
- Stop installing a test-only binary

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=639060&view=results
- Installed buddy-build rpm on hyperv vm and it behaves as expected.
