### PR TITLE
Image Customizer: Set VHDX block-size to 2 MiB.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -466,6 +466,12 @@ func toQemuImageFormat(imageFormat string) (string, string) {
 	case ImageFormatVhdFixed:
 		return QemuFormatVpc, "subformat=fixed,force_size"
 
+	case ImageFormatVhdx:
+		// For VHDX, qemu-img dynamically picks the block-size based on the size of the disk.
+		// However, this can result in a significantly larger file size than other formats.
+		// So, use a fixed block-size of 2 MiB to match the block-sizes used for qcow2 and VHD.
+		return ImageFormatVhdx, "block_size=2097152"
+
 	default:
 		return imageFormat, ""
 	}


### PR DESCRIPTION
Currently, the size of outputted VHDX files can be substantially larger than VHD or qcow2 files. This behavior occurs because `qemu-img` dynamically sets the block-size based on the size of the disk. And larger blocks sizes means the file format is less space efficient, which results in a larger image file.

This change sets the block-size to 2 MiB for VHDX files. This matches the `qemu-img` defaults for VHD and QCOW2.

For reference, Windows seems to use a default block-size of 1 MiB for VHDX files.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer.
