### PR TITLE
iptables: Add runtime dependency for alternatives.

### DIFF
--- a/SPECS/iptables/iptables.spec
+++ b/SPECS/iptables/iptables.spec
@@ -1,7 +1,7 @@
 Summary:        Linux kernel packet control tool
 Name:           iptables
 Version:        1.8.10
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -18,6 +18,8 @@ BuildRequires:  libmnl-devel
 BuildRequires:  libnftnl-devel
 BuildRequires:  systemd-bootstrap-rpm-macros
 Requires:       iana-etc
+Requires(post): %{_sbindir}/alternatives
+Requires(postun): %{_sbindir}/alternatives
 # Our build tooling cannot handle this
 #Requires:       systemd
 Provides:       %{name}-services = %{version}-%{release}
@@ -130,6 +132,9 @@ fi
 %{_mandir}/man3/*
 
 %changelog
+* Wed Oct 23 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.8.10-4
+- Add runtime requirements for alternatives
+
 * Fri Oct 18 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.8.10-3
 - Enable nftables and use alternatives.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add runtime dependency on alternatives.

###### Change Log  <!-- REQUIRED -->
- Update Requires in spec file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/54604746

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=662337&view=results)