### PR TITLE
fluent-bit: CVE-2024-34250, CVE-2024-25629, CVE-2024-28182

### DIFF
--- a/SPECS/fluent-bit/CVE-2024-25629.patch
+++ b/SPECS/fluent-bit/CVE-2024-25629.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/c-ares-1.24.0/src/lib/ares__read_line.c b/lib/c-ares-1.24.0/src/lib/ares__read_line.c
+index d65ac1fcf..018f55e8b 100644
+--- a/lib/c-ares-1.24.0/src/lib/ares__read_line.c
++++ b/lib/c-ares-1.24.0/src/lib/ares__read_line.c
+@@ -59,6 +59,14 @@ ares_status_t ares__read_line(FILE *fp, char **buf, size_t *bufsize)
+       return (offset != 0) ? 0 : (ferror(fp)) ? ARES_EFILE : ARES_EOF;
+     }
+     len = offset + ares_strlen(*buf + offset);
++
++    /* Probably means there was an embedded NULL as the first character in
++     * the line, throw away line */
++    if (len == 0) {
++      offset = 0;
++      continue;
++    }
++
+     if ((*buf)[len - 1] == '\n') {
+       (*buf)[len - 1] = 0;
+       break;

--- a/SPECS/fluent-bit/CVE-2024-28182.patch
+++ b/SPECS/fluent-bit/CVE-2024-28182.patch
@@ -1,0 +1,91 @@
+diff --git a/lib/nghttp2/lib/includes/nghttp2/nghttp2.h b/lib/nghttp2/lib/includes/nghttp2/nghttp2.h
+index 66ea3c63c..5378daf43 100644
+--- a/lib/nghttp2/lib/includes/nghttp2/nghttp2.h
++++ b/lib/nghttp2/lib/includes/nghttp2/nghttp2.h
+@@ -440,7 +440,12 @@ typedef enum {
+    * exhaustion on server side to send these frames forever and does
+    * not read network.
+    */
+-  NGHTTP2_ERR_FLOODED = -904
++  NGHTTP2_ERR_FLOODED = -904,
++  /**
++   * When a local endpoint receives too many CONTINUATION frames
++   * following a HEADER frame.
++   */
++  NGHTTP2_ERR_TOO_MANY_CONTINUATIONS = -905,
+ } nghttp2_error;
+ 
+ /**
+diff --git a/lib/nghttp2/lib/nghttp2_helper.c b/lib/nghttp2/lib/nghttp2_helper.c
+index 93dd4754b..b3563d98e 100644
+--- a/lib/nghttp2/lib/nghttp2_helper.c
++++ b/lib/nghttp2/lib/nghttp2_helper.c
+@@ -336,6 +336,8 @@ const char *nghttp2_strerror(int error_code) {
+            "closed";
+   case NGHTTP2_ERR_TOO_MANY_SETTINGS:
+     return "SETTINGS frame contained more than the maximum allowed entries";
++  case NGHTTP2_ERR_TOO_MANY_CONTINUATIONS:
++    return "Too many CONTINUATION frames following a HEADER frame";
+   default:
+     return "Unknown error code";
+   }
+diff --git a/lib/nghttp2/lib/nghttp2_session.c b/lib/nghttp2/lib/nghttp2_session.c
+index c0d86026a..51ed4494e 100644
+--- a/lib/nghttp2/lib/nghttp2_session.c
++++ b/lib/nghttp2/lib/nghttp2_session.c
+@@ -496,6 +496,7 @@ static int session_new(nghttp2_session **session_ptr,
+   (*session_ptr)->max_send_header_block_length = NGHTTP2_MAX_HEADERSLEN;
+   (*session_ptr)->max_outbound_ack = NGHTTP2_DEFAULT_MAX_OBQ_FLOOD_ITEM;
+   (*session_ptr)->max_settings = NGHTTP2_DEFAULT_MAX_SETTINGS;
++  (*session_ptr)->max_continuations = NGHTTP2_DEFAULT_MAX_CONTINUATIONS;
+ 
+   if (option) {
+     if ((option->opt_set_mask & NGHTTP2_OPT_NO_AUTO_WINDOW_UPDATE) &&
+@@ -6778,6 +6779,8 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+           }
+         }
+         session_inbound_frame_reset(session);
++
++        session->num_continuations = 0;
+       }
+       break;
+     }
+@@ -6899,6 +6902,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+       }
+ #endif /* DEBUGBUILD */
+ 
++      if (++session->num_continuations > session->max_continuations) {
++        return NGHTTP2_ERR_TOO_MANY_CONTINUATIONS;
++      }
++
+       readlen = inbound_frame_buf_read(iframe, in, last);
+       in += readlen;
+ 
+diff --git a/lib/nghttp2/lib/nghttp2_session.h b/lib/nghttp2/lib/nghttp2_session.h
+index b119329a0..ef8f7b27d 100644
+--- a/lib/nghttp2/lib/nghttp2_session.h
++++ b/lib/nghttp2/lib/nghttp2_session.h
+@@ -110,6 +110,10 @@ typedef struct {
+ #define NGHTTP2_DEFAULT_STREAM_RESET_BURST 1000
+ #define NGHTTP2_DEFAULT_STREAM_RESET_RATE 33
+ 
++/* The default max number of CONTINUATION frames following an incoming
++   HEADER frame. */
++#define NGHTTP2_DEFAULT_MAX_CONTINUATIONS 8
++
+ /* Internal state when receiving incoming frame */
+ typedef enum {
+   /* Receiving frame header */
+@@ -290,6 +294,12 @@ struct nghttp2_session {
+   size_t max_send_header_block_length;
+   /* The maximum number of settings accepted per SETTINGS frame. */
+   size_t max_settings;
++  /* The maximum number of CONTINUATION frames following an incoming
++     HEADER frame. */
++  size_t max_continuations;
++  /* The number of CONTINUATION frames following an incoming HEADER
++     frame.  This variable is reset when END_HEADERS flag is seen. */
++  size_t num_continuations;
+   /* Next Stream ID. Made unsigned int to detect >= (1 << 31). */
+   uint32_t next_stream_id;
+   /* The last stream ID this session initiated.  For client session,

--- a/SPECS/fluent-bit/CVE-2024-34250.patch
+++ b/SPECS/fluent-bit/CVE-2024-34250.patch
@@ -1,0 +1,114 @@
+diff --git a/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_loader.c b/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_loader.c
+index 2a06f42..87af852 100644
+--- a/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_loader.c
++++ b/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_loader.c
+@@ -219,7 +219,10 @@ type2str(uint8 type)
+ static bool
+ is_32bit_type(uint8 type)
+ {
+-    if (type == VALUE_TYPE_I32 || type == VALUE_TYPE_F32
++    if (type == VALUE_TYPE_I32
++        || type == VALUE_TYPE_F32
++        /* the operand stack is in polymorphic state */
++        || type == VALUE_TYPE_ANY
+ #if WASM_ENABLE_REF_TYPES != 0
+         || type == VALUE_TYPE_FUNCREF || type == VALUE_TYPE_EXTERNREF
+ #endif
+@@ -6690,6 +6693,7 @@ wasm_loader_check_br(WASMLoaderContext *loader_ctx, uint32 depth,
+     int32 i, available_stack_cell;
+     uint16 cell_num;
+ 
++    bh_assert(loader_ctx->csp_num > 0);
+     if (loader_ctx->csp_num < depth + 1) {
+         set_error_buf(error_buf, error_buf_size,
+                       "unknown label, "
+@@ -7758,8 +7762,7 @@ re_scan:
+                 }
+ 
+                 if (available_stack_cell > 0) {
+-                    if (is_32bit_type(*(loader_ctx->frame_ref - 1))
+-                        || *(loader_ctx->frame_ref - 1) == VALUE_TYPE_ANY) {
++                    if (is_32bit_type(*(loader_ctx->frame_ref - 1))) {
+                         loader_ctx->frame_ref--;
+                         loader_ctx->stack_cell_num--;
+ #if WASM_ENABLE_FAST_INTERP != 0
+diff --git a/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_mini_loader.c b/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_mini_loader.c
+index 47ec549..157a82c 100644
+--- a/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_mini_loader.c
++++ b/lib/wasm-micro-runtime-WAMR-1.3.0/core/iwasm/interpreter/wasm_mini_loader.c
+@@ -51,7 +51,10 @@ set_error_buf(char *error_buf, uint32 error_buf_size, const char *string)
+ static bool
+ is_32bit_type(uint8 type)
+ {
+-    if (type == VALUE_TYPE_I32 || type == VALUE_TYPE_F32
++    if (type == VALUE_TYPE_I32
++        || type == VALUE_TYPE_F32
++        /* the operand stack is in polymorphic state */
++        || type == VALUE_TYPE_ANY
+ #if WASM_ENABLE_REF_TYPES != 0
+         || type == VALUE_TYPE_FUNCREF || type == VALUE_TYPE_EXTERNREF
+ #endif
+@@ -3930,7 +3933,7 @@ wasm_loader_pop_frame_ref(WASMLoaderContext *ctx, uint8 type, char *error_buf,
+     ctx->frame_ref--;
+     ctx->stack_cell_num--;
+ 
+-    if (is_32bit_type(type) || *ctx->frame_ref == VALUE_TYPE_ANY)
++    if (is_32bit_type(type))
+         return true;
+ 
+     ctx->frame_ref--;
+@@ -5839,13 +5842,11 @@ re_scan:
+             case WASM_OP_BR_TABLE:
+             {
+                 uint8 *ret_types = NULL;
+-                uint32 ret_count = 0;
++                uint32 ret_count = 0, depth = 0;
+ #if WASM_ENABLE_FAST_INTERP == 0
+-                uint8 *p_depth_begin, *p_depth;
+-                uint32 depth, j;
+                 BrTableCache *br_table_cache = NULL;
+-
+-                p_org = p - 1;
++                uint8 *p_depth_begin, *p_depth, *p_opcode = p - 1;
++                uint32 j;
+ #endif
+ 
+                 read_leb_uint32(p, p_end, count);
+@@ -5854,6 +5855,16 @@ re_scan:
+ #endif
+                 POP_I32();
+ 
++                /* Get each depth and check it */
++                p_org = p;
++                for (i = 0; i <= count; i++) {
++                    read_leb_uint32(p, p_end, depth);
++                    bh_assert(loader_ctx->csp_num > 0);
++                    bh_assert(loader_ctx->csp_num - 1 >= depth);
++                    (void)depth;
++                }
++                p = p_org;
++
+ #if WASM_ENABLE_FAST_INTERP == 0
+                 p_depth_begin = p_depth = p;
+ #endif
+@@ -5879,8 +5890,8 @@ re_scan:
+                                       error_buf, error_buf_size))) {
+                                 goto fail;
+                             }
+-                            *p_org = EXT_OP_BR_TABLE_CACHE;
+-                            br_table_cache->br_table_op_addr = p_org;
++                            *p_opcode = EXT_OP_BR_TABLE_CACHE;
++                            br_table_cache->br_table_op_addr = p_opcode;
+                             br_table_cache->br_count = count;
+                             /* Copy previous depths which are one byte */
+                             for (j = 0; j < i; j++) {
+@@ -6099,8 +6110,7 @@ re_scan:
+                             && !cur_block->is_stack_polymorphic));
+ 
+                 if (available_stack_cell > 0) {
+-                    if (is_32bit_type(*(loader_ctx->frame_ref - 1))
+-                        || *(loader_ctx->frame_ref - 1) == VALUE_TYPE_ANY) {
++                    if (is_32bit_type(*(loader_ctx->frame_ref - 1))) {
+                         loader_ctx->frame_ref--;
+                         loader_ctx->stack_cell_num--;
+ #if WASM_ENABLE_FAST_INTERP != 0

--- a/SPECS/fluent-bit/fluent-bit.spec
+++ b/SPECS/fluent-bit/fluent-bit.spec
@@ -1,12 +1,15 @@
 Summary:        Fast and Lightweight Log processor and forwarder for Linux, BSD and OSX
 Name:           fluent-bit
 Version:        3.0.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://fluentbit.io
 Source0:        https://github.com/fluent/%{name}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-34250.patch
+Patch1:         CVE-2024-25629.patch
+Patch2:         CVE-2024-28182.patch
 BuildRequires:  bison
 BuildRequires:  cmake
 BuildRequires:  cyrus-sasl-devel
@@ -80,6 +83,11 @@ Development files for %{name}
 %{_libdir}/fluent-bit/*.so
 
 %changelog
+* Tue Oct 15 2024 Chris Gunn <chrisgun@microsoft.com> - 3.0.6-2
+- CVE-2024-34250
+- CVE-2024-25629
+- CVE-2024-28182
+
 * Tue May 28 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 3.0.6-1
 - Update to v3.0.6 to fix CVE-2024-4323.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Patches for fluent-bit CVEs: CVE-2024-34250, CVE-2024-25629, CVE-2024-28182

###### Change Log  <!-- REQUIRED -->

- fluent-bit: Add patch for CVE-2024-34250
- fluent-bit: Add patch for CVE-2024-25629
- fluent-bit: Add patch for CVE-2024-28182

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Links to CVEs  <!-- optional -->

- https://nvd.nist.gov/vuln/detail/CVE-2024-34250
- https://nvd.nist.gov/vuln/detail/CVE-2024-25629
- https://nvd.nist.gov/vuln/detail/CVE-2024-28182

###### Test Methodology

- Ran package tests.
