### PR TITLE
Fix multiple CVEs in Skopeo

### DIFF
--- a/SPECS/skopeo/CVE-2024-24786.patch
+++ b/SPECS/skopeo/CVE-2024-24786.patch
@@ -1,4 +1,4 @@
-From a1d5f8e60ed906d6943bc168d8382c20e0f690ab Mon Sep 17 00:00:00 2001
+From 8b21f5b64ee714e4ada48a03bf8ca5f2cfb065ca Mon Sep 17 00:00:00 2001
 From: Rohit Rawat <xordux@gmail.com>
 Date: Sun, 10 Nov 2024 17:20:59 +0000
 Subject: [PATCH] encoding/protojson, internal/encoding/json: handle missing
@@ -11,20 +11,20 @@ Patch from https://go-review.googlesource.com/c/protobuf/+/569356 by Damien Neil
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
-index 6c37d41..036ccce 100644
+index 6c37d41..d5a6b1f 100644
 --- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
 +++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
-@@ -329,6 +329,10 @@ func (d decoder) skipJSONValue() error {
+@@ -328,6 +328,10 @@ func (d decoder) skipJSONValue() error {
+ 				if err := d.skipJSONValue(); err != nil {
  					return err
  				}
++			case json.EOF:
++				// This can only happen if there's a bug in Decoder.Read.
++				// Avoid an infinite loop if this does happen.
++				return errors.New("unexpected EOF")
  			}
-+		case json.EOF:
-+			// This can only happen if there's a bug in Decoder.Read.
-+			// Avoid an infinite loop if this does happen.
-+			return errors.New("unexpected EOF")
  		}
  
- 	case json.ArrayOpen:
 diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
 index d043a6e..d2b3ac0 100644
 --- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go

--- a/SPECS/skopeo/CVE-2024-24786.patch
+++ b/SPECS/skopeo/CVE-2024-24786.patch
@@ -1,0 +1,43 @@
+From a1d5f8e60ed906d6943bc168d8382c20e0f690ab Mon Sep 17 00:00:00 2001
+From: Rohit Rawat <xordux@gmail.com>
+Date: Sun, 10 Nov 2024 17:20:59 +0000
+Subject: [PATCH] encoding/protojson, internal/encoding/json: handle missing
+ object values
+
+Patch from https://go-review.googlesource.com/c/protobuf/+/569356 by Damien Neil <dneil@google.com>
+---
+ .../protobuf/encoding/protojson/well_known_types.go           | 4 ++++
+ .../protobuf/internal/encoding/json/decode.go                 | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 6c37d41..036ccce 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -329,6 +329,10 @@ func (d decoder) skipJSONValue() error {
+ 					return err
+ 				}
+ 			}
++		case json.EOF:
++			// This can only happen if there's a bug in Decoder.Read.
++			// Avoid an infinite loop if this does happen.
++			return errors.New("unexpected EOF")
+ 		}
+ 
+ 	case json.ArrayOpen:
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index d043a6e..d2b3ac0 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
+ 
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}
+-- 
+2.39.4
+

