### PR TITLE
Patch gdk-pixbuf2 for CVE-2022-48622.

### DIFF
--- a/SPECS/gdk-pixbuf2/CVE-2022-48622.patch
+++ b/SPECS/gdk-pixbuf2/CVE-2022-48622.patch
@@ -1,0 +1,112 @@
+From 00c071dd11f723ca608608eef45cb1aa98da89cc Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <bgilbert@backtick.net>
+Date: Tue, 30 Apr 2024 07:26:54 -0500
+Subject: [PATCH 1/3] ANI: Reject files with multiple anih chunks
+
+An anih chunk causes us to initialize a bunch of state, which we only
+expect to do once per file.
+
+Fixes: #202
+Fixes: CVE-2022-48622
+---
+ gdk-pixbuf/io-ani.c                       |   9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/gdk-pixbuf/io-ani.c b/gdk-pixbuf/io-ani.c
+index c6c4642cf4..a78ea7ace4 100644
+--- a/gdk-pixbuf/io-ani.c
++++ b/gdk-pixbuf/io-ani.c
+@@ -295,6 +295,15 @@ ani_load_chunk (AniLoaderContext *context, GError **error)
+         
+         if (context->chunk_id == TAG_anih) 
+ 	{
++		if (context->animation)
++		{
++			g_set_error_literal (error,
++                                             GDK_PIXBUF_ERROR,
++                                             GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
++                                             _("Invalid header in animation"));
++			return FALSE;
++		}
++
+ 		context->HeaderSize = read_int32 (context);
+ 		context->NumFrames = read_int32 (context);
+ 		context->NumSteps = read_int32 (context);
+-- 
+GitLab
+
+
+From d52134373594ff76614fb415125b0d1c723ddd56 Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <bgilbert@backtick.net>
+Date: Tue, 30 Apr 2024 07:13:37 -0500
+Subject: [PATCH 2/3] ANI: Reject files with multiple INAM or IART chunks
+
+There should be at most one chunk each.  These would cause memory leaks
+otherwise.
+---
+ gdk-pixbuf/io-ani.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gdk-pixbuf/io-ani.c b/gdk-pixbuf/io-ani.c
+index a78ea7ace4..8e8414117c 100644
+--- a/gdk-pixbuf/io-ani.c
++++ b/gdk-pixbuf/io-ani.c
+@@ -445,7 +445,7 @@ ani_load_chunk (AniLoaderContext *context, GError **error)
+ 	}
+         else if (context->chunk_id == TAG_INAM) 
+ 	{
+-		if (!context->animation) 
++		if (!context->animation || context->title)
+ 		{
+ 			g_set_error_literal (error,
+                                              GDK_PIXBUF_ERROR,
+@@ -472,7 +472,7 @@ ani_load_chunk (AniLoaderContext *context, GError **error)
+ 	}
+         else if (context->chunk_id == TAG_IART) 
+ 	{
+-		if (!context->animation) 
++		if (!context->animation || context->author)
+ 		{
+ 			g_set_error_literal (error,
+                                              GDK_PIXBUF_ERROR,
+-- 
+GitLab
+
+
+From 91b8aa5cd8a0eea28acb51f0e121827ca2e7eb78 Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <bgilbert@backtick.net>
+Date: Tue, 30 Apr 2024 08:17:25 -0500
+Subject: [PATCH 3/3] ANI: Validate anih chunk size
+
+Before reading a chunk, we verify that enough bytes are available to match
+the chunk size declared by the file.  However, uniquely, the anih chunk
+loader doesn't verify that this size matches the number of bytes it
+actually intends to read.  Thus, if the chunk size is too small and the
+file ends in the middle of the chunk, we populate some context fields with
+stack garbage.  (But we'd still fail later on because the file doesn't
+contain any images.)  Fix this.
+---
+ gdk-pixbuf/io-ani.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/gdk-pixbuf/io-ani.c b/gdk-pixbuf/io-ani.c
+index 8e8414117c..cfafd7b196 100644
+--- a/gdk-pixbuf/io-ani.c
++++ b/gdk-pixbuf/io-ani.c
+@@ -295,6 +295,14 @@ ani_load_chunk (AniLoaderContext *context, GError **error)
+         
+         if (context->chunk_id == TAG_anih) 
+ 	{
++		if (context->chunk_size < 36)
++		{
++			g_set_error_literal (error,
++                                             GDK_PIXBUF_ERROR,
++                                             GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
++                                             _("Malformed chunk in animation"));
++			return FALSE;
++		}
+ 		if (context->animation)
+ 		{
+ 			g_set_error_literal (error,
+-- 
+GitLab

--- a/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
+++ b/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
@@ -2,12 +2,13 @@
 Summary:        An image loading library
 Name:           gdk-pixbuf2
 Version:        2.40.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://gitlab.gnome.org/GNOME/gdk-pixbuf
 Source0:        https://download.gnome.org/sources/gdk-pixbuf/2.40/gdk-pixbuf-%{version}.tar.xz
+Patch0:         CVE-2022-48622.patch
 BuildRequires:  gettext
 BuildRequires:  gtk-doc
 BuildRequires:  jasper-devel
@@ -116,6 +117,9 @@ gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
 %{_datadir}/installed-tests
 
 %changelog
+* Thu Sep 19 2024 Sumedh Sharma <sumsharma@microsoft.com> - 2.40.0-6
+- Add patch for CVE-2022-48622
+
 * Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.40.0-5
 - Bumping release to re-build with newer 'libtiff' libraries.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch for CVE-2022-48622
Even though the build is configured with -Dbuiltin_loaders=png, the `ani` loader is built by default in `gdk-pixbuf/meson.build`

###### Change Log  <!-- REQUIRED -->
- Add patch file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-48622

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Local Build
