### PR TITLE
OSModifier: Explicitly setting enforcing=0 for SELinux permissive mode

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -55,6 +55,9 @@ const (
 	// CmdlineSELinuxEnforcingArg is the arg required for forcing SELinux to be in enforcing mode.
 	CmdlineSELinuxEnforcingArg = "enforcing=1"
 
+	// CmdlineSELinuxPermissiveArg is the arg required for SELinux in permissive mode.
+	CmdlineSELinuxPermissiveArg = "enforcing=0"
+
 	// CmdlineSELinuxSettings is the kernel command-line args for enabling SELinux.
 	CmdlineSELinuxSettings = CmdlineSELinuxSecurityArg + " " + CmdlineSELinuxEnabledArg
 

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
@@ -64,7 +64,7 @@ func TestBootCustomizerSELinuxMode20(t *testing.T) {
 	expectedGrubCfgDiff := `22c22
 < 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline   $kernelopts
 ---
-> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline    security=selinux selinux=1 $kernelopts
+> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline    security=selinux selinux=1 enforcing=0 $kernelopts
 `
 	checkDiffs20(t, b, expectedGrubCfgDiff, "")
 
@@ -113,7 +113,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff := `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity  security=selinux selinux=1 "
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity  security=selinux selinux=1 enforcing=0"
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
@@ -127,7 +127,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff = `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity   security=selinux selinux=1 enforcing=1 "
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity    security=selinux selinux=1 enforcing=1 "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 
@@ -141,7 +141,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff = `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity     selinux=0 "
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity      selinux=0 "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
@@ -78,7 +78,7 @@ func TestBootCustomizerSELinuxMode20(t *testing.T) {
 	expectedGrubCfgDiff = `22c22
 < 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline   $kernelopts
 ---
-> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline     security=selinux selinux=1 enforcing=1 $kernelopts
+> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline      security=selinux selinux=1 enforcing=1 $kernelopts
 `
 	checkDiffs20(t, b, expectedGrubCfgDiff, "")
 
@@ -92,7 +92,7 @@ func TestBootCustomizerSELinuxMode20(t *testing.T) {
 	expectedGrubCfgDiff = `22c22
 < 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline   $kernelopts
 ---
-> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline       selinux=0 $kernelopts
+> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline        selinux=0 $kernelopts
 `
 	checkDiffs20(t, b, expectedGrubCfgDiff, "")
 }
@@ -113,7 +113,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff := `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity  security=selinux selinux=1 enforcing=0"
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity  security=selinux selinux=1 enforcing=0 "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -581,8 +581,11 @@ func selinuxModeToArgs(selinuxMode imagecustomizerapi.SELinuxMode) ([]string, er
 		newSELinuxArgs = []string{installutils.CmdlineSELinuxSecurityArg, installutils.CmdlineSELinuxEnabledArg,
 			installutils.CmdlineSELinuxEnforcingArg}
 
-	case imagecustomizerapi.SELinuxModePermissive, imagecustomizerapi.SELinuxModeEnforcing:
+	case imagecustomizerapi.SELinuxModeEnforcing:
 		newSELinuxArgs = []string{installutils.CmdlineSELinuxSecurityArg, installutils.CmdlineSELinuxEnabledArg}
+
+	case imagecustomizerapi.SELinuxModePermissive:
+		newSELinuxArgs = []string{installutils.CmdlineSELinuxSecurityArg, installutils.CmdlineSELinuxEnabledArg, installutils.CmdlineSELinuxPermissiveArg}
 
 	default:
 		return nil, fmt.Errorf("unknown SELinux mode (%s)", selinuxMode)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Found failure in trident pipeline deployments with permissive mode failed, while other deployments, this PR experiments explicitly setting enforcing=0 to ensure SELinux is in permissive mode from the very start of the boot process.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Will publish new EMU and test in trident pipeline
