### PR TITLE
Fixed toolkit's handling of RPMs with epoch values in their name

### DIFF
--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -553,6 +553,7 @@ func assignRPMPath(node *pkggraph.PkgNode, outDir string, resolvedPackages []str
 
 func rpmPackageToRPMPath(rpmPackage, outDir string) string {
 	// Construct the RPM path of the cloned package.
+	rpmPackage = rpm.StripEpochFromPackageFullQualifiedName(rpmPackage)
 	rpmName := fmt.Sprintf("%s.rpm", rpmPackage)
 	return filepath.Join(outDir, rpmName)
 }

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -552,7 +552,7 @@ func assignRPMPath(node *pkggraph.PkgNode, outDir string, resolvedPackages []str
 }
 
 func rpmPackageToRPMPath(rpmPackage, outDir string) string {
-	// Construct the rpm path of the cloned package.
+	// Construct the RPM path of the cloned package.
 	rpmName := fmt.Sprintf("%s.rpm", rpmPackage)
 	return filepath.Join(outDir, rpmName)
 }

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -113,7 +113,7 @@ var (
 	//   - version:			1.2.3
 	//   - release:			4.azl3
 	//   - architecture:	x86_64
-	//   - extension:		.rpm
+	//   - extension:		rpm
 	packageFQNRegex = regexp.MustCompile(`^\s*(\S+[^-])-(?:(\d+):)?(\d[^-:_]*)-(\d+(?:[^-\s]*?))(?:\.(noarch|x86_64|aarch64|src))?(?:\.(rpm))?\s*$`)
 
 	// Output from 'rpm' prints installed RPMs in a line with the following format:

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -114,7 +114,7 @@ var (
 	//   - release:			4.azl3
 	//   - architecture:	x86_64
 	//   - extension:		.rpm
-	packageFQNRegex = regexp.MustCompile(`^\s*(\S+[^-])-(?:(\d+):)?(\d[^-:_]*)-(\d+(?:\.[^-.\s]+)+?)(?:\.(noarch|x86_64|aarch64))?(?:\.(rpm))?\s*$`)
+	packageFQNRegex = regexp.MustCompile(`^\s*(\S+[^-])-(?:(\d+):)?(\d[^-:_]*)-(\d+(?:[^-\s]*?))(?:\.(noarch|x86_64|aarch64|src))?(?:\.(rpm))?\s*$`)
 
 	// Output from 'rpm' prints installed RPMs in a line with the following format:
 	//

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -527,9 +527,7 @@ func extractCompetingPackageInfoFromLine(line string) (match bool, pkgName strin
 		version := matches[installedRPMRegexVersionIndex]
 		arch := matches[installedRPMRegexArchIndex]
 		// Names should not contain the epoch, strip everything before the ":"" in the string. "Version": "0:1.2-3", becomes "1.2-3"
-		if strings.Contains(version, ":") {
-			version = strings.Split(version, ":")[1]
-		}
+		version = StripEpochFromVersion(version)
 
 		return true, fmt.Sprintf("%s-%s.%s", pkgName, version, arch)
 	}
@@ -634,6 +632,14 @@ func BuildCompatibleSpecsList(baseDir string, inputSpecPaths []string, defines m
 	}
 
 	return filterCompatibleSpecs(specPaths, defines)
+}
+
+// StripEpochFromVersion removes the epoch from a version string if it is present.
+func StripEpochFromVersion(version string) string {
+	if strings.Contains(version, ":") {
+		return strings.Split(version, ":")[1]
+	}
+	return version
 }
 
 // TestRPMFromSRPM builds an RPM from the given SRPM and runs its '%check' section SRPM file

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -470,7 +470,7 @@ func TestConflictingPackageRegex(t *testing.T) {
 			name:           "perl with epoch",
 			inputLine:      "D: ========== +++ perl-4:5.34.1-489.cm2 x86_64-linux 0x0",
 			expectedMatch:  true,
-			expectedOutput: "perl-5.34.1-489.cm2.x86_64",
+			expectedOutput: "perl-4:5.34.1-489.cm2.x86_64",
 		},
 		{
 			name:           "systemd no epoch",

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -556,6 +556,11 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 			input:          "pkg-name-1.2.3-45.azl3~2.x86_64.rpm",
 			expectedGroups: []string{"pkg-name", "", "1.2.3", "45.azl3~2", "x86_64", "rpm"},
 		},
+		{
+			name:           "package with double dash in name",
+			input:          "nvidia-container-toolkit-1.15.0-1.azl3.x86_64.rpm",
+			expectedGroups: []string{"nvidia-container-toolkit", "", "1.15.0", "1.azl3", "x86_64", "rpm"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -614,42 +614,6 @@ func TestPackageFQNRegexWithInvalidInput(t *testing.T) {
 	}
 }
 
-func TestConflictingPackageRegex(t *testing.T) {
-	tests := []struct {
-		name           string
-		inputLine      string
-		expectedMatch  bool
-		expectedOutput string
-	}{
-		{
-			name:           "perl with epoch",
-			inputLine:      "D: ========== +++ perl-4:5.34.1-489.cm2 x86_64-linux 0x0",
-			expectedMatch:  true,
-			expectedOutput: "perl-4:5.34.1-489.cm2.x86_64",
-		},
-		{
-			name:           "systemd no epoch",
-			inputLine:      "D: ========== +++ systemd-devel-239-42.cm2 x86_64-linux 0x0",
-			expectedMatch:  true,
-			expectedOutput: "systemd-devel-239-42.cm2.x86_64",
-		},
-		{
-			name:           "non-matching line",
-			inputLine:      "D: ========== tsorting packages (order, #predecessors, #succesors, depth)",
-			expectedMatch:  false,
-			expectedOutput: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			match, actualOut := extractCompetingPackageInfoFromLine(tt.inputLine)
-			assert.Equal(t, tt.expectedMatch, match)
-			assert.Equal(t, tt.expectedOutput, actualOut)
-		})
-	}
-}
-
 func TestStripEpochFromPackageFullQualifiedNameWithValidInput(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -495,48 +495,259 @@ func TestConflictingPackageRegex(t *testing.T) {
 	}
 }
 
-func TestStripEpochFromVersion(t *testing.T) {
+func TestPackageFQNRegexWithValidInput(t *testing.T) {
 	tests := []struct {
 		name           string
-		inputVersion   string
-		expectedOutput string
+		input          string
+		expectedGroups []string
 	}{
 		{
-			name:           "version with epoch",
-			inputVersion:   "4:5.34.1-489.azlX",
-			expectedOutput: "5.34.1-489.azlX",
+			name:           "package with epoch and architecture",
+			input:          "pkg-name-0:1.2.3-4.azl3.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", "x86_64"},
 		},
 		{
-			name:           "version without epoch",
-			inputVersion:   "5.34.1-489.azlX",
-			expectedOutput: "5.34.1-489.azlX",
+			name:           "package with epoch and architecture but no '.rpm' suffix",
+			input:          "pkg-name-0:1.2.3-4.azl3.x86_64",
+			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", "x86_64"},
 		},
 		{
-			name:           "version with zero epoch",
-			inputVersion:   "0:5.34.1-489.azlX",
-			expectedOutput: "5.34.1-489.azlX",
+			name:           "package without epoch, and architecture",
+			input:          "pkg-name-1.2.3-4.azl3.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", ""},
 		},
 		{
-			name:           "empty version",
-			inputVersion:   "",
-			expectedOutput: "",
+			name:           "package with architecture but no epoch",
+			input:          "pkg-name-1.2.3-4.azl3.aarch64",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "aarch64"},
 		},
 		{
-			name:           "version with only epoch",
-			inputVersion:   "4:",
-			expectedOutput: "",
+			name:           "package with epoch but no architecture",
+			input:          "pkg-name-0:1.2.3-4.azl3",
+			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", ""},
 		},
 		{
-			name:           "version with underscore in the release",
-			inputVersion:   "4:5.34.1-489_azlX",
-			expectedOutput: "5.34.1-489_azlX",
+			name:           "package without '.rpm' suffix",
+			input:          "pkg-name-1.2.3-4.azl3.x86_64",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "x86_64"},
+		},
+		{
+			name:           "package with version containing the '+' character",
+			input:          "pkg-name-1.2.3+4-4.azl3.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3+4", "4.azl3", "x86_64"},
+		},
+		{
+			name:           "package with version containing the '~' character",
+			input:          "pkg-name-1.2.3~4-4.azl3.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3~4", "4.azl3", "x86_64"},
+		},
+		{
+			name:           "package with release containing two '.' characters",
+			input:          "pkg-name-1.2.3-4.5.azl3.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.5.azl3", "x86_64"},
+		},
+		{
+			name:           "package with release containing the '_' character",
+			input:          "pkg-name-1.2.3-4_5.azl3.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4_5.azl3", "x86_64"},
+		},
+		{
+			name:           "package with release containing the `~` character",
+			input:          "pkg-name-1.2.3-4~5.azl3.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4~5.azl3", "x86_64"},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			output := StripEpochFromVersion(test.inputVersion)
-			assert.Equal(t, test.expectedOutput, output)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := packageFQNRegex.FindStringSubmatch(tt.input)
+			assert.NotNil(t, matches)
+			assert.Equal(t, tt.expectedGroups, matches[1:])
+		})
+	}
+}
+
+func TestPackageFQNRegexWithInvalidInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "package with missing version",
+			input: "pkg-name--4.azl3.x86_64.rpm",
+		},
+		{
+			name:  "package with missing release",
+			input: "pkg-name-1.2.3-.azl3.x86_64.rpm",
+		},
+		{
+			name:  "package with missing name",
+			input: "-1.2.3-4.azl3.x86_64.rpm",
+		},
+		{
+			name:  "package with only hyphen",
+			input: "-",
+		},
+		{
+			name:  "package with version not beginning with a digit",
+			input: "pkg-name-0:a1.2.3-4.azl3.x86_64.rpm",
+		},
+		{
+			name:  "package with release not beginning with a digit",
+			input: "pkg-name-0:1.2.3-D4.azl3.x86_64.rpm",
+		},
+		{
+			name:  "package with epoch not beginning with a digit",
+			input: "pkg-name-0:1.2.3-D4.azl3.x86_64.rpm",
+		},
+		{
+			name:  "package with epoch unsupported architecture",
+			input: "pkg-name-0:1.2.3-D4.azl3.other_arch.rpm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := packageFQNRegex.FindStringSubmatch(tt.input)
+			assert.Nil(t, matches)
+		})
+	}
+}
+
+func TestConflictingPackageRegex(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputLine      string
+		expectedMatch  bool
+		expectedOutput string
+	}{
+		{
+			name:           "perl with epoch",
+			inputLine:      "D: ========== +++ perl-4:5.34.1-489.cm2 x86_64-linux 0x0",
+			expectedMatch:  true,
+			expectedOutput: "perl-4:5.34.1-489.cm2.x86_64",
+		},
+		{
+			name:           "systemd no epoch",
+			inputLine:      "D: ========== +++ systemd-devel-239-42.cm2 x86_64-linux 0x0",
+			expectedMatch:  true,
+			expectedOutput: "systemd-devel-239-42.cm2.x86_64",
+		},
+		{
+			name:           "non-matching line",
+			inputLine:      "D: ========== tsorting packages (order, #predecessors, #succesors, depth)",
+			expectedMatch:  false,
+			expectedOutput: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, actualOut := extractCompetingPackageInfoFromLine(tt.inputLine)
+			assert.Equal(t, tt.expectedMatch, match)
+			assert.Equal(t, tt.expectedOutput, actualOut)
+		})
+	}
+}
+
+func TestStripEpochFromPackageFullQualifiedNameWithValidInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "package with epoch and architecture",
+			input:    "pkg-name-0:1.2.3-4.azl3.x86_64.rpm",
+			expected: "pkg-name-1.2.3-4.azl3.x86_64.rpm",
+		},
+		{
+			name:     "package with epoch and architecture but no '.rpm' suffix",
+			input:    "pkg-name-0:1.2.3-4.azl3.x86_64",
+			expected: "pkg-name-1.2.3-4.azl3.x86_64",
+		},
+		{
+			name:     "package with epoch but no architecture",
+			input:    "pkg-name-0:1.2.3-4.azl3",
+			expected: "pkg-name-1.2.3-4.azl3",
+		},
+		{
+			name:     "package with architecture but no epoch",
+			input:    "pkg-name-1.2.3-4.azl3.aarch64",
+			expected: "pkg-name-1.2.3-4.azl3.aarch64",
+		},
+		{
+			name:     "package without epoch, and architecture",
+			input:    "pkg-name-1.2.3-4.azl3.rpm",
+			expected: "pkg-name-1.2.3-4.azl3.rpm",
+		},
+		{
+			name:     "package with version containing the '+' character",
+			input:    "pkg-name-1.2.3+4-4.azl3.x86_64.rpm",
+			expected: "pkg-name-1.2.3+4-4.azl3.x86_64.rpm",
+		},
+		{
+			name:     "package with version containing the '~' character",
+			input:    "pkg-name-1.2.3~4-4.azl3.x86_64.rpm",
+			expected: "pkg-name-1.2.3~4-4.azl3.x86_64.rpm",
+		},
+		{
+			name:     "package with release containing two '.' characters",
+			input:    "pkg-name-1.2.3-4.5.azl3.x86_64.rpm",
+			expected: "pkg-name-1.2.3-4.5.azl3.x86_64.rpm",
+		},
+		{
+			name:     "package with release containing the '_' character",
+			input:    "pkg-name-1.2.3-4_5.azl3.x86_64.rpm",
+			expected: "pkg-name-1.2.3-4_5.azl3.x86_64.rpm",
+		},
+		{
+			name:     "package with release containing the `~` character",
+			input:    "pkg-name-1.2.3-4~5.azl3.x86_64.rpm",
+			expected: "pkg-name-1.2.3-4~5.azl3.x86_64.rpm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := StripEpochFromPackageFullQualifiedName(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestStripEpochFromPackageFullQualifiedNameWithInvalidInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "invalid package name",
+			input:    "invalid-package-name",
+			expected: "invalid-package-name",
+		},
+		{
+			name:     "empty package name",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "package name with only hyphens",
+			input:    "----",
+			expected: "----",
+		},
+		{
+			name:     "package name with spaces",
+			input:    "pkg name-1.2.3-4.azl3.x86_64.rpm",
+			expected: "pkg name-1.2.3-4.azl3.x86_64.rpm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := StripEpochFromPackageFullQualifiedName(tt.input)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -509,7 +509,7 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 		{
 			name:           "package with epoch and architecture but no '.rpm' suffix",
 			input:          "pkg-name-0:1.2.3-4.azl3.x86_64",
-			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", "x86_64"},
+			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", "x86_64", ""},
 		},
 		{
 			name:           "package without epoch, and architecture",
@@ -519,17 +519,17 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 		{
 			name:           "package with architecture but no epoch",
 			input:          "pkg-name-1.2.3-4.azl3.aarch64",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "aarch64"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "aarch64", ""},
 		},
 		{
 			name:           "package with epoch but no architecture",
 			input:          "pkg-name-0:1.2.3-4.azl3",
-			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", ""},
+			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", "", ""},
 		},
 		{
 			name:           "package without '.rpm' suffix",
 			input:          "pkg-name-1.2.3-4.azl3.x86_64",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "x86_64", "rpm"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "x86_64", ""},
 		},
 		{
 			name:           "package with version containing the '+' character",
@@ -549,12 +549,12 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 		{
 			name:           "package with release containing the '_' character",
 			input:          "pkg-name-1.2.3-45.az_l3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4_5.azl3", "x86_64", "rpm"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "45.az_l3", "x86_64", "rpm"},
 		},
 		{
 			name:           "package with release containing the `~` character",
-			input:          "pkg-name-1.2.3-4~5.azl3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4~5.azl3", "x86_64", "rpm"},
+			input:          "pkg-name-1.2.3-45.azl3~2.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "45.azl3~2", "x86_64", "rpm"},
 		},
 	}
 

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -504,7 +504,7 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 		{
 			name:           "package with epoch and architecture",
 			input:          "pkg-name-0:1.2.3-4.azl3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", "x86_64"},
