### PR TITLE
Image Customizer: Rename additionDirs fields.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -170,8 +170,8 @@ os:
         - [permissions](#permissions-string)
     - [additionalDirs](#additionaldirs-dirconfig)
       - [dirConfig](#dirconfig-type)
-        - [sourcePath](#dirconfig-sourcePath)
-        - [destinationPath](#dirconfig-destinationPath)
+        - [source](#dirconfig-source)
+        - [destination](#dirconfig-destination)
         - [newDirPermissions](#newdirpermissions-string)
         - [mergedDirPermissions](#mergeddirpermissions-string)
         - [childFilePermissions](#childfilepermissions-string)
@@ -620,15 +620,15 @@ Specifies options for placing a directory in the OS.
 
 Type is used by: [additionalDirs](#additionaldirs-dirconfig)
 
-<div id="dirconfig-sourcePath"></div>
+<div id="dirconfig-source"></div>
 
-### sourcePath [string]
+### source [string]
 
 The absolute path to the source directory that will be copied.
 
-<div id="dirconfig-destinationPath"></div>
+<div id="dirconfig-destination"></div>
 
-### destinationPath [string]
+### destination [string]
 
 The absolute path in the target OS that the source directory will be copied to.
 
@@ -637,8 +637,8 @@ Example:
 ```yaml
 os:
   additionalDirs:
-    - sourcePath: "home/files/targetDir"
-      destinationPath: "usr/project/targetDir"
+    - source: "home/files/targetDir"
+      destination: "usr/project/targetDir"
 ```
 
 ### newDirPermissions [string]
@@ -666,8 +666,8 @@ Example:
 ```yaml
 os:
   additionalDirs:
-    - sourcePath: "home/files/targetDir"
-      destinationPath: "usr/project/targetDir"
+    - source: "home/files/targetDir"
+      destination: "usr/project/targetDir"
       newDirPermissions: "644"
       mergedDirPermissions: "777"
       childFilePermissions: "644"
@@ -1324,11 +1324,11 @@ Example:
 os:
   additionalDirs:
     # Copying directory with default permission options.
-    - sourcePath: "path/to/local/directory/"
-      destinationPath: "/path/to/destination/directory/"
+    - source: "path/to/local/directory/"
+      destination: "/path/to/destination/directory/"
     # Copying directory with specific permission options.
-    - sourcePath: "path/to/local/directory/"
-      destinationPath: "/path/to/destination/directory/"
+    - source: "path/to/local/directory/"
+      destination: "/path/to/destination/directory/"
       newDirPermissions: 0644
       mergedDirPermissions: 0777
       childFilePermissions: 0644

--- a/toolkit/tools/imagecustomizerapi/dirconfig.go
+++ b/toolkit/tools/imagecustomizerapi/dirconfig.go
@@ -13,10 +13,10 @@ type DirConfigList []DirConfig
 
 type DirConfig struct {
 	// The path to the source directory that will be copied (can be relative or absolute path).
-	SourcePath string `yaml:"sourcePath"`
+	Source string `yaml:"source"`
 
 	// The absolute path in the target OS that the directory will be copied to.
-	DestinationPath string `yaml:"destinationPath"`
+	Destination string `yaml:"destination"`
 
 	// The permissions to set on all of the new directories being created on the target OS (including the top-level directory).
 	// Note: If this value is not specified in the config, the permissions for these directories will be set to 0755.
@@ -44,11 +44,11 @@ func (l *DirConfigList) IsValid() (err error) {
 
 func (d *DirConfig) IsValid() (err error) {
 	// Paths
-	if d.SourcePath == "" {
-		return fmt.Errorf("invalid sourcePath value: empty string")
+	if d.Source == "" {
+		return fmt.Errorf("invalid 'source' value: empty string")
 	}
-	if d.DestinationPath == "" {
-		return fmt.Errorf("invalid destinationPath value: empty string")
+	if d.Destination == "" {
+		return fmt.Errorf("invalid 'destination' value: empty string")
 	}
 
 	// Permissions

--- a/toolkit/tools/imagecustomizerapi/dirconfig_test.go
+++ b/toolkit/tools/imagecustomizerapi/dirconfig_test.go
@@ -19,8 +19,8 @@ func TestDirConfigListIsValidEmpty(t *testing.T) {
 func TestDirConfigListIsValidValidItem(t *testing.T) {
 	list := DirConfigList{
 		DirConfig{
-			SourcePath:      "a.txt",
-			DestinationPath: "/a.txt",
+			Source:      "a.txt",
+			Destination: "/a.txt",
 		},
 	}
 	err := list.IsValid()
@@ -30,8 +30,8 @@ func TestDirConfigListIsValidValidItem(t *testing.T) {
 func TestDirConfigListIsValidValidItemWithPermissions(t *testing.T) {
 	list := DirConfigList{
 		DirConfig{
-			SourcePath:           "a.txt",
-			DestinationPath:      "/a.txt",
+			Source:               "a.txt",
+			Destination:          "/a.txt",
 			NewDirPermissions:    ptrutils.PtrTo(FilePermissions(0o777)),
 			MergedDirPermissions: ptrutils.PtrTo(FilePermissions(0o777)),
 			ChildFilePermissions: ptrutils.PtrTo(FilePermissions(0o777)),
@@ -44,32 +44,32 @@ func TestDirConfigListIsValidValidItemWithPermissions(t *testing.T) {
 func TestDirConfigListIsValidEmptySource(t *testing.T) {
 	list := DirConfigList{
 		DirConfig{
-			SourcePath:      "",
-			DestinationPath: "/a.txt",
+			Source:      "",
+			Destination: "/a.txt",
 		},
 	}
 	err := list.IsValid()
 	assert.ErrorContains(t, err, "invalid value at index 0")
-	assert.ErrorContains(t, err, "invalid sourcePath value: empty string")
+	assert.ErrorContains(t, err, "invalid 'source' value: empty string")
 }
 
 func TestDirConfigListIsValidEmptyDestination(t *testing.T) {
 	list := DirConfigList{
 		DirConfig{
-			SourcePath:      "a.txt",
-			DestinationPath: "",
+			Source:      "a.txt",
+			Destination: "",
 		},
 	}
 	err := list.IsValid()
 	assert.ErrorContains(t, err, "invalid value at index 0")
-	assert.ErrorContains(t, err, "invalid destinationPath value: empty string")
+	assert.ErrorContains(t, err, "invalid 'destination' value: empty string")
 }
 
 func TestDirConfigListIsValidInvalidNewDirPermissions(t *testing.T) {
 	list := DirConfigList{
 		DirConfig{
-			SourcePath:        "a.txt",
-			DestinationPath:   "/a.txt",
+			Source:            "a.txt",
+			Destination:       "/a.txt",
 			NewDirPermissions: ptrutils.PtrTo(FilePermissions(0o1000)),
 		},
 	}
@@ -82,8 +82,8 @@ func TestDirConfigListIsValidInvalidNewDirPermissions(t *testing.T) {
 func TestDirConfigListIsValidInvalidMergedDirPermissions(t *testing.T) {
 	list := DirConfigList{
 		DirConfig{
-			SourcePath:           "a.txt",
-			DestinationPath:      "/a.txt",
+			Source:               "a.txt",
+			Destination:          "/a.txt",
 			MergedDirPermissions: ptrutils.PtrTo(FilePermissions(0o1000)),
 		},
 	}
@@ -96,8 +96,8 @@ func TestDirConfigListIsValidInvalidMergedDirPermissions(t *testing.T) {
 func TestDirConfigListIsValidInvalidChildFilePermissions(t *testing.T) {
 	list := DirConfigList{
 		DirConfig{
-			SourcePath:           "a.txt",
-			DestinationPath:      "/a.txt",
+			Source:               "a.txt",
+			Destination:          "/a.txt",
 			ChildFilePermissions: ptrutils.PtrTo(FilePermissions(0o1000)),
 		},
 	}

--- a/toolkit/tools/imagecustomizerapi/os_test.go
+++ b/toolkit/tools/imagecustomizerapi/os_test.go
@@ -110,8 +110,8 @@ func TestOSIsValidInvalidAdditionalDirs(t *testing.T) {
 	os := OS{
 		AdditionalDirs: DirConfigList{
 			{
-				SourcePath:      "",
-				DestinationPath: "/a",
+				Source:      "",
+				Destination: "/a",
 			},
 		},
 	}
@@ -119,7 +119,7 @@ func TestOSIsValidInvalidAdditionalDirs(t *testing.T) {
 	err := os.IsValid()
 	assert.ErrorContains(t, err, "invalid additionalDirs")
 	assert.ErrorContains(t, err, "invalid value at index 0")
-	assert.ErrorContains(t, err, "invalid sourcePath value: empty string")
+	assert.ErrorContains(t, err, "invalid 'source' value: empty string")
 }
 
 func TestOSIsValidInvalidUser(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles.go
@@ -46,8 +46,8 @@ func copyAdditionalFiles(baseConfigPath string, additionalFiles imagecustomizera
 
 func copyAdditionalDirs(baseConfigPath string, additionalDirs imagecustomizerapi.DirConfigList, imageChroot *safechroot.Chroot) error {
 	for _, dirConfigElement := range additionalDirs {
-		absSourceDir := file.GetAbsPathWithBase(baseConfigPath, dirConfigElement.SourcePath)
-		logger.Log.Infof("Copying %s to %s", absSourceDir, dirConfigElement.DestinationPath)
+		absSourceDir := file.GetAbsPathWithBase(baseConfigPath, dirConfigElement.Source)
+		logger.Log.Infof("Copying %s to %s", absSourceDir, dirConfigElement.Destination)
 
 		// Setting permissions values. They are set to a default value if they have not been specified.
 		newDirPermissionsValue := fs.FileMode(defaultFilePermissions)
@@ -61,14 +61,14 @@ func copyAdditionalDirs(baseConfigPath string, additionalDirs imagecustomizerapi
 
 		dirToCopy := safechroot.DirToCopy{
 			Src:                  absSourceDir,
-			Dest:                 dirConfigElement.DestinationPath,
+			Dest:                 dirConfigElement.Destination,
 			NewDirPermissions:    newDirPermissionsValue,
 			ChildFilePermissions: childFilePermissionsValue,
 			MergedDirPermissions: (*fs.FileMode)(dirConfigElement.MergedDirPermissions),
 		}
 		err := imageChroot.AddDirs(dirToCopy)
 		if err != nil {
-			return fmt.Errorf("failed to copy directory (%s) to (%s):\n%w", absSourceDir, dirConfigElement.DestinationPath, err)
+			return fmt.Errorf("failed to copy directory (%s) to (%s):\n%w", absSourceDir, dirConfigElement.Destination, err)
 		}
 	}
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -148,8 +148,8 @@ func TestCopyAdditionalDirs(t *testing.T) {
 	err = copyAdditionalDirs(baseConfigPath,
 		imagecustomizerapi.DirConfigList{
 			{
-				SourcePath:           "dirs/a",
-				DestinationPath:      "/",
+				Source:               "dirs/a",
+				Destination:          "/",
 				ChildFilePermissions: ptrutils.PtrTo(imagecustomizerapi.FilePermissions(0o755)),
 				NewDirPermissions:    ptrutils.PtrTo(imagecustomizerapi.FilePermissions(0o750)),
 			},
@@ -172,8 +172,8 @@ func TestCopyAdditionalDirs(t *testing.T) {
 	err = copyAdditionalDirs(baseConfigPath,
 		imagecustomizerapi.DirConfigList{
 			{
-				SourcePath:           "dirs/b",
-				DestinationPath:      "/usr/local",
+				Source:               "dirs/b",
+				Destination:          "/usr/local",
 				ChildFilePermissions: ptrutils.PtrTo(imagecustomizerapi.FilePermissions(0o750)),
 				MergedDirPermissions: ptrutils.PtrTo(imagecustomizerapi.FilePermissions(0o755)),
 			},
@@ -249,8 +249,8 @@ func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
 		OS: &imagecustomizerapi.OS{
 			AdditionalDirs: []imagecustomizerapi.DirConfig{
 				{
-					SourcePath:      srcDirPath,
-					DestinationPath: "/a",
+					Source:      srcDirPath,
+					Destination: "/a",
 				},
 			},
 		},

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/adddirs-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/adddirs-config.yaml
@@ -1,4 +1,4 @@
 os:
   additionalDirs:
-  - sourcePath: dirs/a
-    destinationPath: /
+  - source: dirs/a
+    destination: /


### PR DESCRIPTION
Rename `sourcePath` and `destinationPath` to `source` and `destination`.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran tests.
