### PR TITLE
ImageCustomizer: Refresh partitions after veritysetup so that hash partition's UUID is accurate

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -814,6 +814,12 @@ func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *
 		return fmt.Errorf("failed to stat file (%s):\n%w", grubCfgFullPath, err)
 	}
 
+	// Refresh disk partitions so that the hash partition's UUID is correct
+	diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
+	if err != nil {
+		return err
+	}
+
 	err = updateGrubConfigForVerity(rootfsVerity, rootHash, grubCfgFullPath, partIdToPartUuid, diskPartitions)
 	if err != nil {
 		return err


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->

This change corrects the value set for the `systemd.verity_root_hash=` kernel cmdline parameter when `hashDeviceMountIdType`  in the configuration is set to `uuid`.
 
In particular, the veritysetup command earlier in the function generates the UUID for the verity hash partition. But since the diskPartitions array is queried before that call, the partition would be marked as having an empty filesystem UUID.

An alternative would be to edit only the specific partition's UUID in the diskPartitions array, either by passing a manually generated UUID to veritysetup (via the `--uuid=UUID` flag) or by querying the chosen UUID after veritysetup had run.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build