### PR TITLE
Fixed `tdnf provides` parsing to recognize epochs in package names.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -820,7 +820,7 @@ func calculateTotalPackages(packages []string, installRoot string) (installedPac
 		// end with an empty line.
 		for _, line := range splitStdout {
 			matches := tdnf.InstallPackageRegex.FindStringSubmatch(line)
-			if len(matches) != tdnf.InstallMaxMatchLen {
+			if len(matches) != tdnf.InstallPackageMaxMatchLen {
 				// This line contains output other than a package information; skip it
 				continue
 			}

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -474,8 +474,8 @@ func (r *RpmRepoCloner) WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames [
 			// MUST keep order of packages printed by TDNF.
 			// TDNF will print the packages starting from the highest version, which allows us to work around an RPM bug:
 			// https://github.com/rpm-software-management/rpm/issues/2359
-			for _, matches := range tdnf.PackageLookupNameMatchRegex.FindAllStringSubmatch(stdout, -1) {
-				packageName := matches[tdnf.PackageNameIndex]
+			for _, matches := range tdnf.PackageProvidesRegex.FindAllStringSubmatch(stdout, -1) {
+				packageName := matches[tdnf.PackageProvidesNameIndex]
 				if lookupIgnoredCase {
 					logger.Log.Warnf("'%s' was found by case-insensitive lookup of '%s', but this is not valid and will be ignored", packageName, pkgVer.Name)
 					// This is not a valid mapping of requires -> provides, so we skip it. This is not a fatal error since
@@ -556,15 +556,15 @@ func (r *RpmRepoCloner) ClonedRepoContents() (repoContents *repocloner.RepoConte
 	repoContents = &repocloner.RepoContents{}
 	onStdout := func(line string) {
 		matches := tdnf.ListedPackageRegex.FindStringSubmatch(line)
-		if len(matches) != tdnf.ListMaxMatchLen {
+		if len(matches) != tdnf.ListedPackageMaxMatchLen {
 			return
 		}
 
 		pkg := &repocloner.RepoPackage{
-			Name:         matches[tdnf.ListPackageName],
-			Version:      matches[tdnf.ListPackageVersion],
-			Architecture: matches[tdnf.ListPackageArch],
-			Distribution: matches[tdnf.ListPackageDist],
+			Name:         matches[tdnf.ListedPackageName],
+			Version:      matches[tdnf.ListedPackageVersion],
+			Architecture: matches[tdnf.ListedPackageArch],
+			Distribution: matches[tdnf.ListedPackageDist],
 		}
 
 		pkgID := pkg.ID()

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -28,8 +28,7 @@ var (
 	//		Repo	: [repo_name]
 	//
 	// NOTE: we ignore packages installed in the build environment denoted by "Repo	: @System".
-	PackageLookupNameMatchRegex = regexp.MustCompile(`([^:\s]+(x86_64|aarch64|noarch))\s*:[^\n]*\nRepo\s+:\s+[^@]`)
-	PackageNameIndex            = 1
+	PackageProvidesRegex = regexp.MustCompile(`(\S+)\s+:[^\n]*\nRepo\s+:\s+[^@]`)
 
 	// Tdnf may opt to ignore case when doing a provides lookup. While this is useful for a user, it will give
 	// bad results when we're trying to match a package name to a package in the repo. This regex will match the
@@ -63,21 +62,27 @@ var (
 )
 
 const (
-	InstallMatchSubString = iota
-	InstallPackageName    = iota
-	InstallPackageArch    = iota
-	InstallPackageVersion = iota
-	InstallPackageDist    = iota
-	InstallMaxMatchLen    = iota
+	InstallPackageMatchSubString = iota
+	InstallPackageName           = iota
+	InstallPackageArch           = iota
+	InstallPackageVersion        = iota
+	InstallPackageDist           = iota
+	InstallPackageMaxMatchLen    = iota
 )
 
 const (
-	ListMatchSubString = iota
-	ListPackageName    = iota
-	ListPackageArch    = iota
-	ListPackageVersion = iota
-	ListPackageDist    = iota
-	ListMaxMatchLen    = iota
+	PackageProvidesMatchSubString = iota
+	PackageProvidesNameIndex      = iota
+	PackageProvidesMaxMatchLen    = iota
+)
+
+const (
+	ListedPackageMatchSubString = iota
+	ListedPackageName           = iota
+	ListedPackageArch           = iota
+	ListedPackageVersion        = iota
+	ListedPackageDist           = iota
+	ListedPackageMaxMatchLen    = iota
 )
 
 const (


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've recently started seeing builds failing with following errors:
```
failed to clone (7.70-506.azl3.noarch) from RPM repo
```

This seems to be related with invalid parsing of the `tdnf provides` output where the tool's regex failed to take a potential `:` into the account. A few lines above the mentioned error, we can see TDNF finding the right package:
```
time="2024-09-30T21:52:54Z" level=debug msg="Executing: [tdnf provides perl(ExtUtils::MakeMaker) --releasever=3.0 --disablerepo=* --enablerepo=toolchain-repo]"
time="2024-09-30T21:52:54Z" level=debug msg="tdnf search for provide 'perl(ExtUtils::MakeMaker)':
Loaded plugin: tdnfrepogpgcheck
[using capability match for 'perl(ExtUtils::MakeMaker)']
perl-ExtUtils-MakeMaker-2:7.70-506.azl3.noarch : Create a module Makefile
Repo	 : toolchain-repo
```

The `:` character in `2:7.70-506.azl3.noarch` is what confused the regex.

The current (as of 09/30/2024) version of TDNF (3.5.6) is printing the versions without the epoch and that's why we haven't hit this issue until now. It seems that the bump to version 3.5.8 added the epoch number to the `tdnf provides` output.

Sample output for 3.5.6:
```bash
root [ / ]# tdnf provides 'perl(ExtUtils::MakeMaker)'
Loaded plugin: tdnfrepogpgcheck
[using capability match for 'perl(ExtUtils::MakeMaker)']
perl-ExtUtils-MakeMaker-7.70-506.azl3.noarch : Create a module Makefile
Repo     : azurelinux-official-base
```

Notice no epoch in `7.70-506.azl3.noarch`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Go tests.