### PR TITLE
iptables: Enable nftables.

### DIFF
--- a/SPECS/ebtables/ebtables.spec
+++ b/SPECS/ebtables/ebtables.spec
@@ -2,7 +2,7 @@
 
 Name:          ebtables
 Version:		   2.0.11
-Release:		   8%{?dist}
+Release:		   9%{?dist}
 Summary:		   Ethernet Bridge frame table administration tool
 License:		   GPLv2+
 URL:           http://ebtables.sourceforge.net/
@@ -35,6 +35,9 @@ like iptables. There are no known incompatibility issues.
 
 %package legacy
 Summary: Legacy user space tool to configure bridge netfilter rules in kernel
+Requires(post):   %{_sbindir}/update-alternatives
+Requires(post):   %{_bindir}/readlink
+Requires(postun): %{_sbindir}/update-alternatives
 Provides: ebtables
 
 %description legacy
@@ -90,10 +93,22 @@ rm %{buildroot}/%{_libdir}/libebtc.la
 # Drop these binaries (for now at least)
 rm %{buildroot}/%{_sbindir}/ebtables{d,u}
 
-# Symlink ebtables-legacy to ebtables
-ln -sf ebtables-legacy %{buildroot}%{_sbindir}/ebtables
-ln -sf ebtables-legacy-save %{buildroot}%{_sbindir}/ebtables-save
-ln -sf ebtables-legacy-restore %{buildroot}%{_sbindir}/ebtables-restore
+# Prepare for Alternatives system
+touch %{buildroot}%{_sbindir}/ebtables
+touch %{buildroot}%{_sbindir}/ebtables-save
+touch %{buildroot}%{_sbindir}/ebtables-restore
+
+%post legacy
+pfx=%{_sbindir}/ebtables
+%{_sbindir}/update-alternatives --install %{_sbindir}/%{name} %{name} %{_sbindir}/%{name}-legacy 10000 \
+  --slave %{_sbindir}/%{name}-save %{name}-save %{_sbindir}/%{name}-legacy-save \
+  --slave %{_sbindir}/%{name}-restore %{name}-restore %{_sbindir}/%{name}-legacy-restore
+
+%postun legacy
+if [ $1 -eq 0 ]; then
+	%{_sbindir}/update-alternatives --remove \
+		%{name} %{_sbindir}/%{name}-legacy
+fi
 
 %post services
 %systemd_post ebtables.service
@@ -108,10 +123,10 @@ ln -sf ebtables-legacy-restore %{buildroot}%{_sbindir}/ebtables-restore
 %license COPYING
 %doc ChangeLog THANKS
 %{_sbindir}/ebtables-legacy*
