### PR TITLE
rubygem-async-http: remove version dependency of rubygem-protocol-http1

### DIFF
--- a/SPECS/rubygem-async-http/0001-add-patch.patch
+++ b/SPECS/rubygem-async-http/0001-add-patch.patch
@@ -1,0 +1,25 @@
+From 058c72f0bdc5daa6078de96674aa68d8895ae921 Mon Sep 17 00:00:00 2001
+From: Dallas Delaney <dadelan@example.com>
+Date: Tue, 8 Oct 2024 12:59:09 -0700
+Subject: [PATCH] add patch
+
+---
+ async-http.gemspec | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/async-http.gemspec b/async-http.gemspec
+index 5078ab0..44c8035 100644
+--- a/async-http.gemspec
++++ b/async-http.gemspec
+@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
+ 	spec.add_dependency "async-io", ">= 1.28"
+ 	spec.add_dependency "async-pool", ">= 0.2"
+ 	spec.add_dependency "protocol-http", "~> 0.22.0"
+-	spec.add_dependency "protocol-http1", "~> 0.14.0"
++	spec.add_dependency "protocol-http1"
+ 	spec.add_dependency "protocol-http2", "~> 0.14.0"
+ 	
+ 	spec.add_development_dependency "async-container", "~> 0.14"
+-- 
+2.34.1
+

--- a/SPECS/rubygem-async-http/remove-http-protocol1-dep.patch
+++ b/SPECS/rubygem-async-http/remove-http-protocol1-dep.patch
@@ -1,7 +1,7 @@
 From 058c72f0bdc5daa6078de96674aa68d8895ae921 Mon Sep 17 00:00:00 2001
-From: Dallas Delaney <dadelan@example.com>
+From: Dallas Delaney <dadelan@microsoft.com>
 Date: Tue, 8 Oct 2024 12:59:09 -0700
-Subject: [PATCH] add patch
+Subject: [PATCH] remove version dependency on protocol-http1
 
 ---
  async-http.gemspec | 2 +-

--- a/SPECS/rubygem-async-http/rubygem-async-http.spec
+++ b/SPECS/rubygem-async-http/rubygem-async-http.spec
@@ -10,7 +10,7 @@ Distribution:   Mariner
 Group:          Development/Languages
 URL:            https://github.com/socketry/async-http
 Source0:        https://github.com/socketry/async-http/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
-Patch0:         0001-add-patch.patch
+Patch0:         remove-http-protocol1-dep.patch
 BuildRequires:  ruby
 Requires:       rubygem-async
 Requires:       rubygem-async-io

--- a/SPECS/rubygem-async-http/rubygem-async-http.spec
+++ b/SPECS/rubygem-async-http/rubygem-async-http.spec
@@ -3,13 +3,14 @@
 Summary:        A HTTP client and server library
 Name:           rubygem-%{gem_name}
 Version:        0.56.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Languages
 URL:            https://github.com/socketry/async-http
 Source0:        https://github.com/socketry/async-http/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
+Patch0:         0001-add-patch.patch
 BuildRequires:  ruby
 Requires:       rubygem-async
 Requires:       rubygem-async-io
@@ -25,7 +26,7 @@ HTTP/1.1 and HTTP/2 including TLS. Support for streaming requests
 and responses.
 
 %prep
-%setup -q -n %{gem_name}-%{version}
+%autosetup -p1 -n %{gem_name}-%{version}
 
 %build
 gem build %{gem_name}
@@ -38,6 +39,9 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
+* Thu Oct 03 2024 Dallas Delaney <dadelan@microsoft.com> - 0.56.5-2
+- Add patch to remove dependency on pinned version of rubygem-protocol-http1
+
 * Wed Jun 22 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 0.56.5-1
 - Update to v0.56.5.
 - Build from .tar.gz source.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Remove version dependency of rubygem-protocol-http1 from rubygem-async-http. This will allow upgrades of rubygem-protocol-http1 where both packages are installed on the host.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove version dependency of rubygem-protocol-http1 from rubygem-async-http

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=657278&view=results