+			expectedGroups: []string{"pkg-name", "0", "1.2.3", "4.azl3", "x86_64", "rpm"},
 		},
 		{
 			name:           "package with epoch and architecture but no '.rpm' suffix",
@@ -514,7 +514,7 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 		{
 			name:           "package without epoch, and architecture",
 			input:          "pkg-name-1.2.3-4.azl3.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", ""},
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "", "rpm"},
 		},
 		{
 			name:           "package with architecture but no epoch",
@@ -529,32 +529,32 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 		{
 			name:           "package without '.rpm' suffix",
 			input:          "pkg-name-1.2.3-4.azl3.x86_64",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "x86_64"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.azl3", "x86_64", "rpm"},
 		},
 		{
 			name:           "package with version containing the '+' character",
 			input:          "pkg-name-1.2.3+4-4.azl3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3+4", "4.azl3", "x86_64"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3+4", "4.azl3", "x86_64", "rpm"},
 		},
 		{
 			name:           "package with version containing the '~' character",
 			input:          "pkg-name-1.2.3~4-4.azl3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3~4", "4.azl3", "x86_64"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3~4", "4.azl3", "x86_64", "rpm"},
 		},
 		{
 			name:           "package with release containing two '.' characters",
 			input:          "pkg-name-1.2.3-4.5.azl3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.5.azl3", "x86_64"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4.5.azl3", "x86_64", "rpm"},
 		},
 		{
 			name:           "package with release containing the '_' character",
-			input:          "pkg-name-1.2.3-4_5.azl3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4_5.azl3", "x86_64"},
+			input:          "pkg-name-1.2.3-45.az_l3.x86_64.rpm",
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4_5.azl3", "x86_64", "rpm"},
 		},
 		{
 			name:           "package with release containing the `~` character",
 			input:          "pkg-name-1.2.3-4~5.azl3.x86_64.rpm",
-			expectedGroups: []string{"pkg-name", "", "1.2.3", "4~5.azl3", "x86_64"},
+			expectedGroups: []string{"pkg-name", "", "1.2.3", "4~5.azl3", "x86_64", "rpm"},
 		},
 	}
 
