### PR TITLE
Image Customizer: Move `resetPartitionsUuidsType` into `storage`.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -134,7 +134,7 @@ os:
             - [idType](#idtype-string)
             - [options](#options-string)
             - [path](#mountpoint-path)
-  - [resetPartitionsUuidsType](#resetpartitionsuuidstype-string)
+    - [resetPartitionsUuidsType](#resetpartitionsuuidstype-string)
   - [iso](#iso-type)
     - [additionalFiles](#iso-additionalfiles)
       - [additionalFile type](#additionalfile-type)
@@ -260,31 +260,6 @@ storage:
     type: ext4
     mountPoint:
       path: /
-
-os:
-  resetBootLoaderType: hard-reset
-```
-
-### resetPartitionsUuidsType [string]
-
-Specifies that the partition UUIDs and filesystem UUIDs should be reset.
-
-Value is optional.
-
-This value cannot be specified if [storage](#storage-storage) is specified (since
-customizing the partition layout resets all the UUIDs anyway).
-
-If this value is specified, then [os.resetBootLoaderType](#resetbootloadertype-string)
-must also be specified.
-
-Supported options:
-
-- `reset-all`: Resets the partition UUIDs and filesystem UUIDs for all the partitions.
-
-Example:
-
-```yaml
-resetPartitionsUuidsType: reset-all
 
 os:
   resetBootLoaderType: hard-reset
@@ -1600,3 +1575,29 @@ Contains the options for provisioning disks and their partitions.
 ### filesystems [[filesystem](#filesystem-type)[]]
 
 Specifies the mount options of the partitions.
+
+### resetPartitionsUuidsType [string]
+
+Specifies that the partition UUIDs and filesystem UUIDs should be reset.
+
+Value is optional.
+
+This value cannot be specified if [storage](#storage-storage) is specified (since
+customizing the partition layout resets all the UUIDs anyway).
+
+If this value is specified, then [os.resetBootLoaderType](#resetbootloadertype-string)
+must also be specified.
+
+Supported options:
+
+- `reset-all`: Resets the partition UUIDs and filesystem UUIDs for all the partitions.
+
+Example:
+
+```yaml
+storage:
+  resetPartitionsUuidsType: reset-all
+
+os:
+  resetBootLoaderType: hard-reset
+```

--- a/toolkit/tools/imagecustomizerapi/boottype.go
+++ b/toolkit/tools/imagecustomizerapi/boottype.go
@@ -10,13 +10,14 @@ import (
 type BootType string
 
 const (
+	BootTypeNone   BootType = ""
 	BootTypeEfi    BootType = "efi"
 	BootTypeLegacy BootType = "legacy"
 )
 
 func (t BootType) IsValid() error {
 	switch t {
-	case BootTypeEfi, BootTypeLegacy:
+	case BootTypeNone, BootTypeEfi, BootTypeLegacy:
 		// All good.
 		return nil
 

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -6,28 +6,19 @@ package imagecustomizerapi
 import "fmt"
 
 type Config struct {
-	Storage                  *Storage                 `yaml:"storage"`
-	ResetPartitionsUuidsType ResetPartitionsUuidsType `yaml:"resetPartitionsUuidsType"`
-	Iso                      *Iso                     `yaml:"iso"`
-	OS                       *OS                      `yaml:"os"`
-	Scripts                  *Scripts                 `yaml:"scripts"`
+	Storage Storage `yaml:"storage"`
+	Iso     *Iso    `yaml:"iso"`
+	OS      *OS     `yaml:"os"`
+	Scripts Scripts `yaml:"scripts"`
 }
 
 func (c *Config) IsValid() (err error) {
-	hasStorage := false
-	if c.Storage != nil {
-		err = c.Storage.IsValid()
-		if err != nil {
-			return err
-		}
-		hasStorage = true
-	}
-
-	err = c.ResetPartitionsUuidsType.IsValid()
+	err = c.Storage.IsValid()
 	if err != nil {
 		return err
 	}
-	hasResetPartitionsUuids := c.ResetPartitionsUuidsType != ResetPartitionsUuidsTypeDefault
+
+	hasResetPartitionsUuids := c.Storage.ResetPartitionsUuidsType != ResetPartitionsUuidsTypeDefault
 
 	if c.Iso != nil {
 		err = c.Iso.IsValid()
@@ -45,32 +36,26 @@ func (c *Config) IsValid() (err error) {
 		hasResetBootLoader = c.OS.ResetBootLoaderType != ResetBootLoaderTypeDefault
 	}
 
-	if c.Scripts != nil {
-		err = c.Scripts.IsValid()
-		if err != nil {
-			return err
-		}
+	err = c.Scripts.IsValid()
+	if err != nil {
+		return err
 	}
 
-	if hasStorage && hasResetPartitionsUuids {
-		return fmt.Errorf("storage and resetPartitionsUuidsType cannot be specified together")
-	}
-
-	if hasStorage && !hasResetBootLoader {
-		return fmt.Errorf("os.resetBootLoaderType must be specified if storage is specified")
+	if c.CustomizePartitions() && !hasResetBootLoader {
+		return fmt.Errorf("'os.resetBootLoaderType' must be specified if 'storage.disks' is specified")
 	}
 
 	if hasResetPartitionsUuids && !hasResetBootLoader {
-		return fmt.Errorf("os.resetBootLoaderType must be specified if resetPartitionsUuidsType is specified")
+		return fmt.Errorf("'os.resetBootLoaderType' must be specified if 'storage.resetPartitionsUuidsType' is specified")
 	}
 
 	if c.OS != nil && c.OS.Verity != nil {
-		err := ensureVerityPartitionIdExists(c.OS.Verity.DataPartition, c.Storage)
+		err := ensureVerityPartitionIdExists(c.OS.Verity.DataPartition, &c.Storage)
 		if err != nil {
 			return fmt.Errorf("invalid verity 'dataPartition':\n%w", err)
 		}
 
-		err = ensureVerityPartitionIdExists(c.OS.Verity.HashPartition, c.Storage)
+		err = ensureVerityPartitionIdExists(c.OS.Verity.HashPartition, &c.Storage)
 		if err != nil {
 			return fmt.Errorf("invalid verity 'hashPartition':\n%w", err)
 		}
@@ -82,8 +67,8 @@ func (c *Config) IsValid() (err error) {
 func ensureVerityPartitionIdExists(verityPartition IdentifiedPartition, storage *Storage) error {
 	switch verityPartition.IdType {
 	case IdTypeId:
-		if storage == nil {
-			return fmt.Errorf("'idType' cannot be 'id' if 'storage' is not specified")
+		if !storage.CustomizePartitions() {
+			return fmt.Errorf("'idType' cannot be 'id' if 'storage.disks' is not specified")
 		}
 
 		foundPartition := false
@@ -102,4 +87,8 @@ func ensureVerityPartitionIdExists(verityPartition IdentifiedPartition, storage 
 	}
 
 	return nil
+}
+
+func (c *Config) CustomizePartitions() bool {
+	return c.Storage.CustomizePartitions()
 }

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestConfigIsValid(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				MaxSize:            ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
@@ -40,7 +40,7 @@ func TestConfigIsValid(t *testing.T) {
 			ResetBootLoaderType: "hard-reset",
 			Hostname:            "test",
 		},
-		Scripts: &Scripts{},
+		Scripts: Scripts{},
 		Iso:     &Iso{},
 	}
 
@@ -50,7 +50,7 @@ func TestConfigIsValid(t *testing.T) {
 
 func TestConfigIsValidLegacy(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				MaxSize:            ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
@@ -81,10 +81,10 @@ func TestConfigIsValidLegacy(t *testing.T) {
 
 func TestConfigIsValidNoBootType(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
-				MaxSize:            ptrutils.PtrTo(DiskSize(2 * diskutils.MiB)),
+				MaxSize:            ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
 				Partitions: []Partition{
 					{
 						Id:    "a",
@@ -101,12 +101,12 @@ func TestConfigIsValidNoBootType(t *testing.T) {
 
 	err := config.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "invalid bootType value ()")
+	assert.ErrorContains(t, err, "must specify 'bootType' if 'disks' are specified")
 }
 
 func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				MaxSize:            ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
@@ -136,12 +136,27 @@ func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 
 	err := config.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "os.resetBootLoaderType must be specified if storage is specified")
+	assert.ErrorContains(t, err, "'os.resetBootLoaderType' must be specified if 'storage.disks' is specified")
+}
+
+func TestConfigIsValidResetUuidsMissingBootLoaderReset(t *testing.T) {
+	config := &Config{
+		Storage: Storage{
+			ResetPartitionsUuidsType: ResetPartitionsUuidsTypeAll,
+		},
+		OS: &OS{
+			Hostname: "test",
+		},
+	}
+
+	err := config.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "'os.resetBootLoaderType' must be specified if 'storage.resetPartitionsUuidsType' is specified")
 }
 
 func TestConfigIsValidMultipleDisks(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{
 				{
 					PartitionTableType: "gpt",
@@ -167,7 +182,7 @@ func TestConfigIsValidMultipleDisks(t *testing.T) {
 
 func TestConfigIsValidZeroDisks(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			BootType: BootTypeEfi,
 			Disks:    []Disk{},
 		},
@@ -178,7 +193,7 @@ func TestConfigIsValidZeroDisks(t *testing.T) {
 
 	err := config.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "at least 1 disk must be specified")
+	assert.ErrorContains(t, err, "cannot specify 'bootType' without specifying 'disks'")
 }
 
 func TestConfigIsValidBadHostname(t *testing.T) {
@@ -195,7 +210,7 @@ func TestConfigIsValidBadHostname(t *testing.T) {
 
 func TestConfigIsValidBadDisk(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			BootType: BootTypeEfi,
 			Disks: []Disk{{
 				PartitionTableType: PartitionTableTypeGpt,
@@ -215,7 +230,7 @@ func TestConfigIsValidBadDisk(t *testing.T) {
 
 func TestConfigIsValidMissingEsp(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				MaxSize:            ptrutils.PtrTo(DiskSize(2 * diskutils.MiB)),
@@ -236,7 +251,7 @@ func TestConfigIsValidMissingEsp(t *testing.T) {
 
 func TestConfigIsValidMissingBiosBoot(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				MaxSize:            ptrutils.PtrTo(DiskSize(2 * diskutils.MiB)),
@@ -257,7 +272,7 @@ func TestConfigIsValidMissingBiosBoot(t *testing.T) {
 
 func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				MaxSize:            ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
@@ -295,7 +310,7 @@ func TestConfigIsValidInvalidMountPoint(t *testing.T) {
 
 func TestConfigIsValidKernelCLI(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				MaxSize:            ptrutils.PtrTo(DiskSize(3 * diskutils.MiB)),
@@ -345,7 +360,7 @@ func TestConfigIsValidInvalidIso(t *testing.T) {
 
 func TestConfigIsValidInvalidScripts(t *testing.T) {
 	config := &Config{
-		Scripts: &Scripts{
+		Scripts: Scripts{
 			PostCustomization: []Script{
 				{
 					Path: "",
@@ -360,7 +375,7 @@ func TestConfigIsValidInvalidScripts(t *testing.T) {
 
 func TestConfigIsValidVerityValid(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				Partitions: []Partition{
@@ -426,7 +441,7 @@ func TestConfigIsValidVerityValid(t *testing.T) {
 
 func TestConfigIsValidVerityPartitionNotFound(t *testing.T) {
 	config := &Config{
-		Storage: &Storage{
+		Storage: Storage{
 			Disks: []Disk{{
 				PartitionTableType: "gpt",
 				Partitions: []Partition{
@@ -508,5 +523,5 @@ func TestConfigIsValidVerityNoStorage(t *testing.T) {
 	}
 	err := config.IsValid()
 	assert.ErrorContains(t, err, "invalid verity 'hashPartition'")
-	assert.ErrorContains(t, err, "'idType' cannot be 'id' if 'storage' is not specified")
+	assert.ErrorContains(t, err, "'idType' cannot be 'id' if 'storage.disks' is not specified")
 }

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Partition struct {
-	// ID is used to correlate `Partition` objects with `PartitionSetting` objects.
+	// ID is used to correlate `Partition` objects with `FileSystem` objects.
 	Id string `yaml:"id"`
 	// Name is the label to assign to the partition.
 	Label string `yaml:"label"`

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -8,22 +8,25 @@ import (
 )
 
 type Storage struct {
-	BootType    BootType     `yaml:"bootType"`
-	Disks       []Disk       `yaml:"disks"`
-	FileSystems []FileSystem `yaml:"filesystems"`
+	ResetPartitionsUuidsType ResetPartitionsUuidsType `yaml:"resetPartitionsUuidsType"`
+	BootType                 BootType                 `yaml:"bootType"`
+	Disks                    []Disk                   `yaml:"disks"`
+	FileSystems              []FileSystem             `yaml:"filesystems"`
 }
 
 func (s *Storage) IsValid() error {
 	var err error
+
+	err = s.ResetPartitionsUuidsType.IsValid()
+	if err != nil {
+		return err
+	}
 
 	err = s.BootType.IsValid()
 	if err != nil {
 		return err
 	}
 
-	if len(s.Disks) < 1 {
-		return fmt.Errorf("at least 1 disk must be specified")
-	}
 	if len(s.Disks) > 1 {
 		return fmt.Errorf("defining multiple disks is not currently supported")
 	}
@@ -49,6 +52,27 @@ func (s *Storage) IsValid() error {
 		}
 
 		fileSystemSet[fileSystem.DeviceId] = fileSystem
+	}
+
+	hasResetUuids := s.ResetPartitionsUuidsType != ResetPartitionsUuidsTypeDefault
+	hasBootType := s.BootType != BootTypeNone
+	hasDisks := len(s.Disks) > 0
+	hasFileSystems := len(s.FileSystems) > 0
+
+	if hasResetUuids && hasDisks {
+		return fmt.Errorf("cannot specify both 'resetPartitionsUuidsType' and 'disks'")
+	}
+
+	if !hasBootType && hasDisks {
+		return fmt.Errorf("must specify 'bootType' if 'disks' are specified")
+	}
+
+	if hasBootType && !hasDisks {
+		return fmt.Errorf("cannot specify 'bootType' without specifying 'disks'")
+	}
+
+	if hasFileSystems && !hasDisks {
+		return fmt.Errorf("cannot specify 'filesystems' without specifying 'disks'")
 	}
 
 	partitionSet := make(map[string]Partition)
@@ -137,4 +161,8 @@ func (s *Storage) IsValid() error {
 	}
 
 	return nil
+}
+
+func (s *Storage) CustomizePartitions() bool {
+	return len(s.Disks) > 0
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader.go
@@ -50,7 +50,7 @@ func hardResetBootLoader(baseConfigPath string, config *imagecustomizerapi.Confi
 
 	var rootMountIdType imagecustomizerapi.MountIdentifierType
 	var bootType imagecustomizerapi.BootType
-	if config.Storage != nil {
+	if config.CustomizePartitions() {
 		rootFileSystem, foundRootFileSystem := sliceutils.FindValueFunc(config.Storage.FileSystems,
 			func(fileSystem imagecustomizerapi.FileSystem) bool {
 				return fileSystem.MountPoint != nil &&

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -92,11 +92,9 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 		}
 	}
 
-	if config.Scripts != nil {
-		err = runUserScripts(baseConfigPath, config.Scripts.PostCustomization, "postCustomization", imageChroot)
-		if err != nil {
-			return err
-		}
+	err = runUserScripts(baseConfigPath, config.Scripts.PostCustomization, "postCustomization", imageChroot)
+	if err != nil {
+		return err
 	}
 
 	err = restoreResolvConf(resolvConf, imageChroot)
@@ -109,11 +107,9 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 		return err
 	}
 
-	if config.Scripts != nil {
-		err = runUserScripts(baseConfigPath, config.Scripts.FinalizeCustomization, "finalizeCustomization", imageChroot)
-		if err != nil {
-			return err
-		}
+	err = runUserScripts(baseConfigPath, config.Scripts.FinalizeCustomization, "finalizeCustomization", imageChroot)
+	if err != nil {
+		return err
 	}
 
 	err = checkForInstalledKernel(imageChroot)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
@@ -14,7 +14,7 @@ func customizePartitions(buildDir string, baseConfigPath string, config *imagecu
 	buildImageFile string,
 ) (bool, string, map[string]string, error) {
 	switch {
-	case config.Storage != nil:
+	case config.CustomizePartitions():
 		logger.Log.Infof("Customizing partitions")
 
 		newBuildImageFile := filepath.Join(buildDir, PartitionCustomizedImageName)
@@ -29,7 +29,7 @@ func customizePartitions(buildDir string, baseConfigPath string, config *imagecu
 
 		return true, newBuildImageFile, partIdToPartUuid, nil
 
-	case config.ResetPartitionsUuidsType != imagecustomizerapi.ResetPartitionsUuidsTypeDefault:
+	case config.Storage.ResetPartitionsUuidsType != imagecustomizerapi.ResetPartitionsUuidsTypeDefault:
 		err := resetPartitionsUuids(buildImageFile, buildDir)
 		if err != nil {
 			return false, "", nil, err

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/newpartitionsuuids-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/newpartitionsuuids-config.yaml
@@ -1,4 +1,5 @@
-resetPartitionsUuidsType: reset-all
+storage:
+  resetPartitionsUuidsType: reset-all
 
 os:
   resetBootLoaderType: hard-reset


### PR DESCRIPTION
This change moves the `resetPartitionsUuidsType` property to `storage.resetPartitionsUuidsType`.

Most of this change is just handling the fact that we can no longer use the existence of `storage` to indicate that the partitions are being customized. This will be beneficial when `verity` is also moved into `storage`.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran UTs.
