### PR TITLE
Image Customizer: Use fixed xfs filesystem options.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -879,8 +879,7 @@ func getMkfsOptions(fsType string) ([]string, error) {
 			return nil, err
 		}
 
-		// Feature  xfsprogs   kernel
-		// nrext64  v5.19      v5.19
+		// 'nrext64' was both added and enabled by default in xfsprogs v5.19.
 		if mkfsXfsVersion.Compare(versioncompare.New("5.19")) >= 0 {
 			// Disable feature that is not supported on older kernel.
 			options := []string{"-i", "nrext64=0"}


### PR DESCRIPTION
Currently, we have a fixed set of options that are used when formatting with the ext4 filesystem type. However, this is currently missing for xfs. This means that if an Azure Linux 2.0 image is customized in Azure Linux 3.0, then the OS won't be able to boot since the xfs partition will have some features enabled that aren't supported on the older kernel/grub versions.

This change sets the xfs options so that they are consistent regardless of the OS being used to build/customize the image.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.
