### PR TITLE
binutils: Address multiple CVEs

### DIFF
--- a/SPECS/binutils/CVE-2022-47007.patch
+++ b/SPECS/binutils/CVE-2022-47007.patch
@@ -1,0 +1,29 @@
+From 0ebc886149c22aceaf8ed74267821a59ca9d03eb Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Fri, 17 Jun 2022 09:00:41 +0930
+Subject: [PATCH] PR29254, memory leak in stab_demangle_v3_arg
+
+	PR 29254
+	* stabs.c (stab_demangle_v3_arg): Free dt on failure path.
+---
+ binutils/stabs.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/binutils/stabs.c b/binutils/stabs.c
+index 2b5241637c1..796ff85b86a 100644
+--- a/binutils/stabs.c
++++ b/binutils/stabs.c
+@@ -5467,7 +5467,10 @@ stab_demangle_v3_arg (void *dhandle, struct stab_handle *info,
+ 					  dc->u.s_binary.right,
+ 					  &varargs);
+ 	if (pargs == NULL)
+-	  return NULL;
++	  {
++	    free (dt);
++	    return NULL;
++	  }
+ 
+ 	return debug_make_function_type (dhandle, dt, pargs, varargs);
+       }
+-- 
+2.43.5

--- a/SPECS/binutils/CVE-2022-47008.patch
+++ b/SPECS/binutils/CVE-2022-47008.patch
@@ -1,0 +1,61 @@
+From d6e1d48c83b165c129cb0aa78905f7ca80a1f682 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Fri, 17 Jun 2022 09:13:38 +0930
+Subject: [PATCH] PR29255, memory leak in make_tempdir
+
+	PR 29255
+	* bucomm.c (make_tempdir, make_tempname): Free template on all
+	failure paths.
+---
+ binutils/bucomm.c | 20 +++++++++++---------
+ 1 file changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/binutils/bucomm.c b/binutils/bucomm.c
+index fdc2209df9c..4395cb9f7f5 100644
+--- a/binutils/bucomm.c
++++ b/binutils/bucomm.c
+@@ -537,8 +537,9 @@ make_tempname (const char *filename, int *ofd)
+ #else
+   tmpname = mktemp (tmpname);
+   if (tmpname == NULL)
+-    return NULL;
+-  fd = open (tmpname, O_RDWR | O_CREAT | O_EXCL, 0600);
++    fd = -1;
++  else
++    fd = open (tmpname, O_RDWR | O_CREAT | O_EXCL, 0600);
+ #endif
+   if (fd == -1)
+     {
+@@ -556,22 +557,23 @@ char *
+ make_tempdir (const char *filename)
+ {
+   char *tmpname = template_in_dir (filename);
++  char *ret;
+ 
+ #ifdef HAVE_MKDTEMP
+-  return mkdtemp (tmpname);
++  ret = mkdtemp (tmpname);
+ #else
+-  tmpname = mktemp (tmpname);
+-  if (tmpname == NULL)
+-    return NULL;
++  ret = mktemp (tmpname);
+ #if defined (_WIN32) && !defined (__CYGWIN32__)
+   if (mkdir (tmpname) != 0)
+-    return NULL;
++    ret = NULL;
+ #else
+   if (mkdir (tmpname, 0700) != 0)
+-    return NULL;
++    ret = NULL;
+ #endif
+-  return tmpname;
+ #endif
++  if (ret == NULL)
++    free (tmpname);
++  return ret;
+ }
+ 
+ /* Parse a string into a VMA, with a fatal error if it can't be
+-- 
+2.43.5

--- a/SPECS/binutils/CVE-2022-47010.patch
+++ b/SPECS/binutils/CVE-2022-47010.patch
@@ -1,0 +1,32 @@
+From 0d02e70b197c786f26175b9a73f94e01d14abdab Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Mon, 20 Jun 2022 10:39:31 +0930
+Subject: [PATCH] PR29262, memory leak in pr_function_type
+
+	PR 29262
+	* prdbg.c (pr_function_type): Free "s" on failure path.
+---
+ binutils/prdbg.c | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/binutils/prdbg.c b/binutils/prdbg.c
+index c1e41628d26..bb42a5b6c2d 100644
+--- a/binutils/prdbg.c
++++ b/binutils/prdbg.c
+@@ -742,12 +742,9 @@ pr_function_type (void *p, int argcount, bool varargs)
+ 
+   strcat (s, ")");
+ 
+-  if (! substitute_type (info, s))
+-    return false;
+-
++  bool ret = substitute_type (info, s);
+   free (s);
+-
+-  return true;
++  return ret;
+ }
+ 
+ /* Turn the top type on the stack into a reference to that type.  */
+-- 
+2.43.5

--- a/SPECS/binutils/CVE-2022-47011.patch
+++ b/SPECS/binutils/CVE-2022-47011.patch
@@ -1,0 +1,29 @@
+From 8a24927bc8dbf6beac2000593b21235c3796dc35 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Mon, 20 Jun 2022 10:39:13 +0930
+Subject: [PATCH] PR29261, memory leak in parse_stab_struct_fields
+
+	PR 29261
+	* stabs.c (parse_stab_struct_fields): Free "fields" on failure path.
+---
+ binutils/stabs.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/binutils/stabs.c b/binutils/stabs.c
+index 796ff85b86a..bf3f578cbcc 100644
+--- a/binutils/stabs.c
++++ b/binutils/stabs.c
+@@ -2367,7 +2367,10 @@ parse_stab_struct_fields (void *dhandle,
+ 
+       if (! parse_stab_one_struct_field (dhandle, info, pp, p, fields + c,
+ 					 staticsp, p_end))
+-	return false;
++	{
++	  free (fields);
++	  return false;
++	}
+ 
+       ++c;
+     }
+-- 
+2.43.5

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -21,7 +21,7 @@
 Summary:        Contains a linker, an assembler, and other tools
 Name:           binutils
 Version:        2.37
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -38,6 +38,11 @@ Patch4:         CVE-2022-38533.patch
 Patch5:         CVE-2022-4285.patch
 # The gold linker doesn't understand the 'module_info.ld' script passed to all linkers and the tests fail to correctly link.
 Patch6:         disable_gold_test.patch
+Patch7:         CVE-2022-47007.patch
+Patch8:         CVE-2022-47008.patch
+Patch9:         CVE-2022-47010.patch
+Patch10:        CVE-2022-47011.patch
+
 Provides:       bundled(libiberty)
 
 # Moving macro before the "SourceX" tags breaks PR checks parsing the specs.
@@ -294,6 +299,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %do_files aarch64-linux-gnu %{build_aarch64}
 
 %changelog
+* Thu oct 03 2024 Ankita Pareek <ankitapareek@microsoft.com> - 2.37-9
+- Add patches to fix CVE-2022-47007, CVE-2022-47008, CVE-2022-47010, CVE-2022-47011
+
 * Fri Nov 17 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.37-8
 - Add the cross-compilation subpackage for aarch64.
 - Used Fedora 38 spec (license: MIT) for guidance.

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.13-2.cm2.aarch64.rpm
 file-5.40-2.cm2.aarch64.rpm
 file-devel-5.40-2.cm2.aarch64.rpm
 file-libs-5.40-2.cm2.aarch64.rpm
-binutils-2.37-8.cm2.aarch64.rpm
-binutils-devel-2.37-8.cm2.aarch64.rpm
+binutils-2.37-9.cm2.aarch64.rpm
+binutils-devel-2.37-9.cm2.aarch64.rpm
 gmp-6.2.1-4.cm2.aarch64.rpm
 gmp-devel-6.2.1-4.cm2.aarch64.rpm
 mpfr-4.1.0-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.13-2.cm2.x86_64.rpm
 file-5.40-2.cm2.x86_64.rpm
 file-devel-5.40-2.cm2.x86_64.rpm
 file-libs-5.40-2.cm2.x86_64.rpm
-binutils-2.37-8.cm2.x86_64.rpm
-binutils-devel-2.37-8.cm2.x86_64.rpm
+binutils-2.37-9.cm2.x86_64.rpm
+binutils-devel-2.37-9.cm2.x86_64.rpm
 gmp-6.2.1-4.cm2.x86_64.rpm
 gmp-devel-6.2.1-4.cm2.x86_64.rpm
 mpfr-4.1.0-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -9,9 +9,9 @@ bash-5.1.8-4.cm2.aarch64.rpm
 bash-debuginfo-5.1.8-4.cm2.aarch64.rpm
 bash-devel-5.1.8-4.cm2.aarch64.rpm
 bash-lang-5.1.8-4.cm2.aarch64.rpm
-binutils-2.37-8.cm2.aarch64.rpm
-binutils-debuginfo-2.37-8.cm2.aarch64.rpm
-binutils-devel-2.37-8.cm2.aarch64.rpm
+binutils-2.37-9.cm2.aarch64.rpm
+binutils-debuginfo-2.37-9.cm2.aarch64.rpm
+binutils-devel-2.37-9.cm2.aarch64.rpm
 bison-3.7.6-2.cm2.aarch64.rpm
 bison-debuginfo-3.7.6-2.cm2.aarch64.rpm
 bzip2-1.0.8-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -9,10 +9,10 @@ bash-5.1.8-4.cm2.x86_64.rpm
 bash-debuginfo-5.1.8-4.cm2.x86_64.rpm
 bash-devel-5.1.8-4.cm2.x86_64.rpm
 bash-lang-5.1.8-4.cm2.x86_64.rpm
-binutils-2.37-8.cm2.x86_64.rpm
-binutils-aarch64-linux-gnu-2.37-8.cm2.x86_64.rpm
-binutils-debuginfo-2.37-8.cm2.x86_64.rpm
-binutils-devel-2.37-8.cm2.x86_64.rpm
+binutils-2.37-9.cm2.x86_64.rpm
+binutils-aarch64-linux-gnu-2.37-9.cm2.x86_64.rpm
+binutils-debuginfo-2.37-9.cm2.x86_64.rpm
+binutils-devel-2.37-9.cm2.x86_64.rpm
 bison-3.7.6-2.cm2.x86_64.rpm
 bison-debuginfo-3.7.6-2.cm2.x86_64.rpm
 bzip2-1.0.8-1.cm2.x86_64.rpm
@@ -47,7 +47,7 @@ cracklib-lang-2.9.7-5.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-devel-0.17.5-1.cm2.x86_64.rpm
-cross-binutils-common-2.37-8.cm2.noarch.rpm
+cross-binutils-common-2.37-9.cm2.noarch.rpm
 cross-gcc-common-11.2.0-8.cm2.noarch.rpm
 curl-8.8.0-2.cm2.x86_64.rpm
 curl-debuginfo-8.8.0-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fixes CVE-2022-47007, CVE-2022-47008, CVE-2022-47010 and CVE-2022-47011 in binutils package

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch for fixing CVE-2022-47007, CVE-2022-47008, CVE-2022-47010, CVE-2022-47011 in binutils

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-47007
- https://nvd.nist.gov/vuln/detail/CVE-2022-47008
- https://nvd.nist.gov/vuln/detail/CVE-2022-47010
- https://nvd.nist.gov/vuln/detail/CVE-2022-47011

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [650937](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=650937&view=results)
