### PR TITLE
Fixes CVE-2022-32149 by backporting the fix as a patch file

### DIFF
--- a/SPECS/cf-cli/CVE-2022-32149.patch
+++ b/SPECS/cf-cli/CVE-2022-32149.patch
@@ -1,0 +1,66 @@
+From 434eadcdbc3b0256971992e8c70027278364c72c Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <bracewell@google.com>
+Date: Fri, 2 Sep 2022 09:35:37 -0700
+Subject: [PATCH] language: reject excessively large Accept-Language strings
+
+The BCP 47 tag parser has quadratic time complexity due to inherent
+aspects of its design. Since the parser is, by design, exposed to
+untrusted user input, this can be leveraged to force a program to
+consume significant time parsing Accept-Language headers.
+
+The parser cannot be easily rewritten to fix this behavior for
+various reasons. Instead the solution implemented in this CL is to
+limit the total complexity of tags passed into ParseAcceptLanguage
+by limiting the number of dashes in the string to 1000. This should
+be more than enough for the majority of real world use cases, where
+the number of tags being sent is likely to be in the single digits.
+
+Thanks to the OSS-Fuzz project for discovering this issue and to Adam
+Korczynski (ADA Logics) for writing the fuzz case and for reporting the
+issue.
+
+Fixes CVE-2022-32149
+Fixes golang/go#56152
+
+Change-Id: I7bda1d84cee2b945039c203f26869d58ee9374ae
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1565112
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/text/+/442235
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Auto-Submit: Roland Shoemaker <roland@golang.org>
+Run-TryBot: Roland Shoemaker <roland@golang.org>
+
+Modified to apply to vendored code by: Jiri Appl <jiria@microsoft.com>
+ - Adjusted paths
+ - Removed reference to parse_test.go
+---
+ vendor/golang.org/x/text/language/parse.go      |  5 +++++
+ 1 files changed, 18 insertions(+)
+
+diff --git a/vendor/golang.org/x/text/language/parse.go b/vendor/golang.org/x/text/language/parse.go
+index 59b0410..b982d9e 100644
+--- a/vendor/golang.org/x/text/language/parse.go
++++ b/vendor/golang.org/x/text/language/parse.go
+@@ -147,6 +147,7 @@ func update(b *language.Builder, part ...interface{}) (err error) {
+ }
+ 
+ var errInvalidWeight = errors.New("ParseAcceptLanguage: invalid weight")
++var errTagListTooLarge = errors.New("tag list exceeds max length")
+ 
+ // ParseAcceptLanguage parses the contents of an Accept-Language header as
+ // defined in http://www.ietf.org/rfc/rfc2616.txt and returns a list of Tags and
+@@ -164,6 +165,10 @@ func ParseAcceptLanguage(s string) (tag []Tag, q []float32, err error) {
+ 		}
+ 	}()
+ 
++	if strings.Count(s, "-") > 1000 {
++		return nil, nil, errTagListTooLarge
++	}
++
+ 	var entry string
+ 	for s != "" {
+ 		if entry, s = split(s, ','); entry == "" {
+-- 
+2.34.1
+

--- a/SPECS/cf-cli/cf-cli.spec
+++ b/SPECS/cf-cli/cf-cli.spec
@@ -1,7 +1,7 @@
 Summary:        The official command line client for Cloud Foundry.
 Name:           cf-cli
 Version:        8.4.0
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -30,6 +30,9 @@ Source1:        cli-%{version}-vendor.tar.gz
 Patch0:         CVE-2023-44487.patch
 Patch1:         CVE-2021-44716.patch
 Patch2:         CVE-2021-43565.patch
+# Produced by git clone https://github.com/golang/text && cd text && 
+# git checkout 434eadcdbc3b0256971992e8c70027278364c72c && git format-patch -1 HEAD
+Patch3:         CVE-2022-32149.patch
 
 BuildRequires:  golang
 %global debug_package %{nil}
@@ -64,6 +67,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./out/cf
 %{_bindir}/cf
 
 %changelog
+* Tue Sep 17 2024 Jiri Appl <jiria@microsoft.com> - 8.4.0-21
+- Patch CVE-2022-32149 bringing upstream patch over the vendored golang.org/x/text module
+
 * Mon Sep 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.4.0-20
 - Bump release to rebuild with go 1.22.7
 


### PR DESCRIPTION
Fixes CVE-2022-32149 by backporting the fix as a patch file

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR fixes CVE-2022-32149, which is present in one of the vendored dependencies. The issue was fixed in a single commit, and this PR brings that commit as a patch file. The patch has been modified to accurately reflect the vendored paths and the test file was removed, as it is not part of the vendored files.

###### Change Log  <!-- REQUIRED -->
- Adds a patch file with a fix for CVE-2022-32149

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-32149

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with RUN_CHECK=y
