### PR TITLE
patch wget to prevent debug output from printing binary request bodies

### DIFF
--- a/SPECS/wget/set-debug_skip_body-for-OCSP-requests-in-openssl-tls-provider.patch
+++ b/SPECS/wget/set-debug_skip_body-for-OCSP-requests-in-openssl-tls-provider.patch
@@ -1,0 +1,66 @@
+From 3359e3e182a24722d601dfa5e4652143817ef24f Mon Sep 17 00:00:00 2001
+From: "Tobias Brick (he/him)" <tobiasb@microsoft.com>
+Date: Mon, 16 Sep 2024 15:34:19 +0000
+Subject: [PATCH] set debug_skip_body for OCSP requests in openssl tls provider
+
+---
+ include/wget/wget.h      | 1 +
+ libwget/http_highlevel.c | 6 ++++++
+ libwget/ssl_openssl.c    | 1 +
+ 3 files changed, 8 insertions(+)
+
+diff --git a/include/wget/wget.h b/include/wget/wget.h
+index 62ec38364..2dfe56968 100644
+--- a/include/wget/wget.h
++++ b/include/wget/wget.h
+@@ -250,6 +250,7 @@ WGET_BEGIN_DECLS
+ #define WGET_HTTP_BODY_SAVEAS           2018
+ #define WGET_HTTP_USER_DATA             2019
+ #define WGET_HTTP_RESPONSE_IGNORELENGTH 2020
++#define WGET_HTTP_DEBUG_SKIP_BODY       2021
+ 
+ // definition of error conditions
+ typedef enum {
+diff --git a/libwget/http_highlevel.c b/libwget/http_highlevel.c
+index 14c5bea72..3971f8ed0 100644
+--- a/libwget/http_highlevel.c
++++ b/libwget/http_highlevel.c
+@@ -83,6 +83,7 @@ wget_http_response *wget_http_get(int first_key, ...)
+ 	size_t bodylen = 0;
+ 	const void *body = NULL;
+ 	void *header_user_data = NULL, *body_user_data = NULL;
++	bool debug_skip_body = 0;
+ 
+ 	struct {
+ 		bool
+@@ -157,6 +158,9 @@ wget_http_response *wget_http_get(int first_key, ...)
+ 			body = va_arg(args, const void *);
+ 			bodylen = va_arg(args, size_t);
+ 			break;
++		case WGET_HTTP_DEBUG_SKIP_BODY:
++			debug_skip_body = 1;
++			break;
+ 		default:
+ 			error_printf(_("Unknown option %d\n"), key);
+ 			va_end(args);
+@@ -239,6 +243,8 @@ wget_http_response *wget_http_get(int first_key, ...)
+ 			if (body && bodylen)
+ 				wget_http_request_set_body(req, NULL, wget_memdup(body, bodylen), bodylen);
+ 
++			req->debug_skip_body = debug_skip_body;
++
+ 			rc = wget_http_send_request(conn, req);
+ 
+ 			if (rc == 0) {
+diff --git a/libwget/ssl_openssl.c b/libwget/ssl_openssl.c
+index 6cac6ecb0..7a52792d8 100644
+--- a/libwget/ssl_openssl.c
++++ b/libwget/ssl_openssl.c
+@@ -762,6 +762,7 @@ static OCSP_REQUEST *send_ocsp_request(const char *uri,
+ 		WGET_HTTP_HEADER_ADD, "Content-Type", "application/ocsp-request",
+ 		WGET_HTTP_MAX_REDIRECTIONS, 5,
+ 		WGET_HTTP_BODY, ocspreq_bytes, ocspreq_bytes_len,
++		WGET_HTTP_DEBUG_SKIP_BODY,
+ 		0);
+ 
+ 	OPENSSL_free(ocspreq_bytes);

--- a/SPECS/wget/wget.spec
+++ b/SPECS/wget/wget.spec
@@ -3,7 +3,7 @@
 Summary:        An advanced file and recursive website downloader
 Name:           wget
 Version:        2.1.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND GFDL-1.3-or-later
 URL:            https://gitlab.com/gnuwget/wget2
 Group:          System Environment/NetworkingPrograms
@@ -29,6 +29,8 @@ Patch0005:      0005-Accept-progress-dot-.-for-backwards-compatibility.patch
 Patch0006:      0006-Disable-TCP-Fast-Open-by-default.patch
 # https://github.com/rockdaboot/wget2/issues/342
 Patch0007:      fix-ssl-read-and-write-error-check.patch
+# https://github.com/rockdaboot/wget2/issues/344
+Patch0008:      set-debug_skip_body-for-OCSP-requests-in-openssl-tls-provider.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -155,6 +157,9 @@ echo ".so man1/%{name}.1" > %{buildroot}%{_mandir}/man1/wget.1
 %{_mandir}/man3/libwget*.3*
 
 %changelog
+* Tue Sep 17 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-4
+- Add patch to prevent debug output from printing binary request bodies.
+
 * Fri Sep 13 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-3
 - Add patch to fix SSL read and write error check.
 

--- a/SPECS/wget/wget.spec
+++ b/SPECS/wget/wget.spec
@@ -157,7 +157,7 @@ echo ".so man1/%{name}.1" > %{buildroot}%{_mandir}/man1/wget.1
 %{_mandir}/man3/libwget*.3*
 
 %changelog
-* Tue Sep 17 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-4
+* Wed Sep 18 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-4
 - Add patch to prevent debug output from printing binary request bodies.
 
 * Fri Sep 13 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-3


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
`wget` using `openssl` for `tls` (which we compile with), with `--debug` turned on prints the body of `ocsp` requests (if `--ocsp` is specified; it's off by default) to `stderr` even though it's the body is binary.

This change patches `wget` with the [proposed fix](https://github.com/rockdaboot/wget2/pull/345) for [upstream issue](https://github.com/rockdaboot/wget2/issues/344).

###### Change Log  <!-- REQUIRED -->
- Patch `wget` to fix binary debug spew issue.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
- Tested locally
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=642524&view=results