-%{_sbindir}/ebtables*
 %{_mandir}/*/ebtables-legacy*
 %{_libdir}/libebtc.so*
 %{_sysconfdir}/ethertypes
+%ghost %{_sbindir}/ebtables{,-save,-restore}
 
 %files services
 %{_unitdir}/ebtables.service
@@ -120,6 +135,9 @@ ln -sf ebtables-legacy-restore %{buildroot}%{_sbindir}/ebtables-restore
 %ghost %{_sysconfdir}/sysconfig/ebtables
 
 %changelog
+* Tue Nov 12 2024 Sumedh Sharma <sumsharma@microsoft.com> - 2.0.11-9
+- introduce alternatives for legacy
+
 * Tue Sep 03 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 2.0.11-8
 - Add missing Vendor and Distribution tags.
 

--- a/SPECS/iptables/iptables.spec
+++ b/SPECS/iptables/iptables.spec
@@ -1,7 +1,7 @@
 Summary:        Linux kernel packet control tool
 Name:           iptables
 Version:        1.8.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -18,6 +18,9 @@ BuildRequires:  libmnl-devel
 BuildRequires:  libnftnl-devel
 BuildRequires:  systemd-bootstrap-rpm-macros
 Requires:       iana-etc
+Requires:       libnftnl
+Requires(post):   %{_sbindir}/update-alternatives
+Requires(postun): %{_sbindir}/update-alternatives
 # Our build tooling cannot handle this
 #Requires:       systemd
 Provides:       %{name}-services = %{version}-%{release}
@@ -43,15 +46,14 @@ It contains the libraries and header files to create applications.
     --exec-prefix= \
     --with-xtlibdir=%{_libdir}/iptables \
     --with-pkgconfigdir=%{_libdir}/pkgconfig \
-    --disable-nftables \
     --enable-libipq \
     --enable-devel
 
-make V=0
+%make_build
 
 %install
 %make_install
-ln -sfv ../../sbin/xtables-multi %{buildroot}%{_libdir}/iptables-xml
+
 #   Install daemon scripts
 install -vdm755 %{buildroot}%{_unitdir}
 install -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
@@ -65,14 +67,40 @@ find %{buildroot} -name '*.a'  -delete
 find %{buildroot} -type f -name "*.la" -delete -print
 %{_fixperms} %{buildroot}/*
 
-%preun
-%systemd_preun iptables.service
+ln -sf --relative %{buildroot}%{_sbindir}/xtables-legacy-multi %{buildroot}%{_bindir}/iptables-xml
 
 %post
+for target in %{name} \
+              ip6tables \
+              ebtables \
+              arptables; do
+  %{_sbindir}/update-alternatives --install %{_sbindir}/${target} ${target} %{_sbindir}/${target}-nft 30000 \
+    --slave %{_sbindir}/${target}-save ${target}-save %{_sbindir}/${target}-nft-save \
+    --slave %{_sbindir}/${target}-restore ${target}-restore %{_sbindir}/${target}-nft-restore
+done
+
+for target in %{name} \
+              ip6tables; do
+  %{_sbindir}/update-alternatives --install %{_sbindir}/${target} ${target} %{_sbindir}/${target}-legacy 10000 \
+    --slave %{_sbindir}/${target}-save ${target}-save %{_sbindir}/${target}-legacy-save \
+    --slave %{_sbindir}/${target}-restore ${target}-restore %{_sbindir}/${target}-legacy-restore
+done
+
 /sbin/ldconfig
 %systemd_post iptables.service
 
+%preun
+%systemd_preun iptables.service
+
 %postun
+if [ $1 -eq 0 ]; then
+	%{_sbindir}/update-alternatives --remove %{name} %{_sbindir}/%{name}-nft
+	%{_sbindir}/update-alternatives --remove ip6tables %{_sbindir}/ip6tables-nft
+	%{_sbindir}/update-alternatives --remove ebtables %{_sbindir}/ebtables-nft
+	%{_sbindir}/update-alternatives --remove arptables %{_sbindir}/arptables-nft
+	%{_sbindir}/update-alternatives --remove %{name} %{_sbindir}/%{name}-legacy
+	%{_sbindir}/update-alternatives --remove ip6tables %{_sbindir}/ip6tables-legacy
+fi
 /sbin/ldconfig
 %systemd_postun_with_restart iptables.service
 
@@ -83,15 +111,18 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %config(noreplace) %{_sysconfdir}/systemd/scripts/iptables.stop
 %config(noreplace) %{_sysconfdir}/systemd/scripts/ip4save
 %config(noreplace) %{_sysconfdir}/systemd/scripts/ip6save
+%config(noreplace) %{_sysconfdir}/ethertypes
 %{_unitdir}/iptables.service
 %{_sbindir}/*
 %{_bindir}/*
 %{_libdir}/*.so.*
 %{_libdir}/iptables/*
-%{_libdir}/iptables-xml
+%{_bindir}/iptables-xml
 %{_mandir}/man1/*
 %{_mandir}/man8/*
 /usr/share/xtables/iptables.xslt
+%ghost %{_sbindir}/ip{,6}tables{,-save,-restore}
+%ghost %{_sbindir}/{eb,arp}tables{,-save,-restore}
 
 %files devel
 %{_libdir}/*.so
@@ -100,6 +131,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_mandir}/man3/*
 
 %changelog
+* Tue Nov 12 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.8.10-3
+- Enable nftables and use alternatives.
+
 * Mon Mar 18 2024 Andy Zaugg <azaugg@linkedin.com> - 1.8.10-2
 - Flush raw table when restarting iptables service
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR enables nftables in iptables to provide iptables-nft (default) & iptables-legacy commands.

This PR fixes https://microsoft.visualstudio.com/OS/_workitems/edit/53647336.

- When upgrading iptables to this variant, introduction of alternatives provides **nft** variant as default for iptables | ip6tables | ebtables | arptables.
   The legacy iptables is installed as **-legacy** variant
![iptables_nft_install](https://github.com/user-attachments/assets/59715b3d-2bd3-4eae-b780-27f4d35f80b6)

- The upgrade of iptables will start the iptables service and use the nft variant to restore the ipv4|ipv6 configs (by default the one provided as part of the package)
![iptables_new_config](https://github.com/user-attachments/assets/2dd105bf-7480-4901-8974-d41381aaf496)

- The equivalent nft ruleset can be seen by using `nft` provided by nftables.
[nft_ruleset.txt](https://github.com/user-attachments/files/17716259/nft_ruleset.txt)

- Without reboot, the old legacy iptables **tables and chains** will exist. A reboot will clear the legacy iptables rules.

- Adding new rules will correctly update the nft table.
![iptables_new_add_rule](https://github.com/user-attachments/assets/7ac88d52-10a2-4dac-aaae-1de76bce5434)

-  A warning exists when looking at the rules list using iptables-nft (even when the legacy rules are empty):
   # Warning: iptables-legacy tables present, use iptables-legacy to see them
   This is due to still loaded kernel modules which were loaded by the legacy iptables, namely:
    iptable_filter
    iptable_nat
    iptable_mangle
    iptable_raw
    iptable_security
    [and their ip6 variants]

###### Change Log  <!-- REQUIRED -->
- Build iptables with nftables enabled and use alternatives to install the variants
- Update ebtables to use alternatives to provide legacy variant

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id:

- [Delta Dev-Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=676285&view=results) 
Verified BuildImage - cvm logs to confirm iptables is installed correctly without any warnings/errors.

- [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=674025&view=results)
