### PR TITLE
Update openssl to 3.3.2 under cloud-hypervisor-cvm in order to address CVE-2024-6119

### DIFF
--- a/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.signatures.json
+++ b/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "cloud-hypervisor-cvm-38.0.72.2-cargo.tar.gz": "12190a4f2fbd29b2c6c197388a958eab5dff91e8d75927841669d81d794eadf4",
+  "cloud-hypervisor-cvm-38.0.72.2-2-cargo.tar.gz": "68d1dc8f2a70fddad934e9131ccad7ce2c96323869433419e2f488062396bcc8",
   "cloud-hypervisor-cvm-38.0.72.2.tar.gz": "1a357a0805f7b6d90993d5ae246c2dedff88cf98c9c0eab0903dc8071be0dae2",
   "config.toml": "74c28b7520c157109b8990b325fe8f13504e56561a9bac51499d4c6bf4a66e52"
  }

--- a/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.spec
+++ b/SPECS/cloud-hypervisor-cvm/cloud-hypervisor-cvm.spec
@@ -5,7 +5,7 @@
 Name:           cloud-hypervisor-cvm
 Summary:        Cloud Hypervisor CVM is an open source Virtual Machine Monitor (VMM) that enables running SEV SNP enabled VMs on top of MSHV using the IGVM file format as payload.
 Version:        38.0.72.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -15,14 +15,22 @@ Source0:        https://github.com/microsoft/cloud-hypervisor/archive/refs/tags/
 %if 0%{?using_vendored_crates}
 # Note: the %%{name}-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
 # To update the cache and config.toml run:
-#   tar -xf %{name}-%{version}.tar.gz
-#   cd %{name}-%{version}
+#   tar -xf %%{name}-%%{version}.tar.gz
+#   cd %%{name}-%%{version}
+#   patch -u -p0 < ../upgrade-openssl-to-3.3.2-to-address-CVE-2024-6119.patch
 #   cargo vendor > config.toml
-#   tar -czf %{name}-%{version}-cargo.tar.gz vendor/
-# rename the tarball to %{name}-%{version}-cargo.tar.gz when updating version
-Source1:        %{name}-%{version}-cargo.tar.gz
+#   tar -czf %%{name}-%%{version}-cargo.tar.gz vendor/
+# rename the tarball to %%{name}-%%{version}-2-cargo.tar.gz when updating version
+# (feel free to drop -2 and this comment on version change)
+Source1:        %{name}-%{version}-2-cargo.tar.gz
 Source2:        config.toml
 %endif
+# Generated using:
+#   tar -xf %%{name}-%%{version}.tar.gz
+#   cd %%{name}-%%{version}
+#   cargo update -p openssl-src --precise 300.3.2+3.3.2
+#   diff -u ../cloud-hypervisor-msft-v38.0.72.2.backup/Cargo.lock Cargo.lock > ../upgrade-openssl-to-3.3.2-to-address-CVE-2024-6119.patch
+Patch0:         upgrade-openssl-to-3.3.2-to-address-CVE-2024-6119.patch
 
 BuildRequires:  binutils
 BuildRequires:  gcc
@@ -75,6 +83,9 @@ tar xf %{SOURCE1}
 mkdir -p .cargo
 cp %{SOURCE2} .cargo/
 %endif
+# The vendored archive has been populated based on the patch, so we need to
+# repatch here as well in order to use the same versions
+%autopatch -p0
 
 %install
 install -d %{buildroot}%{_bindir}
@@ -136,6 +147,9 @@ cargo build --release --target=%{rust_musl_target} %{cargo_pkg_feature_opts} %{c
 %license LICENSE-BSD-3-Clause
 
 %changelog
+* Tue Sep 17 2024 Jiri Appl <jiria@microsoft.com> - 38.0.72.2-2
+- Patch openssl in the vendored archive to 3.3.2 to address CVE-2024-6119
+
 * Fri Jul 12 2024 Archana Choudhary <archana1@microsoft.com> - 38.0.72.2-1
 - Upgrade to v38.0.72.2
 - Fixes CVE-2023-45853, CVE-2018-25032, CVE-2023-5363, CVE-2023-5678, CVE-2023-6129, CVE-2023-6237, CVE-2024-0727, CVE-2024-4603

--- a/SPECS/cloud-hypervisor-cvm/upgrade-openssl-to-3.3.2-to-address-CVE-2024-6119.patch
+++ b/SPECS/cloud-hypervisor-cvm/upgrade-openssl-to-3.3.2-to-address-CVE-2024-6119.patch
@@ -1,0 +1,14 @@
+--- ../cloud-hypervisor-msft-v38.0.72.2.backup/Cargo.lock	2024-09-17 12:55:41.269905595 -0700
++++ Cargo.lock	2024-09-17 13:49:15.579003678 -0700
+@@ -1421,9 +1421,9 @@
+ 
+ [[package]]
+ name = "openssl-src"
+-version = "300.3.1+3.3.1"
++version = "300.3.2+3.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
++checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+ dependencies = [
+  "cc",
+ ]


### PR DESCRIPTION
Update openssl to 3.3.2 under cloud-hypervisor-cvm in order to address CVE-2024-6119

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR updates `openssl` dependency of `cloud-hypervisor-cvm` to version `3.3.2`, as that is the version that contains a patch for CVE-2024-6119. The patch has been included into the vendored archive and is also part of this change.

###### Change Log  <!-- REQUIRED -->
- Cargo.lock patch of the openssl version and updated vendored archive name

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-6119

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with RUN_CHECK=y
