### PR TITLE
python-argcomplete: drop check dep BR fish to enable build

### DIFF
--- a/SPECS-EXTENDED/python-argcomplete/python-argcomplete.spec
+++ b/SPECS-EXTENDED/python-argcomplete/python-argcomplete.spec
@@ -7,14 +7,14 @@ Distribution:   Azure Linux
 Name:          python-%{modname}
 Summary:       Bash tab completion for argparse
 Version:       1.10.0
-Release:       6%{?dist}
+Release:       7%{?dist}
 License:       ASL 2.0
 URL:           https://github.com/kislyuk/argcomplete
 Source0:       %pypi_source argcomplete
 
 %if %{with check}
 BuildRequires: tcsh
-BuildRequires: fish
+#BuildRequires: fish
 %endif
 
 BuildArch:     noarch
@@ -84,6 +84,9 @@ install -p -m0644 %{buildroot}%{python3_sitelib}/%{modname}/bash_completion.d/py
 %{_sysconfdir}/bash_completion.d/python-argcomplete.sh
 
 %changelog
+* Wed Sep 25 2024 Muhammad Falak <mwani@microsoft.com> - 1.10.0-7
+- Drop BR on fish to enable build
+
 * Mon Jul 05 2022 Daniel McIlvaney <damcilva@microsoft.com> - 1.10.0-6
 - Bump release due to bump in fish to 3.5.0.
 - License verified.


### PR DESCRIPTION
NOTE: The target of the PR is to enable the build of python-argcomplete instead of break the build. As a result we have commented a `BuildRequire: fish`, which will result in failing ptest.
The ptest fixing is not in the scope of this PR as it is for unblocking a new added package.
The fixing of ptest will be taken up in a new PR.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Drop BR on `fish` (check) to enable build
For WorkItem: [389-ds-base](https://microsoft.visualstudio.com/OS/_workitems/edit/51717004)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Drop BR on `fish` (check) to enable build

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #10545

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y

 Pipeline build id: 
- [PR-10546](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=646919&view=results)
- [PR-10546](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=646928&view=results)
