### PR TITLE
Upgrade cert-manager to 1.12.13 to get upstream patches for CVE-2024-25620 and CVE-2024-26147

### DIFF
--- a/SPECS/cert-manager/cert-manager.signatures.json
+++ b/SPECS/cert-manager/cert-manager.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "cert-manager-1.12.12-vendor.tar.gz": "eb2c70859fb2b73880f682e0c69eaeeec523481f94386b7d0150440799d7eecc",
-  "cert-manager-1.12.12.tar.gz": "2bdcc466ed77457616ea8732d002c4985524998da2c3dcc579d6e8f2af708484"
+  "cert-manager-1.12.13-vendor.tar.gz": "18894907e56205351f148a1aae828db6752d1189557d618720d782295abe4f84",
+  "cert-manager-1.12.13.tar.gz": "1bd650f7d066f98e2566397787caf938737c64ef4ab41284246acaffcdac7eb1"
  }
 }

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -1,7 +1,7 @@
 Summary:        Automatically provision and manage TLS certificates in Kubernetes
 Name:           cert-manager
-Version:        1.12.12
-Release:        2%{?dist}
+Version:        1.12.13
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -13,7 +13,6 @@ Source0:        https://github.com/jetstack/%{name}/archive/refs/tags/v%{version
 # 1. wget https://github.com/jetstack/%%{name}/archive/refs/tags/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
 # 2. <repo-root>/SPECS/cert-manager/generate_source_tarball.sh --srcTarball %%{name}-%%{version}.tar.gz --pkgVersion %%{version}
 Source1:        %{name}-%{version}-vendor.tar.gz
-Patch0:         CVE-2024-25620.patch
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
 Requires:       %{name}-cainjector
@@ -59,8 +58,6 @@ Webhook component providing API validation, mutation and conversion functionalit
 
 %prep
 %setup -q -a 1
-%autopatch -p1
-
 
 %build
 
@@ -106,6 +103,9 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %{_bindir}/webhook
 
 %changelog
+* Mon Sep 16 2024 Jiri Appl <jiria@microsoft.com> - 1.12.13-1
+- Upgrade to 1.12.13 which carries helm 3.14.2 to fix CVE-2024-26147 and CVE-2024-25620
+
 * Wed Aug 07 2024 Bhagyashri Pathak <bhapathak@microsoft.com> - 1.12.12-2
 - Patch for CVE-2024-25620
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1547,8 +1547,8 @@
         "type": "other",
         "other": {
           "name": "cert-manager",
-          "version": "1.12.12",
-          "downloadUrl": "https://github.com/jetstack/cert-manager/archive/refs/tags/v1.12.12.tar.gz"
+          "version": "1.12.13",
+          "downloadUrl": "https://github.com/jetstack/cert-manager/archive/refs/tags/v1.12.13.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Upgrade cert-manager to 1.12.13 to get upstream patches for CVE-2024-25620 and CVE-2024-26147

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
[CVE-2024-26147](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26147) is fixed in Helm 3.14.2, [CVE-2024-25620](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25620) is fixed in Helm 3.14.1. Helm is a vendored package used by `cert-manager` package. The current version of `cert-manager` 1.12.12 carries Helm 3.12.0. 1.12.13 of `cert-manager` carries Helm 3.14.2, hence fixing both CVEs. As such, this PR is also removing the custom patch for CVE-2024-25620 that was added into the `cert-manager` spec file.

###### Change Log  <!-- REQUIRED -->
- Fixes CVE-2024-26147 by updating to 1.12.13
- Removes need for a custom patch for CVE-2024-25620 by updating to 1.12.13

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25620
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26147

###### Test Methodology
- Local build with RUN_CHECK=y