### PR TITLE
Generate log files for raw toolchain builds

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -165,7 +165,10 @@ $(raw_toolchain): $(toolchain_files)
 			$(SOURCE_URL) \
 			$(INCREMENTAL_TOOLCHAIN) \
 			$(ARCHIVE_TOOL) \
-			$(toolchain_raw_logs_dir) 2>&1 | tee $(toolchain_raw_logs_dir)/create_toolchain_in_container_full.log
+			$(toolchain_raw_logs_dir) 2>&1 | tee $(toolchain_raw_logs_dir)/create_toolchain_in_container_full.log; \
+		if [ $${PIPESTATUS[0]} -ne 0 ]; then \
+			$(call print_error, create_toolchain_in_container.sh failed); \
+		fi
 
 # This target establishes a cache of toolchain RPMs for partially rehydrating the toolchain from package repos.
 # $(toolchain_from_repos) is a staging folder for these RPMs. We use the toolchain manifest to get a list of
@@ -229,7 +232,10 @@ $(final_toolchain): $(no_repo_acl) $(raw_toolchain) $(toolchain_rpms_rehydrated)
 			"$(toolchain_from_repos)" \
 			"$(TOOLCHAIN_MANIFEST)" \
 			"$(go-bldtracker)" \
-			"$(TIMESTAMP_DIR)/build_mariner_toolchain.jsonl" 2>&1 | tee $(toolchain_official_logs_dir)/build_official_rpms.log && \
+			"$(TIMESTAMP_DIR)/build_mariner_toolchain.jsonl" 2>&1 | tee $(toolchain_official_logs_dir)/build_official_rpms.log; \
+		if [ $${PIPESTATUS[0]} -ne 0 ]; then \
+			$(call print_error, build_mariner_toolchain.sh failed); \
+		fi && \
 	$(if $(filter y,$(UPDATE_TOOLCHAIN_LIST)), ls -1 $(toolchain_build_dir)/built_rpms_all > $(MANIFESTS_DIR)/package/toolchain_$(build_arch).txt && ) \
 	touch $@
 

--- a/toolkit/scripts/toolchain/create_toolchain_in_container.sh
+++ b/toolkit/scripts/toolchain/create_toolchain_in_container.sh
@@ -10,6 +10,12 @@ MARINER_SPECS_DIR=$2
 MARINER_SOURCE_URL=$3
 INCREMENTAL_TOOLCHAIN=$4
 ARCHIVE_TOOL=$5
+LOG_DIR=$6
+
+if [ -z "$MARINER_BUILD_DIR" ] || [ -z "$MARINER_SPECS_DIR" ] || [ -z "$MARINER_SOURCE_URL" ] || [ -z "$INCREMENTAL_TOOLCHAIN" ] || [ -z "$ARCHIVE_TOOL" ] || [ -z "$LOG_DIR" ]; then
+    echo "Usage: $0 <MARINER_BUILD_DIR> <MARINER_SPECS_DIR> <MARINER_SOURCE_URL> <INCREMENTAL_TOOLCHAIN> <ARCHIVE_TOOL> <LOG_DIR>"
+    exit 1
+fi
 
 # Grab an identity for the raw toolchain components so we can avoid rebuilding it if it hasn't changed
 files_to_watch=(    "./create_toolchain_in_container.sh" \
@@ -85,7 +91,10 @@ pushd $MARINER_BUILD_DIR/toolchain
 # Pull out the populated toolchain from the container
 docker rm -f marinertoolchain-container-temp 2>/dev/null || true
 temporary_toolchain_container=$(docker create --name marinertoolchain-container-temp marinertoolchain_populated:${sha_component_tag})
+rm -rf ${LOG_DIR}/logs
+mkdir -p ${LOG_DIR}/logs
 docker cp "${temporary_toolchain_container}":/temptoolchain/lfs .
+docker cp "${temporary_toolchain_container}":/temptoolchain/lfs/logs ${LOG_DIR}
 docker rm marinertoolchain-container-temp
 
 rm -rf ./populated_toolchain
@@ -104,5 +113,11 @@ popd
 rm -vf ./container/*.patch
 rm -vf ./container/.bashrc
 rm -vf ./container/toolchain-local-wget-list
+
+# Ensure the populated toolchain was created successfully
+if [ ! -f ${LOG_DIR}/logs/status_building_in_chroot_complete ]; then
+    echo "Error: Raw toolchain container build failed, check logs in ${LOG_DIR} for details"
+    exit 1
+fi
 
 echo Raw toolchain build complete


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When we build the raw bootstrap toolchain and the official toolchain rpms, we do not generate log files in a durable way. This change will log the script output via `tee`, and also extract the logs from the docker container once the build is complete.

We also detect a failure of the build in the raw toolchain by checking for the presence of `status_building_in_chroot_complete`. Currently the docker build may abort at any point in `docker run ...` and we will continue as it if worked. We won't see failures until we try to use the raw container later.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Collect log files from the toolchain build stages
- Explicitly fail the raw toolchain build if any part fails

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/54315733

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- ~https://dev.azure.com/mariner-org/mariner/_build/results?buildId=654157&view=results~
- With expected fail: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=654640&view=results
- With toolchain fix: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=654795&view=results
- Local builds
