### PR TITLE
gnutls: upgrade 3.7.7 -> 3.7.11 to address CVE-2023-5981, CVE-2024-28835, CVE-2024-28834 & CVE-2024-0553

### DIFF
--- a/SPECS/gnutls/gnutls.signatures.json
+++ b/SPECS/gnutls/gnutls.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "gnutls-3.7.7.tar.xz": "be9143d0d58eab64dba9b77114aaafac529b6c0d7e81de6bdf1c9b59027d2106"
+  "gnutls-3.7.11.tar.xz": "90e337504031ef7d3077ab1a52ca8bac9b2f72bc454c95365a1cd1e0e81e06e9"
  }
 }

--- a/SPECS/gnutls/gnutls.spec
+++ b/SPECS/gnutls/gnutls.spec
@@ -1,15 +1,13 @@
 Summary:        The GnuTLS Transport Layer Security Library
 Name:           gnutls
-Version:        3.7.7
-Release:        4%{?dist}
+Version:        3.7.11
+Release:        1%{?dist}
 License:        GPLv3+ AND LGPLv2.1+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://www.gnutls.org
 Source0:        https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/%{name}-%{version}.tar.xz
-Patch0:         CVE-2023-0361.patch
-Patch1:         CVE-2024-0567.patch
 BuildRequires:  autogen-libopts-devel
 BuildRequires:  gc-devel
 BuildRequires:  guile-devel
@@ -96,6 +94,10 @@ sed -i 's/TESTS += test-ciphers-openssl.sh//'  tests/slow/Makefile.am
 %{_mandir}/man3/*
 
 %changelog
+* Mon Sep 30 2024 Muhammad Falak <mwani@microsoft.com> - 3.7.11-1
+- Upgrade to v3.7.11 to address CVE-2023-5981, CVE-2024-28835, CVE-2024-28834, CVE-2024-0553
+- Drop patches which are already included in the source.
+
 * Wed Sep 20 2023 Zhichun Wan <zhichunwan@microsoft.com> - 3.7.7-4
 - Add patch to fix CVE-2024-0567
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4570,8 +4570,8 @@
         "type": "other",
         "other": {
           "name": "gnutls",
-          "version": "3.7.7",
-          "downloadUrl": "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.7.tar.xz"
+          "version": "3.7.11",
+          "downloadUrl": "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.11.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- **gnutls: upgrade 3.7.7 -> 3.7.11 to address CVE-2023-5981, CVE-2024-28835, CVE-2024-28834, CVE-2024-0553**
Reference: https://gitlab.com/gnutls/gnutls/-/blob/gnutls_3_7_x/NEWS

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade 3.7.7 -> 3.7.11 to address CVE-2023-5981, CVE-2024-28835, CVE-2024-28834, CVE-2024-0553
- Drop patches already in upstream

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-5981
- https://nvd.nist.gov/vuln/detail/CVE-2024-28835
- https://nvd.nist.gov/vuln/detail/CVE-2024-28834
- https://nvd.nist.gov/vuln/detail/CVE-2024-0553

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [PR-10578](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=649236&view=results)
