### PR TITLE
Patch cni-plugins to resolve CVE-2023-3978

### DIFF
--- a/SPECS/cni-plugins/CVE-2023-3978.patch
+++ b/SPECS/cni-plugins/CVE-2023-3978.patch
@@ -1,0 +1,78 @@
+From 8ffa475fbdb33da97e8bf79cc5791ee8751fca5e Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <bracewell@google.com>
+Date: Thu, 06 Jul 2023 10:25:47 -0700
+Subject: [PATCH] html: only render content literally in the HTML namespace
+
+Per the WHATWG HTML specification, section 13.3, only append the literal
+content of a text node if we are in the HTML namespace.
+
+Thanks to Mohammad Thoriq Aziz for reporting this issue.
+
+Fixes golang/go#61615
+Fixes CVE-2023-3978
+
+Change-Id: I332152904d4e7646bd2441602bcbe591fc655fa4
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1942896
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Run-TryBot: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Damien Neil <dneil@google.com>
+TryBot-Result: Security TryBots <security-trybots@go-security-trybots.iam.gserviceaccount.com>
+Reviewed-on: https://go-review.googlesource.com/c/net/+/514896
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Run-TryBot: Damien Neil <dneil@google.com>
+---
+
+diff --git a/vendor/golang.org/x/net/html/render.go b/vendor/golang.org/x/net/html/render.go
+index 8b28031..e8c1233 100644
+--- a/vendor/golang.org/x/net/html/render.go
++++ b/vendor/golang.org/x/net/html/render.go
+@@ -194,9 +194,8 @@
+ 		}
+ 	}
+ 
+-	// Render any child nodes.
+-	switch n.Data {
+-	case "iframe", "noembed", "noframes", "noscript", "plaintext", "script", "style", "xmp":
++	// Render any child nodes
++	if childTextNodesAreLiteral(n) {
+ 		for c := n.FirstChild; c != nil; c = c.NextSibling {
+ 			if c.Type == TextNode {
+ 				if _, err := w.WriteString(c.Data); err != nil {
+@@ -213,7 +212,7 @@
+ 			// last element in the file, with no closing tag.
+ 			return plaintextAbort
+ 		}
+-	default:
++	} else {
+ 		for c := n.FirstChild; c != nil; c = c.NextSibling {
+ 			if err := render1(w, c); err != nil {
+ 				return err
+@@ -231,6 +230,27 @@
+ 	return w.WriteByte('>')
+ }
+ 
++func childTextNodesAreLiteral(n *Node) bool {
++	// Per WHATWG HTML 13.3, if the parent of the current node is a style,
++	// script, xmp, iframe, noembed, noframes, or plaintext element, and the
++	// current node is a text node, append the value of the node's data
++	// literally. The specification is not explicit about it, but we only
++	// enforce this if we are in the HTML namespace (i.e. when the namespace is
++	// "").
++	// NOTE: we also always include noscript elements, although the
++	// specification states that they should only be rendered as such if
++	// scripting is enabled for the node (which is not something we track).
++	if n.Namespace != "" {
++		return false
++	}
++	switch n.Data {
++	case "iframe", "noembed", "noframes", "noscript", "plaintext", "script", "style", "xmp":
++		return true
++	default:
++		return false
++	}
++}
++
+ // writeQuoted writes s to w surrounded by quotes. Normally it will use double
+ // quotes, but if s contains a double quote, it will use single quotes.
+ // It is used for writing the identifiers in a doctype declaration.

--- a/SPECS/cni-plugins/cni-plugins.spec
+++ b/SPECS/cni-plugins/cni-plugins.spec
@@ -1,7 +1,7 @@
 Summary:        Container Network Interface (CNI) plugins
 Name:           cni-plugins
 Version:        1.3.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ Group:          Development/Tools
 URL:            https://github.com/containernetworking/plugins
 #Source0:       https://github.com/containernetworking/plugins/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+Patch0:         CVE-2023-3978.patch
 %define _default_cni_plugins_dir /opt/cni/bin
 BuildRequires:  golang
 Provides:       kubernetes-cni
@@ -18,7 +19,7 @@ Provides:       kubernetes-cni
 The CNI (Container Network Interface) project consists of a specification and libraries for writing plugins to configure network interfaces in Linux containers, along with a number of supported plugins.
 
 %prep
-%setup -q -n plugins-%{version}
+%autosetup -p1 -n plugins-%{version}
 
 %build
 ./build_linux.sh -ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=v%{version}"
@@ -39,6 +40,9 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_default_cni_plugins_dir}/*
 
 %changelog
+* Thu Oct 10 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.3.0-6
+- Add patch to resolve CVE-2023-3978.
+
 * Mon Sep 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.3.0-5
 - Bump release to rebuild with go 1.22.7
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch to resolve CVE-2023-3978

###### Change Log  <!-- REQUIRED -->
- Add patch file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-3978

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=655164&view=results)
