### PR TITLE
Fixed spec entanglement PR check

### DIFF
--- a/toolkit/scripts/check_entangled_specs.py
+++ b/toolkit/scripts/check_entangled_specs.py
@@ -88,9 +88,7 @@ def check_spec_tags(base_path: str, tags: List[str], groups: List[FrozenSet]) ->
         for spec_filename in group:
             parsed_spec = Spec.from_file(path.join(base_path, spec_filename))
             for tag in tags:
-                tag_value = getattr(parsed_spec, tag)
-                if tag_value:
-                    tag_value = replace_macros(tag_value, parsed_spec)
+                tag_value = get_tag_value(parsed_spec, tag)
                 variants[tag].add(tag_value)
 
         for tag in tags:
@@ -147,6 +145,13 @@ def check_matches(base_path: str):
                 printer.pprint(e)
                 
         sys.exit(1)
+
+
+def get_tag_value(spec: "Spec", tag: str) -> str:
+    value = getattr(spec, tag)
+    if value:
+        value = replace_macros(value, spec)
+    return value
 
 
 if __name__ == '__main__':

--- a/toolkit/scripts/check_entangled_specs.py
+++ b/toolkit/scripts/check_entangled_specs.py
@@ -2,14 +2,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from typing import FrozenSet, List, Set
-from pyrpm.spec import Spec
-
-import argparse
 from collections import defaultdict
-from pathlib import Path
+from os import path
+from typing import FrozenSet, List, Set
+import argparse
 import pprint
 import sys
+
+from pyrpm.spec import replace_macros, Spec
 
 version_release_matching_groups = [
     frozenset([
@@ -86,9 +86,12 @@ def check_spec_tags(base_path: str, tags: List[str], groups: List[FrozenSet]) ->
         variants = defaultdict(set)
 
         for spec_filename in group:
-            parsed_spec = Spec.from_file(Path(base_path, spec_filename))
+            parsed_spec = Spec.from_file(path.join(base_path, spec_filename))
             for tag in tags:
-                variants[tag].add(getattr(parsed_spec, tag))
+                tag_value = getattr(parsed_spec, tag)
+                if tag_value:
+                    tag_value = replace_macros(tag_value, parsed_spec)
+                variants[tag].add(tag_value)
 
         for tag in tags:
             if len(variants[tag]) > 1: err_groups.add(group)


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The entanglement PR check was not expanding macros in the checked tags (`Version`, `Epoch`, etc.). This caused it to fail for cases where some versions were expressed in form of macro. This change adds a step, which replaces the macros with their values.

This issue came up in a [PR check](https://github.com/microsoft/azurelinux/actions/runs/11114493630/job/30881072622?pr=10329) for #10329.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #10329

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local run for changes from #10329.