### PR TITLE
ccache: remove dangling link to host-cc

### DIFF
--- a/SPECS/ccache/ccache.spec
+++ b/SPECS/ccache/ccache.spec
@@ -58,7 +58,7 @@ done
 
 %changelog
 * Tue Sep 17 2024 Andrew Phelps <anphel@microsoft.com> - 4.8.3-3
-- Remove dangling link to %{_host}-cc
+- Remove dangling link to %%{_host}-cc
 
 * Tue Sep 03 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.8.3-2
 - Fix the 'Distribution' tag.

--- a/SPECS/ccache/ccache.spec
+++ b/SPECS/ccache/ccache.spec
@@ -1,7 +1,7 @@
 Summary:        Compiler Cache
 Name:           ccache
 Version:        4.8.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BeOpen AND BSD AND GPLv3+ AND (Patrick Powell's AND Holger Weiss' license) AND Public Domain AND Python AND zlib
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -28,10 +28,11 @@ pushd build
 %make_install
 popd
 install -dm 755 %{buildroot}%{_libdir}/ccache
-for n in cc gcc g++ c++ ; do
+for n in gcc g++ c++ ; do
     ln -sf ../../bin/ccache %{buildroot}%{_libdir}/ccache/$n
     ln -sf ../../bin/ccache %{buildroot}%{_libdir}/ccache/%{_host}-$n
 done
+ln -sf ../../bin/ccache %{buildroot}%{_libdir}/ccache/cc
 ln -sf ../../bin/ccache %{buildroot}%{_libdir}/ccache/clang
 ln -sf ../../bin/ccache %{buildroot}%{_libdir}/ccache/clang++
 
@@ -56,6 +57,9 @@ done
 %{_libdir}/*
 
 %changelog
+* Tue Sep 17 2024 Andrew Phelps <anphel@microsoft.com> - 4.8.3-3
+- Remove dangling link to %{_host}-cc
+
 * Tue Sep 03 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.8.3-2
 - Fix the 'Distribution' tag.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -42,8 +42,8 @@ ca-certificates-base-3.0.0-7.azl3.noarch.rpm
 ca-certificates-legacy-3.0.0-7.azl3.noarch.rpm
 ca-certificates-shared-3.0.0-7.azl3.noarch.rpm
 ca-certificates-tools-3.0.0-7.azl3.noarch.rpm
-ccache-4.8.3-2.azl3.aarch64.rpm
-ccache-debuginfo-4.8.3-2.azl3.aarch64.rpm
+ccache-4.8.3-3.azl3.aarch64.rpm
+ccache-debuginfo-4.8.3-3.azl3.aarch64.rpm
 check-0.15.2-1.azl3.aarch64.rpm
 check-debuginfo-0.15.2-1.azl3.aarch64.rpm
 chkconfig-1.25-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -43,8 +43,8 @@ ca-certificates-base-3.0.0-7.azl3.noarch.rpm
 ca-certificates-legacy-3.0.0-7.azl3.noarch.rpm
 ca-certificates-shared-3.0.0-7.azl3.noarch.rpm
 ca-certificates-tools-3.0.0-7.azl3.noarch.rpm
-ccache-4.8.3-2.azl3.x86_64.rpm
-ccache-debuginfo-4.8.3-2.azl3.x86_64.rpm
+ccache-4.8.3-3.azl3.x86_64.rpm
+ccache-debuginfo-4.8.3-3.azl3.x86_64.rpm
 check-0.15.2-1.azl3.x86_64.rpm
 check-debuginfo-0.15.2-1.azl3.x86_64.rpm
 chkconfig-1.25-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Our ccache package creates a link to a binary not provided by gcc, which caused build breaks in some packages (including php-pecl-apcu). Remove the dangling link, ex: `/usr/lib/ccache/x86_64-pc-linux-gnu-cc -> /usr/bin/ccache`

From config.log generated by the configure script in php-pecl-apcu:
```
"configure:3112: checking for C compiler version"
"configure:3121: x86_64-pc-linux-gnu-cc --version >&5"
"ccache: error: Could not find compiler \"x86_64-pc-linux-gnu-cc\" in PATH"
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove bad link from ccache

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=642258&view=results
