### PR TITLE
use build type RelWithDebInfo to generate debug info with sources

### DIFF
--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
@@ -1,7 +1,7 @@
 Summary:        The SymCrypt engine for OpenSSL (SCOSSL) allows the use of OpenSSL with SymCrypt as the provider for core cryptographic operations
 Name:           SymCrypt-OpenSSL
 Version:        1.5.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -39,7 +39,7 @@ cmake   .. \
         -DOPENSSL_ROOT_DIR="%{_prefix}/local/ssl" \
         -DSYMCRYPT_ROOT_DIR=%{buildroot}%{_includedir}/.. \
         -DCMAKE_TOOLCHAIN_FILE="../cmake-toolchain/LinuxUserMode-%{symcrypt_arch}.cmake" \
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 cmake --build .
 
@@ -67,6 +67,9 @@ install SymCryptProvider/symcrypt_prov.cnf %{buildroot}%{_sysconfdir}/pki/tls/sy
 %{_sysconfdir}/pki/tls/symcrypt_prov.cnf
 
 %changelog
+* Wed Oct 02 2024 Tobias Brick <tobiasb@microsoft.com> - 1.5.1-2
+- Add sources to debuginfo package
+
 * Wed Aug 21 2024 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.5.1-1
 - Fix minor behavior differences with default provider
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Changes build of `SymCrypt-OpenSSL` so sources are included in the `debuginfo` rpm. We had been building with `CMAKE_BUILD_TYPE` set to `Release` rather than `RelWithDebInfo`. [Here's a good discussion of the differences](https://stackoverflow.com/questions/48754619/what-are-cmake-build-type-debug-release-relwithdebinfo-and-minsizerel).

###### Change Log  <!-- REQUIRED -->
- set `-DCMAKE_BUILD_TYPE=` to `RelWithDebInfo`

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Built locally and tested symbols and source in gdb.
- Ran a [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=650766&view=results) and used `rpm2cpio` on the resulting `debuginfo` rpm to confirm the sources are there.
- Did a verbose build before and after and validated that it still does the same level of optimization (`-O3`).
