### PR TITLE
[DRAFT / RFC] Add PR checks for build/test/install

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,318 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# NOTES:
+#
+# This is a starting point for a validation workflow that can detect the specs that
+# have changed in a given git commit, build the RPMs for those specs, and run ptests
+# for those.
+#
+# Known limitations/concerns:
+#
+# * We build + test the packages in an Ubuntu VM runner. This is easiest in a GitHub
+#   action, since it's the only Linux OS supported running in the VM; in time,
+#   it may be worthwhile looking into running the package build itself in an
+#   Azure Linux 3.0 environment.
+#
+# * We take a specific dependency on daily repos in Azure Linux 3.0+, as well as the
+#   Azure Linux 3.0 container. To extend support to 2.0, some work will be required
+#   to make these dependencies conditional.
+#
+# * Packages without %check sections will have failed test runs.
+#
+# * This workflow doesn't yet support building or running tests for "EXTENDED" specs.
+#
+
+name: "Spec Build/Test"
+
+on:
+  # N.B. For now we enable this for 3.0-dev, but expect that the logic below will work
+  # for other branches as well.
+  push:
+    branches: [3.0-dev]
+  pull_request:
+    branches: [3.0-dev]
+  workflow_dispatch:
+    inputs:
+      comparison_base_ref:
+        description: 'The base ref to compare changest against.'
+        required: true
+        default: 'refs/heads/3.0-dev'
+
+env:
+  # For consistency, we use the same major/minor version of the latest version of Python that
+  # Azure Linux ships.
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  detect-changes:
+    name: 'Detect spec changes'
+    runs-on: ubuntu-latest
+
+    outputs:
+      updated_specs: ${{ steps.export.outputs.UPDATED_SPECS }}
+      updated_extended_specs: ${{ steps.export.outputs.UPDATED_EXTENDED_SPECS }}
+      target_ref: ${{ steps.export.outputs.TARGET_REF }}
+      azl_extra_make_args: ${{ steps.export.outputs.AZL_EXTRA_MAKE_ARGS }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies for tools
+        run: python3 -m pip install -r toolkit/scripts/requirements.txt
+
+      #
+      # We first get oriented, figuring out which version of the code we're building
+      # and which version of the code we should be comparing against.
+      #
+      # We define the following:
+      #   - base_sha: The commit hash of the commit we're comparing against.
+      #   - target_ref: The ref we're building.
+      #
+
+      - name: "Find base commit (PRs)"
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          # In a PR workflow, 'github.base_ref' is the *target* branch of the PR.
+          git fetch origin ${{ github.base_ref }}
+          echo "base_sha=$(git rev-parse origin/${{ github.base_ref }})" >>$GITHUB_ENV
+          echo "target_ref=${{ github.base_ref }}" >>$GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.base_ref }}"
+
+      - name: "Find base commit (pushes)"
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          # In a push workflow, 'github.event.before' is the SHA hash of the commit
+          # immediately preceding the commit being pushed. 
+          git fetch origin ${{ github.event.before }}
+          echo "base_sha=${{ github.event.before }}" >>$GITHUB_ENV
+          echo "target_ref=${{ github.ref }}" >>$GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
+
+      - name: "Find base commit (manual)"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          # In a manually triggered workflow, we don't necessarily have a base commit to compare against.
+          # We rely on inputs providing it.
+          echo "base_sha=$(git rev-parse ${{ inputs.comparison_base_ref }})" >>$GITHUB_ENV
+          echo "target_ref=${{ github.ref }}" >>$GITHUB_ENV
+          echo "Building ${{ github.ref }} and comparing against ${{ inputs.comparison_base_ref }}"
+
+      - name: Compute tooling args
+        run: |
+          # TODO: We naively assume that this is a 3.0+ version that will have a daily build.
+          # To support older versions, some work may be required.
+          echo 'azl_extra_make_args=DAILY_BUILD_ID=lkg' >>$GITHUB_ENV
+
+      - name: Infer changed specs
+        run: |
+          updated_specs=$(./toolkit/scripts/detect_changes.py --since ${{ env.base_sha }} --spec-names)
+          updated_extended_specs=$(./toolkit/scripts/detect_changes.py --since ${{ env.base_sha }} --extended-spec-names)
+          echo "Specs updated: '${updated_specs}'"
+          echo "Extended specs updated: '${updated_extended_specs}'"
+          echo "updated_specs=$(echo ${updated_specs})" >>$GITHUB_ENV
+          echo "updated_extended_specs=$(echo ${updated_extended_specs})" >>$GITHUB_ENV
+
+      - name: Export outputs
+        id: export
+        run: |
+          echo "UPDATED_SPECS=${{ env.updated_specs }}" >>$GITHUB_OUTPUT
+          echo "UPDATED_EXTENDED_SPECS=${{ env.updated_extended_specs }}" >>$GITHUB_OUTPUT
+          echo "TARGET_REF=${{ env.target_ref }}" >>$GITHUB_OUTPUT
+          echo "AZL_EXTRA_MAKE_ARGS=${{ env.azl_extra_make_args }}" >>$GITHUB_OUTPUT
+
+  build:
+    name: 'Build RPMS'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    needs: [detect-changes]
+    env:
+      updated_specs: ${{ needs.detect-changes.outputs.updated_specs }}
+      updated_extended_specs: ${{ needs.detect-changes.outputs.updated_extended_specs }}
+      azl_extra_make_args: ${{ needs.detect-changes.outputs.azl_extra_make_args }}
+
+    outputs:
+      daily_build_id: ${{ steps.find-daily-repo.outputs.DAILY_BUILD_ID }}
+      daily_build_arch: ${{ steps.find-daily-repo.outputs.DAILY_BUILD_ARCH }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies for tools
+        run: python3 -m pip install -r toolkit/scripts/requirements.txt
+
+      - name: Find daily repo
+        id: find-daily-repo
+        run: |
+          DAILY_BUILD_ID=$(toolkit/scripts/get_lkg_id.sh /tmp)
+          echo "DAILY_BUILD_ID=${DAILY_BUILD_ID}" >>$GITHUB_OUTPUT
+          echo "DAILY_BUILD_ARCH=x86-64" >>$GITHUB_OUTPUT
+
+      - name: "Build modified specs (base)"
+        id: build-specs
+        if: ${{ env.updated_specs != '' }}
+        run: |
+          sudo make -C toolkit \
+            build-packages \
+            $azl_extra_make_args \
+            -j$(nproc) \
+            REBUILD_TOOLS=y \
+            SRPM_PACK_LIST='${{ env.updated_specs }}'
+
+      - name: "Build modified specs (extended)"
+        id: build-extended-specs
+        if: ${{ env.updated_extended_specs != '' }}
+        run: |
+          sudo make -C toolkit \
+            build-packages \
+            $azl_extra_make_args \
+            -j$(nproc) \
+            REBUILD_TOOLS=y \
+            SPECS_DIR=$(pwd)/SPECS-EXTENDED \
+            SRPM_PACK_LIST='${{ env.updated_extended_specs }}'
+
+      - name: Upload built RPMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms
+          path: out/RPMS
+
+      - name: Upload build logs
+        id: upload-build-logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ github.run_attempt }}
+          path: build/logs
+
+      - name: Publish result
+        if: always()
+        run: |
+          if [[ ${{ steps.build-specs.outcome }} == 'success' && ${{ steps.build-extended-specs.outcome }} == 'success' ]]; then
+            echo "✅ Build succeeded" >>${GITHUB_STEP_SUMMARY}
+          else
+            echo "❌ Build failed" >>${GITHUB_STEP_SUMMARY}
+          fi
+
+      - name: Advertise build logs
+        if: always() && steps.upload-build-logs.outcome == 'success'
+        run: |
+          echo "_Build logs available [for download](${{ steps.upload-build-logs.outputs.artifact-url }})_" >>${GITHUB_STEP_SUMMARY}
+
+  test:
+    name: 'Run component tests (ptests)'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    needs: [detect-changes]
+    env:
+      updated_specs: ${{ needs.detect-changes.outputs.updated_specs }}
+      updated_extended_specs: ${{ needs.detect-changes.outputs.updated_extended_specs }}
+      azl_extra_make_args: ${{ needs.detect-changes.outputs.azl_extra_make_args }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies for tools
+        run: python3 -m pip install -r toolkit/scripts/requirements.txt
+
+      - name: Test modified specs
+        run: |
+          set -euxo pipefail
+
+          declare -a args=()
+          for spec in ${{ env.updated_specs }}; do
+            args+=(-s "${spec}")
+          done
+          for spec in ${{ env.updated_extended_specs }}; do
+            args+=(-e "${spec}")
+          done
+
+          ./toolkit/scripts/run_ptests.py --verbose --markdown-report=${GITHUB_STEP_SUMMARY} ${args[@]}
+
+      - name: Upload logs
+        id: upload-test-logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ github.run_attempt }}
+          path: build/logs
+
+      - name: Post results
+        if: always() && steps.upload-test-logs.outcome == 'success'
+        run: |
+          echo "_Test logs available [for download](${{ steps.upload-test-logs.outputs.artifact-url }})_" >>${GITHUB_STEP_SUMMARY}
+
+  install:
+    name: 'Test installing RPM'
+    needs: [build, detect-changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      # Use a base Azure Linux 3.0 container.
+      image: mcr.microsoft.com/azurelinux/base/core:3.0
+      env:
+        daily_build_id: ${{ needs.build.outputs.daily_build_id }}
+        daily_build_arch: ${{ needs.build.outputs.daily_build_arch }}
+
+          # Reference: https://github.com/Azure/azure-cli/issues/29835
+        GNUPGHOME: /root/.gnupg
+
+    defaults:
+      run:
+        shell: bash
+    env:
+      target_ref: ${{ needs.detect-changes.outputs.target_ref }}
+
+    steps:
+      - name: Install prerequisites
+        run: |
+          tdnf install -y ca-certificates createrepo_c jq sudo tar wget
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Download built RPMs
+        uses: actions/download-artifact@v4
+        with:
+          name: rpms
+          path: RPMS
+
+      - name: Prepare downloaded RPMs
+        run: |
+          set -euxo pipefail
+
+          # Inventory what we downloaded
+          ls -l -R RPMS
+          find RPMS -type f -name "*.rpm" ! -name "*.src.rpm" ! -name "*debuginfo*" >rpms.txt
+          cat rpms.txt
+
+      - name: "Test package install/uninstall"
+        # TODO: For now we hard-code .azl3 + use of latest daily repo
+        run: |
+          set -euxo pipefail
+
+          declare -a rpm_names=()
+          for rpm_path in $(cat rpms.txt); do
+            rpm_names+=("$(basename ${rpm_path})")
+          done
+
+          ./toolkit/scripts/test_package_install.sh -p RPMS -s "${rpm_names[@]}" -y latest -d ".azl3"

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -133,6 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.updated_specs != '' || needs.detect-changes.outputs.updated_extended_specs != '' }}
     env:
       updated_specs: ${{ needs.detect-changes.outputs.updated_specs }}
       updated_extended_specs: ${{ needs.detect-changes.outputs.updated_extended_specs }}
