### PR TITLE
add Provides for "shim-unsigned"

### DIFF
--- a/SPECS/shim-unsigned-aarch64/shim-unsigned-aarch64.spec
+++ b/SPECS/shim-unsigned-aarch64/shim-unsigned-aarch64.spec
@@ -32,7 +32,7 @@ Name:		shim-unsigned-aarch64
 Provides:       shim-unsigned-%{efiarch}
 
 Version:	15.8
-Release:	4%{?dist}
+Release:	5%{?dist}
 Summary:	First-stage UEFI bootloader
 ExclusiveArch:	aarch64
 License:	BSD
@@ -160,6 +160,9 @@ HASH=$(cat %{buildroot}%{shimdir}/shim%{efiarch}.hash | cut -d ' ' -f 1)
 %files debugsource -f build-%{efiarch}/debugsource.list
 
 %changelog
+* Thu Nov 28 2024 Chris Co <chrco@microsoft.com> - 15.8-5
+- Bump to match shim release
+
 * Tue Nov 26 2024 Chris Co <chrco@microsoft.com> - 15.8-4
 - Bump to match shim release
 

--- a/SPECS/shim-unsigned-x64/shim-unsigned-x64.spec
+++ b/SPECS/shim-unsigned-x64/shim-unsigned-x64.spec
@@ -36,7 +36,7 @@
 
 Name:		shim-unsigned-%{efiarch}
 Version:	15.8
-Release:	4%{?dist}
+Release:	5%{?dist}
 Summary:	First-stage UEFI bootloader
 ExclusiveArch:	x86_64
 License:	BSD
@@ -221,6 +221,9 @@ HASH=$(cat %{buildroot}%{shimdir}/shim%{efiarch}.hash | cut -d ' ' -f 1)
 %files debugsource -f build-%{efiarch}/debugsource.list
 
 %changelog
+* Thu Nov 28 2024 Chris Co <chrco@microsoft.com> - 15.8-5
+- Bump to match shim release
+
 * Tue Nov 26 2024 Chris Co <chrco@microsoft.com> - 15.8-4
 - Bump to match shim release
 

--- a/SPECS/shim/shim.spec
+++ b/SPECS/shim/shim.spec
@@ -37,7 +37,7 @@
 Summary:        First stage UEFI bootloader
 Name:           shim
 Version:        15.8
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -47,6 +47,8 @@ ExclusiveArch:  x86_64 aarch64
 
 Provides:       shim = %{version}-%{release}
 Obsoletes:      shim < %{version}-%{release}
+Provides:       shim-signed = %{version}-%{release}
+Provides:       shim-signed-%{efiarch} = %{version}-%{release}
 # Prior images and installations historically used "shim-unsigned" v15.4
 # in order to boot without Secure Boot enforcing.
 # To ensure a seamless upgrade experience from the older unsigned shim to
@@ -54,8 +56,19 @@ Obsoletes:      shim < %{version}-%{release}
 # installations will upgrade cleanly from the unsigned shim v15.4 to this new
 # signed version of the shim v15.8+
 Obsoletes:      shim-unsigned <= 15.4
-Provides:       shim-signed = %{version}-%{release}
-Provides:       shim-signed-%{efiarch} = %{version}-%{release}
+# Unlike dnf, our current tdnf does not gracefully handle Obsoletes properly.
+# When the user runs "tdnf install shim-unsigned". The proper
+# behavior with Obsoletes only in place is for this transaction to
+# complete with nothing to do, which is what dnf does. However tdnf still
+# attempts to perform the transaction, which yields undesired results and
+# potential RPM transaction errors.
+#
+# As a workaround to tdnf's lack of correct support of Obsoletes, add an
+# additional Provides to the shim package to have it "provide" for
+# shim-unsigned as well.
+# This workaround can be removed when tdnf is updated with proper RPM
+# Obsoletes behavior.
+Provides:       shim-unsigned = %{version}-%{release}
 
 # This is when grub was updated to be signed with the newer Azure Linux certificate
 Conflicts:      grub2-efi-binary < 2.06-22
@@ -174,6 +187,9 @@ fi
 /boot/efi/EFI/%{efidir}/*
 
 %changelog
+* Thu Nov 28 2024 Chris Co <chrco@microsoft.com> - 15.8-5
+- Add Provides for shim-unsigned
+
 * Tue Nov 26 2024 Chris Co <chrco@microsoft.com> - 15.8-4
 - Add obsoletes for shim-unsigned v15.4 package
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Unlike dnf, our current tdnf does not gracefully handle Obsoletes properly. When the user runs "tdnf install shim-unsigned". The proper behavior with Obsoletes only in place is for this transaction to complete with nothing to do, which is what dnf does. However tdnf still attempts to perform the transaction, which yields undesired results.

As a workaround to tdnf's lack of correct support of Obsoletes, add an additional Provides to the shim package to have it "provide" for shim-unsigned as well.

This workaround can be removed when tdnf is updated with proper RPM Obsoletes behavior.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/55260537

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
