### PR TITLE
[2.0] Resolve CVE-2024-28180 in dcos-cli and kubernetes

### DIFF
--- a/SPECS/dcos-cli/CVE-2024-28180.patch
+++ b/SPECS/dcos-cli/CVE-2024-28180.patch
@@ -1,0 +1,76 @@
+diff --git a/vendor/gopkg.in/square/go-jose.v2/crypter.go b/vendor/gopkg.in/square/go-jose.v2/crypter.go
+index d24cabf6..a6283865 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/crypter.go
++++ b/vendor/gopkg.in/square/go-jose.v2/crypter.go
+@@ -405,6 +405,9 @@ func (ctx *genericEncrypter) Options() EncrypterOptions {
+ // Decrypt and validate the object and return the plaintext. Note that this
+ // function does not support multi-recipient, if you desire multi-recipient
+ // decryption use DecryptMulti instead.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >10x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) {
+ 	headers := obj.mergedHeaders(nil)
+ 
+@@ -469,6 +472,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error)
+ // with support for multiple recipients. It returns the index of the recipient
+ // for which the decryption was successful, the merged headers for that recipient,
+ // and the plaintext.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >3x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Header, []byte, error) {
+ 	globalHeaders := obj.mergedHeaders(nil)
+ 
+diff --git a/vendor/gopkg.in/square/go-jose.v2/encoding.go b/vendor/gopkg.in/square/go-jose.v2/encoding.go
+index 70f7385c..ab9e0867 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/encoding.go
++++ b/vendor/gopkg.in/square/go-jose.v2/encoding.go
+@@ -21,6 +21,7 @@ import (
+ 	"compress/flate"
+ 	"encoding/base64"
+ 	"encoding/binary"
++	"fmt"
+ 	"io"
+ 	"math/big"
+ 	"strings"
+@@ -85,7 +86,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
+ 	}
+ }
+ 
+-// Compress with DEFLATE
++// deflate compresses the input.
+ func deflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 
+@@ -97,15 +98,27 @@ func deflate(input []byte) ([]byte, error) {
+ 	return output.Bytes(), err
+ }
+ 
+-// Decompress with DEFLATE
++// inflate decompresses the input.
++//
++// Errors if the decompressed data would be >250kB or >10x the size of the
++// compressed data, whichever is larger.
+ func inflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 	reader := flate.NewReader(bytes.NewBuffer(input))
+ 
+-	_, err := io.Copy(output, reader)
+-	if err != nil {
++	maxCompressedSize := 10 * int64(len(input))
++	if maxCompressedSize < 250000 {
++		maxCompressedSize = 250000
++	}
++
++	limit := maxCompressedSize + 1
++	n, err := io.CopyN(output, reader, limit)
++	if err != nil && err != io.EOF {
+ 		return nil, err
+ 	}
++	if n == limit {
++		return nil, fmt.Errorf("uncompressed data would be too large (>%d bytes)", maxCompressedSize)
++	}
+ 
+ 	err = reader.Close()
+ 	return output.Bytes(), err

--- a/SPECS/dcos-cli/dcos-cli.spec
+++ b/SPECS/dcos-cli/dcos-cli.spec
@@ -1,13 +1,14 @@
 Summary:        The command line for DC/OS
 Name:           dcos-cli
 Version:        1.2.0
-Release:        18%{?dist}
+Release:        19%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/Tools
 URL:            https://github.com/dcos/dcos-cli
 Source0:        https://github.com/dcos/dcos-cli/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-28180.patch
 
 BuildRequires:  golang
 BuildRequires:  git
@@ -45,6 +46,9 @@ go test -mod=vendor
 %{_bindir}/dcos
 
 %changelog
+* Mon Oct 01 2024 Henry Li <lihl@microsoft.com> - 1.2.0-19
+- Add patch to resolve CVE-2024-28180
+
 * Mon Sep 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.2.0-18
 - Bump release to rebuild with go 1.22.7
 

--- a/SPECS/kubernetes/CVE-2024-28180.patch
+++ b/SPECS/kubernetes/CVE-2024-28180.patch
@@ -1,0 +1,76 @@
+diff --git a/./vendor/gopkg.in/square/go-jose.v2/crypter.go b/../kubernetes/vendor/gopkg.in/square/go-jose.v2/crypter.go
+index be7433e..763eae0 100644
+--- a/./vendor/gopkg.in/square/go-jose.v2/crypter.go
++++ b/../kubernetes/vendor/gopkg.in/square/go-jose.v2/crypter.go
+@@ -406,6 +406,9 @@ func (ctx *genericEncrypter) Options() EncrypterOptions {
+ // Decrypt and validate the object and return the plaintext. Note that this
+ // function does not support multi-recipient, if you desire multi-recipient
+ // decryption use DecryptMulti instead.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >10x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) {
+ 	headers := obj.mergedHeaders(nil)
+ 
+@@ -470,6 +473,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error)
+ // with support for multiple recipients. It returns the index of the recipient
+ // for which the decryption was successful, the merged headers for that recipient,
+ // and the plaintext.
++//
++// Automatically decompresses plaintext, but returns an error if the decompressed
++// data would be >250kB or >3x the size of the compressed data, whichever is larger.
+ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Header, []byte, error) {
+ 	globalHeaders := obj.mergedHeaders(nil)
+ 
+diff --git a/./vendor/gopkg.in/square/go-jose.v2/encoding.go b/../kubernetes/vendor/gopkg.in/square/go-jose.v2/encoding.go
+index 70f7385..ab9e086 100644
+--- a/./vendor/gopkg.in/square/go-jose.v2/encoding.go
++++ b/../kubernetes/vendor/gopkg.in/square/go-jose.v2/encoding.go
+@@ -21,6 +21,7 @@ import (
+ 	"compress/flate"
+ 	"encoding/base64"
+ 	"encoding/binary"
++	"fmt"
+ 	"io"
+ 	"math/big"
+ 	"strings"
+@@ -85,7 +86,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
+ 	}
+ }
+ 
+-// Compress with DEFLATE
++// deflate compresses the input.
+ func deflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 
+@@ -97,15 +98,27 @@ func deflate(input []byte) ([]byte, error) {
+ 	return output.Bytes(), err
+ }
+ 
+-// Decompress with DEFLATE
++// inflate decompresses the input.
++//
++// Errors if the decompressed data would be >250kB or >10x the size of the
++// compressed data, whichever is larger.
+ func inflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 	reader := flate.NewReader(bytes.NewBuffer(input))
+ 
+-	_, err := io.Copy(output, reader)
+-	if err != nil {
++	maxCompressedSize := 10 * int64(len(input))
++	if maxCompressedSize < 250000 {
++		maxCompressedSize = 250000
++	}
++
++	limit := maxCompressedSize + 1
++	n, err := io.CopyN(output, reader, limit)
++	if err != nil && err != io.EOF {
+ 		return nil, err
+ 	}
++	if n == limit {
++		return nil, fmt.Errorf("uncompressed data would be too large (>%d bytes)", maxCompressedSize)
++	}
+ 
+ 	err = reader.Close()
+ 	return output.Bytes(), err

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.28.4
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -22,6 +22,7 @@ Patch0:         CVE-2024-21626.patch
 Patch1:         CVE-2023-48795.patch
 Patch2:         CVE-2023-5408.patch
 Patch3:         CVE-2023-45288.patch
+Patch4:         CVE-2024-28180.patch
 BuildRequires:  flex-devel
 BuildRequires:  glibc-static >= 2.35-7%{?dist}
 BuildRequires:  golang
@@ -268,6 +269,9 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Mon Oct 01 2024 Henry Li <lihl@microsoft.com> - 1.28.4-11
+- Add patch to resolve CVE-2024-28180
+
 * Mon Sep 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.28.4-10
 - Bump release to rebuild with go 1.22.7
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Add patch to resolve CVE-2024-28180 for dcos-cli and kubernetes on 2.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch to resolve CVE-2024-28180

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-28180

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 
  - dcos-cli: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=650126&view=results
  - kubernetes: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=650136&view=results
