### PR TITLE
Cache clean-up fix.

### DIFF
--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -202,7 +202,13 @@ ifeq ($(PRECACHE),y)
 $(cached_file): $(STATUS_FLAGS_DIR)/precache.flag
 endif
 
-$(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(cached_remote_rpms) $(TOOLCHAIN_MANIFEST) $(toolchain_rpms) $(depend_EXTRA_BUILD_LAYERS) $(depend_REPO_SNAPSHOT_TIME) $(STATUS_FLAGS_DIR)/build_packages_cache_cleanup.flag
+ifneq ($(REPO_SNAPSHOT_TIME),)
+# We need to clear the rpm package cache if we have a snapshot time. The filenames will all be
+# the same, but the actual .rpm files may be fundamentally different.
+$(cached_file): $(STATUS_FLAGS_DIR)/build_packages_cache_cleanup.flag
+endif
+
+$(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(cached_remote_rpms) $(TOOLCHAIN_MANIFEST) $(toolchain_rpms) $(depend_EXTRA_BUILD_LAYERS) $(depend_REPO_SNAPSHOT_TIME)
 	mkdir -p $(remote_rpms_cache_dir) && \
 	$(go-graphpkgfetcher) \
 		--input=$(graph_file) \
@@ -265,8 +271,6 @@ clean-compress-rpms:
 clean-compress-srpms:
 	rm -rf $(srpms_archive)
 
-# We need to clear the rpm package cache if we have a snapshot time. The filenames will all be
-# the same, but the actual .rpm files may be fundamentally different.
 $(STATUS_FLAGS_DIR)/build_packages_cache_cleanup.flag: $(depend_REPO_SNAPSHOT_TIME)
 	@echo "REPO_SNAPSHOT_TIME has changed, sanitizing rpm cache"
 	@if [ -d "$(remote_rpms_cache_dir)" ]; then \


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Update to #10369. The original change made the toolkit always clean-up the downloaded RPMs cache, even if the repo snapshot flag was not set. This broke scenarios, where a use pre-populates the cache with `hydrate-cached-rpms`. Now the cache will only be cleaned-up if the `REPO_SNAPSHOT_TIME` flag is set.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #10369

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Fast-track 3.0 build.