### PR TITLE
heimdal: Add backported patch for fixing CVE-2022-3116

### DIFF
--- a/SPECS/heimdal/CVE-2022-3116.patch
+++ b/SPECS/heimdal/CVE-2022-3116.patch
@@ -1,0 +1,52 @@
+From 2584657af19b706fe49225cc9227bbfded0ee704 Mon Sep 17 00:00:00 2001
+From: ankita <ankitapareek@microsoft.com>
+Date: Tue, 1 Oct 2024 16:05:50 +0530
+Subject: [PATCH] heimdal: Fix NULL deref in spnego for fixing CVE-2022-3116
+
+Signed-off-by: ankita <ankitapareek@microsoft.com>
+---
+ lib/gssapi/spnego/accept_sec_context.c | 28 +++++++++++++-------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/lib/gssapi/spnego/accept_sec_context.c b/lib/gssapi/spnego/accept_sec_context.c
+index 5fe1a1a..4920664 100644
+--- a/lib/gssapi/spnego/accept_sec_context.c
++++ b/lib/gssapi/spnego/accept_sec_context.c
+@@ -605,20 +605,20 @@ acceptor_start
+      * If opportunistic token failed, lets try the other mechs.
+      */
+ 
+-    if (!first_ok && ni->mechToken != NULL) {
+-	size_t j;
+-
+-	preferred_mech_type = GSS_C_NO_OID;
+-
+-	/* Call glue layer to find first mech we support */
+-	for (j = 1; j < ni->mechTypes.len; ++j) {
+-	    ret = select_mech(minor_status,
+-			      &ni->mechTypes.val[j],
+-			      1,
+-			      &preferred_mech_type);
+-	    if (ret == 0)
+-		break;
+-	}
++    if (!first_ok) {
++		size_t j;
++
++		preferred_mech_type = GSS_C_NO_OID;
++
++		/* Call glue layer to find first mech we support */
++		for (j = 1; j < ni->mechTypes.len; ++j) {
++			ret = select_mech(minor_status,
++					&ni->mechTypes.val[j],
++					1,
++					&preferred_mech_type);
++			if (ret == 0)
++			break;
++		}
+     }
+ 
+     ctx->preferred_mech_type = preferred_mech_type;
+-- 
+2.34.1
+

--- a/SPECS/heimdal/heimdal.spec
+++ b/SPECS/heimdal/heimdal.spec
@@ -12,7 +12,7 @@
 Summary:        A Kerberos 5 implementation without export restrictions
 Name:           heimdal
 Version:        7.7.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,7 @@ Patch4:         CVE-2022-42898.patch
 Patch5:         0001-lib-krb5-krb5_pac_parse-mem-leak-if-pac_header_size-.patch
 Patch6:         0002-kdc-Check-generate_pac-return-code.patch
 Patch7:         0003-kdc-avoid-re-encoding-KDC-REQ-BODY.patch
+Patch8:         CVE-2022-3116.patch
 BuildRequires:  bison
 #libcom_err-devel is in
 #BuildRequires:  libcom_err-devel
@@ -487,6 +488,9 @@ fi
 %{_sysconfdir}/profile.d/%{name}.csh
 
 %changelog
+* Tue Oct 01 2024 Ankita Pareek <ankitapareek@microsoft.com> - 7.7.1-4
+- Add backported patch for CVE-2022-3116
+
 * Thu Aug 24 2023 Muhammad Falak R Wani <mwani@microsoft.com> - 7.7.1-3
 - Address CVE-2022-42898
 - Introduce 3 more patches that fix bugs: https://github.com/heimdal/heimdal/issues/1011


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Add patch for fixing CVE-2022-3116.

NOTE: This was the original upstream fix available for this CVE - [CVE-2022-3116 fix](https://github.com/heimdal/heimdal/commit/7a19658c1f4fc4adf85bb7bea96caae5ba57b33e)
The code in this package's version of heimdal is not exactly the same as the one being considered in the original version of this patch. Function acceptor_start was changed by commit 4fb6a6adc9, and therefore, the block that is moved outside of the 'if(!first_ok)' conditional in 7a19658c1 is not the same as the one in the original code for this version of heimdal (this block being 'if (ctx->selected_mech_type == GSS_C_NO_OID)' block in the original patch). The chosen backport strategy was to simply move the 'if' block as it is in this version of the code outside of the 'if(!first_ok)' conditional, which means, moving 'if (preferred_mech_type == GSS_C_NO_OID)' outside of 'if(!first_ok)'. That is because 'ctx->selected_mech_type' does not exist in this package's version of heimdal. It seems like 'ctx->selected_mech_type' and 'advertised_mech' were variables created in 4fb6a6adc9 to "substitute" 'preferred_mech_type', so instructions where these are changed/checked were previously using 'preferred_mech_type' instead. Since 'ctx->preferred_mech_type' (the variable that should be checked to avoid the vulnerability) in 'acceptor_start' for this package's version of the code is only ever assigned the value of 'preferred_mech_type' when it is assigned a value, it makes sense that we continue checking this value in order to avoid the 'ctx->preferred_mech_type' NULL pointer dereference. 

In the current version of heimdal i.e. 7.7.1 the code block 'if (ctx->selected_mech_type == GSS_C_NO_OID)' is already outside the  'if(!first_ok)' conditional, so no change has been made to it. Only the 'if(!first_ok)' conditional is modified as per the available patches.

Reference: [Ubuntu's patch](https://launchpadlibrarian.net/628258298/heimdal_7.7.0+dfsg-1ubuntu1_7.7.0+dfsg-1ubuntu1.1.diff.gz)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for fixing CVE-2022-3116 in heimdal

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-3116

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [649937](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=649937&view=results)
