### PR TITLE
[mic][iso] Save input ISO configuration as yaml

### DIFF
--- a/toolkit/tools/imagecustomizerapi/utils.go
+++ b/toolkit/tools/imagecustomizerapi/utils.go
@@ -5,6 +5,7 @@ package imagecustomizerapi
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -50,4 +51,42 @@ func UnmarshalYaml[ValueType HasIsValid](yamlData []byte, value ValueType) error
 	}
 
 	return nil
+}
+
+func MarshalYamlFile[ValueType HasIsValid](yamlfilePath string, value ValueType) (err error) {
+	yamlString, err := MarshalYaml(value)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(yamlfilePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := file.Close()
+		if closeErr != nil {
+			if err != nil {
+				err = fmt.Errorf("%w:\nfailed to close (%s): %w", err, yamlfilePath, closeErr)
+			} else {
+				err = fmt.Errorf("failed to close (%s): %w", yamlfilePath, closeErr)
+			}
+		}
+	}()
+
+	_, err = file.WriteString(yamlString)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MarshalYaml[ValueType HasIsValid](value ValueType) (string, error) {
+	yamlData, err := yaml.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+
+	return string(yamlData), nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -30,7 +30,7 @@ const (
 	grubx64Binary         = "grubx64.efi"
 	grubx64NoPrefixBinary = "grubx64-noprefix.efi"
 
-	grubCfg = "grub.cfg"
+	isoGrubCfg = "grub.cfg"
 
 	searchCommandTemplate = "search --label %s --set root"
 	rootValueTemplate     = "live:LABEL=%s"
@@ -49,11 +49,11 @@ const (
 
 	// location on output iso where some of the input mic configuration will be
 	// saved for future iso-to-iso customizations.
-	savedConfigIsoDir = "azl-customizer-config"
+	savedConfigsDir = "azl-image-customizer"
 	// file holding the iso kernel parameters from the input mic configuration
 	// to be re-appended/merged with newer configures for future iso-to-iso
 	// customizations.
-	savedKernelArgsFileName = "iso-kernel-args.txt"
+	savedConfigsFileName = "saved-configs.yaml"
 
 	dracutConfig = `add_dracutmodules+=" dmsquash-live "
 add_drivers+=" overlay "
@@ -80,15 +80,15 @@ type IsoWorkingDirs struct {
 // `IsoArtifacts` holds the extracted/generated artifacts necessary to build
 // a LiveOS ISO image.
 type IsoArtifacts struct {
-	kernelVersion           string
-	bootx64EfiPath          string
-	grubx64EfiPath          string
-	grubCfgPath             string
-	savedKernelArgsFilePath string
-	vmlinuzPath             string
-	initrdImagePath         string
-	squashfsImagePath       string
-	additionalFiles         map[string]string // local-build-path -> iso-media-path
+	kernelVersion        string
+	bootx64EfiPath       string
+	grubx64EfiPath       string
+	isoGrubCfgPath       string
+	savedConfigsFilePath string
+	vmlinuzPath          string
+	initrdImagePath      string
+	squashfsImagePath    string
+	additionalFiles      map[string]string // local-build-path -> iso-media-path
 }
 
 type LiveOSIsoBuilder struct {
@@ -242,26 +242,29 @@ func (b *LiveOSIsoBuilder) prepareRootfsForDracut(writeableRootfsDir string) err
 	return nil
 }
 
-func mergeKernelParameters(savedConfigKernelArgsFilePath string, newKernelArgs string) (string, error) {
-	exists, err := file.PathExists(savedConfigKernelArgsFilePath)
+func mergeConfigs(savedConfigsFilePath string, newKernelArgs imagecustomizerapi.KernelExtraArguments) (mergedConfigs *SavedConfigs, err error) {
+	mergedConfigs = &SavedConfigs{}
+	mergedConfigs.Iso.KernelCommandLine.ExtraCommandLine = newKernelArgs
+
+	savedConfigs, err := loadSavedConfigs(savedConfigsFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to check if (%s) exists:\n%w", savedConfigKernelArgsFilePath, err)
+		return nil, fmt.Errorf("failed to load saved configurations (%s):\n%w", savedConfigsFilePath, err)
 	}
 
-	if exists {
-		savedConfigKernelArgs, err := file.Read(savedConfigKernelArgsFilePath)
-		if err != nil {
-			return "", err
-		}
-		if savedConfigKernelArgs != "" {
-			newKernelArgs = savedConfigKernelArgs + " " + newKernelArgs
+	if savedConfigs != nil && !savedConfigs.IsEmpty() {
+		// do we have kernel arguments from a previous run?
+		if savedConfigs.Iso.KernelCommandLine.ExtraCommandLine != "" {
+			// If yes, add them before the new kernel arguments.
+			savedArgs := strings.TrimSpace(string(savedConfigs.Iso.KernelCommandLine.ExtraCommandLine))
+			newArgs := strings.TrimSpace(string(newKernelArgs))
+			mergedConfigs.Iso.KernelCommandLine.ExtraCommandLine = imagecustomizerapi.KernelExtraArguments(savedArgs + " " + newArgs)
 		}
 	}
 
-	return newKernelArgs, nil
+	return mergedConfigs, nil
 }
 
-func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigKernelArgsFilePath string, grubCfgFileName string, extraCommandLine string) error {
+func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigsFilePath string, grubCfgFileName string, extraCommandLine imagecustomizerapi.KernelExtraArguments) error {
 
 	inputContentString, err := file.Read(grubCfgFileName)
 	if err != nil {
@@ -321,13 +324,13 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigKernelArgsFilePath string, g
 		return fmt.Errorf("failed to set SELinux mode:\n%w", err)
 	}
 
-	mergedExtraCommandLine, err := mergeKernelParameters(savedConfigKernelArgsFilePath, extraCommandLine)
+	mergedConfigs, err := mergeConfigs(savedConfigsFilePath, extraCommandLine)
 	if err != nil {
 		return fmt.Errorf("failed to combine additional kernel command line parameters:\n%w", err)
 	}
 
 	liveosKernelArgs := fmt.Sprintf(kernelArgsLiveOSTemplate, liveOSDir, liveOSImage)
-	additionalKernelCommandline := liveosKernelArgs + " " + mergedExtraCommandLine
+	additionalKernelCommandline := liveosKernelArgs + " " + string(mergedConfigs.Iso.KernelCommandLine.ExtraCommandLine)
 
 	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline,
 		true /*allowMultiple*/, false /*requireKernelOpts*/)
@@ -335,15 +338,9 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(savedConfigKernelArgsFilePath string, g
 		return fmt.Errorf("failed to update the kernel arguments with the LiveOS configuration and user configuration in the iso grub.cfg:\n%w", err)
 	}
 
-	if mergedExtraCommandLine != "" {
-		err = os.MkdirAll(filepath.Dir(savedConfigKernelArgsFilePath), os.ModePerm)
-		if err != nil {
-			return fmt.Errorf("failed to create directory for (%s):\n%w", savedConfigKernelArgsFilePath, err)
-		}
-		err = file.Write(mergedExtraCommandLine, savedConfigKernelArgsFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to write %s:\n%w", savedConfigKernelArgsFilePath, err)
-		}
+	err = mergedConfigs.persistSavedConfigs(savedConfigsFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to save iso configs:\n%w", err)
 	}
 
 	err = file.Write(inputContentString, grubCfgFileName)
@@ -462,7 +459,7 @@ func (b *LiveOSIsoBuilder) extractBootDirFiles(writeableRootfsDir string) error 
 			// in the iso media - so no need to schedule it as an additional
 			// file.
 			scheduleAdditionalFile = false
-		case grubCfg:
+		case isoGrubCfg:
 			if usingGrubNoPrefix {
 				// When using the grubx64-noprefix.efi, the 'prefix' grub
 				// variable is set to an empty string. When 'prefix' is an
@@ -479,9 +476,9 @@ func (b *LiveOSIsoBuilder) extractBootDirFiles(writeableRootfsDir string) error 
 				// So, once grubx64.efi loads EFI/BOOT/grub.cfg, it will set
 				// bootprefix to the usual location boot/grub2 and will proceed
 				// as usual from there.
-				targetPath = filepath.Join(b.workingDirs.isoArtifactsDir, "EFI/BOOT", grubCfg)
+				targetPath = filepath.Join(b.workingDirs.isoArtifactsDir, "EFI/BOOT", isoGrubCfg)
 			}
-			b.artifacts.grubCfgPath = targetPath
+			b.artifacts.isoGrubCfgPath = targetPath
 			// grub.cfg is passed as a parameter to isomaker.
 			scheduleAdditionalFile = false
 		}
@@ -580,10 +577,10 @@ func (b *LiveOSIsoBuilder) findKernelVersion(writeableRootfsDir string) error {
 //	- creates the squashfs.
 //
 // inputs:
-//   - inputIsoSavedKernelArgsFilePath:
+//   - 'inputSavedConfigsFilePath':
 //   - writeableRootfsDir:
 //     A writeable folder where the rootfs content is.
-//   - isoMakerArtifactsStagingDir:
+//   - 'isoMakerArtifactsStagingDir':
 //     The folder where the artifacts needed by isoMaker will be staged before
 //     'dracut' is run. 'dracut' will include this folder as-is and place it in
 //     the initrd image.
@@ -593,8 +590,8 @@ func (b *LiveOSIsoBuilder) findKernelVersion(writeableRootfsDir string) error {
 // outputs
 //   - customized writeableRootfsDir (new files, deleted files, etc)
 //   - extracted artifacts
-func (b *LiveOSIsoBuilder) prepareLiveOSDir(inputIsoSavedKernelArgsFilePath string, writeableRootfsDir string,
-	isoMakerArtifactsStagingDir string, extraCommandLine string) error {
+func (b *LiveOSIsoBuilder) prepareLiveOSDir(inputSavedConfigsFilePath string, writeableRootfsDir string,
+	isoMakerArtifactsStagingDir string, extraCommandLine imagecustomizerapi.KernelExtraArguments) error {
 
 	logger.Log.Debugf("Creating LiveOS squashfs image")
 
@@ -608,18 +605,18 @@ func (b *LiveOSIsoBuilder) prepareLiveOSDir(inputIsoSavedKernelArgsFilePath stri
 		return err
 	}
 
-	exists, err := file.PathExists(inputIsoSavedKernelArgsFilePath)
+	exists, err := file.PathExists(inputSavedConfigsFilePath)
 	if err != nil {
 		return err
 	}
 	if exists {
-		err = file.Copy(inputIsoSavedKernelArgsFilePath, b.artifacts.savedKernelArgsFilePath)
+		err = file.Copy(inputSavedConfigsFilePath, b.artifacts.savedConfigsFilePath)
 		if err != nil {
-			return fmt.Errorf("failed to copy generated initrd:\n%w", err)
+			return fmt.Errorf("failed to copy (%s) to (%s):\n%w", inputSavedConfigsFilePath, b.artifacts.savedConfigsFilePath, err)
 		}
 	}
 
-	err = b.updateGrubCfg(b.artifacts.savedKernelArgsFilePath, b.artifacts.grubCfgPath, extraCommandLine)
+	err = b.updateGrubCfg(b.artifacts.savedConfigsFilePath, b.artifacts.isoGrubCfgPath, extraCommandLine)
 	if err != nil {
 		return fmt.Errorf("failed to update grub.cfg:\n%w", err)
 	}
@@ -744,7 +741,7 @@ func (b *LiveOSIsoBuilder) generateInitrdImage(rootfsSourceDir, artifactsSourceD
 //	image (has boot and rootfs partitions).
 //
 // inputs:
-//   - 'inputIsoSavedKernelArgsFilePath':
+//   - 'inputSavedConfigsFilePath':
 //   - 'rawImageFile':
 //     path to an existing raw full disk image (i.e. image with boot
 //     partition and a rootfs partition).
@@ -756,7 +753,7 @@ func (b *LiveOSIsoBuilder) generateInitrdImage(rootfsSourceDir, artifactsSourceD
 //     `LiveOSIsoBuilder.workingDirs.isoArtifactsDir` folder.
 //   - the paths to individual artifaces are found in the
 //     `LiveOSIsoBuilder.artifacts` data structure.
-func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputIsoSavedKernelArgsFilePath string, rawImageFile string, extraCommandLine string) error {
+func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputSavedConfigsFilePath string, rawImageFile string, extraCommandLine imagecustomizerapi.KernelExtraArguments) error {
 
 	logger.Log.Infof("Preparing iso artifacts")
 
@@ -774,7 +771,7 @@ func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputIsoSavedKernelArgs
 	}
 
 	isoMakerArtifactsStagingDir := "/boot-staging"
-	err = b.prepareLiveOSDir(inputIsoSavedKernelArgsFilePath, writeableRootfsDir, isoMakerArtifactsStagingDir, extraCommandLine)
+	err = b.prepareLiveOSDir(inputSavedConfigsFilePath, writeableRootfsDir, isoMakerArtifactsStagingDir, extraCommandLine)
 	if err != nil {
 		return fmt.Errorf("failed to convert rootfs folder to a LiveOS folder:\n%w", err)
 	}
@@ -810,7 +807,7 @@ func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputIsoSavedKernelArgs
 //
 // ouptuts:
 //   - create a LiveOS ISO.
-func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileToCopy, isoOutputDir, isoOutputBaseName string) error {
+func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileToCopy, isoOutputDir, isoOutputBaseName string) (isoRepoDirPath string, err error) {
 	baseDirPath := ""
 
 	// unattended install is where the ISO OS configures a persistent storage
@@ -827,12 +824,13 @@ func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileTo
 	// No stock resources are needed for the LiveOS scenario.
 	// No rpms are needed for the LiveOS scenario.
 	enableRpmRepo := false
-	isoRepoDirPath := ""
+	isoRepoDirPath = ""
 
 	// isoMaker constructs the final image name as follows:
 	// {isoOutputDir}/{isoOutputBaseName}{releaseVersion}{imageNameTag}.iso
 	releaseVersion := ""
 	imageNameTag := ""
+	isoImagePath := filepath.Join(isoOutputDir, isoOutputBaseName+releaseVersion+imageNameTag+".iso")
 
 	// empty target system config since LiveOS does not install the OS
 	// artifacts to the target system.
@@ -855,22 +853,22 @@ func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileTo
 		additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
 	}
 
-	// Add the iso config file
-	exists, err := file.PathExists(b.artifacts.savedKernelArgsFilePath)
+	// Add the iso saved config file
+	exists, err := file.PathExists(b.artifacts.savedConfigsFilePath)
 	if err != nil {
-		return nil
+		return "", fmt.Errorf("failed to check if (%s) exists:\n%w", b.artifacts.savedConfigsFilePath, err)
 	}
 	if exists {
-		isoKernelArgsToCopy := safechroot.FileToCopy{
-			Src:  b.artifacts.savedKernelArgsFilePath,
-			Dest: filepath.Join("/", savedConfigIsoDir, savedKernelArgsFileName),
+		fileToCopy := safechroot.FileToCopy{
+			Src:  b.artifacts.savedConfigsFilePath,
+			Dest: filepath.Join("/", savedConfigsDir, savedConfigsFileName),
 		}
-		additionalIsoFiles = append(additionalIsoFiles, isoKernelArgsToCopy)
+		additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
 	}
 
 	err = os.MkdirAll(isoOutputDir, os.ModePerm)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	isoMaker, err := isomakerlib.NewIsoMakerWithConfig(
@@ -885,21 +883,21 @@ func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileTo
 		targetSystemConfig,
 		isoBootDir,
 		b.artifacts.initrdImagePath,
-		b.artifacts.grubCfgPath,
+		b.artifacts.isoGrubCfgPath,
 		isoRepoDirPath,
 		isoOutputDir,
 		isoOutputBaseName,
 		imageNameTag)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = isoMaker.Make()
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return isoImagePath, nil
 }
 
 // micIsoConfigToIsoMakerConfig
@@ -918,13 +916,11 @@ func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileTo
 // outputs:
 //   - 'additionalIsoFiles'
 //     list of files to copy from the build machine to the iso media.
-func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomizerapi.Iso) (additionalIsoFiles []safechroot.FileToCopy, extraCommandLine string, err error) {
+func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomizerapi.Iso) (additionalIsoFiles []safechroot.FileToCopy, extraCommandLine imagecustomizerapi.KernelExtraArguments, err error) {
 
 	if isoConfig == nil {
 		return
 	}
-
-	extraCommandLine = strings.TrimSpace(string(isoConfig.KernelCommandLine.ExtraCommandLine))
 
 	additionalIsoFiles = []safechroot.FileToCopy{}
 
@@ -942,7 +938,7 @@ func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomi
 		additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
 	}
 
-	return additionalIsoFiles, extraCommandLine, nil
+	return additionalIsoFiles, isoConfig.KernelCommandLine.ExtraCommandLine, nil
 }
 
 // createLiveOSIsoImage
@@ -1004,7 +1000,7 @@ func createLiveOSIsoImage(buildDir, baseConfigPath string, inputIsoArtifacts *Li
 			isomakerBuildDir: isomakerBuildDir,
 		},
 		artifacts: IsoArtifacts{
-			savedKernelArgsFilePath: filepath.Join(isoArtifactsDir, savedConfigIsoDir, savedKernelArgsFileName),
+			savedConfigsFilePath: filepath.Join(isoArtifactsDir, savedConfigsDir, savedConfigsFileName),
 		},
 	}
 	defer func() {
@@ -1020,12 +1016,12 @@ func createLiveOSIsoImage(buildDir, baseConfigPath string, inputIsoArtifacts *Li
 
 	// if there is an input iso, make sure to pick-up it's saved kernel args
 	// file.
-	inputIsoSavedKernelArgsFilePath := ""
+	inputSavedConfigsFilePath := ""
 	if inputIsoArtifacts != nil {
-		inputIsoSavedKernelArgsFilePath = inputIsoArtifacts.artifacts.savedKernelArgsFilePath
+		inputSavedConfigsFilePath = inputIsoArtifacts.artifacts.savedConfigsFilePath
 	}
 
-	err = isoBuilder.prepareArtifactsFromFullImage(inputIsoSavedKernelArgsFilePath, rawImageFile, extraCommandLine)
+	err = isoBuilder.prepareArtifactsFromFullImage(inputSavedConfigsFilePath, rawImageFile, extraCommandLine)
 	if err != nil {
 		return err
 	}
@@ -1052,7 +1048,7 @@ func createLiveOSIsoImage(buildDir, baseConfigPath string, inputIsoArtifacts *Li
 		}
 	}
 
-	err = isoBuilder.createIsoImage(additionalIsoFiles, outputImageDir, outputImageBase)
+	_, err = isoBuilder.createIsoImage(additionalIsoFiles, outputImageDir, outputImageBase)
 	if err != nil {
 		return err
 	}
@@ -1162,7 +1158,7 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 			isomakerBuildDir: isomakerBuildDir,
 		},
 		artifacts: IsoArtifacts{
-			savedKernelArgsFilePath: filepath.Join(isoArtifactsDir, savedConfigIsoDir, savedKernelArgsFileName),
+			savedConfigsFilePath: filepath.Join(isoArtifactsDir, savedConfigsDir, savedConfigsFileName),
 		},
 	}
 	defer func() {
@@ -1223,8 +1219,8 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 			// in the iso media - so no need to schedule it as an additional
 			// file.
 			scheduleAdditionalFile = false
-		case grubCfg:
-			isoBuilder.artifacts.grubCfgPath = isoFile
+		case isoGrubCfg:
+			isoBuilder.artifacts.isoGrubCfgPath = isoFile
 			// grub.cfg is passed as a parameter to isomaker.
 			scheduleAdditionalFile = false
 		case liveOSImage:
@@ -1236,8 +1232,8 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 			isoBuilder.artifacts.initrdImagePath = isoFile
 			// initrd.img is passed as a parameter to isomaker.
 			scheduleAdditionalFile = false
-		case savedKernelArgsFileName:
-			isoBuilder.artifacts.savedKernelArgsFilePath = isoFile
+		case savedConfigsFileName:
+			isoBuilder.artifacts.savedConfigsFilePath = isoFile
 			scheduleAdditionalFile = false
 		}
 		if strings.HasPrefix(fileName, vmLinuzPrefix) {
@@ -1289,12 +1285,12 @@ func (b *LiveOSIsoBuilder) createImageFromUnchangedOS(baseConfigPath string, iso
 		return fmt.Errorf("failed to convert iso configuration to isomaker configuration format:\n%w", err)
 	}
 
-	err = b.updateGrubCfg(b.artifacts.savedKernelArgsFilePath, b.artifacts.grubCfgPath, extraCommandLine)
+	err = b.updateGrubCfg(b.artifacts.savedConfigsFilePath, b.artifacts.isoGrubCfgPath, extraCommandLine)
 	if err != nil {
 		return fmt.Errorf("failed to update grub.cfg:\n%w", err)
 	}
 
-	err = b.createIsoImage(additionalIsoFiles, outputImageDir, outputImageBase)
+	_, err = b.createIsoImage(additionalIsoFiles, outputImageDir, outputImageBase)
 	if err != nil {
 		return fmt.Errorf("failed to create iso image:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -59,11 +59,12 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 	assert.NoError(t, err, "read grub.cfg file")
 	assert.Regexp(t, "linux.* rd.info ", grubCfgContents)
 
-	// Check the iso-kernel-args.txt file.
-	isoKernelArgsPath := filepath.Join(isoMountDir, savedConfigIsoDir, savedKernelArgsFileName)
-	isoKernelArgsContents, err := file.Read(isoKernelArgsPath)
-	assert.NoErrorf(t, err, "read (%s) file", savedKernelArgsFileName)
-	assert.Equal(t, "rd.info", isoKernelArgsContents)
+	// Check the saved-configs.yaml file.
+	savedConfigsFilePath := filepath.Join(isoMountDir, savedConfigsDir, savedConfigsFileName)
+	savedConfigs := &SavedConfigs{}
+	err = imagecustomizerapi.UnmarshalYamlFile(savedConfigsFilePath, savedConfigs)
+	assert.NoErrorf(t, err, "read (%s) file", savedConfigsFilePath)
+	assert.Equal(t, "rd.info", string(savedConfigs.Iso.KernelCommandLine.ExtraCommandLine))
 
 	err = isoImageMount.CleanClose()
 	if !assert.NoError(t, err) {
@@ -130,9 +131,10 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 	assert.Regexp(t, "linux.* rd.debug ", grubCfgContents)
 
 	// Check the iso-kernel-args.txt file.
-	isoKernelArgsContents, err = file.Read(isoKernelArgsPath)
-	assert.NoErrorf(t, err, "read (%s) file", savedKernelArgsFileName)
-	assert.Equal(t, "rd.info rd.debug", isoKernelArgsContents)
+	savedConfigs = &SavedConfigs{}
+	err = imagecustomizerapi.UnmarshalYamlFile(savedConfigsFilePath, savedConfigs)
+	assert.NoErrorf(t, err, "read (%s) file", savedConfigsFilePath)
+	assert.Equal(t, "rd.info rd.debug", string(savedConfigs.Iso.KernelCommandLine.ExtraCommandLine))
 }
 
 // Tests:

--- a/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 )
 
@@ -26,8 +25,22 @@ import (
 // and we need to remember to add the ISO specific arguments from the previous
 // runs. SavedConfigs is the place where we can store such arguments so we can
 // re-apply them.
+
+type IsoSavedConfigs struct {
+	KernelCommandLine imagecustomizerapi.KernelCommandLine  `yaml:"kernelCommandLine"`
+}
+
+func (i *IsoSavedConfigs) IsValid() error {
+	err := i.KernelCommandLine.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid kernelCommandLine: %w", err)
+	}
+
+	return nil
+}
+
 type SavedConfigs struct {
-	Iso imagecustomizerapi.Iso `yaml:"iso"`
+	Iso IsoSavedConfigs `yaml:"iso"`
 }
 
 func (c *SavedConfigs) IsValid() (err error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+)
+
+// 'SavedConfigs' is a subset of the Image Customizer input configurations that
+// needs to be saved on the output media so that it can be used in subsequent
+// runs of the Image Customizer against that same output media.
+//
+// This preservation of input configuration is necessary for subsequent runs if
+// the configuration does not result in updating root file system.
+//
+// For example, if the user specifies a kernel argument that is specific to the
+// ISO image, it will not be present in any of the grub config files on the
+// root file system - only in the final ISO image grub.cfg. When that ISO image
+// is further customized, the root file system grub.cfg migith get re-generated
+// and we need to remember to add the ISO specific arguments from the previous
+// runs. SavedConfigs is the place where we can store such arguments so we can
+// re-apply them.
+type SavedConfigs struct {
+	Iso imagecustomizerapi.Iso `yaml:"iso"`
+}
+
+func (c *SavedConfigs) IsValid() (err error) {
+	err = c.Iso.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid 'iso' field:\n%w", err)
+	}
+
+	return nil
+}
+
+func (c *SavedConfigs) IsEmpty() bool {
+	isoConfigEmpty := c.Iso.KernelCommandLine.ExtraCommandLine == ""
+	return isoConfigEmpty
+}
+
+func (c *SavedConfigs) persistSavedConfigs(savedConfigsFilePath string) (err error) {
+	if c.IsEmpty() {
+		return nil
+	}
+
+	err = os.MkdirAll(filepath.Dir(savedConfigsFilePath), os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create directory for (%s):\n%w", savedConfigsFilePath, err)
+	}
+
+	err = imagecustomizerapi.MarshalYamlFile(savedConfigsFilePath, c)
+	if err != nil {
+		return fmt.Errorf("failed to persist saved configs file to (%s):\n%w", savedConfigsFilePath, err)
+	}
+
+	return nil
+}
+
+func loadSavedConfigs(savedConfigsFilePath string) (savedConfigs *SavedConfigs, err error) {
+	exists, err := file.PathExists(savedConfigsFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if (%s) exists:\n%w", savedConfigsFilePath, err)
+	}
+
+	if !exists {
+		return nil, nil
+	}
+
+	savedConfigs = &SavedConfigs{}
+	err = imagecustomizerapi.UnmarshalYamlFile(savedConfigsFilePath, savedConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load saved configs file (%s):\n%w", savedConfigsFilePath, err)
+	}
+
+	return savedConfigs, nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
@@ -22,7 +22,7 @@ import (
 // For example, if the user specifies a kernel argument that is specific to the
 // ISO image, it will not be present in any of the grub config files on the
 // root file system - only in the final ISO image grub.cfg. When that ISO image
-// is further customized, the root file system grub.cfg migith get re-generated
+// is further customized, the root file system grub.cfg might get re-generated
 // and we need to remember to add the ISO specific arguments from the previous
 // runs. SavedConfigs is the place where we can store such arguments so we can
 // re-apply them.

--- a/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 )
 
@@ -27,7 +28,7 @@ import (
 // re-apply them.
 
 type IsoSavedConfigs struct {
-	KernelCommandLine imagecustomizerapi.KernelCommandLine  `yaml:"kernelCommandLine"`
+	KernelCommandLine imagecustomizerapi.KernelCommandLine `yaml:"kernelCommandLine"`
 }
 
 func (i *IsoSavedConfigs) IsValid() error {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
[mix][iso] Save input ISO configuration as yaml.

'SavedConfigs' is a subset of the Image Customizer input configurations that needs to be saved on the output media so that it can be used in subsequent runs of the Image Customizer against that same output media.

This change updates the code from saving just the kernel parameters in a plain-text file, to saving the same yaml that's using in the input configuration. This allows the code to scale when we want to save other input configuration constructs. This is a step preparing for adding PXE specific configurations.

Background:

This preservation of input configuration is necessary for subsequent runs if the configuration does not result in updating root file system.

For example, if the user specifies a kernel argument that is specific to the ISO image, it will not be present in any of the grub config files on the root file system - only in the final ISO image grub.cfg. When that ISO image is further customized, the root file system grub.cfg migith get re-generated and we need to remember to add the ISO specific arguments from the previous
runs. SavedConfigs is the place where we can store such arguments so we can re-apply them.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- [[mic][iso] Save input ISO configuration as yaml](https://github.com/microsoft/azurelinux/pull/10743/commits/ef6c344b8384a7b5589a3394f2e87d6447052d03)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [7913: [MIC ISO] Enable PXE booting for mic generated iso](https://dev.azure.com/mariner-org/ECF/_workitems/edit/7913)

###### Links to CVEs  <!-- optional -->
- n/a

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build iso from vhdx - boot a virtual machine with it.
- Build iso from iso - boot a virtual machine with it. Ensure ISO kernel parameters carry over.
