### PR TITLE
update wget to fix potential infinite loop

### DIFF
--- a/SPECS/wget/fix-ssl-read-and-write-error-check.patch
+++ b/SPECS/wget/fix-ssl-read-and-write-error-check.patch
@@ -1,0 +1,32 @@
+From 3d4e70f8591d84c48d449d0b8d600d6e138ca6c2 Mon Sep 17 00:00:00 2001
+From: "Tobias Brick (he/him)" <tobiasb@microsoft.com>
+Date: Wed, 11 Sep 2024 22:46:37 +0000
+Subject: [PATCH] count 0 as an error for SSL_read and SS_write, per
+ documentation
+
+---
+ libwget/ssl_openssl.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libwget/ssl_openssl.c b/libwget/ssl_openssl.c
+index 6cac6ecb..2a892ff5 100644
+--- a/libwget/ssl_openssl.c
++++ b/libwget/ssl_openssl.c
+@@ -1816,7 +1816,7 @@ static int ssl_transfer(int want,
+ 		else
+ 			retval = SSL_write(ssl, buf, count);
+ 
+-		if (retval < 0) {
++		if (retval <= 0) {
+ 			error = SSL_get_error(ssl, retval);
+ 
+ 			if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
+@@ -1830,7 +1830,7 @@ static int ssl_transfer(int want,
+ 				return WGET_E_HANDSHAKE;
+ 			}
+ 		}
+-	} while (retval < 0);
++	} while (retval <= 0);
+ 
+ 	return retval;
+ }

--- a/SPECS/wget/wget.spec
+++ b/SPECS/wget/wget.spec
@@ -3,7 +3,7 @@
 Summary:        An advanced file and recursive website downloader
 Name:           wget
 Version:        2.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND GFDL-1.3-or-later
 URL:            https://gitlab.com/gnuwget/wget2
 Group:          System Environment/NetworkingPrograms
@@ -27,6 +27,8 @@ Patch0005:      0005-Accept-progress-dot-.-for-backwards-compatibility.patch
 # Disable TCP Fast Open by default
 # rhbz#2291017
 Patch0006:      0006-Disable-TCP-Fast-Open-by-default.patch
+# https://github.com/rockdaboot/wget2/issues/342
+Patch0007:      fix-ssl-read-and-write-error-check.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -153,6 +155,9 @@ echo ".so man1/%{name}.1" > %{buildroot}%{_mandir}/man1/wget.1
 %{_mandir}/man3/libwget*.3*
 
 %changelog
+* Fri Sep 13 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-3
+- Add patch to fix SSL read and write error check.
+
 * Thu Sep 12 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-2
 - Add patches from Fedora upstream. Important ones include disabling OCSP and TCP Fast Open by default.
 - Don't install wget2_noinstall binary, which is specifically for testing.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
With our configuration of `wget2`, which uses the `openssl` `tls` provider, we can get into an infinite loop with certain error conditions. The issue is that for both `SSL_read` and `SSL_open`, a return value of `0` is an error but the code treats it as success.

This is tracked upstream with [this issue](https://github.com/rockdaboot/wget2/issues/342).

###### Change Log  <!-- REQUIRED -->
- Apply patch to fix error handling in `openssl` `tls` povider.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=641218&view=results
- Installed and tested on a local hyperv vm
