### PR TITLE
Added directory check before cleaning-up the RPM caches.

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -79,8 +79,10 @@ clean-imagegen:
 # the same, but the actual .rpm files may be fundamentally different.
 $(STATUS_FLAGS_DIR)/imagegen_cleanup.flag: $(depend_REPO_SNAPSHOT_TIME)
 	@echo "REPO_SNAPSHOT_TIME has changed, sanitizing rpm cache"
-	find "$(local_and_external_rpm_cache)" -type f -name '*.rpm' -delete
-	touch $@
+	@if [ -d "$(local_and_external_rpm_cache)" ]; then \
+		find "$(local_and_external_rpm_cache)" -type f -name '*.rpm' -delete; \
+	fi
+	@touch $@
 
 ##help:target:fetch-image-packages=Locate and download all packages required for an image build.
 fetch-image-packages: $(image_package_cache_summary)

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -269,8 +269,10 @@ clean-compress-srpms:
 # the same, but the actual .rpm files may be fundamentally different.
 $(STATUS_FLAGS_DIR)/build_packages_cache_cleanup.flag: $(depend_REPO_SNAPSHOT_TIME)
 	@echo "REPO_SNAPSHOT_TIME has changed, sanitizing rpm cache"
-	find "$(remote_rpms_cache_dir)" -type f -name '*.rpm' -delete
-	touch $@
+	@if [ -d "$(remote_rpms_cache_dir)" ]; then \
+		find "$(remote_rpms_cache_dir)" -type f -name '*.rpm' -delete; \
+	fi
+	@touch $@
 
 ifeq ($(REBUILD_PACKAGES),y)
 $(RPMS_DIR): $(STATUS_FLAGS_DIR)/build-rpms.flag


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

This is a fix-up for #10756. We've missed doing a check for the existence of the searched directory before running `find`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #10756

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds.