### PR TITLE
Update fluent-bit to 3.1.9 and allow lua plugin

### DIFF
--- a/SPECS/fluent-bit/fluent-bit.signatures.json
+++ b/SPECS/fluent-bit/fluent-bit.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "fluent-bit-3.0.6.tar.gz": "2cad0ac1e04646bc084b7bb3d5552589fa1997eaa5ba3fe2137a65ecf101cd9f"
+  "fluent-bit-3.1.9.tar.gz": "ac3a3e235e7f8a92d35f10c99f400f0b0571417a92e3c4caa467073733d42547"
  }
 }

--- a/SPECS/fluent-bit/fluent-bit.spec
+++ b/SPECS/fluent-bit/fluent-bit.spec
@@ -1,6 +1,6 @@
 Summary:        Fast and Lightweight Log processor and forwarder for Linux, BSD and OSX
 Name:           fluent-bit
-Version:        3.0.6
+Version:        3.1.9
 Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation

--- a/SPECS/fluent-bit/fluent-bit.spec
+++ b/SPECS/fluent-bit/fluent-bit.spec
@@ -23,6 +23,7 @@ BuildRequires:  pkgconfig
 BuildRequires:  systemd-devel
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  zlib-devel
+BuildRequires:  luajit-devel
 
 %description
 
@@ -57,7 +58,7 @@ Development files for %{name}
     -DFLB_DEBUG=Off \
     -DFLB_TLS=On \
     -DFLB_JEMALLOC=On \
-    -DFLB_LUAJIT=Off \
+    -DFLB_PREFER_SYSTEM_LIBS=On
 
 %cmake_build
 
@@ -65,7 +66,7 @@ Development files for %{name}
 %cmake_install
 
 %check
-%ctest --exclude-regex "flb-rt-in_podman_metrics|flb-rt-filter_lua|.*\\.sh"
+%ctest --exclude-regex "flb-rt-in_podman_metrics|.*\\.sh"
 
 %files
 %license LICENSE
@@ -80,6 +81,9 @@ Development files for %{name}
 %{_libdir}/fluent-bit/*.so
 
 %changelog
+* Thu Oct 10 2024 Paul Meyer <paul.meyer@microsoft.com> - 3.1.9-1
+- Update to 3.1.9 to enable Lua filter plugin using system luajit library.
+
 * Tue May 28 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.0.6-1
 - Update to v3.0.6 to fix CVE-2024-4323.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3678,8 +3678,8 @@
         "type": "other",
         "other": {
           "name": "fluent-bit",
-          "version": "3.0.6",
-          "downloadUrl": "https://github.com/fluent/fluent-bit/archive/refs/tags/v3.0.6.tar.gz"
+          "version": "3.1.9",
+          "downloadUrl": "https://github.com/fluent/fluent-bit/archive/refs/tags/v3.1.9.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### PR Description <!-- REQUIRED -->
<!-- This is your changelog message for this PR -->
<!-- Ensure you are covering the following areas in your PR description
   - Describe the problem being fixed.
   - Describe what happens if we don’t fix the problem.
   - Describe what the pull request is changing.  
   - To the best of your knowledge, where potential regressions might arise? 
   - Link to the upstream patch: 
-->
Enabled the lua filter plugin which was previously disabled because it pulled in a copy of the luajit library, which it wanted to install.
https://github.com/fluent/fluent-bit/pull/7286 (in 3.1.5) makes it possible to use the system luajit library instead of the vendored version.
With this change, the lua filter plugin can be built with the system luajit library.

Also, according to https://fluentbit.io/announcements/older-versions/, the 3.0 line went EOL on Sep 11 2024.

- Updated fluent-bit to upstream 3.1.9. Enabled use of lua filter plugin with system luajit library.
- Fixes #10675

###### Test Methodology
<!-- Describe how this change was validated. -->

<!-- For changes targeted at our stable release, please also include the following -->
- Fix verification
   - Tested local RPM build with %with_check=1
   - Impacted user verification - xxxx
- Package Tests
   - Package build & ptest - xxxx
   - Upgrade/downgrade test - xxxx
- Scenario Test results (or explain why the scenario does not need to be tested)
   - AKS: xxxx
   - Azure VM: xxxx
   - BVT: xxxx
   - BareMetal: xxxx
   - ISO: xxxx
   - Container: xxxx

###### Regression Risk <!-- REQUIRED for PRs targeting our Stable Release. OPTIONAL otherwise -->
To the best of your knowledge, where might potential problems/regressions arise?

According to [Upgrade Notes | Fluent Bit: Official Manual](https://docs.fluentbit.io/manual/installation/upgrade-notes), there have not been any breaking changes for a long time. None of the [release notes](https://fluentbit.io/announcements/older-versions/) between 3.0.6 and 3.1.9 mention any breaking changes either.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Relevant links  <!-- optional -->
<!-- Link to Github issues, ADO URL, NIST CVE -->
- https://github.com/fluent/fluent-bit/pull/7286
- https://fluentbit.io/announcements/older-versions/
- https://docs.fluentbit.io/manual/installation/upgrade-notes
