### PR TITLE
Enable iptables by default

### DIFF
--- a/SPECS/azurelinux-release/90-default.preset
+++ b/SPECS/azurelinux-release/90-default.preset
@@ -28,7 +28,7 @@ enable rsyslog.*
 enable syslog-ng.*
 enable sysklogd.*
 
-enable firewalld.service
+enable iptables.service
 
 enable virtqemud.socket
 enable virtqemud-ro.socket

--- a/SPECS/azurelinux-release/azurelinux-release.signatures.json
+++ b/SPECS/azurelinux-release/azurelinux-release.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "90-default.preset": "50ed546e79e3c9f5c4f2d4a9796255537f4900d5d1d78c0564fbe7362634531b",
+  "90-default.preset": "073dd8a72f9ef915280bb608f5ea0b394c0d658fe0537d552135332168fadb03",
   "90-default-user.preset": "7cf8f4d2ca1760e04ff46bd2444609cfd27a7ab456be2f9e73b0f89c284e134d",
   "99-default-disable.preset": "3127b197b9eae62eb84eeed69b0413419612238332006183e36a3fba89578378",
   "15-azurelinux-default.conf": "63a46ecbed4b92f996718ea9202e914ff119c2c06fdaeed3d1e2710aabc663b4"

--- a/SPECS/azurelinux-release/azurelinux-release.spec
+++ b/SPECS/azurelinux-release/azurelinux-release.spec
@@ -5,7 +5,7 @@
 Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        %{dist_version}.0
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -118,6 +118,9 @@ install -Dm0644 %{SOURCE4} -t %{buildroot}%{_sysctldir}/
 %{_sysctldir}/*.conf
 
 %changelog
+* Fri Sep 27 2024 CBL-Mariner Servicing Account <rachelmenge@microsoft.com> - 3.0-20
+- enable iptables as default firewall
+
 * Wed Sep 25 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.0-19
 - Bump release for October 2024 Update
 

--- a/SPECS/azurelinux-release/azurelinux-release.spec
+++ b/SPECS/azurelinux-release/azurelinux-release.spec
@@ -118,8 +118,8 @@ install -Dm0644 %{SOURCE4} -t %{buildroot}%{_sysctldir}/
 %{_sysctldir}/*.conf
 
 %changelog
-* Fri Sep 27 2024 CBL-Mariner Servicing Account <rachelmenge@microsoft.com> - 3.0-20
-- enable iptables as default firewall
+* Fri Sep 27 2024 Rachel Menge <rachelmenge@microsoft.com> - 3.0-20
+- Enable iptables as default firewall
 
 * Wed Sep 25 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.0-19
 - Bump release for October 2024 Update


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Default presets were introduced here https://github.com/microsoft/azurelinux/pull/8028. The default firewall was firewalld which is not fully supported for Azl3. Therefore, set as iptables. 

- For an image upgrade, this PR will cause the iptables.service to run by default and thus, will introduce firewall rules by default.
- For a package upgrade to `azurelinux-release-3.0-20`, the iptables service will be recognized as being allowed by the preset but will NOT be enabled by default. That being said, if an iptables.rpm upgrade comes in afterwards, the rules WILL be turned on
- For a package downgrade to an older package (< `azurelinux-release-3.0-20`), the preset will show that the iptables service is disabled by the preset but iptables WILL continue to run even after reboot 
Ex of a downgrade then reboot:
<img width="491" alt="image" src="https://github.com/user-attachments/assets/bb86d00b-fab6-42a4-a7c9-85b760118695">


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enable iptables service by default

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/54133320

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- locally built vhdx and booted in hyperv and saw iptables
`sudo make image REBUILD_TOOLS=y CONFIG_FILE=./imageconfigs/core-efi.json QUICK_REBUILD_PACKAGES=y DAILY_BUILD_ID=3-0-20240925 ALLOW_TOOLCHAIN_REBUILDS=y`

<img width="395" alt="image" src="https://github.com/user-attachments/assets/82036136-8ea6-4b3e-9421-30b5eff06ef6">


<img width="512" alt="image" src="https://github.com/user-attachments/assets/f085e9fe-87d2-48fb-b3ac-7ec6716b8423">


- Buddy Build:
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=647914&view=results