--- a/SPECS/skopeo/CVE-2024-28180.patch
+++ b/SPECS/skopeo/CVE-2024-28180.patch
@@ -1,0 +1,110 @@
+From ad7025b5d7f719f0e17788395f36db2151f27a98 Mon Sep 17 00:00:00 2001
+From: Rohit Rawat <xordux@gmail.com>
+Date: Sun, 10 Nov 2024 18:00:09 +0000
+Subject: [PATCH] backport decompression limit fix
+
+Patch from: PR #107 and #109 in https://github.com/go-jose/go-jose by Jacob Hoffman-Andrews <github@hoffman-andrews.com>
+---
+ .../github.com/go-jose/go-jose/v3/encoding.go | 21 +++++++++++++++----
+ .../gopkg.in/go-jose/go-jose.v2/encoding.go   | 20 ++++++++++++++----
+ 2 files changed, 33 insertions(+), 8 deletions(-)
+
+diff --git a/vendor/github.com/go-jose/go-jose/v3/encoding.go b/vendor/github.com/go-jose/go-jose/v3/encoding.go
+index 968a424..e2c003a 100644
+--- a/vendor/github.com/go-jose/go-jose/v3/encoding.go
++++ b/vendor/github.com/go-jose/go-jose/v3/encoding.go
+@@ -21,6 +21,7 @@ import (
+ 	"compress/flate"
+ 	"encoding/base64"
+ 	"encoding/binary"
++	"fmt"
+ 	"io"
+ 	"math/big"
+ 	"strings"
+@@ -85,7 +86,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
+ 	}
+ }
+ 
+-// Compress with DEFLATE
++// deflate compresses the input.
+ func deflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 
+@@ -97,15 +98,27 @@ func deflate(input []byte) ([]byte, error) {
+ 	return output.Bytes(), err
+ }
+ 
+-// Decompress with DEFLATE
++// inflate decompresses the input.
++//
++// Errors if the decompressed data would be >250kB or >10x the size of the
++// compressed data, whichever is larger.
+ func inflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 	reader := flate.NewReader(bytes.NewBuffer(input))
+ 
+-	_, err := io.Copy(output, reader)
+-	if err != nil {
++	maxCompressedSize := 10 * int64(len(input))
++	if maxCompressedSize < 250000 {
++		maxCompressedSize = 250000
++	}
++
++	limit := maxCompressedSize + 1
++	n, err := io.CopyN(output, reader, limit)
++	if err != nil && err != io.EOF {
+ 		return nil, err
+ 	}
++	if n == limit {
++		return nil, fmt.Errorf("uncompressed data would be too large (>%d bytes)", maxCompressedSize)
++	}
+ 
+ 	err = reader.Close()
+ 	return output.Bytes(), err
+diff --git a/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go b/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go
+index 40b688b..115944d 100644
+--- a/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go
++++ b/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go
+@@ -85,7 +85,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
+ 	}
+ }
+ 
+-// Compress with DEFLATE
++// deflate compresses the input.
+ func deflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 
+@@ -97,15 +97,27 @@ func deflate(input []byte) ([]byte, error) {
+ 	return output.Bytes(), err
+ }
+ 
+-// Decompress with DEFLATE
++// inflate decompresses the input.
++//
++// Errors if the decompressed data would be >250kB or >10x the size of the
++// compressed data, whichever is larger.
+ func inflate(input []byte) ([]byte, error) {
+ 	output := new(bytes.Buffer)
+ 	reader := flate.NewReader(bytes.NewBuffer(input))
+ 
+-	_, err := io.Copy(output, reader)
+-	if err != nil {
++	maxCompressedSize := 10 * int64(len(input))
++	if maxCompressedSize < 250000 {
++		maxCompressedSize = 250000
++	}
++
++	limit := maxCompressedSize + 1
++	n, err := io.CopyN(output, reader, limit)
++	if err != nil && err != io.EOF {
+ 		return nil, err
+ 	}
++	if n == limit {
++		return nil, fmt.Errorf("uncompressed data would be too large (>%d bytes)", maxCompressedSize)
++	}
+ 
+ 	err = reader.Close()
+ 	return output.Bytes(), err
+-- 
+2.39.4
+

--- a/SPECS/skopeo/CVE-2024-28180.patch
+++ b/SPECS/skopeo/CVE-2024-28180.patch
@@ -1,13 +1,13 @@
-From ad7025b5d7f719f0e17788395f36db2151f27a98 Mon Sep 17 00:00:00 2001
+From 0849cf7e3480031bdf508f44b339a8a65baabd38 Mon Sep 17 00:00:00 2001
 From: Rohit Rawat <xordux@gmail.com>
-Date: Sun, 10 Nov 2024 18:00:09 +0000
+Date: Mon, 11 Nov 2024 09:10:52 +0000
 Subject: [PATCH] backport decompression limit fix
 
 Patch from: PR #107 and #109 in https://github.com/go-jose/go-jose by Jacob Hoffman-Andrews <github@hoffman-andrews.com>
 ---
  .../github.com/go-jose/go-jose/v3/encoding.go | 21 +++++++++++++++----
- .../gopkg.in/go-jose/go-jose.v2/encoding.go   | 20 ++++++++++++++----
- 2 files changed, 33 insertions(+), 8 deletions(-)
+ .../gopkg.in/go-jose/go-jose.v2/encoding.go   | 21 +++++++++++++++----
+ 2 files changed, 34 insertions(+), 8 deletions(-)
 
 diff --git a/vendor/github.com/go-jose/go-jose/v3/encoding.go b/vendor/github.com/go-jose/go-jose/v3/encoding.go
 index 968a424..e2c003a 100644
@@ -62,10 +62,18 @@ index 968a424..e2c003a 100644
  	err = reader.Close()
  	return output.Bytes(), err
 diff --git a/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go b/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go
-index 40b688b..115944d 100644
+index 40b688b..636f6c8 100644
 --- a/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go
 +++ b/vendor/gopkg.in/go-jose/go-jose.v2/encoding.go
-@@ -85,7 +85,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
+@@ -21,6 +21,7 @@ import (
+ 	"compress/flate"
+ 	"encoding/base64"
+ 	"encoding/binary"
++	"fmt"
+ 	"io"
+ 	"math/big"
+ 	"strings"
+@@ -85,7 +86,7 @@ func decompress(algorithm CompressionAlgorithm, input []byte) ([]byte, error) {
  	}
  }
  
@@ -74,7 +82,7 @@ index 40b688b..115944d 100644
  func deflate(input []byte) ([]byte, error) {
  	output := new(bytes.Buffer)
  
-@@ -97,15 +97,27 @@ func deflate(input []byte) ([]byte, error) {
+@@ -97,15 +98,27 @@ func deflate(input []byte) ([]byte, error) {
  	return output.Bytes(), err
  }
  

--- a/SPECS/skopeo/CVE-2024-9676.patch
+++ b/SPECS/skopeo/CVE-2024-9676.patch
@@ -1,0 +1,182 @@
+From d461620d47450c72d9f0da215606949272df3398 Mon Sep 17 00:00:00 2001
+From: Rohit Rawat <xordux@gmail.com>
+Date: Sun, 10 Nov 2024 18:36:17 +0000
+Subject: [PATCH] Backport CVE-2024-9676 fix
+
+Patch from https://github.com/containers/storage/pull/2146 by Matt Heon <mheon@redhat.com>
+---
+ .../github.com/containers/storage/.cirrus.yml |  2 +-
+ .../github.com/containers/storage/userns.go   | 92 +++++++++++++------
+ .../containers/storage/userns_unsupported.go  | 14 +++
+ 3 files changed, 80 insertions(+), 28 deletions(-)
+ create mode 100644 vendor/github.com/containers/storage/userns_unsupported.go
+
+diff --git a/vendor/github.com/containers/storage/.cirrus.yml b/vendor/github.com/containers/storage/.cirrus.yml
+index c41dd5d..9e61509 100644
+--- a/vendor/github.com/containers/storage/.cirrus.yml
++++ b/vendor/github.com/containers/storage/.cirrus.yml
+@@ -119,7 +119,7 @@ lint_task:
+     env:
+         CIRRUS_WORKING_DIR: "/go/src/github.com/containers/storage"
+     container:
+-        image: golang
++        image: golang:1.19
+     modules_cache:
+         fingerprint_script: cat go.sum
+         folder: $GOPATH/pkg/mod
+diff --git a/vendor/github.com/containers/storage/userns.go b/vendor/github.com/containers/storage/userns.go
+index 32ae830..2c855da 100644
+--- a/vendor/github.com/containers/storage/userns.go
++++ b/vendor/github.com/containers/storage/userns.go
+@@ -1,18 +1,21 @@
++//go:build linux
++
+ package storage
+ 
+ import (
+ 	"fmt"
+ 	"os"
+ 	"os/user"
+-	"path/filepath"
+ 	"strconv"
+ 
+ 	drivers "github.com/containers/storage/drivers"
+ 	"github.com/containers/storage/pkg/idtools"
+ 	"github.com/containers/storage/pkg/unshare"
+ 	"github.com/containers/storage/types"
++	securejoin "github.com/cyphar/filepath-securejoin"
+ 	libcontainerUser "github.com/opencontainers/runc/libcontainer/user"
+ 	"github.com/sirupsen/logrus"
++	"golang.org/x/sys/unix"
+ )
+ 
+ // getAdditionalSubIDs looks up the additional IDs configured for
+@@ -85,40 +88,59 @@ const nobodyUser = 65534
+ // parseMountedFiles returns the maximum UID and GID found in the /etc/passwd and
+ // /etc/group files.
+ func parseMountedFiles(containerMount, passwdFile, groupFile string) uint32 {
++	var (
++		passwd *os.File
++		group  *os.File
++		size   int
++		err    error
++	)
+ 	if passwdFile == "" {
+-		passwdFile = filepath.Join(containerMount, "etc/passwd")
+-	}
+-	if groupFile == "" {
+-		groupFile = filepath.Join(groupFile, "etc/group")
++		passwd, err = secureOpen(containerMount, "/etc/passwd")
++	} else {
++		// User-specified override from a volume. Will not be in
++		// container root.
++		passwd, err = os.Open(passwdFile)
+ 	}
+-
+-	size := 0
+-
+-	users, err := libcontainerUser.ParsePasswdFile(passwdFile)
+ 	if err == nil {
+-		for _, u := range users {
+-			// Skip the "nobody" user otherwise we end up with 65536
+-			// ids with most images
+-			if u.Name == "nobody" {
+-				continue
+-			}
+-			if u.Uid > size && u.Uid != nobodyUser {
+-				size = u.Uid
+-			}
+-			if u.Gid > size && u.Gid != nobodyUser {
+-				size = u.Gid
++		defer passwd.Close()
++
++		users, err := libcontainerUser.ParsePasswd(passwd)
++		if err == nil {
++			for _, u := range users {
++				// Skip the "nobody" user otherwise we end up with 65536
++				// ids with most images
++				if u.Name == "nobody" || u.Name == "nogroup" {
++					continue
++				}
++				if u.Uid > size && u.Uid != nobodyUser {
++					size = u.Uid + 1
++				}
++				if u.Gid > size && u.Gid != nobodyUser {
++					size = u.Gid + 1
++				}
+ 			}
+ 		}
+ 	}
+ 
+-	groups, err := libcontainerUser.ParseGroupFile(groupFile)
++	if groupFile == "" {
++		group, err = secureOpen(containerMount, "/etc/group")
++	} else {
++		// User-specified override from a volume. Will not be in
++		// container root.
++		group, err = os.Open(groupFile)
++	}
+ 	if err == nil {
+-		for _, g := range groups {
+-			if g.Name == "nobody" {
+-				continue
+-			}
+-			if g.Gid > size && g.Gid != nobodyUser {
+-				size = g.Gid
++		defer group.Close()
++
++		groups, err := libcontainerUser.ParseGroup(group)
++		if err == nil {
++			for _, g := range groups {
++				if g.Name == "nobody" || g.Name == "nogroup" {
++					continue
++				}
++				if g.Gid > size && g.Gid != nobodyUser {
++					size = g.Gid + 1
++				}
+ 			}
+ 		}
+ 	}
+@@ -309,3 +331,19 @@ func getAutoUserNSIDMappings(
+ 	gidMap := append(availableGIDs.zip(requestedContainerGIDs), additionalGIDMappings...)
+ 	return uidMap, gidMap, nil
+ }
++
++// Securely open (read-only) a file in a container mount.
++func secureOpen(containerMount, file string) (*os.File, error) {
++	filePath, err := securejoin.SecureJoin(containerMount, file)
++	if err != nil {
++		return nil, err
++	}
++
++	flags := unix.O_PATH | unix.O_CLOEXEC | unix.O_RDONLY
++	fileHandle, err := os.OpenFile(filePath, flags, 0)
++	if err != nil {
++		return nil, err
++	}
++
++	return fileHandle, nil
++}
+diff --git a/vendor/github.com/containers/storage/userns_unsupported.go b/vendor/github.com/containers/storage/userns_unsupported.go
+new file mode 100644
+index 0000000..e37c18f
+--- /dev/null
++++ b/vendor/github.com/containers/storage/userns_unsupported.go
+@@ -0,0 +1,14 @@
++//go:build !linux
++
++package storage
++
++import (
++	"errors"
++
++	"github.com/containers/storage/pkg/idtools"
++	"github.com/containers/storage/types"
++)
++
++func (s *store) getAutoUserNS(_ *types.AutoUserNsOptions, _ *Image, _ rwLayerStore, _ []roLayerStore) ([]idtools.IDMap, []idtools.IDMap, error) {
++	return nil, nil, errors.New("user namespaces are not supported on this platform")
++}
+-- 
+2.39.4
+

--- a/SPECS/skopeo/skopeo.spec
+++ b/SPECS/skopeo/skopeo.spec
@@ -1,7 +1,7 @@
 Summary:        Inspect container images and repositories on registries
 Name:           skopeo
 Version:        1.14.2
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,9 @@ Source0:        https://github.com/containers/skopeo/archive/refs/tags/v%{versio
 Patch0:         CVE-2023-45288.patch
 Patch1:         CVE-2024-3727.patch
 Patch2:         CVE-2024-6104.patch
+Patch3:         CVE-2024-9676.patch
+Patch4:         CVE-2024-28180.patch
+Patch5:         CVE-2024-24786.patch
 %global debug_package %{nil}
 %define our_gopath %{_topdir}/.gopath
 BuildRequires:  btrfs-progs-devel
@@ -48,6 +51,9 @@ make test-unit-local
 %{_mandir}/man1/%%{name}*
 
 %changelog
+* Mon Nov 11 2024 Rohit Rawat <rohitrawat@microsoft.com> - 1.14.2-9
+- Fix CVE-2024-9676, CVE-2024-28180 and CVE-2024-24786
+
 * Mon Sep 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.14.2-8
 - Bump release to rebuild with go 1.22.7
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fixes multiple High and Medium CVEs for skopeo package (listed below)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2024-9676
- CVE-2024-28180
- CVE-2024-24786

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-9676
- https://nvd.nist.gov/vuln/detail/CVE-2024-28180
- https://nvd.nist.gov/vuln/detail/CVE-2024-24786

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Github PR checks

#### Note: The following p-tests are failing in the github PR check. This isn't a new failure, these p-tests are already failing in 2.0:
- rubygem-rake
- libguestfs
- rubygem-introspection
- rubygem-metaclass