### PR TITLE
Image Customizer: Support filesystem-less partitions.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -66,7 +66,6 @@ func TestConfigIsValidLegacy(t *testing.T) {
 			FileSystems: []FileSystem{
 				{
 					DeviceId: "boot",
-					Type:     "fat32",
 				},
 			},
 		},

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -76,7 +76,7 @@ func (d *Disk) IsValid() error {
 			}
 		}
 
-		if partition.IsBiosBoot() {
+		if partition.Type == PartitionTypeBiosGrub {
 			if *partition.Start != diskutils.MiB {
 				return fmt.Errorf("BIOS boot partition must start at 1 MiB")
 			}

--- a/toolkit/tools/imagecustomizerapi/filesystemtype.go
+++ b/toolkit/tools/imagecustomizerapi/filesystemtype.go
@@ -11,6 +11,7 @@ import (
 type FileSystemType string
 
 const (
+	FileSystemTypeNone  FileSystemType = ""
 	FileSystemTypeExt4  FileSystemType = "ext4"
 	FileSystemTypeXfs   FileSystemType = "xfs"
 	FileSystemTypeFat32 FileSystemType = "fat32"
@@ -19,7 +20,7 @@ const (
 
 func (t FileSystemType) IsValid() error {
 	switch t {
-	case FileSystemTypeExt4, FileSystemTypeXfs, FileSystemTypeFat32, FileSystemTypeVfat:
+	case FileSystemTypeNone, FileSystemTypeExt4, FileSystemTypeXfs, FileSystemTypeFat32, FileSystemTypeVfat:
 		// All good.
 		return nil
 

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -58,14 +58,6 @@ func (p *Partition) GetEnd() (DiskSize, bool) {
 	return 0, false
 }
 
-func (p *Partition) IsESP() bool {
-	return p.Type == PartitionTypeESP
-}
-
-func (p *Partition) IsBiosBoot() bool {
-	return p.Type == PartitionTypeBiosGrub
-}
-
 // isGPTNameValid checks if a GPT partition name is valid.
 func isGPTNameValid(name string) error {
 	// The max partition name length is 36 UTF-16 code units, including a null terminator.

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -586,7 +586,11 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		fsType = "fat32"
 	}
 
-	mkpartArgs = append(mkpartArgs, fsType, fmt.Sprintf(sFmt, start))
+	if fsType != "" {
+		mkpartArgs = append(mkpartArgs, fsType)
+	}
+
+	mkpartArgs = append(mkpartArgs, fmt.Sprintf(sFmt, start))
 
 	if end == 0 {
 		mkpartArgs = append(mkpartArgs, fillToEndOption)

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config.yaml
@@ -15,9 +15,6 @@ storage:
   bootType: legacy
 
   filesystems:
-  - deviceId: boot
-    type: fat32
-
   - deviceId: rootfs
     type: ext4
     mountPoint:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -42,9 +42,6 @@ storage:
     type: ext4
     mountPoint:
       path: /
-      
-  - deviceId: verityhash
-    type: fat32
 
   - deviceId: var
     type: ext4

--- a/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
@@ -78,14 +78,11 @@ func partitionsToImager(partitions []imagecustomizerapi.Partition, fileSystems [
 
 func partitionToImager(partition imagecustomizerapi.Partition, fileSystems []imagecustomizerapi.FileSystem,
 ) (configuration.Partition, error) {
-	fileSystem, foundMountPoint := sliceutils.FindValueFunc(fileSystems,
+	fileSystem, _ := sliceutils.FindValueFunc(fileSystems,
 		func(fileSystem imagecustomizerapi.FileSystem) bool {
 			return fileSystem.DeviceId == partition.Id
 		},
 	)
-	if !foundMountPoint {
-		return configuration.Partition{}, fmt.Errorf("failed to find filesystem entry with ID (%s)", partition.Id)
-	}
 
 	imagerStart := *partition.Start / diskutils.MiB
 	if *partition.Start%diskutils.MiB != 0 {


### PR DESCRIPTION
Allow partitions to be specified without specifying a filesystem type. This is particularly useful for the BIOS boot partition and the verity hash partition.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added/updated UTs.

