### PR TITLE
Image Customizer: Allow verity partitions to be specified by 'id'.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -519,8 +519,8 @@ please refer to the [overlay type](#overlay-type) section.
   at each system boot.
 
   - `idType`: Specifies the type of id for the partition. The options are
-    `part-label` (partition label), `uuid` (filesystem UUID), and `part-uuid`
-    (partition UUID).
+    `id` (partition [id](#id-string)), `part-label` (partition label),
+    `uuid` (filesystem UUID), and `part-uuid` (partition UUID).
 
   - `id`: The unique identifier value of the partition, corresponding to the
     specified IdType.

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -64,5 +64,42 @@ func (c *Config) IsValid() (err error) {
 		return fmt.Errorf("os.resetBootLoaderType must be specified if resetPartitionsUuidsType is specified")
 	}
 
+	if c.OS != nil && c.OS.Verity != nil {
+		err := ensureVerityPartitionIdExists(c.OS.Verity.DataPartition, c.Storage)
+		if err != nil {
+			return fmt.Errorf("invalid verity 'dataPartition':\n%w", err)
+		}
+
+		err = ensureVerityPartitionIdExists(c.OS.Verity.HashPartition, c.Storage)
+		if err != nil {
+			return fmt.Errorf("invalid verity 'hashPartition':\n%w", err)
+		}
+	}
+
+	return nil
+}
+
+func ensureVerityPartitionIdExists(verityPartition IdentifiedPartition, storage *Storage) error {
+	switch verityPartition.IdType {
+	case IdTypeId:
+		if storage == nil {
+			return fmt.Errorf("'idType' cannot be 'id' if 'storage' is not specified")
+		}
+
+		foundPartition := false
+		for _, disk := range storage.Disks {
+			for _, partition := range disk.Partitions {
+				if partition.Id == verityPartition.Id {
+					foundPartition = true
+					break
+				}
+			}
+		}
+
+		if !foundPartition {
+			return fmt.Errorf("partition with 'id' (%s) not found", verityPartition.Id)
+		}
+	}
+
 	return nil
 }

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -357,3 +357,156 @@ func TestConfigIsValidInvalidScripts(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid postCustomization script at index 0")
 	assert.ErrorContains(t, err, "either path or content must have a value")
 }
+
+func TestConfigIsValidVerityValid(t *testing.T) {
+	config := &Config{
+		Storage: &Storage{
+			Disks: []Disk{{
+				PartitionTableType: "gpt",
+				Partitions: []Partition{
+					{
+						Id: "esp",
+						Size: PartitionSize{
+							Type: PartitionSizeTypeExplicit,
+							Size: 8 * diskutils.MiB,
+						},
+						Type: PartitionTypeESP,
+					},
+					{
+						Id: "root",
+						Size: PartitionSize{
+							Type: PartitionSizeTypeExplicit,
+							Size: 1 * diskutils.GiB,
+						},
+					},
+					{
+						Id: "verityhash",
+						Size: PartitionSize{
+							Type: PartitionSizeTypeExplicit,
+							Size: 100 * diskutils.MiB,
+						},
+					},
+				},
+			}},
+			BootType: "efi",
+			FileSystems: []FileSystem{
+				{
+					DeviceId: "esp",
+					Type:     "fat32",
+					MountPoint: &MountPoint{
+						Path: "/boot/efi",
+					},
+				},
+				{
+					DeviceId: "root",
+					Type:     "ext4",
+					MountPoint: &MountPoint{
+						Path: "/",
+					},
+				},
+			},
+		},
+		OS: &OS{
+			ResetBootLoaderType: "hard-reset",
+			Verity: &Verity{
+				DataPartition: IdentifiedPartition{
+					IdType: IdTypeId,
+					Id:     "root",
+				},
+				HashPartition: IdentifiedPartition{
+					IdType: IdTypeId,
+					Id:     "verityhash",
+				},
+			},
+		},
+	}
+	err := config.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestConfigIsValidVerityPartitionNotFound(t *testing.T) {
+	config := &Config{
+		Storage: &Storage{
+			Disks: []Disk{{
+				PartitionTableType: "gpt",
+				Partitions: []Partition{
+					{
+						Id: "esp",
+						Size: PartitionSize{
+							Type: PartitionSizeTypeExplicit,
+							Size: 8 * diskutils.MiB,
+						},
+						Type: PartitionTypeESP,
+					},
+					{
+						Id: "root",
+						Size: PartitionSize{
+							Type: PartitionSizeTypeExplicit,
+							Size: 1 * diskutils.GiB,
+						},
+					},
+					{
+						Id: "verityhash",
+						Size: PartitionSize{
+							Type: PartitionSizeTypeExplicit,
+							Size: 100 * diskutils.MiB,
+						},
+					},
+				},
+			}},
+			BootType: "efi",
+			FileSystems: []FileSystem{
+				{
+					DeviceId: "esp",
+					Type:     "fat32",
+					MountPoint: &MountPoint{
+						Path: "/boot/efi",
+					},
+				},
+				{
+					DeviceId: "root",
+					Type:     "ext4",
+					MountPoint: &MountPoint{
+						Path: "/",
+					},
+				},
+			},
+		},
+		OS: &OS{
+			ResetBootLoaderType: "hard-reset",
+			Verity: &Verity{
+				DataPartition: IdentifiedPartition{
+					IdType: IdTypeId,
+					Id:     "wrongname",
+				},
+				HashPartition: IdentifiedPartition{
+					IdType: IdTypeId,
+					Id:     "verityhash",
+				},
+			},
+		},
+	}
+	err := config.IsValid()
+	assert.ErrorContains(t, err, "invalid verity 'dataPartition'")
+	assert.ErrorContains(t, err, "partition with 'id' (wrongname) not found")
+}
+
+func TestConfigIsValidVerityNoStorage(t *testing.T) {
+	config := &Config{
+		OS: &OS{
+			Verity: &Verity{
+				DataPartition: IdentifiedPartition{
+					IdType: IdTypePartLabel,
+					Id:     "root",
+				},
+				HashPartition: IdentifiedPartition{
+					IdType: IdTypeId,
+					Id:     "verityhash",
+				},
+			},
+		},
+	}
+	err := config.IsValid()
+	assert.ErrorContains(t, err, "invalid verity 'hashPartition'")
+	assert.ErrorContains(t, err, "'idType' cannot be 'id' if 'storage' is not specified")
+}

--- a/toolkit/tools/imagecustomizerapi/idtype.go
+++ b/toolkit/tools/imagecustomizerapi/idtype.go
@@ -10,6 +10,7 @@ import (
 type IdType string
 
 const (
+	IdTypeId        IdType = "id"
 	IdTypePartLabel IdType = "part-label"
 	IdTypeUuid      IdType = "uuid"
 	IdTypePartUuid  IdType = "part-uuid"
@@ -17,7 +18,7 @@ const (
 
 func (i IdType) IsValid() error {
 	switch i {
-	case IdTypePartLabel, IdTypeUuid, IdTypePartUuid:
+	case IdTypeId, IdTypePartLabel, IdTypeUuid, IdTypePartUuid:
 		// All good.
 		return nil
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -14,10 +14,10 @@ import (
 
 func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
-) error {
+) (map[string]string, error) {
 	existingImageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer existingImageConnection.Close()
 
@@ -27,18 +27,18 @@ func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, co
 		return copyFilesIntoNewDisk(existingImageConnection.Chroot(), imageChroot)
 	}
 
-	err = createNewImage(newBuildImageFile, diskConfig, config.Storage.FileSystems,
+	partIdToPartUuid, err := createNewImage(newBuildImageFile, diskConfig, config.Storage.FileSystems,
 		buildDir, "newimageroot", installOSFunc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = existingImageConnection.CleanClose()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return partIdToPartUuid, nil
 }
 
 func copyFilesIntoNewDisk(existingImageChroot *safechroot.Chroot, newImageChroot *safechroot.Chroot) error {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -97,23 +97,22 @@ func prepareGrubConfigForVerity(imageChroot *safechroot.Chroot) error {
 	return nil
 }
 
-func updateGrubConfigForVerity(dataPartitionIdType imagecustomizerapi.IdType, dataPartitionId string,
-	hashPartitionIdType imagecustomizerapi.IdType, hashPartitionId string,
-	corruptionOption imagecustomizerapi.CorruptionOption, rootHash string, grubCfgFullPath string,
+func updateGrubConfigForVerity(verity *imagecustomizerapi.Verity, rootHash string, grubCfgFullPath string,
+	partIdToPartUuid map[string]string,
 ) error {
 	var err error
 
 	// Format the dataPartitionId and hashPartitionId using the helper function.
-	formattedDataPartition, err := systemdFormatPartitionId(dataPartitionIdType, dataPartitionId)
+	formattedDataPartition, err := systemdFormatPartitionId(verity.DataPartition, partIdToPartUuid)
 	if err != nil {
 		return err
 	}
-	formattedHashPartition, err := systemdFormatPartitionId(hashPartitionIdType, hashPartitionId)
+	formattedHashPartition, err := systemdFormatPartitionId(verity.HashPartition, partIdToPartUuid)
 	if err != nil {
 		return err
 	}
 
-	formattedCorruptionOption, err := systemdFormatCorruptionOption(corruptionOption)
+	formattedCorruptionOption, err := systemdFormatCorruptionOption(verity.CorruptionOption)
 	if err != nil {
 		return err
 	}
@@ -164,11 +163,11 @@ func updateGrubConfigForVerity(dataPartitionIdType imagecustomizerapi.IdType, da
 
 // idToPartitionBlockDevicePath returns the block device path for a given idType and id.
 func idToPartitionBlockDevicePath(partitionId imagecustomizerapi.IdentifiedPartition,
-	diskPartitions []diskutils.PartitionInfo,
+	diskPartitions []diskutils.PartitionInfo, partIdToPartUuid map[string]string,
 ) (string, error) {
 	// Iterate over each partition to find the matching id.
 	for _, partition := range diskPartitions {
-		matches, err := partitionMatchesId(partitionId, partition)
+		matches, err := partitionMatchesId(partitionId, partition, partIdToPartUuid)
 		if err != nil {
 			return "", err
 		}
@@ -183,38 +182,46 @@ func idToPartitionBlockDevicePath(partitionId imagecustomizerapi.IdentifiedParti
 }
 
 func partitionMatchesId(partitionId imagecustomizerapi.IdentifiedPartition, partition diskutils.PartitionInfo,
+	partIdToPartUuid map[string]string,
 ) (bool, error) {
 	switch partitionId.IdType {
+	case imagecustomizerapi.IdTypeId:
+		partUuid := partIdToPartUuid[partitionId.Id]
+		return partition.PartUuid == partUuid, nil
+
 	case imagecustomizerapi.IdTypePartLabel:
-		if partition.PartLabel == partitionId.Id {
-			return true, nil
-		}
+		return partition.PartLabel == partitionId.Id, nil
+
 	case imagecustomizerapi.IdTypeUuid:
-		if partition.Uuid == partitionId.Id {
-			return true, nil
-		}
+		return partition.Uuid == partitionId.Id, nil
+
 	case imagecustomizerapi.IdTypePartUuid:
-		if partition.PartUuid == partitionId.Id {
-			return true, nil
-		}
+		return partition.PartUuid == partitionId.Id, nil
+
 	default:
 		return true, fmt.Errorf("invalid idType provided (%s)", string(partitionId.IdType))
 	}
-
-	return false, nil
 }
 
 // systemdFormatPartitionId formats the partition ID based on the ID type following systemd dm-verity style.
-func systemdFormatPartitionId(idType imagecustomizerapi.IdType, id string) (string, error) {
-	switch idType {
+func systemdFormatPartitionId(partition imagecustomizerapi.IdentifiedPartition, partIdToPartUuid map[string]string,
+) (string, error) {
+	switch partition.IdType {
+	case imagecustomizerapi.IdTypeId:
+		partUuid := partIdToPartUuid[partition.Id]
+		return fmt.Sprintf("%s=%s", "PARTUUID", partUuid), nil
+
 	case imagecustomizerapi.IdTypePartLabel:
-		return fmt.Sprintf("%s=%s", "PARTLABEL", id), nil
+		return fmt.Sprintf("%s=%s", "PARTLABEL", partition.Id), nil
+
 	case imagecustomizerapi.IdTypeUuid:
-		return fmt.Sprintf("%s=%s", "UUID", id), nil
+		return fmt.Sprintf("%s=%s", "UUID", partition.Id), nil
+
 	case imagecustomizerapi.IdTypePartUuid:
-		return fmt.Sprintf("%s=%s", "PARTUUID", id), nil
+		return fmt.Sprintf("%s=%s", "PARTUUID", partition.Id), nil
+
 	default:
-		return "", fmt.Errorf("invalid idType provided (%s)", string(idType))
+		return "", fmt.Errorf("invalid idType provided (%s)", string(partition.IdType))
 	}
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -1479,7 +1479,7 @@ func (b *LiveOSIsoBuilder) createWriteableImageFromSquashfs(buildDir, rawImageFi
 
 	// create the new raw disk image
 	writeableChrootDir := "writeable-raw-image"
-	err = createNewImage(rawImageFile, diskConfig, fileSystemConfigs, buildDir, writeableChrootDir, installOSFunc)
+	_, err = createNewImage(rawImageFile, diskConfig, fileSystemConfigs, buildDir, writeableChrootDir, installOSFunc)
 	if err != nil {
 		return fmt.Errorf("failed to copy squashfs into new writeable image (%s):\n%w", rawImageFile, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -23,7 +23,9 @@ var (
 	fdiskPartitionsTableEntryRegexp  = regexp.MustCompile(`^([0-9A-Za-z-_/]+)[\t ]+(\d+)[\t ]+`)
 )
 
-func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomizerapi.IdentifiedPartition) error {
+func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomizerapi.IdentifiedPartition,
+	partIdToPartUuid map[string]string,
+) error {
 	logger.Log.Infof("Shrinking filesystems")
 
 	// Get partition info
@@ -53,7 +55,7 @@ func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomi
 		}
 
 		if verityHashPartition != nil {
-			matches, err := partitionMatchesId(*verityHashPartition, diskPartition)
+			matches, err := partitionMatchesId(*verityHashPartition, diskPartition, partIdToPartUuid)
 			if err != nil {
 				return err
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
@@ -14,10 +14,12 @@ storage:
       end: 1024M
 
     - id: root
+      label: root
       start: 1024M
       end: 3072M
 
-    - id: roothash
+    - id: verityhash
+      label: root-hash
       start: 3072M
       end: 3200M
 
@@ -40,6 +42,9 @@ storage:
     type: ext4
     mountPoint:
       path: /
+      
+  - deviceId: verityhash
+    type: fat32
 
   - deviceId: var
     type: ext4
@@ -63,11 +68,11 @@ os:
   verity:
     corruptionOption: panic
     dataPartition:
-      idType: id
+      idType: part-label
       id: root
     hashPartition:
-      idType: id
-      id: roothash
+      idType: part-label
+      id: root-hash
 
   additionalFiles:
     # Change the directory that the sshd-keygen service writes the SSH host keys to.


### PR DESCRIPTION
Permit the verity 'hashPartition' and 'dataPartition' to be specified by partition 'id' instead of needing to be specified by partition 'label'.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Updated tests.

