### PR TITLE
swap fix-ssl-read-and-write-error-check.patch for a slightly different version from upstream

### DIFF
--- a/SPECS/wget/fix-ssl-read-and-write-error-check.patch
+++ b/SPECS/wget/fix-ssl-read-and-write-error-check.patch
@@ -1,32 +1,80 @@
-From 3d4e70f8591d84c48d449d0b8d600d6e138ca6c2 Mon Sep 17 00:00:00 2001
-From: "Tobias Brick (he/him)" <tobiasb@microsoft.com>
-Date: Wed, 11 Sep 2024 22:46:37 +0000
-Subject: [PATCH] count 0 as an error for SSL_read and SS_write, per
+From 8877050c3f00a19d43e539029d2346d1040d8c02 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Sun, 22 Sep 2024 12:12:42 +0200
+Subject: [PATCH] Count 0 as an error for SSL_read and SSL_write, per
  documentation
 
+* libwget/ssl_openssl.c (ssl_transfer): Take 0 as error,
+  slightly refactor code.
+
+Fixes https://github.com/rockdaboot/wget2/issues/342
+
+Reported-by: Tobias Brick (he/him) <tobiasb@microsoft.com>
+Co-authored-by: Tobias Brick (he/him) <tobiasb@microsoft.com>
 ---
- libwget/ssl_openssl.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ libwget/ssl_openssl.c | 34 +++++++++++++++++++---------------
+ 1 file changed, 19 insertions(+), 15 deletions(-)
 
 diff --git a/libwget/ssl_openssl.c b/libwget/ssl_openssl.c
-index 6cac6ecb..2a892ff5 100644
+index 7a52792d..885b0c2c 100644
 --- a/libwget/ssl_openssl.c
 +++ b/libwget/ssl_openssl.c
-@@ -1816,7 +1816,7 @@ static int ssl_transfer(int want,
+@@ -1789,7 +1789,7 @@ static int ssl_transfer(int want,
+ 		void *buf, int count)
+ {
+ 	SSL *ssl;
+-	int fd, retval, error, ops = want;
++	int fd;
+ 
+ 	if (count == 0)
+ 		return 0;
+@@ -1801,7 +1801,9 @@ static int ssl_transfer(int want,
+ 	if (timeout < -1)
+ 		timeout = -1;
+ 
+-	do {
++	for (int ops = want;;) {
++		int retval;
++
+ 		if (timeout) {
+ 			/* Wait until file descriptor becomes ready */
+ 			retval = wget_ready_2_transfer(fd, timeout, ops);
+@@ -1817,23 +1819,25 @@ static int ssl_transfer(int want,
  		else
  			retval = SSL_write(ssl, buf, count);
  
 -		if (retval < 0) {
-+		if (retval <= 0) {
- 			error = SSL_get_error(ssl, retval);
+-			error = SSL_get_error(ssl, retval);
++		if (retval > 0)
++			return retval;
  
- 			if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
-@@ -1830,7 +1830,7 @@ static int ssl_transfer(int want,
- 				return WGET_E_HANDSHAKE;
- 			}
+-			if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
+-				/* Socket not ready - let's try again (unless timeout was zero) */
+-				ops = WGET_IO_WRITABLE | WGET_IO_READABLE;
++		// The OpenSSL docs consider <= 0 an error.
++		int error = SSL_get_error(ssl, retval);
++		if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
++			/* Socket not ready - let's try again (unless timeout was zero) */
++			ops = WGET_IO_WRITABLE | WGET_IO_READABLE;
+ 
+-				if (timeout == 0)
+-					return 0;
+-			} else {
+-				/* Not exactly a handshake error, but this is the closest one to signal TLS layer errors */
+-				return WGET_E_HANDSHAKE;
+-			}
++			if (timeout == 0)
++				return 0;
++		} else {
++			/* Not exactly a handshake error, but this is the closest one to signal TLS layer errors */
++			return WGET_E_HANDSHAKE;
  		}
 -	} while (retval < 0);
-+	} while (retval <= 0);
++	}
  
- 	return retval;
+-	return retval;
++	// The execution can never get here.
++	return WGET_E_UNKNOWN;
  }
+ 
+ /**

--- a/SPECS/wget/wget.spec
+++ b/SPECS/wget/wget.spec
@@ -3,7 +3,7 @@
 Summary:        An advanced file and recursive website downloader
 Name:           wget
 Version:        2.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND GFDL-1.3-or-later
 URL:            https://gitlab.com/gnuwget/wget2
 Group:          System Environment/NetworkingPrograms
@@ -157,6 +157,9 @@ echo ".so man1/%{name}.1" > %{buildroot}%{_mandir}/man1/wget.1
 %{_mandir}/man3/libwget*.3*
 
 %changelog
+* Mon Sep 23 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-5
+- Align fix for SSL read and write error check with upstream.
+
 * Wed Sep 18 2024 Tobias Brick <tobiasb@microsoft.com> - 2.1.0-4
 - Add patch to prevent debug output from printing binary request bodies.
 


### PR DESCRIPTION
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Change #10461  fixed `wget2` an [upstream issue with openssl error handling](https://github.com/rockdaboot/wget2/issues/342) using the [proposed fix](https://github.com/rockdaboot/wget2/pull/343). However, in the end the upstream owner went with a [different fix](https://github.com/rockdaboot/wget2/commit/8877050c3f00a19d43e539029d2346d1040d8c02) that included a minor refactor.

This change swaps out the original fix for the upstream, to keep us closer to the upstream for future patching.

###### Change Log  <!-- REQUIRED -->
- Swapped `fix-ssl-read-and-write-error-check.patch` for the upstream version of the fix.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
- Built locally and tested resulting rpms in an environment that reproed the bug infinite loop bug.
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=645530&view=results
