### PR TITLE
OSModifier: Read root device from grub.cfg

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -212,10 +212,13 @@ func (b *BootCustomizer) WriteToFile(imageChroot safechroot.ChrootInterface) err
 	return nil
 }
 
-func (b *BootCustomizer) GetDefaultGrubFileContent() string {
-	return b.defaultGrubFileContent
-}
+func (b *BootCustomizer) SetRootDevice(rootDevice string) error {
+	updatedGrubFileContent, err := UpdateDefaultGrubFileVariable(b.defaultGrubFileContent, "GRUB_DEVICE", rootDevice)
+	if err != nil {
+		return err
+	}
 
-func (b *BootCustomizer) SetDefaultGrubFileContent(content string) {
-	b.defaultGrubFileContent = content
+	b.defaultGrubFileContent = updatedGrubFileContent
+
+	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -211,3 +211,11 @@ func (b *BootCustomizer) WriteToFile(imageChroot safechroot.ChrootInterface) err
 
 	return nil
 }
+
+func (b *BootCustomizer) GetDefaultGrubFileContent() string {
+	return b.defaultGrubFileContent
+}
+
+func (b *BootCustomizer) SetDefaultGrubFileContent(content string) {
+	b.defaultGrubFileContent = content
+}

--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -44,12 +44,10 @@ func modifyDefaultGrub() error {
 	}
 
 	// Stamp root device to /etc/default/grub
-	defaultGrubFileContent, err := imagecustomizerlib.UpdateDefaultGrubFileVariable(bootCustomizer.GetDefaultGrubFileContent(), "GRUB_DEVICE", rootDevice)
+	err = bootCustomizer.SetRootDevice(rootDevice)
 	if err != nil {
 		return err
 	}
-
-	bootCustomizer.SetDefaultGrubFileContent(defaultGrubFileContent)
 
 	err = bootCustomizer.WriteToFile(dummyChroot)
 	if err != nil {

--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -15,6 +15,7 @@ import (
 var grubArgs = []string{
 	"rd.overlayfs",
 	"roothash",
+	"root",
 	"rd.systemd.verity",
 	"systemd.verity_root_data",
 	"systemd.verity_root_hash",
@@ -26,7 +27,7 @@ var grubArgs = []string{
 func modifyDefaultGrub() error {
 	var dummyChroot safechroot.ChrootInterface = &safechroot.DummyChroot{}
 	// Get verity, selinux, overlayfs, and root device values from /boot/grub2/grub.cfg
-	values, err := extractValuesFromGrubConfig(dummyChroot)
+	values, rootDevice, err := extractValuesFromGrubConfig(dummyChroot)
 	if err != nil {
 		return fmt.Errorf("error getting verity, selinux and overlayfs values from grub.cfg:\n%w", err)
 	}
@@ -36,17 +37,19 @@ func modifyDefaultGrub() error {
 		return err
 	}
 
-	// Stamp root device value to /etc/default/grub
-	err = bootCustomizer.PrepareForVerity()
-	if err != nil {
-		return fmt.Errorf("failed to prepare grub config files for verity:\n%w", err)
-	}
-
 	// Stamp verity, selinux and overlayfs values to /etc/default/grub
 	err = bootCustomizer.UpdateKernelCommandLineArgs("GRUB_CMDLINE_LINUX", grubArgs, values)
 	if err != nil {
 		return err
 	}
+
+	// Stamp root device to /etc/default/grub
+	defaultGrubFileContent, err := imagecustomizerlib.UpdateDefaultGrubFileVariable(bootCustomizer.GetDefaultGrubFileContent(), "GRUB_DEVICE", rootDevice)
+	if err != nil {
+		return err
+	}
+
+	bootCustomizer.SetDefaultGrubFileContent(defaultGrubFileContent)
 
 	err = bootCustomizer.WriteToFile(dummyChroot)
 	if err != nil {
@@ -58,34 +61,39 @@ func modifyDefaultGrub() error {
 	return nil
 }
 
-func extractValuesFromGrubConfig(imageChroot safechroot.ChrootInterface) ([]string, error) {
+func extractValuesFromGrubConfig(imageChroot safechroot.ChrootInterface) ([]string, string, error) {
 	grubCfgContent, err := imagecustomizerlib.ReadGrub2ConfigFile(imageChroot)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	lines, err := imagecustomizerlib.FindNonRecoveryLinuxLine(grubCfgContent)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if len(lines) != 1 {
-		return nil, fmt.Errorf("expected 1 non-recovery linux line, found %d", len(lines))
+		return nil, "", fmt.Errorf("expected 1 non-recovery linux line, found %d", len(lines))
 	}
 
 	argTokens, err := imagecustomizerlib.ParseCommandLineArgs(lines[0].Tokens)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	var values []string
+	var rootDevice string
 	for _, arg := range argTokens {
 		if sliceutils.ContainsValue(grubArgs, arg.Name) {
 			if arg.Value != "" {
-				values = append(values, arg.Name+"="+arg.Value)
+				if arg.Name == "root" {
+					rootDevice = arg.Value
+				} else {
+					values = append(values, arg.Name+"="+arg.Value)
+				}
 			}
 		}
 	}
 
-	return values, nil
+	return values, rootDevice, nil
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

In trident e2e pipeline there are deployments not using verity test images, and in those images, root device path is not /dev/mapper/root, thus it cause the failure: `/dev/mapper/root does not exist`. It is incorrect for EMU to always set root device to /dev/mapper/root, and it should read it from grub.cfg,  for example, root=UUID=2303cd9a-ab00-4e39-9b5a-8bf8da5a6118, we need to pass the real root device either via UUID= or PARTUUID=. With this change, EMU should be able to handle all test images in that pipeline. 


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- tested locally and will publish new EMU and rerun trident pipeline