### PR TITLE
golang: fix cgmanifest.json after bad update

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4590,8 +4590,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.23.3",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.23.3-1/go1.23.3-20241107.5.src.tar.gz"
+          "version": "1.22.7",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.7-3/go1.22.7-20240925.5.src.tar.gz"
         }
       }
     },
@@ -4600,8 +4600,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.23.1",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.23.1-3/go1.23.1-20240925.6.src.tar.gz"
+          "version": "1.23.3",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.23.3-1/go1.23.3-20241107.5.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Fix cgmanifest.json after it was broken by https://github.com/microsoft/azurelinux/pull/10979. That PR was generated by tooling that hadn't yet been updated to work with the split golang.spec changes, and while the tooling has been fixed, this issue in the PR generated by the earlier tooling version wasn't spotted.