### PR TITLE
Fix partition initialization bug.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -682,13 +682,19 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int,
 	partitionNumberStr := strconv.Itoa(partitionNumber)
 
 	// There are two primary partition naming conventions:
-	// /dev/sdN<y> style or /dev/loopNp<x> style
+	// - /dev/sdN<y>
+	// - /dev/loopNp<x>
 	// Detect the exact one we are using.
-	// Make sure we check for /dev/loopNp<x> FIRST, since /dev/loop1 would generate /dev/loop11 as a partition
-	// device which may be a valid device. We want to select /dev/loop1p1 first.
 	testPartDevPaths := []string{
 		fmt.Sprintf("%sp%s", diskDevPath, partitionNumberStr),
-		fmt.Sprintf("%s%s", diskDevPath, partitionNumberStr),
+	}
+
+	// If disk path ends in a digit, then the 'p<x>' style must be used.
+	// So, don't check the other style to avoid ambiguities. For example, /dev/loop1 vs. /dev/loop11.
+	// The is particularly relevant on Ubuntu, due to snap's use of loopback devices.
+	if !isDigit(diskDevPath[len(diskDevPath)-1]) {
+		devPath := fmt.Sprintf("%s%s", diskDevPath, partitionNumberStr)
+		testPartDevPaths = append(testPartDevPaths, devPath)
 	}
 
 	err = retry.Run(func() error {
@@ -757,6 +763,10 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int,
 	logger.Log.Debugf("Partprobe -s returned: %s", stdout)
 
 	return
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
 }
 
 func setGptPartitionType(partition configuration.Partition, timeoutInSeconds, diskDevPath, partitionNumberStr string) (err error) {


### PR DESCRIPTION
After creating a partition, the toolkit must wait for the partition device to be created (under /dev). However, the naming scheme of partitions is inconsistent, with both `/dev/<name>XX` and `/dev/<name>pXX` being used, depending on the device driver. So, the toolkit checks for both.

However, a problem occurs when the device name itself ends in a digit. If the disk device path is say `/dev/loop1`, then `/dev/loop11` is also a valid disk device path. For such disks, the `/dev/<name>pXX` form must be used for partitions.

While the toolkit prioritizes `/dev/loop1p1` over `/dev/loop11`, if the `/dev/loop1p1` device doesn't exist yet and `/dev/loop11` is in use, then the toolkit may pick the wrong device path for the partition.

This change fixes this by ignoring the `/dev/<name>XX` variant if the disk device path ends in a digit.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran image customizer UTs.
- Manually built and tested installer ISO.
