### PR TITLE
OSModifier: allow two linux cmdline in grub.cfg

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -138,11 +138,11 @@ func FindNonRecoveryLinuxLine(inputGrubCfgContent string) ([]grub.Line, error) {
 	grubLines := grub.SplitTokensIntoLines(grubTokens)
 	var linuxLines []grub.Line
 	inMenuEntry := false
-	var isRecoveryMenu bool
+	isRecoveryMenu := false
 
 	// Iterate over all lines to find non-recovery mode menuentry and its linux line
 	for _, line := range grubLines {
-		if len(line.Tokens) > 0 && grub.IsTokenKeyword(line.Tokens[0], "menuentry") {
+		if len(line.Tokens) > 1 && grub.IsTokenKeyword(line.Tokens[0], "menuentry") {
 			// Found a new 'menuentry', reset flags
 			inMenuEntry = true
 			isRecoveryMenu = false

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -120,8 +120,8 @@ func findLinuxOrInitrdLineAll(inputGrubCfgContent string, commandName string, al
 }
 
 // Find the linux command within the grub config file.
-func FindLinuxLine(inputGrubCfgContent string) (grub.Line, error) {
-	lines, err := findLinuxOrInitrdLineAll(inputGrubCfgContent, linuxCommand, false /*allowMultiple*/)
+func FindLinuxLine(inputGrubCfgContent string, allowMultiple bool) (grub.Line, error) {
+	lines, err := findLinuxOrInitrdLineAll(inputGrubCfgContent, linuxCommand, allowMultiple)
 	if err != nil {
 		return grub.Line{}, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -137,22 +137,19 @@ func FindNonRecoveryLinuxLine(inputGrubCfgContent string) ([]grub.Line, error) {
 
 	grubLines := grub.SplitTokensIntoLines(grubTokens)
 	var linuxLines []grub.Line
-	var inMenuEntry bool
+	inMenuEntry := false
 	var isRecoveryMenu bool
 
 	// Iterate over all lines to find non-recovery mode menuentry and its linux line
 	for _, line := range grubLines {
-		if strings.HasPrefix(line.Tokens[0].RawContent, "menuentry") {
+		if len(line.Tokens) > 0 && grub.IsTokenKeyword(line.Tokens[0], "menuentry") {
 			// Found a new 'menuentry', reset flags
 			inMenuEntry = true
 			isRecoveryMenu = false
 
-			// Check if this 'menuentry' contains the word 'recovery'
-			for _, token := range line.Tokens {
-				if strings.Contains(token.RawContent, "recovery") {
-					isRecoveryMenu = true
-					break
-				}
+			// Check if the title (second token) contains the word 'recovery'
+			if strings.Contains(line.Tokens[1].RawContent, "recovery") {
+				isRecoveryMenu = true
 			}
 
 			// If it's a recovery menuentry, ignore this block
@@ -161,7 +158,7 @@ func FindNonRecoveryLinuxLine(inputGrubCfgContent string) ([]grub.Line, error) {
 			}
 		} else if inMenuEntry {
 			// We are inside a non-recovery menuentry block
-			if len(line.Tokens) > 0 && strings.HasPrefix(line.Tokens[0].RawContent, "linux") {
+			if len(line.Tokens) > 0 && grub.IsTokenKeyword(line.Tokens[0], "linux") {
 				// Append only lines that contain the 'linux' command
 				linuxLines = append(linuxLines, line)
 			}

--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -71,6 +71,10 @@ func extractValuesFromGrubConfig(imageChroot safechroot.ChrootInterface) ([]stri
 
 	// TODO: Currently there is only one non-recovery menuentry in Trident test images, so lines[0]
 	// If there will be multiple non-recovery menuentries, update this code accordingly
+	if len(lines) != 1 {
+		return nil, fmt.Errorf("expected 1 non-recovery linux line, found %d", len(lines))
+	}
+
 	argTokens, err := imagecustomizerlib.ParseCommandLineArgs(lines[0].Tokens)
 	if err != nil {
 		return nil, err

--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -64,12 +64,14 @@ func extractValuesFromGrubConfig(imageChroot safechroot.ChrootInterface) ([]stri
 		return nil, err
 	}
 
-	line, err := imagecustomizerlib.FindLinuxLine(grubCfgContent, true)
+	lines, err := imagecustomizerlib.FindNonRecoveryLinuxLine(grubCfgContent)
 	if err != nil {
 		return nil, err
 	}
 
-	argTokens, err := imagecustomizerlib.ParseCommandLineArgs(line.Tokens)
+	// TODO: Currently there is only one non-recovery menuentry in Trident test images, so lines[0]
+	// If there will be multiple non-recovery menuentries, update this code accordingly
+	argTokens, err := imagecustomizerlib.ParseCommandLineArgs(lines[0].Tokens)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -64,7 +64,7 @@ func extractValuesFromGrubConfig(imageChroot safechroot.ChrootInterface) ([]stri
 		return nil, err
 	}
 
-	line, err := imagecustomizerlib.FindLinuxLine(grubCfgContent)
+	line, err := imagecustomizerlib.FindLinuxLine(grubCfgContent, true)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -69,8 +69,6 @@ func extractValuesFromGrubConfig(imageChroot safechroot.ChrootInterface) ([]stri
 		return nil, err
 	}
 
-	// TODO: Currently there is only one non-recovery menuentry in Trident test images, so lines[0]
-	// If there will be multiple non-recovery menuentries, update this code accordingly
 	if len(lines) != 1 {
 		return nil, fmt.Errorf("expected 1 non-recovery linux line, found %d", len(lines))
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
there is one linux cmdline in grub.cfg in trident verity test images, however, there are 2 linux in regular trident test images, one is recovery mode
![image](https://github.com/user-attachments/assets/54c39f26-8afe-4ba9-b9e5-c1fa27d5090c)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Allow 2 linux cmdline

###### Does this affect the toolchain?  <!-- REQUIRED -->
no


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
locally tested with sample grub.cfg, 
![image](https://github.com/user-attachments/assets/3346f179-d735-4fec-b6ef-3ae0f2aa38cc)
and with the new function, it only extract linux cmdline object in non recovery mode menuentry:
![image](https://github.com/user-attachments/assets/319114d9-0d29-42d6-9ea2-878261ecc348)


- Will publish new EMU and test in trident e2e pipeline
