### PR TITLE
Upgrade graphene to 1.10.8-1

### DIFF
--- a/SPECS-EXTENDED/graphene/graphene.signatures.json
+++ b/SPECS-EXTENDED/graphene/graphene.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "graphene-1.10.4.tar.xz": "b2a45f230f332478553bd79666eca8df1d1c6dbf208c344ba9f5120592772414"
+  "graphene-1.10.8.tar.gz": "922dc109d2dc5dc56617a29bd716c79dd84db31721a8493a13a5f79109a4a4ed"
  }
 }

--- a/SPECS-EXTENDED/graphene/graphene.spec
+++ b/SPECS-EXTENDED/graphene/graphene.spec
@@ -1,13 +1,13 @@
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Name:           graphene
-Version:        1.10.4
-Release:        3%{?dist}
+Version:        1.10.8
+Release:        1%{?dist}
 Summary:        Thin layer of types for graphic libraries
 
 License:        MIT
 URL:            https://github.com/ebassi/graphene
-Source:         %{url}/releases/download/%{version}/%{name}-%{version}.tar.xz
+Source:		%{url}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  %{_bindir}/xsltproc
 BuildRequires:  gcc
@@ -65,6 +65,10 @@ the functionality of the installed %{name} package.
 %{_datadir}/installed-tests/
 
 %changelog
+* Thu Oct 17 2024 Kevin Lockwood <v-klockwood@microsoft.com> - 1.10.8-1
+- Upgrade to 1.10.8
+- License Verified
+
 * Mon Mar 21 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.10.4-3
 - Adding BR on '%%{_bindir}/xsltproc'.
 - Disabled gtk doc generation to remove network dependency during build-time.

--- a/SPECS-EXTENDED/graphene/graphene.spec
+++ b/SPECS-EXTENDED/graphene/graphene.spec
@@ -7,7 +7,7 @@ Summary:        Thin layer of types for graphic libraries
 
 License:        MIT
 URL:            https://github.com/ebassi/graphene
-Source:		%{url}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source:         %{url}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  %{_bindir}/xsltproc
 BuildRequires:  gcc

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4800,8 +4800,8 @@
         "type": "other",
         "other": {
           "name": "graphene",
-          "version": "1.10.4",
-          "downloadUrl": "https://github.com/ebassi/graphene/releases/download/1.10.4/graphene-1.10.4.tar.xz"
+          "version": "1.10.8",
+          "downloadUrl": "https://github.com/ebassi/graphene/archive/refs/tags/1.10.8.tar.gz"
         }
       }
     },


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Bump `graphene` to 1.10.8

###### Build/Dependency Info  <!-- REQUIRED -->
This PR is a leaf PR which builds alone successfully.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- I had to change the download URL as for the 1.10.8 release there was not
a named release like before (graphene-1.10.4.tar.xz), instead it was
just a versioned release (1.10.8.tar.gz)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
