### PR TITLE
Bump prometheus to 2.37.9 to fix CVE 2022 41717

### DIFF
--- a/SPECS/prometheus/prometheus.signatures.json
+++ b/SPECS/prometheus/prometheus.signatures.json
@@ -1,11 +1,11 @@
 {
  "Signatures": {
-  "prometheus-2.37.0.tar.gz": "98892e82b97004a458e81f03d804859d485323af2d85c34f8a996e25fe1305a9",
+  "prometheus-2.37.9.tar.gz": "f26eba405e0836c5a53bfff91b45dc71b14900d5edc0fe8db7238d3c85ac45fb",
   "prometheus.conf": "ce522e82dfb2945c520b482b15b5cf591364f7a571f0f28259b64dbeda42b043",
   "prometheus.logrotate": "061b92500cd40fcaaf486ff488bcf1b09eac6743d8e840ba6966dc70d4e2067b",
   "prometheus.service": "29bf1c886e1d55080e859f2afe112bb7344490e6992e946efe3360fd94d1a604",
   "prometheus.sysconfig": "ec89a45641e3411478794106246aa91e7b72f86070a28a4782e3b8be955e4587",
   "prometheus.yml": "0112e0bf54660c5e2391fff11a56404a25684c588caa7281677f7f8e19da6f28",
-  "promu-0.13.0.tar.gz": "3473b87214968c79158f553228baef6e9a37ed3e11e1a4f3e7267ffd3180a8b6"
+  "promu-0.14.0.tar.gz": "d71d2a0d54093f3f17dc406d7a5825b6d6acd304cd90d9c60ed3f1335fb6ed2a"
  }
 }

--- a/SPECS/prometheus/prometheus.spec
+++ b/SPECS/prometheus/prometheus.spec
@@ -1,10 +1,10 @@
 # When upgrading Prometheus, run `./generate_source_tarball.sh --pkgVersion <version>`
 # The script will spit out custom tarballs for `prometheus` and `promu` (More details in the script)
-%global promu_version 0.13.0
+%global promu_version 0.14.0
 Summary:        Prometheus monitoring system and time series database
 Name:           prometheus
-Version:        2.37.0
-Release:        15%{?dist}
+Version:        2.37.9
+Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -132,6 +132,9 @@ fi
 %doc README.md RELEASE.md documentation
 
 %changelog
+* Thu Oct 10 2024 Sumedh Sharma <sumsharma@microsoft.com> - 2.37.9-1
+- Bump version to patch CVE-2022-41717
+
 * Mon Sep 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.37.0-15
 - Bump release to rebuild with go 1.22.7
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21574,8 +21574,8 @@
         "type": "other",
         "other": {
           "name": "prometheus",
-          "version": "2.37.0",
-          "downloadUrl": "https://github.com/prometheus/prometheus/archive/refs/tags/v2.37.0.tar.gz"
+          "version": "2.37.9",
+          "downloadUrl": "https://github.com/prometheus/prometheus/archive/refs/tags/v2.37.9.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Bump to version 2.37.9 to fix CVE-2022-41717
Reference:
https://github.com/prometheus/prometheus/pull/11690
https://go-review.googlesource.com/c/net/+/455635
https://go-review.googlesource.com/c/go/+/455717

###### Change Log  <!-- REQUIRED -->
- Bump package version

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-41717

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=655716&view=results)