@@ -217,6 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.updated_specs != '' || needs.detect-changes.outputs.updated_extended_specs != '' }}
     env:
       updated_specs: ${{ needs.detect-changes.outputs.updated_specs }}
       updated_extended_specs: ${{ needs.detect-changes.outputs.updated_extended_specs }}
@@ -264,6 +266,7 @@ jobs:
   install:
     name: 'Test installing RPM'
     needs: [build, detect-changes]
+    if: ${{ needs.detect-changes.outputs.updated_specs != '' || needs.detect-changes.outputs.updated_extended_specs != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:

--- a/toolkit/scripts/detect_changes.py
+++ b/toolkit/scripts/detect_changes.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser(description="Detect changes in the repository")
+parser.add_argument("--display-compare-ref", dest="display_compare_ref", action="store_true", help="Display the detected comparison ref and exit")
+parser.add_argument("--since", dest="compare_ref", required=False, help="Identifies the git ref to compare against")
+parser.add_argument("-t", "--target-ref", dest="target_ref", default="HEAD", help="Identifies the target git ref with changes")
+parser.add_argument("-u", "--include-uncommitted", dest="include_uncommitted", action="store_true", help="Include uncommitted files from working tree")
+parser.add_argument("--include-untracked", dest="include_untracked", action="store_true", help="Include untracked files in working tree")
+parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Enable verbose output")
+
+spec_options = parser.add_mutually_exclusive_group()
+spec_options.add_argument("-s", "--spec-names", dest="spec_names_only", action="store_true", help="Only detect changes in SPECS .spec files and print out their base names")
+spec_options.add_argument("-e", "--extended-spec-names", dest="extended_spec_names_only", action="store_true", help="Only detect changes in SPECS-EXTENDED .spec files and print out their base names")
+
+args = parser.parse_args()
+
+if args.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.INFO
+
+logging.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
+
+def autodetect_compare_ref(target_ref: str) -> str:
+    # Find the registered remotes
+    result = subprocess.run(["git", "remote"], capture_output=True, check=True)
+    remotes = result.stdout.decode("utf-8").splitlines()
+
+    # Find all branches.
+    git_args = ["git", "for-each-ref", "refs/heads/"]
+    for remote in remotes:
+        git_args.append(f"refs/remotes/{remote}/")
+    git_args.append("--format=%(refname)")
+    result = subprocess.run(git_args, capture_output=True, check=True)
+    branch_refs = result.stdout.decode("utf-8").splitlines()    
+
+    # Find the branches that look like official release or dev branches.
+    well_known_refs = [branch_ref for branch_ref in branch_refs if is_well_known_branch_ref(branch_ref)]
+
+    # Figure out which of these branches is our closest ancestor.
+    return get_closest_git_ancestor(target_ref, well_known_refs)
+
+def is_well_known_branch_ref(branch_ref: str) -> bool:
+    branch_pieces = branch_ref.split("/")
+    if not branch_pieces:
+        return False
+
+    if branch_ref.startswith("refs/heads/"):
+        # Make sure there's no prefix on the branch name.
+        if len(branch_pieces) != 3:
+            return False
+    elif branch_ref.startswith("refs/remotes/"):
+        # Make sure there's no prefix on the branch name.
+        if len(branch_pieces) != 4:
+            return False
+
+    last_piece = branch_pieces[-1]
+    return last_piece == "main" or last_piece.endswith(".0") or last_piece.endswith(".0-dev")
+
+def get_closest_git_ancestor(target_ref: str, refs: Sequence[str]) -> str:
+    # First filter down to fork points.
+    fork_points = {}
+    for ref in refs:
+        result = subprocess.run(["git", "merge-base", "--fork-point", ref, target_ref], capture_output=True)
+        if result.returncode == 0:
+            fork_point_ref = result.stdout.decode("utf-8").strip()
+            fork_points[ref] = fork_point_ref
+
+    best_distance = None
+    best_candidate_ref = None
+
+    for candidate_ancestor, fork_point in fork_points.items():
+        # Find the distance in the chain.
+        result = subprocess.run(["git", "rev-list", "--count", f"{fork_point}..{target_ref}"], capture_output=True, check=True)
+        distance = int(result.stdout.decode("utf-8").strip())
+
+        if best_distance is None or distance < best_distance:
+            best_distance = distance
+            best_candidate_ref = candidate_ancestor
+        
+    return best_candidate_ref
+
+# If a comparison ref wasn't provided, then we go into auto-detect mode.
+if not args.compare_ref:
+    args.compare_ref = autodetect_compare_ref(args.target_ref)
+    if not args.compare_ref:
+        logger.error("could not autodetect comparison branch")
+        sys.exit(1)
+
+# If requested, display the comparison ref and then exit.
+if args.display_compare_ref:
+    print(args.compare_ref)
+    sys.exit(0)
+
+# Log output
+logger.debug(f"comparing against ref: {args.compare_ref}")
+
+# Try to find the files changed since the reference ref.
+if args.include_uncommitted:
+    if args.target_ref != "HEAD":
+        logger.error("cannot include uncommitted files when target ref is not HEAD")
+        sys.exit(1)
+
+    git_cmd = ["git", "diff-index", "--name-only", args.compare_ref]
+else:
+    git_cmd = ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", args.compare_ref, args.target_ref]
+
+result = subprocess.run(git_cmd, capture_output=True, check=True)
+changed_files = result.stdout.decode("utf-8").splitlines()
+
+# If requested, look for untracked files.
+if args.include_untracked:
+    # This is not compatible with a target ref other than HEAD.
+    if args.target_ref != "HEAD":
+        logger.error("cannot include untracked files when target ref is not HEAD")
+        sys.exit(1)
+
+    result = subprocess.run(["git", "ls-files", "--others", "--exclude-standard"], capture_output=True, check=True)
+    changed_files.extend(result.stdout.decode("utf-8").splitlines())
+
+# Identify any base dir filter.
+if args.spec_names_only:
+    base_dir = "SPECS/"
+elif args.extended_spec_names_only:
+    base_dir = "SPECS-EXTENDED/"
+else:
+    base_dir = None
+
+for changed_file in changed_files:
+    # If a base dir filter is provided, then apply it.
+    if base_dir is not None and not changed_file.startswith(base_dir):
+        continue
+
+    # If requested, filter out non-spec files.
+    if args.spec_names_only or args.extended_spec_names_only:
+        if not changed_file.endswith(".spec"):
+            continue
+
+        filename = os.path.basename(changed_file)
+        base_name = os.path.splitext(filename)[0]
+
+        print(base_name)
+    else:
+        print(changed_file)
+
+# Log output
+if args.verbose:
+    logger.debug(f"found {len(changed_files)} changed files")

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -38,6 +38,7 @@ cached_file              = $(PKGBUILD_DIR)/cached_graph.dot
 preprocessed_file        = $(PKGBUILD_DIR)/preprocessed_graph.dot
 built_file               = $(PKGBUILD_DIR)/built_graph.dot
 output_csv_file          = $(PKGBUILD_DIR)/build_state.csv
+test_results_file		 = $(PKGBUILD_DIR)/test_results.json
 pkg_license_summary_file = $(PKGBUILD_DIR)/license_issues.txt
 pkg_license_results_file = $(PKGBUILD_DIR)/license_issues.json
 
@@ -313,6 +314,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(no_repo_acl) $(preprocessed_file) $(chroo
 		--ignored-tests="$(TEST_IGNORE_LIST)" \
 		--tests="$(TEST_RUN_LIST)" \
 		--rerun-tests="$(TEST_RERUN_LIST)" \
+		--test-results-file="$(test_results_file)" \
 		--license-check-mode="$(LICENSE_CHECK_MODE)" \
 		--license-check-exception-file="$(LICENSE_CHECK_EXCEPTION_FILE)" \
 		--license-check-name-file="$(LICENSE_CHECK_NAME_FILE)" \

--- a/toolkit/scripts/run_ptests.py
+++ b/toolkit/scripts/run_ptests.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import dataclasses
+import json
+import logging
+import multiprocessing
+import os
+import subprocess
+import sys
+import time
+
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+self_path = os.path.abspath(__file__)
+script_dir_path = os.path.dirname(self_path)
+toolkit_dir_path = os.path.dirname(script_dir_path)
+repo_root_dir_path = os.path.dirname(toolkit_dir_path)
+build_dir_path = os.path.join(repo_root_dir_path, "build")
+test_results_path = os.path.join(build_dir_path, "pkg_artifacts", "test_results.json")
+logs_dir_path = os.path.join(build_dir_path, "logs")
+ptest_logs_dir_path = os.path.join(logs_dir_path, "pkggen", "rpmbuilding")
+
+parser = argparse.ArgumentParser(description="Run package tests")
+parser.add_argument("-s", "--spec", dest="specs", action="append", help="Names of base specs to run tests for")
+parser.add_argument("-e", "--extended-spec", dest="extended_specs", action="append", help="Names of extended specs to run tests for")
+parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Enable verbose output")
+parser.add_argument("--markdown-report", dest="markdown_report", help="Path to output markdown report of test results")
+
+args = parser.parse_args()
+
+if args.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.INFO
+
+logging.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
+
+if not os.path.isfile(os.path.join(toolkit_dir_path, "Makefile")):
+    logger.error("can't find toolkit path")
+    sys.exit(1)
+
+
+def run_ptests(spec_names: Sequence[str], specs_dir_path: str):
+    toolkit_log_level = "info" if args.verbose else "warn"
+
+    # N.B. We do *not* use TEST_RUN_LIST or TEST_RERUN_LIST, because those
+    # fail in undesirable ways on specs with no %check sections. We instead
+    # just set RUN_CHECK=y and figure out after the fact what happened.
+    cmd = [
+        "sudo",
+        "make",
+        "build-packages",
+        "-j",
+        str(multiprocessing.cpu_count()),
+        "REBUILD_TOOLS=y",
+        f"SPECS_DIR={specs_dir_path}",
+        f"LOG_LEVEL={toolkit_log_level}",
+        f"SRPM_PACK_LIST={' '.join(spec_names)}",
+        f"PACKAGE_REBUILD_LIST={' '.join(spec_names)}",
+        "RUN_CHECK=y",
+        "DAILY_BUILD_ID=lkg"
+    ]
+
+    start_time = time.time()
+
+    result = subprocess.run(cmd, cwd=toolkit_dir_path)
+    if result.returncode != 0:
+        logger.error("build tools invocation failed")
+        sys.exit(1)
+
+    elapsed_time = time.time() - start_time
+
+    logger.info(f"Ran tests in {elapsed_time:.2f}s.")
+
+class ReadableTestReporter:
+    def on_skipped(self, name: str):
+        print(f"⏩ {name}: SKIPPED")
+
+    def on_blocked(self, name: str):
+        print(f"🚫 {name}: BLOCKED")
+
+    def on_failed(self, name: str, expected_failure: bool, log_path: str):
+        if expected_failure:
+            print(f"🟡 {name}: FAILED (expected)")
+        else:
+            print(f"❌ {name}: FAILED")
+            print(f"    Log: {log_path}")
+
+    def on_succeeded(self, name: str, expected_failure: bool):
+        if expected_failure:
+            print(f"🔴 {name}: PASSED (unexpected)")
+        else:
+            print(f"✅ {name}: PASSED")
+
+    def on_unknown_result(self, name: str, result: str):
+        print(f"❓ {name}: {result}")
+
+class MarkdownTestReporter:
+    def __init__(self, report_path: str):
+        self._report_file = open(report_path, "w")
+
+    def close(self):
+        self._report_file.close()
+
+    def on_skipped(self, name: str):
+        self._test_heading(name)
+        self._write_line(f"⏩ {name}: SKIPPED")
+        self._write_line("")
+
+    def on_blocked(self, name: str):
+        self._test_heading(name)
+        self._write_line(f"🚫 {name}: BLOCKED")
+        self._write_line("")
+
+    def on_failed(self, name: str, expected_failure: bool, log_path: str):
+        self._test_heading(name)
+
+        if expected_failure:
+            self._write_line(f"🟡 {name}: FAILED (expected)")
+        else:
+            self._write_line(f"❌ {name}: FAILED")
+
+        LINES_TO_SHOW = 100
+
+        self._write_line("")
+        self._write_line(f"Last {LINES_TO_SHOW} lines of test output:\n")
+
+        self._write_line("```")
+        with open(log_path, "r") as log_file:
+            for line in log_file.readlines()[-LINES_TO_SHOW:]:
+                self._report_file.write(line)
+        self._write_line("```")
+        self._write_line("")
+
+    def on_succeeded(self, name: str, expected_failure: bool):
+        self._test_heading(name)
+
+        if expected_failure:
+            self._write_line(f"🔴 {name}: PASSED (unexpected)")
+        else:
+            self._write_line(f"✅ {name}: PASSED")
+
+        self._write_line("")
+
+    def on_unknown_result(self, name: str, result: str):
+        self._test_heading(name)
+        self._write_line(f"❓ {name}: {result}")
+        self._write_line("")
+
+    def _test_heading(self, name: str):
+        self._write_line(f"## `{name}`\n\n")
+
+    def _write_line(self, line: str):
+        self._report_file.write(line)
+        self._report_file.write("\n")
+
+
+@dataclasses.dataclass
+class Results:
+    unexpected_fail_count: int = 0
+    expected_fail_count: int = 0
+    skip_count: int = 0
+    block_count: int = 0
+    expected_success_count: int = 0
+    unexpected_success_count: int = 0
+
+
+def analyze_test_results(reporters, results):
+    logger.debug(f"Analyzing test results: {test_results_path}")
+
+    with open(test_results_path, "r") as test_results:
+        test_results_text = test_results.read()
+        test_results = json.loads(test_results_text)
+
+    #
+    # Report results.
+    #
+
+    # TODO: Figure out which components didn't *have* any checks to run.
+    for srpm_name, srpm_results in test_results.items():
+        result = srpm_results["Result"]
+        expected_failure = srpm_results["ExpectedFailure"]
+
+        if result == "skipped":
+            for reporter in reporters:
+                reporter.on_skipped(srpm_name)
+            results.skip_count += 1
+        elif result == "blocked":
+            for reporter in reporters:
+                reporter.on_blocked(srpm_name)
+            results.block_count += 1
+        elif result == "failed":
+            if expected_failure:
+                results.expected_fail_count += 1
+            else:
+                results.unexpected_fail_count += 1  
+            for reporter in reporters:
+                reporter.on_failed(srpm_name, expected_failure, srpm_results["LogPath"])
+        elif result == "succeeded":
+            if expected_failure:
+                results.unexpected_success_count += 1
+            else:
+                results.expected_success_count += 1
+            for reporter in reporters:
+                reporter.on_succeeded(srpm_name, expected_failure)
+        else:
+            for reporter in reporters:
+                reporter.on_unknown_result(srpm_name, result)
+
+
+#
+# Run tests
+#
+
+if not args.specs and not args.extended_specs:
+    logger.error("no specs provided")
+    sys.exit(1)
+
+results = Results()
+
+reporters = [ReadableTestReporter()]
+
+markdown_reporter = None
+if args.markdown_report:
+    logger.debug(f"Writing markdown report to: {args.markdown_report}")
+    markdown_reporter = MarkdownTestReporter(args.markdown_report)
+    reporters.append(markdown_reporter)
+
+if args.specs:
+    logger.debug("Running ptests against base specs")
+    run_ptests(args.specs, os.path.join(repo_root_dir_path, "SPECS"))
+    analyze_test_results(reporters, results)
+
+if args.extended_specs:
+    logger.debug("Running ptests against extended specs")
+    run_ptests(args.extended_specs, os.path.join(repo_root_dir_path, "SPECS-EXTENDED"))
+    analyze_test_results(reporters, results)
+
+if markdown_reporter:
+    logger.debug(f"Saving markdown report")
+    markdown_reporter.close()
+
+
+#
+# Display a readable summary.
+#
+
+print("")
+if results.expected_success_count > 0:
+    print(f"Tests succeeded:              {results.expected_success_count}")
+if results.unexpected_success_count > 0:
+    print(f"Tests succeeded unexpectedly: {results.unexpected_success_count}")
+if results.expected_fail_count > 0:
+    print(f"Tests expected to fail:       {results.expected_fail_count}")
+if results.unexpected_fail_count > 0:
+    print(f"Tests failed:                 {results.unexpected_fail_count}")
+if results.block_count > 0:
+    print(f"Tests blocked:                {results.block_count}")
+if results.skip_count > 0:
+    print(f"Tests skipped:                {results.skip_count}")
+
+if results.unexpected_fail_count > 0 or results.block_count > 0:
+    logger.error("One or more tests were failed or blocked; exiting with error.")
+    sys.exit(1)

--- a/toolkit/scripts/test_package_install.sh
+++ b/toolkit/scripts/test_package_install.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+
+set -e
+
+DAILY_BUILD_ID=""
+
+# parse script parameters:
+#
+# -p -> folder where built RPMs/SRPMs are published
+# -s -> packages to test for install and uninstall functionality
+# -i -> packages to not install
+# -u -> packages to not uninstall
+# -y -> daily build ID
+# -d -> dist tag
+# -v -> verbose output
+
+while getopts ":p:s:i:u:y:d:v" OPTIONS; do
+  case "${OPTIONS}" in
+    p ) RPM_DIRECTORY=$OPTARG;;
+    s ) RPMS_TO_INSTALL=${OPTARG//,/ } ;;
+    i ) PACKAGES_TO_NOT_INSTALL=${OPTARG//,/ } ;;
+    u ) PACKAGES_TO_NOT_UNINSTALL=${OPTARG//,/ } ;;
+    y ) DAILY_BUILD_ID=$OPTARG ;;
+    d ) DIST_TAG=$OPTARG ;;
+    v ) set -x ;;
+
+    \? )
+        echo "Error - Invalid Option: -$OPTARG" 1>&2
+        exit 1
+        ;;
+    : )
+        echo "Error - Invalid Option: -$OPTARG requires an argument" 1>&2
+        exit 1
+        ;;
+  esac
+done
+
+ARCHITECTURE=$(uname -p)
+
+# Determine LKG_BASE_URL
+if [[ -n $DAILY_BUILD_ID &&
+      $DAILY_BUILD_ID == "latest" &&
+      $DIST_TAG == ".azl3" ]]; then
+    echo "Determine LKG_BASE_URL directly from lkg-3.0-dev.json"
+    wget -nv https://mariner3dailydevrepo.blob.core.windows.net/lkg/lkg-3.0-dev.json
+    LKG_BASE_URL=$(cat lkg-3.0-dev.json | jq -r .repo.$ARCHITECTURE)
+else
+    echo "Determine LKG_BASE_URL from provided DAILY_BUILD_ID"
+    if [[ $ARCHITECTURE == "x86_64" ]]; then
+        DAILY_BUILD_ARCH="-x86-64"
+    else
+        DAILY_BUILD_ARCH="-aarch64"
+    fi
+    LKG_BASE_URL=https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$DAILY_BUILD_ID$DAILY_BUILD_ARCH
+fi
+
+echo "---------------------------------------------------------------"
+echo "-- Install packages in provided folder --"
+echo "---------------------------------------------------------------"
+echo "-- RPM_DIRECTORY                            -> $RPM_DIRECTORY"
+echo "-- RPMS_TO_INSTALL                          -> $RPMS_TO_INSTALL"
+echo "-- LKG_BASE_URL                             -> '$LKG_BASE_URL'"
+echo "-- DAILY_BUILD_ID                           -> '$DAILY_BUILD_ID'"
+echo "-- DAILY_BUILD_ARCH                         -> '$DAILY_BUILD_ARCH'"
+echo "-- DIST_TAG                                 -> '$DIST_TAG'"
+echo "-- PACKAGES_TO_NOT_INSTALL                  -> $PACKAGES_TO_NOT_INSTALL"
+echo "-- PACKAGES_TO_NOT_UNINSTALL                -> $PACKAGES_TO_NOT_UNINSTALL"
+echo ""
+
+echo "##[debug]Installing these space separated packages:"
+echo "$RPMS_TO_INSTALL"
+echo ""
+
+RPMS_TO_INSTALL=($RPMS_TO_INSTALL)
+PACKAGES_TO_NOT_INSTALL=($PACKAGES_TO_NOT_INSTALL)
+PACKAGES_TO_NOT_UNINSTALL=($PACKAGES_TO_NOT_UNINSTALL)
+
+
+exists_in_list() {
+    local VALUE=$1
+    shift
+    local LIST=("$@")
+
+    for x in "${LIST[@]}"; do
+        if [ "$x" = "$VALUE" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Add built packages as a local repo for tdnf
+sudo createrepo --compatibility "$RPM_DIRECTORY"
+
+repo_content=$(cat << EOF
+[builtpackages]
+name=Local Built Packages($ARCHITECTURE)
+baseurl=file://$RPM_DIRECTORY
+enabled=1
+priority=0
+skip_if_unavailable=True
+enabled=1
+EOF
+)
+
+# create the repo metadata file
+echo "$repo_content" | sudo tee /etc/yum.repos.d/builtpackages.repo > /dev/null
+
+echo "##[debug]Created repo file with content:"
+sudo cat /etc/yum.repos.d/builtpackages.repo
+echo ""
+
+# Add daily 3.0 repo if available
+repo_content_daily=$(cat << EOF
+[daily3]
+name=Daily 3.0 repo
+baseurl=$LKG_BASE_URL
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY file:///etc/pki/rpm-gpg/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+skip_if_unavailable=True
+sslverify=0
+EOF
+)
+
+if [[ $DIST_TAG == ".azl3" ]]; then
+    echo "$repo_content_daily" | sudo tee /etc/yum.repos.d/daily3.repo > /dev/null
+    echo "##[debug]Created daily repo file with content:"
+    sudo cat /etc/yum.repos.d/daily3.repo
+    echo ""
+else
+    echo "Mariner 3.0 was not detected, so skipping daily repo setup"
+fi
+
+# update the cached binary metadata.
+sudo tdnf makecache
+
+sudo tdnf repolist --refresh
+
+PACKAGES_FAIL_INSTALL=()
+PACKAGES_FAIL_UNINSTALL=()
+
+for rpm_to_install in "${RPMS_TO_INSTALL[@]}"; do
+    path_to_rpm=$(find $RPM_DIRECTORY -name "$rpm_to_install")
+    package_name_to_install=$(rpm -qp --queryformat "%{name}" "$path_to_rpm" 2>/dev/null)
+
+    if exists_in_list "$package_name_to_install" "${PACKAGES_TO_NOT_INSTALL[@]}"; then
+        echo "##[debug]Skipping package $package_name_to_install for installation test"
+        continue
+    fi
+
+    echo "------------------------------------------------"
+    echo "About to tdnf install package '$package_name_to_install' ('$rpm_to_install')"
+    # we are using package files instead of names to include subpackages produces with %{name}-{subpackage_name}
+    if ! sudo tdnf install -y "$path_to_rpm"; then
+        PACKAGES_FAIL_INSTALL+=("$package_name_to_install")
+        # package did not install, skip uninstall test
+        echo "The following package failed to install: '$package_name_to_install'"
+        continue
+    fi
+
+    if exists_in_list "$package_name_to_install" "${PACKAGES_TO_NOT_UNINSTALL[@]}"; then
+        echo "##[debug]Skipping package $package_name_to_install for uninstallation test"
+        continue
+    fi
+
+    # tdnf cannot accept the package rpm for uninstalling, only name. So we cannot test uninstalling of subpackages
+    echo "About to tdnf remove package '$package_name_to_install'"
+    if ! sudo tdnf remove -y "$package_name_to_install"; then
+        PACKAGES_FAIL_UNINSTALL+=("$package_name_to_install")
+    fi
+    echo ""
+    echo ""
+done
+
+echo ""
+echo "------------------------------------------------"
+echo "-- Printing install + uninstall error details --"
+echo "------------------------------------------------"
+echo ""
+
+if [ "${#PACKAGES_FAIL_INSTALL[@]}" -gt 0 ]; then
+    echo "##vso[task.logissue type=error]Error, ${#PACKAGES_FAIL_INSTALL[@]} packages failed to install, check logs to see the list"
+    echo "Failed installed packages:"
+    echo "${PACKAGES_FAIL_INSTALL[@]}"
+    echo ""
+fi
+
+if [ "${#PACKAGES_FAIL_UNINSTALL[@]}" -gt 0 ]; then
+    echo "##vso[task.logissue type=error]Error, ${#PACKAGES_FAIL_UNINSTALL[@]} packages failed to uninstall, check logs to see the list"
+    echo "Failed installed packages:"
+    echo "${PACKAGES_FAIL_UNINSTALL[@]}"
+fi
+
+if [[ "${#PACKAGES_FAIL_UNINSTALL[@]}" -gt 0 || "${#PACKAGES_FAIL_INSTALL[@]}" -gt 0 ]]; then
+    exit 1
+fi

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -193,6 +193,8 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	}
 	logger.Log.Debugf("Adding test node (%s) with id %d", newTestNode.FriendlyName(), newTestNode.ID())
 
+	newTestNode.ExpectedToFail = pkg.TestExpectedToFail
+
 	// A "test" node has a dependency on its corresponding "build" node. This dependency is required
 	// to guarantee we will first check if the build node needs to be built or not before we make
 	// any decisions about running the tests.

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -93,19 +93,20 @@ var lookupNodesTypes = map[NodeType]bool{
 
 // PkgNode represents a package.
 type PkgNode struct {
-	nodeID       int64               // Unique ID for the node
-	VersionedPkg *pkgjson.PackageVer // JSON derived structure holding the exact version information for a graph
-	State        NodeState           // The current state of the node (ie needs to be build, up-to-date, cached, etc)
-	Type         NodeType            // The purpose of the node (build, run , meta goal, etc)
-	SrpmPath     string              // SRPM file used to generate this package (likely shared with multiple other nodes)
-	RpmPath      string              // RPM file that produces this package (likely shared with multiple other nodes)
-	SpecPath     string              // The SPEC file extracted from the SRPM
-	SourceDir    string              // The directory containing extracted sources from the SRPM
-	Architecture string              // The architecture of the resulting package built.
-	SourceRepo   string              // The location this package was acquired from
-	GoalName     string              // Optional string for goal nodes
-	Implicit     bool                // If the package is an implicit provide
-	This         *PkgNode            // Self reference since the graph library returns nodes by value, not reference
+	nodeID         int64               // Unique ID for the node
+	VersionedPkg   *pkgjson.PackageVer // JSON derived structure holding the exact version information for a graph
+	State          NodeState           // The current state of the node (ie needs to be build, up-to-date, cached, etc)
+	Type           NodeType            // The purpose of the node (build, run , meta goal, etc)
+	SrpmPath       string              // SRPM file used to generate this package (likely shared with multiple other nodes)
+	RpmPath        string              // RPM file that produces this package (likely shared with multiple other nodes)
+	SpecPath       string              // The SPEC file extracted from the SRPM
+	SourceDir      string              // The directory containing extracted sources from the SRPM
+	Architecture   string              // The architecture of the resulting package built.
+	SourceRepo     string              // The location this package was acquired from
+	GoalName       string              // Optional string for goal nodes
+	Implicit       bool                // If the package is an implicit provide
+	ExpectedToFail bool                // Is this node *expected* to fail
+	This           *PkgNode            // Self reference since the graph library returns nodes by value, not reference
 }
 
 // ID implements the graph.Node interface, returns the node's unique ID

--- a/toolkit/tools/internal/pkgjson/pkgjson.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson.go
@@ -60,17 +60,18 @@ type PackageVerInterval struct {
 
 // Package is a representation of a package with name and version information
 type Package struct {
-	Provides      *PackageVer   `json:"Provides"`      // Version information and name of package
-	SrpmPath      string        `json:"SrpmPath"`      // Reconstructed name of the SRPM the spec is from
-	RpmPath       string        `json:"RpmPath"`       // Reconstructed name of the RPM the package comes from
-	SourceDir     string        `json:"SourceDir"`     // The path to the directory of sources for this package
-	SpecPath      string        `json:"SpecPath"`      // The path to the spec file that builds this package
-	Architecture  string        `json:"Architecture"`  // The architecture of the package
-	Requires      []*PackageVer `json:"Requires"`      // List of targets this spec requires to install
-	BuildRequires []*PackageVer `json:"BuildRequires"` // List of targets this spec requires to build
-	TestRequires  []*PackageVer `json:"TestRequires"`  // List of targets this spec requires to run tests.
-	IsToolchain   bool          `json:"IsToolchain"`   // Is this package part of the toolchain
-	RunTests      bool          `json:"RunTests"`      // Should we run tests for this package.
+	Provides           *PackageVer   `json:"Provides"`           // Version information and name of package
+	SrpmPath           string        `json:"SrpmPath"`           // Reconstructed name of the SRPM the spec is from
+	RpmPath            string        `json:"RpmPath"`            // Reconstructed name of the RPM the package comes from
+	SourceDir          string        `json:"SourceDir"`          // The path to the directory of sources for this package
+	SpecPath           string        `json:"SpecPath"`           // The path to the spec file that builds this package
+	Architecture       string        `json:"Architecture"`       // The architecture of the package
+	Requires           []*PackageVer `json:"Requires"`           // List of targets this spec requires to install
+	BuildRequires      []*PackageVer `json:"BuildRequires"`      // List of targets this spec requires to build
+	TestRequires       []*PackageVer `json:"TestRequires"`       // List of targets this spec requires to run tests.
+	IsToolchain        bool          `json:"IsToolchain"`        // Is this package part of the toolchain
+	RunTests           bool          `json:"RunTests"`           // Should we run tests for this package.
+	TestExpectedToFail bool          `json:"TestExpectedToFail"` // Should we expect tests to fail for this package.
 }
 
 // ParsePackageJSON reads a package list json file

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -107,9 +107,10 @@ var (
 	pkgsToBuild   = app.Flag("packages", "Space separated list of top-level packages that should be built. Omit this argument to build all packages.").String()
 	pkgsToRebuild = app.Flag("rebuild-packages", "Space separated list of base package names packages that should be rebuilt.").String()
 
-	testsToIgnore = app.Flag("ignored-tests", "Space separated list of package tests that should not be ran.").String()
-	testsToRun    = app.Flag("tests", "Space separated list of tests that should be ran. Omit this argument to run package tests.").String()
-	testsToRerun  = app.Flag("rerun-tests", "Space separated list of package tests that should be re-ran.").String()
+	testsToIgnore   = app.Flag("ignored-tests", "Space separated list of package tests that should not be ran.").String()
+	testsToRun      = app.Flag("tests", "Space separated list of tests that should be ran. Omit this argument to run package tests.").String()
+	testsToRerun    = app.Flag("rerun-tests", "Space separated list of package tests that should be re-ran.").String()
+	testResultsFile = app.Flag("test-results-file", "Path to test results JSON file.").Required().String()
 
 	logFlags      = exe.SetupLogFlags(app)
 	profFlags     = exe.SetupProfileFlags(app)
@@ -556,6 +557,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 	schedulerutils.RecordLicenseSummary(licenseChecker)
 	schedulerutils.PrintBuildSummary(builtGraph, graphMutex, buildState, allowToolchainRebuilds, licenseChecker)
 	schedulerutils.RecordBuildSummary(builtGraph, graphMutex, buildState, *outputCSVFile)
+	schedulerutils.RecordTestSummary(builtGraph, graphMutex, buildState, *testResultsFile)
 	if !allowToolchainRebuilds && (len(buildState.ConflictingRPMs()) > 0 || len(buildState.ConflictingSRPMs()) > 0) {
 		err = fmt.Errorf("toolchain packages rebuilt. See build summary for details. Use 'ALLOW_TOOLCHAIN_REBUILDS=y' to suppress this error if rebuilds were expected")
 	}


### PR DESCRIPTION
_(Draft change -- requesting feedback/comments)_

This is an initial attempt at adding PR checks that detect changed specs, build + test them, and try to install/uninstall the built RPMs. For an example run, see this [private run](https://github.com/reubeno/azurelinux/actions/runs/11787998425).

Note that the install/uninstall script is an as-is copy from existing ADO pipeline scripts.

The changes to the toolkit golang code needs the most feedback (e.g., the emitting of a tests results JSON). Specifically note the proposal to allow a .spec to use a specialized comment in this line:

```
#!AZL expected-test-failure
```

to denote a baselined ptest failure.