### PR TITLE
fluent-bit: CVE-2024-26455, CVE-2024-25629

### DIFF
--- a/SPECS/fluent-bit/CVE-2024-25629.patch
+++ b/SPECS/fluent-bit/CVE-2024-25629.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/c-ares-1.24.0/src/lib/ares__read_line.c b/lib/c-ares-1.24.0/src/lib/ares__read_line.c
+index d65ac1fcf..018f55e8b 100644
+--- a/lib/c-ares-1.24.0/src/lib/ares__read_line.c
++++ b/lib/c-ares-1.24.0/src/lib/ares__read_line.c
+@@ -59,6 +59,14 @@ ares_status_t ares__read_line(FILE *fp, char **buf, size_t *bufsize)
+       return (offset != 0) ? 0 : (ferror(fp)) ? ARES_EFILE : ARES_EOF;
+     }
+     len = offset + ares_strlen(*buf + offset);
++
++    /* Probably means there was an embedded NULL as the first character in
++     * the line, throw away line */
++    if (len == 0) {
++      offset = 0;
++      continue;
++    }
++
+     if ((*buf)[len - 1] == '\n') {
+       (*buf)[len - 1] = 0;
+       break;

--- a/SPECS/fluent-bit/CVE-2024-26455.patch
+++ b/SPECS/fluent-bit/CVE-2024-26455.patch
@@ -1,0 +1,60 @@
+diff --git a/plugins/custom_calyptia/calyptia.c b/plugins/custom_calyptia/calyptia.c
+index 5639af427..4aba53ca7 100644
+--- a/plugins/custom_calyptia/calyptia.c
++++ b/plugins/custom_calyptia/calyptia.c
+@@ -245,7 +245,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
+ 
+     if (!cloud) {
+         flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
+-        flb_free(ctx);
+         return NULL;
+     }
+ 
+@@ -254,7 +253,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
+ 
+     if (ret != 0) {
+         flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
+-        flb_free(ctx);
+         return NULL;
+     }
+ 
+@@ -268,7 +266,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
+             label = flb_sds_create_size(strlen(key->str) + strlen(val->str) + 1);
+ 
+             if (!label) {
+-                flb_free(ctx);
+                 return NULL;
+             }
+ 
+@@ -316,7 +313,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
+         label = flb_sds_create_size(strlen("fleet_id") + strlen(ctx->fleet_id) + 1);
+ 
+         if (!label) {
+-            flb_free(ctx);
+             return NULL;
+         }
+ 
+@@ -424,6 +420,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
+ 
+         if (ctx->machine_id == NULL) {
+             flb_plg_error(ctx->ins, "unable to retrieve machine_id");
++            flb_free(ctx);
+             return -1;
+         }
+ 
+@@ -435,6 +432,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
+ 
+     if (!ctx->i) {
+         flb_plg_error(ctx->ins, "could not load metrics collector");
++        flb_free(ctx);
+         return -1;
+     }
+ 
+@@ -455,6 +453,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
+         ctx->o = setup_cloud_output(config, ctx);
+ 
+         if (ctx->o == NULL) {
++            flb_free(ctx);
+             return -1;
+         }
+     }

--- a/SPECS/fluent-bit/fluent-bit.spec
+++ b/SPECS/fluent-bit/fluent-bit.spec
@@ -1,7 +1,7 @@
 Summary:        Fast and Lightweight Log processor and forwarder for Linux, BSD and OSX
 Name:           fluent-bit
 Version:        2.2.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,8 @@ Source0:        https://github.com/fluent/%{name}/archive/refs/tags/v%{version}.
 Patch0:         CVE-2024-34250.patch
 Patch1:         in_emitter_fix_issue_8198.patch
 Patch2:         fix_issue_8025.patch
+Patch3:         CVE-2024-26455.patch
+Patch4:         CVE-2024-25629.patch
 BuildRequires:  bison
 BuildRequires:  cmake
 BuildRequires:  cyrus-sasl-devel
@@ -83,6 +85,10 @@ Development files for %{name}
 %{_libdir}/fluent-bit/*.so
 
 %changelog
+* Tue Oct 15 2024 Chris Gunn <chrisgun@microsoft.com> - 2.2.3-4
+- CVE-2024-26455
+- CVE-2024-25629
+
 * Wed Jun 05 2024 Sindhu Karri <lakarri@microsoft.com> - 2.2.3-3
 - Apply patch in_emitter_fix_issue_8198.patch to fix #8198 ( Potential log loss during high load at Multiline & Rewrite Tag Filter (in_emitter) )
 - Fix issue #8025 with a patch ( in_tail: missing log for offset processing due to non-existent old inodes in sqlite )


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Patches for fluent-bit CVEs: CVE-2024-26455, CVE-2024-25629

###### Change Log  <!-- REQUIRED -->

- fluent-bit: Add patch for CVE-2024-26455
- fluent-bit: Add patch for CVE-2024-25629

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-26455
- https://nvd.nist.gov/vuln/detail/CVE-2024-25629

###### Test Methodology

- Ran UTs,
