### PR TITLE
Image Customizer: Fix ISO customization.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -1444,16 +1444,18 @@ func (b *LiveOSIsoBuilder) createWriteableImageFromSquashfs(buildDir, rawImageFi
 
 	fileSystemConfigs := []imagecustomizerapi.FileSystem{
 		{
-			DeviceId: "esp",
-			Type:     imagecustomizerapi.FileSystemTypeFat32,
+			DeviceId:    "esp",
+			PartitionId: "esp",
+			Type:        imagecustomizerapi.FileSystemTypeFat32,
 			MountPoint: &imagecustomizerapi.MountPoint{
 				Path:    "/boot/efi",
 				Options: "umask=0077",
 			},
 		},
 		{
-			DeviceId: "rootfs",
-			Type:     imagecustomizerapi.FileSystemTypeExt4,
+			DeviceId:    "rootfs",
+			PartitionId: "rootfs",
+			Type:        imagecustomizerapi.FileSystemTypeExt4,
 			MountPoint: &imagecustomizerapi.MountPoint{
 				Path: "/",
 			},


### PR DESCRIPTION
In change #10789, the `imagecustomizerapi.FileSystem` type had an internal field added called `PartitionId` which is filled in by the API validity checks.

ISO to ISO customization supports cracking open the squashfs file and modifying the Live-OS. However, to do this, a temporary OS image must be created. This creation logic uses the `imagecustomizerapi.FileSystem` type but the code wasn't updated to ensure the `PartitionId` field has a value.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran UTs.
