### PR TITLE
make install_dependencies work with file dependencies

### DIFF
--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -84,6 +84,7 @@ script_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 topdir=/usr/src/azl
 enable_local_repo=false
 keep_container="--rm"
+packages_to_install="azurelinux-release vim git jq"
 
 while (( "$#")); do
   case "$1" in
@@ -92,7 +93,7 @@ while (( "$#")); do
     -p ) repo_path="$(realpath $2)"; shift 2 ;;
     -mo ) extra_mounts="$2"; shift 2 ;;
     -b ) build_mount_dir="$(realpath $2)"; shift 2;;
-    -ep ) extra_packages="$2"; shift 2;;
+    -ep ) packages_to_install="${packages_to_install} $2"; shift 2;;
     -r ) enable_local_repo=true; shift ;;
     -k ) keep_container=""; shift ;;
     -q ) STD_OUT_REDIRECT=/dev/null; shift ;;
@@ -268,7 +269,7 @@ docker build -q \
                 --build-arg enable_local_repo="$enable_local_repo" \
                 --build-arg azl_repo="$repo_path" \
                 --build-arg mode="$mode" \
-                --build-arg extra_packages="$extra_packages" \
+                --build-arg packages_to_install="$packages_to_install" \
                 .
 
 echo "docker_image_tag is ${docker_image_tag}"

--- a/toolkit/scripts/containerized-build/resources/azl.Dockerfile
+++ b/toolkit/scripts/containerized-build/resources/azl.Dockerfile
@@ -4,7 +4,7 @@ ARG version
 ARG enable_local_repo
 ARG azl_repo
 ARG mode
-ARG extra_packages
+ARG packages_to_install
 LABEL containerized-rpmbuild=$azl_repo/build
 
 COPY resources/local_repo /etc/yum.repos.d/local_repo.disabled_repo
@@ -23,5 +23,5 @@ RUN if [[ "${mode}" == "build" ]]; then echo "cd /usr/src/azl || { echo \"ERROR:
 RUN if [[ "${mode}" == "test" ]]; then echo "cd /mnt || { echo \"ERROR: Could not change directory to /mnt \"; exit 1; }"  >> /root/.bashrc; fi
 
 # Install packages from bashrc so we can use the previously setup tdnf defaults.
-RUN echo "echo installing packages azurelinux-release vim git ${extra_packages}" >> /root/.bashrc && \
-    echo "tdnf install --releasever=${version} -qy azurelinux-release vim git ${extra_packages}" >> /root/.bashrc
+RUN echo "echo installing packages ${packages_to_install}" >> /root/.bashrc && \
+    echo "tdnf install --releasever=${version} -qy ${packages_to_install}" >> /root/.bashrc


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
In a `containerized-rpmbuild` environment, the function `install_dependencies` will install all `BuildRequires` dependencies from a spec file. However, it wasn't able to handle file dependencies like `BuildRequires: %{_bindir}/cmp`, which requires looking up the package that provides the file.

This change uses `tdnf repoquery` to get the appropriate package.

I also added usage of `jq` in that function, so I added it to the list of packages we always install (it's useful anyway), and did a minor refactor of how we do that.

###### Change Log  <!-- REQUIRED -->
- Updated `install_dependencies` to support file dependencies.
- Minor refactor of how we pass packages to add to a container to the docker file.
- Added `jq` as a package to always install in the container.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Tested locally; there are no pipelines that exercise this.
