### PR TITLE
Fix overlayfs xen dracut subpackage entanglement

### DIFF
--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        102
-Release:        4%{?dist}
+Release:        5%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -113,6 +113,7 @@ This package contains tools to assemble the local initrd and host configuration.
 %package overlayfs
 Summary:        dracut module to build a dracut initramfs with OverlayFS support
 Requires:       %{name} = %{version}-%{release}
+Conflicts:      %{name}-xen <= 102-4
 
 %description overlayfs
 This package contains dracut module needed to build an initramfs with OverlayFS support.
@@ -269,6 +270,10 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %files overlayfs
 %dir %{dracutlibdir}/modules.d/20overlayfs
 %{dracutlibdir}/modules.d/20overlayfs/*
+%{_bindir}/%{name}-catimages
+%dir /boot/%{name}
+%dir %{_sharedstatedir}/%{name}
+%dir %{_sharedstatedir}/%{name}/overlay
 
 %files virtio
 %defattr(-,root,root,0755)
@@ -282,12 +287,10 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %defattr(-,root,root,0755)
 %{_sysconfdir}/dracut.conf.d/00-xen.conf
 
-%{_bindir}/%{name}-catimages
-%dir /boot/%{name}
-%dir %{_sharedstatedir}/%{name}
-%dir %{_sharedstatedir}/%{name}/overlay
-
 %changelog
+* Mon Oct 07 2024 Cameron Baird <cameronbaird@microsoft.com> - 102-5
+- Return loose files to the correct subpackage, dracut-overlayfs
+
 * Mon Aug 19 2024 Cameron Baird <cameronbaird@microsoft.com> - 102-4
 - Drop 0002-disable-xattr.patch
 - Introduce dracut-noxattr subpackage to expose this behavior as an option

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -113,6 +113,7 @@ This package contains tools to assemble the local initrd and host configuration.
 %package overlayfs
 Summary:        dracut module to build a dracut initramfs with OverlayFS support
 Requires:       %{name} = %{version}-%{release}
+# Version 102-4 and below of the xen subpackage owned files packaged by overlayfs
 Conflicts:      %{name}-xen <= 102-4
 
 %description overlayfs


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
During a previous change, we inadvertently took some files belonging to dracut-overlayfs and gave them to dracut-xen. This PR fixes that entanglement. 

See introducing change: https://github.com/microsoft/azurelinux/commit/3ce79012a33322bdcdfa68601d2b0129b2c5ab0b#diff-aaff17f1c552b2af5d9d0f054230df6757145a7c7bf500d490903f808ab20e03R277 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move files from dracut-xen to dracut-overlayfs
- Make latest dracut-overlayfs Conflicts with previous versions of dracut-xen

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
-  https://dev.azure.com/mariner-org/mariner/_build/results?buildId=653563&view=results