@@ -595,6 +595,10 @@ func TestPackageFQNRegexWithInvalidInput(t *testing.T) {
 		{
 			name:  "package with release not beginning with a digit",
 			input: "pkg-name-0:1.2.3-D4.azl3.x86_64.rpm",
+		},
+		{
+			name:  "package with release not beginning with a number followed by a '.'",
+			input: "pkg-name-0:1.2.3-4_1.azl3.x86_64.rpm",
 		},
 		{
 			name:  "package with epoch not beginning with a digit",

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -561,6 +561,11 @@ func TestPackageFQNRegexWithValidInput(t *testing.T) {
 			input:          "nvidia-container-toolkit-1.15.0-1.azl3.x86_64.rpm",
 			expectedGroups: []string{"nvidia-container-toolkit", "", "1.15.0", "1.azl3", "x86_64", "rpm"},
 		},
+		{
+			name:           "package with underscore in release",
+			input:          "nvidia-container-toolkit-550.54.15-2_5.15.162.2.1.azl3.x86_64.rpm",
+			expectedGroups: []string{"nvidia-container-toolkit", "", "550.54.15", "2_5.15.162.2.1.azl3", "x86_64", "rpm"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -600,10 +605,6 @@ func TestPackageFQNRegexWithInvalidInput(t *testing.T) {
 		{
 			name:  "package with release not beginning with a digit",
 			input: "pkg-name-0:1.2.3-D4.azl3.x86_64.rpm",
-		},
-		{
-			name:  "package with release not beginning with a number followed by a '.'",
-			input: "pkg-name-0:1.2.3-4_1.azl3.x86_64.rpm",
 		},
 		{
 			name:  "package with epoch not beginning with a digit",

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -494,3 +494,49 @@ func TestConflictingPackageRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestStripEpochFromVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputVersion   string
+		expectedOutput string
+	}{
+		{
+			name:           "version with epoch",
+			inputVersion:   "4:5.34.1-489.azlX",
+			expectedOutput: "5.34.1-489.azlX",
+		},
+		{
+			name:           "version without epoch",
+			inputVersion:   "5.34.1-489.azlX",
+			expectedOutput: "5.34.1-489.azlX",
+		},
+		{
+			name:           "version with zero epoch",
+			inputVersion:   "0:5.34.1-489.azlX",
+			expectedOutput: "5.34.1-489.azlX",
+		},
+		{
+			name:           "empty version",
+			inputVersion:   "",
+			expectedOutput: "",
+		},
+		{
+			name:           "version with only epoch",
+			inputVersion:   "4:",
+			expectedOutput: "",
+		},
+		{
+			name:           "version with underscore in the release",
+			inputVersion:   "4:5.34.1-489_azlX",
+			expectedOutput: "5.34.1-489_azlX",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := StripEpochFromVersion(test.inputVersion)
+			assert.Equal(t, test.expectedOutput, output)
+		})
+	}
+}

--- a/toolkit/tools/precacher/precacher.go
+++ b/toolkit/tools/precacher/precacher.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/network"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/packagerepo/repocloner"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/packagerepo/repoutils"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/rpm"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/timestamp"
 	"github.com/microsoft/azurelinux/toolkit/tools/pkg/profile"
 	"github.com/sirupsen/logrus"
@@ -267,10 +267,7 @@ func precachePackage(pkg *repocloner.RepoPackage, packagesAvailableFromRepos map
 
 func formatName(pkg *repocloner.RepoPackage) (pkgName, fileName string) {
 	// Names should not contain the epoch, strip everything before the ":"" in the string. "Version": "0:1.2-3", becomes "1.2-3"
-	version := pkg.Version
-	if strings.Contains(version, ":") {
-		version = strings.Split(version, ":")[1]
-	}
+	version := rpm.StripEpochFromVersion(pkg.Version)
 
 	pkgName = fmt.Sprintf("%s-%s.%s.%s", pkg.Name, version, pkg.Distribution, pkg.Architecture)
 	fileName = fmt.Sprintf("%s.rpm", pkgName)

--- a/toolkit/tools/precacher/precacher.go
+++ b/toolkit/tools/precacher/precacher.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/network"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/packagerepo/repocloner"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/packagerepo/repoutils"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/rpm"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/timestamp"
 	"github.com/microsoft/azurelinux/toolkit/tools/pkg/profile"
 	"github.com/sirupsen/logrus"
@@ -267,7 +267,10 @@ func precachePackage(pkg *repocloner.RepoPackage, packagesAvailableFromRepos map
 
 func formatName(pkg *repocloner.RepoPackage) (pkgName, fileName string) {
 	// Names should not contain the epoch, strip everything before the ":"" in the string. "Version": "0:1.2-3", becomes "1.2-3"
-	version := rpm.StripEpochFromVersion(pkg.Version)
+	version := pkg.Version
+	if strings.Contains(version, ":") {
+		version = strings.Split(version, ":")[1]
+	}
 
 	pkgName = fmt.Sprintf("%s-%s.%s.%s", pkg.Name, version, pkg.Distribution, pkg.Architecture)
 	fileName = fmt.Sprintf("%s.rpm", pkgName)

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -269,6 +269,7 @@ func calculateExpectedFreshness(dependencyNode *pkggraph.PkgNode, buildState *Gr
 // If any of the RPMs produced by the SRPM are missing, we must build the SRPM and reset the freshness of the node.
 func nodeHasMissingRPMs(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode) (rpmsMissing bool) {
 	if node.SrpmPath == pkggraph.NoSRPMPath {
+		logger.Log.Debugf("Node %v has no SRPM path, skipping check for missing RPMs.", node.FriendlyName())
 		return
 	}
 

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -133,7 +133,7 @@ func buildRequest(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildState, pack
 		Freshness:      buildState.GetMaxFreshness(),
 	}
 
-	requiredRebuild := isRequiredRebuild(pkgGraph, builtNode, packagesToRebuild)
+	requiredRebuild := isRequiredRebuild(pkgGraph, request.Node, packagesToRebuild)
 	if !requiredRebuild && isCacheAllowed {
 		// We might be able to use the cache, set the freshness based on node's dependencies.
 		request.UseCache, request.Freshness = canUseCacheForNode(pkgGraph, request.Node, buildState)


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
### Continuation of #10587


We've recently started seeing builds failing with following errors:
```
failed to clone (7.70-506.azl3.noarch) from RPM repo
```

This seems to be related with invalid parsing of the `tdnf provides` output where the tool's regex failed to take a potential `:` into the account. A few lines above the mentioned error, we can see TDNF finding the right package:
```
time="2024-09-30T21:52:54Z" level=debug msg="Executing: [tdnf provides perl(ExtUtils::MakeMaker) --releasever=3.0 --disablerepo=* --enablerepo=toolchain-repo]"
time="2024-09-30T21:52:54Z" level=debug msg="tdnf search for provide 'perl(ExtUtils::MakeMaker)':
Loaded plugin: tdnfrepogpgcheck
[using capability match for 'perl(ExtUtils::MakeMaker)']
perl-ExtUtils-MakeMaker-2:7.70-506.azl3.noarch : Create a module Makefile
Repo	 : toolchain-repo
```

The `:` character in `2:7.70-506.azl3.noarch` is what confused the regex.

The current (as of 09/30/2024) version of TDNF (3.5.6) is printing the versions without the epoch and that's why we haven't hit this issue until now. It seems that the bump to version 3.5.8 added the epoch number to the `tdnf provides` output.

Sample output for 3.5.6:
```bash
root [ / ]# tdnf provides 'perl(ExtUtils::MakeMaker)'
Loaded plugin: tdnfrepogpgcheck
[using capability match for 'perl(ExtUtils::MakeMaker)']
perl-ExtUtils-MakeMaker-7.70-506.azl3.noarch : Create a module Makefile
Repo     : azurelinux-official-base
```

Notice no epoch in `7.70-506.azl3.noarch`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Go tests.