### PR TITLE
Toolkit: Use systemd-detect-virt instead of /.dockerenv to detect container builds.

### DIFF
--- a/toolkit/docs/building/prerequisites-mariner.md
+++ b/toolkit/docs/building/prerequisites-mariner.md
@@ -32,6 +32,7 @@ sudo tdnf -y install \
     rpm \
     rpm-build \
     sudo \
+    systemd \
     tar \
     wget \
     xfsprogs \

--- a/toolkit/docs/building/prerequisites-ubuntu.md
+++ b/toolkit/docs/building/prerequisites-ubuntu.md
@@ -23,6 +23,7 @@ sudo apt -y install \
     parted \
     pigz \
     openssl \
+    systemd \
     qemu-utils \
     rpm \
     tar \

--- a/toolkit/scripts/chroot.mk
+++ b/toolkit/scripts/chroot.mk
@@ -34,6 +34,7 @@ worker_chroot_rpm_paths := $(shell sed -nr $(sed_regex_full_path) < $(WORKER_CHR
 worker_chroot_deps := \
 	$(WORKER_CHROOT_MANIFEST) \
 	$(worker_chroot_rpm_paths) \
+	$(go-containercheck) \
 	$(PKGGEN_DIR)/worker/create_worker_chroot.sh
 
 ifeq ($(REFRESH_WORKER_CHROOT),y)
@@ -41,7 +42,7 @@ $(chroot_worker): $(worker_chroot_deps) $(depend_REBUILD_TOOLCHAIN) $(depend_TOO
 else
 $(chroot_worker):
 endif
-	$(PKGGEN_DIR)/worker/create_worker_chroot.sh $(BUILD_DIR)/worker $(WORKER_CHROOT_MANIFEST) $(TOOLCHAIN_RPMS_DIR) $(LOGS_DIR)
+	$(PKGGEN_DIR)/worker/create_worker_chroot.sh $(BUILD_DIR)/worker $(WORKER_CHROOT_MANIFEST) $(TOOLCHAIN_RPMS_DIR) $(go-containercheck) $(LOGS_DIR)
 
 validate-chroot: $(go-validatechroot) $(chroot_worker)
 	$(go-validatechroot) \

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -31,6 +31,7 @@ endif
 go_tool_list = \
 	bldtracker \
 	boilerplate \
+	containercheck \
 	depsearch \
 	downloader \
 	grapher \

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -100,7 +100,7 @@ $(foreach var,$(watch_vars),$(eval $(call depend_on_var,$(var))))
 #       to always run the "setfacl" command but not trigger a re-run of the targets
 #       depending on this target.
 $(no_repo_acl): setfacl_always_run_phony
-	@setfacl -bnR $(PROJECT_ROOT) &>/dev/null && \
+	@setfacl -bnR $(PROJECT_ROOT) && \
 	if [ ! -f $@ ]; then \
 		touch $@; \
 	fi

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -100,7 +100,7 @@ $(foreach var,$(watch_vars),$(eval $(call depend_on_var,$(var))))
 #       to always run the "setfacl" command but not trigger a re-run of the targets
 #       depending on this target.
 $(no_repo_acl): setfacl_always_run_phony
-	@setfacl -bnR $(PROJECT_ROOT) && \
+	@setfacl -bnR $(PROJECT_ROOT) &>/dev/null && \
 	if [ ! -f $@ ]; then \
 		touch $@; \
 	fi

--- a/toolkit/tools/containercheck/containercheck.go
+++ b/toolkit/tools/containercheck/containercheck.go
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Returns true (exit code 0) if the current build is a container build, false (exit code 1) otherwise
+
+package main
+
+import (
+	"os"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/buildpipeline"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/exe"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	app      = kingpin.New("containercheck", "Returns true (0) if the current build is a container build, false (1) otherwise")
+	logFlags = exe.SetupLogFlags(app)
+)
+
+func main() {
+	app.Version(exe.ToolkitVersion)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+	logger.InitBestEffort(logFlags)
+
+	if buildpipeline.IsRegularBuild() {
+		os.Exit(1)
+	} else {
+		os.Exit(0)
+	}
+}

--- a/toolkit/tools/internal/buildpipeline/buildpipeline.go
+++ b/toolkit/tools/internal/buildpipeline/buildpipeline.go
@@ -8,28 +8,144 @@ package buildpipeline
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
-
-	"golang.org/x/sys/unix"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 )
 
 const (
-	rootBaseDirEnv = "CHROOT_DIR"
-	chrootLock     = "chroot-pool.lock"
-	chrootUse      = "chroot-used"
+	rootBaseDirEnv        = "CHROOT_DIR"
+	chrootLock            = "chroot-pool.lock"
+	chrootUse             = "chroot-used"
+	systemdDetectVirtTool = "systemd-detect-virt"
 )
+
+var isRegularBuildCached *bool
+
+// checkIfContainerDockerEnvFile checks if the tool is running in a Docker container by checking if /.dockerenv exists. This
+// check may not be reliable in all environments, so it is recommended to use systemd-detect-virt if available.
+func checkIfContainerDockerEnvFile() bool {
+	exists, err := file.PathExists("/.dockerenv")
+	if err != nil {
+		logger.Log.Errorf("Error checking /.dockerenv: %v", err)
+		return false
+	}
+	return exists
+}
+
+// checkIfContainerIgnoreDockerEnvFile checks if the user has placed a file in the root directory to ignore the Docker
+// environment check.
+func checkIfContainerIgnoreDockerEnvFile() bool {
+	ignoreDockerEnvExists, err := file.PathExists("/.mariner-toolkit-ignore-dockerenv")
+	if err != nil {
+		logger.Log.Errorf("Failed to check if /.mariner-toolkit-ignore-dockerenv exists: %s", err)
+		return false
+	}
+	return ignoreDockerEnvExists
+}
+
+// checkIfContainerChrootDirEnv checks if the user has set the CHROOT_DIR environment variable, which is a requirement for
+// Docker-based builds. If the variable exists, it is likely that the tool is running in a Docker container.
+func checkIfContainerChrootDirEnv() bool {
+	_, exists := os.LookupEnv(rootBaseDirEnv)
+	return exists
+}
+
+// checkIfContainerSystemdDetectVirt uses systemd-detect-virt, a tool that can be used to detect if the system is running
+// in a virtualized environment. More specifically, using '-c' flag will detect container-based virtualization only.
+func checkIfContainerSystemdDetectVirt() (bool, error) {
+	// We should have the systemd-detect-virt command available in the environment, but check for it just in case since it
+	// was previously not explicitly required for the toolkit.
+	_, err := exec.LookPath(systemdDetectVirtTool)
+	if err != nil {
+		err = fmt.Errorf("failed to find %s in the PATH: %w", systemdDetectVirtTool, err)
+		return false, err
+	}
+
+	// The tool will return error code 1 based on detection, we only care about the stdout so ignore the return code.
+	stdout, _, _ := shell.Execute(systemdDetectVirtTool, "-c")
+
+	// There are several possible outputs from systemd-detect-virt we care about:
+	// - none: Not running in a virtualized environment, easy
+	// - wsl: Reports as a container, but we don't want to treat it as such. It should be able to handle regular builds
+	// - anything else: We'll assume it's a container
+	stdout = strings.TrimSpace(stdout)
+	switch stdout {
+	case "none":
+		logger.Log.Debugf("Tool is not running in a container, systemd-detect-virt reports: '%s'", stdout)
+		return false, nil
+	case "wsl":
+		logger.Log.Debugf("Tool is running in WSL, treating as a non-container environment, systemd-detect-virt reports: '%s'", stdout)
+		return false, nil
+	default:
+		logger.Log.Debugf("Tool is running in a container, systemd-detect-virt reports: '%s'", stdout)
+		return true, nil
+	}
+}
 
 // IsRegularBuild indicates if it is a regular build (without using docker)
 func IsRegularBuild() bool {
-	// some specific build pipeline builds Azure Linux from a Docker container and
-	// consequently have special requirements with regards to chroot
-	// check if .dockerenv file exist to disambiguate build pipeline
-	dockerEnvExists, _ := file.PathExists("/.dockerenv")
-	ignoreDockerEnvExists, _ := file.PathExists("/.mariner-toolkit-ignore-dockerenv")
-	return ignoreDockerEnvExists || !dockerEnvExists
+	if isRegularBuildCached != nil {
+		return *isRegularBuildCached
+	}
+
+	// If /.mariner-toolkit-ignore-dockerenv exists, then it is a regular build no matter what.
+	if checkIfContainerIgnoreDockerEnvFile() {
+		isRegularBuild := true
+		isRegularBuildCached = &isRegularBuild
+		return isRegularBuild
+	}
+
+	// There are multiple ways to detect if the build is running in a Docker container.
+	// - Check with systemd-detect-virt tool first. This is the most reliable way.
+	// - The legacy way is to check if /.dockerenv exists. However, this is not reliable
+	//   as it may not be present in all environments.
+	// - If the user has set the CHROOT_DIR environment variable, then it is likely a Docker build.
+	isRegularBuild := true
+	isDockerContainer, err := checkIfContainerSystemdDetectVirt()
+	if err != nil {
+		isRegularBuild = !checkIfContainerDockerEnvFile()
+		message := []string{
+			"Failed to detect if the system is running in a container using systemd-detect-virt.",
+			err.Error(),
+			"Checking if the system is running in a container by checking /.dockerenv.",
+		}
+		if isRegularBuild {
+			message = append(message, "Result: Not a container.")
+		} else {
+			message = append(message, "Result: Container detected.")
+		}
+		logger.PrintMessageBox(logrus.WarnLevel, message)
+	} else {
+		isRegularBuild = !isDockerContainer
+		if !isRegularBuild {
+			logger.Log.Info("systemd-detect-virt reports that the tool is running in a container, running as a container build")
+		}
+	}
+
+	// If the user set the CHROOT_DIR environment variable, but we don't detect a container, print a warning. This is
+	// likely a misconfiguration, however trust the user and force the build to run as a container. If this is a mistake,
+	// the tools should fail very quickly after this point.
+	if checkIfContainerChrootDirEnv() && isRegularBuild {
+		message := []string{
+			"CHROOT_DIR is set, but the system is not detected as a container.",
+			"This is likely a misconfiguration!",
+			"**Forcing the build to run as a container build**, however chroot operations may fail.",
+		}
+		logger.PrintMessageBox(logrus.WarnLevel, message)
+		isRegularBuild = false
+	}
+
+	// Cache the result
+	isRegularBuildCached = &isRegularBuild
+	return isRegularBuild
 }
 
 // GetChrootDir returns the chroot folder
@@ -43,7 +159,7 @@ func GetChrootDir(proposedDir string) (chrootDir string, err error) {
 
 	// In docker based pipeline pre-existing chroot pool is under a folder which path
 	// is indicated by an env variable
-	chrootPoolFolder, varExist := unix.Getenv(rootBaseDirEnv)
+	chrootPoolFolder, varExist := os.LookupEnv(rootBaseDirEnv)
 	if !varExist || len(chrootPoolFolder) == 0 {
 		err = fmt.Errorf("env variable %s not defined", rootBaseDirEnv)
 		logger.Log.Errorf("%s", err.Error())

--- a/toolkit/tools/internal/buildpipeline/buildpipeline.go
+++ b/toolkit/tools/internal/buildpipeline/buildpipeline.go
@@ -132,7 +132,7 @@ func IsRegularBuild() bool {
 		}
 		message := []string{
 			"Failed to detect if the system is running in a container using systemd-detect-virt.",
-			systemdErrMsg ,
+			systemdErrMsg,
 			"Checking if the system is running in a container by checking /.dockerenv.",
 		}
 		if isRegularBuild {

--- a/toolkit/tools/internal/buildpipeline/buildpipeline.go
+++ b/toolkit/tools/internal/buildpipeline/buildpipeline.go
@@ -122,6 +122,7 @@ func IsRegularBuild() bool {
 		}
 	} else {
 		// Fallback if systemd-detect-virt isn't available.
+		systemdErrMsg := err.Error()
 		isDockerContainer, err = checkIfContainerDockerEnvFile()
 		if err != nil {
 			// Log the error, but continue with the check.
@@ -131,7 +132,7 @@ func IsRegularBuild() bool {
 		}
 		message := []string{
 			"Failed to detect if the system is running in a container using systemd-detect-virt.",
-			err.Error(),
+			systemdErrMsg ,
 			"Checking if the system is running in a container by checking /.dockerenv.",
 		}
 		if isRegularBuild {

--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -10,7 +10,7 @@ set -o pipefail
 # $3 path to find RPMs. May be in PATH/<arch>/*.rpm
 # $4 path to log directory
 
-[ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] && [ -n "$4" ] && [ -n "$4" ] || { echo "Usage: create_worker.sh <./worker_base_folder> <rpms_to_install.txt> <./path_to_rpms> <./containercheck> <./log_dir>"; exit; }
+[ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] && [ -n "$4" ] && [ -n "$5" ] || { echo "Usage: create_worker.sh <./worker_base_folder> <rpms_to_install.txt> <./path_to_rpms> <./containercheck> <./log_dir>"; exit; }
 
 chroot_base=$1
 packages=$2

--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -10,12 +10,13 @@ set -o pipefail
 # $3 path to find RPMs. May be in PATH/<arch>/*.rpm
 # $4 path to log directory
 
-[ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] && [ -n "$4" ] || { echo "Usage: create_worker.sh <./worker_base_folder> <rpms_to_install.txt> <./path_to_rpms> <./log_dir>"; exit; }
+[ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] && [ -n "$4" ] && [ -n "$4" ] || { echo "Usage: create_worker.sh <./worker_base_folder> <rpms_to_install.txt> <./path_to_rpms> <./containercheck> <./log_dir>"; exit; }
 
 chroot_base=$1
 packages=$2
 rpm_path=$3
-log_path=$4
+container_check_tool=$4
+log_path=$5
 
 chroot_name="worker_chroot"
 chroot_builder_folder=$chroot_base/$chroot_name
@@ -121,8 +122,8 @@ HOME=$ORIGINAL_HOME
 
 # In case of Docker based build do not add the below folders into chroot tarball
 # otherwise safechroot will fail to "untar" the tarball
-DOCKERCONTAINERONLY=/.dockerenv
-if [[ -f "$DOCKERCONTAINERONLY" ]]; then
+if $container_check_tool; then
+    echo "Removing /dev, /proc, /run, /sys from chroot tarball for container based build." | tee -a "$chroot_log"
     rm -rf "${chroot_base:?}/$chroot_name"/dev
     rm -rf "${chroot_base:?}/$chroot_name"/proc
     rm -rf "${chroot_base:?}/$chroot_name"/run


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There have been several issues with a mismatch between the build environment and the detected state by the toolkit. When running in docker, the chroots generally need to be configured externally with their mounts and re-used. This can be done via setting `CHROOT_DIR=/path/to/reusable/chroots`, and if the toolkit thinks it's in a container, it will switch modes.

See https://github.com/microsoft/azurelinux-tutorials/tree/main/build-in-container for more details.

Some builds are currently failing because what is ostensibly a container environment does not have `/.dockerenv` present. 

In the opposite direction, there are also situations where WSL images (which should work fine as a normal build) are reporting as docker because they have a `/.dockerenv` file present.

`systemd` has a tool (`systemd-detect-virt`) which is designed to detect what sort of virtualization is being used to run the current environment. Instead of designing a new system to re-implement this behavior, we can just use this tool. We already have an implicit build dependency on `systemd` (we run the docker service etc.) so adding it as an explicit requirement shouldn't change anything.

Also, to help people self-diagnose, sanity check the configurations and warn the user:
- If the CHROOT_DIR is set, but the tool thinks it's in a normal environment, print a warning. A fatal error will follow immediately after if this is actually broken.
- If the `systemd-detect-virt` tool is not present, print a warning but fallback to the old behavior.

To validate this we will need to add a new testcase to the toolkit sanity test pipeline that ensures the chroots keep working.

**We will need to back-port this to 2.0 as well.**

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Prefer `systemd-detect-virt` over `/.dockerenv` for container detection
- Print warnings if misconfiguration is detected

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/55008881
- https://microsoft.visualstudio.com/OS/_workitems/edit/54578711


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- New sanity test (~pipeline PR soon~): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=675755&view=results
  - PR for new pipeline: https://dev.azure.com/mariner-org/mariner/_git/CBL-Mariner-Pipelines/pullrequest/21071
- Full build: ~https://dev.azure.com/mariner-org/mariner/_build/results?buildId=676056&view=results~ https://dev.azure.com/mariner-org/mariner/_build/results?buildId=678948&view=results
