### PR TITLE
Add '-a' option to build-mic-container.sh for arch selection.

### DIFF
--- a/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+++ b/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
@@ -2,6 +2,6 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-      xfsprogs zstd veritysetup grub2 grub2-pc
+      xfsprogs zstd veritysetup grub2
 
 COPY . /

--- a/toolkit/tools/imagecustomizer/container/build-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-mic-container.sh
@@ -14,18 +14,30 @@ function showUsage() {
     echo "usage:"
     echo
     echo "build-mic-container.sh \\"
-    echo "    -t <container-tag>"
+    echo "    -t <container-tag> \\"
+    echo "    [-a <architecture>]"
+    echo
+    echo "    Architecture can be 'amd64' or 'arm64'. Default is 'amd64'."
     echo
 }
 
-while getopts ":r:n:t:" OPTIONS; do
+while getopts ":a:t:" OPTIONS; do
   case "${OPTIONS}" in
     t ) containerTag=$OPTARG ;;
+    a ) ARCH=$OPTARG ;;
+    \? ) echo "Invalid option: -$OPTARG" >&2; showUsage; exit 1 ;;
+    : ) echo "Option -$OPTARG requires an argument." >&2; showUsage; exit 1 ;;
   esac
 done
 
 if [[ -z $containerTag ]]; then
-    echo "missing required argument '-t containerTag'"
+    echo "missing required argument '-t <container-tag>'"
+    showUsage
+    exit 1
+fi
+
+if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" ]]; then
+    echo "Invalid architecture: $ARCH"
     showUsage
     exit 1
 fi


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add '-a' option to build-mic-container.sh for arch selection.
MIC ARM64 arch binary build needs this PR commit.

We still need:
- Another Dockerfile probably named `Dockerfile.mic-container.arm64`, change the base image from core 2.0 to core 2.0 arm64. However, this probably needs to create a new tag for core arm64 since for now it does not have a stable tag for arm64 arch.
- The package dependency `grub2-pc` does NOT support arm64, we need to find a substitution.
- GPG key issue.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Local build
