### PR TITLE
Toolkit: Add missing `flock` calls.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -811,7 +811,7 @@ func formatSinglePartition(diskDevPath string, partDevPath string, partition con
 		err = retry.Run(func() error {
 			_, stderr, err := shell.Execute("flock", mkfsArgs...)
 			if err != nil {
-				logger.Log.Warnf("Failed to format partition using mkfs: %v", stderr)
+				logger.Log.Warnf("Failed to format partition using mkfs (and flock): %v", stderr)
 				return err
 			}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -88,7 +88,7 @@ func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomi
 		stdout, stderr, err := shell.Execute("flock", "--timeout", "5", imageLoopDevice,
 			"resize2fs", "-M", partitionLoopDevice)
 		if err != nil {
-			return fmt.Errorf("failed to resize %s with resize2fs:\n%v", partitionLoopDevice, stderr)
+			return fmt.Errorf("failed to resize %s with resize2fs (and flock):\n%v", partitionLoopDevice, stderr)
 		}
 
 		// Find the new partition end value
@@ -108,7 +108,7 @@ func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomi
 			"parted", "---pretend-input-tty", imageLoopDevice, "resizepart",
 			strconv.Itoa(partitionNumber), end)
 		if err != nil {
-			return fmt.Errorf("failed to resizepart %s with parted:\n%v", partitionLoopDevice, stderr)
+			return fmt.Errorf("failed to resizepart %s with parted (and flock):\n%v", partitionLoopDevice, stderr)
 		}
 
 		// Re-read the partition table

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -85,7 +85,8 @@ func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomi
 		}
 
 		// Shrink the file system with resize2fs -M
-		stdout, stderr, err := shell.Execute("resize2fs", "-M", partitionLoopDevice)
+		stdout, stderr, err := shell.Execute("flock", "--timeout", "5", imageLoopDevice,
+			"resize2fs", "-M", partitionLoopDevice)
 		if err != nil {
 			return fmt.Errorf("failed to resize %s with resize2fs:\n%v", partitionLoopDevice, stderr)
 		}
@@ -103,8 +104,9 @@ func shrinkFilesystems(imageLoopDevice string, verityHashPartition *imagecustomi
 		}
 
 		// Resize the partition with parted resizepart
-		_, stderr, err = shell.ExecuteWithStdin("yes" /*stdin*/, "parted", "---pretend-input-tty",
-			imageLoopDevice, "resizepart", strconv.Itoa(partitionNumber), end)
+		_, stderr, err = shell.ExecuteWithStdin("yes" /*stdin*/, "flock", "--timeout", "5", imageLoopDevice,
+			"parted", "---pretend-input-tty", imageLoopDevice, "resizepart",
+			strconv.Itoa(partitionNumber), end)
 		if err != nil {
 			return fmt.Errorf("failed to resizepart %s with parted:\n%v", partitionLoopDevice, stderr)
 		}


### PR DESCRIPTION
When making changes to partitions or filesystems, it is recommended to take a file lock over the disk block device as this informs the host OS that you are making changes and that it should avoid scanning or changing the device until you are done. While most of the relevant operations are covered, there a few places that are missing the lock. For example, when calling `mkfs` or `resize2fs`.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran image customizer UTs.
