### PR TITLE
Add (manual) GitHub workflow to build changed specs

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,269 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# NOTES:
+#
+# This is a starting point for a validation workflow that can detect the specs that
+# have changed in a given git commit, build the RPMs for those specs, and run ptests
+# for those. For now, it builds the packages and attempts to validate that they
+# install correctly.
+#
+# Known limitations/concerns:
+#
+# * We build + test the packages in an Ubuntu VM runner. This is easiest in a GitHub
+#   action, since it's the only Linux OS supported running in the VM; in time,
+#   it may be worthwhile looking into running the package build itself in an
+#   Azure Linux 3.0 environment.
+#
+# * We take a specific dependency on daily repos in Azure Linux 3.0+, as well as the
+#   Azure Linux 3.0 container. To extend support to 2.0, some work will be required
+#   to make these dependencies conditional.
+#
+
+name: "Spec Build/Test"
+
+on:
+  # N.B. For now this workflow is only manually invoked. In the future we plan to enable
+  # it for pull requests and pushes.
+  workflow_dispatch:
+    inputs:
+      comparison_base_ref:
+        description: 'The base ref to compare changes against.'
+        required: true
+        default: '3.0-dev'
+
+env:
+  # For consistency, we use the same major/minor version of the latest version of Python that
+  # Azure Linux ships.
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  detect-changes:
+    name: 'Detect spec changes'
+    runs-on: ubuntu-latest
+
+    outputs:
+      updated_specs: ${{ steps.export.outputs.UPDATED_SPECS }}
+      updated_extended_specs: ${{ steps.export.outputs.UPDATED_EXTENDED_SPECS }}
+      target_ref: ${{ steps.export.outputs.TARGET_REF }}
+      azl_extra_make_args: ${{ steps.export.outputs.AZL_EXTRA_MAKE_ARGS }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies for tools
+        run: python3 -m pip install -r toolkit/scripts/requirements.txt
+
+      #
+      # We first get oriented, figuring out which version of the code we're building
+      # and which version of the code we should be comparing against.
+      #
+      # We define the following:
+      #   - base_sha: The commit hash of the commit we're comparing against.
+      #   - target_ref: The ref we're building.
+      #
+
+      - name: "Find base commit (PRs)"
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          set -x
+          # In a PR workflow, 'github.base_ref' is the *target* branch of the PR.
+          git fetch origin ${{ github.base_ref }}
+          echo "base_sha=$(git rev-parse origin/${{ github.base_ref }})" >>$GITHUB_ENV
+          echo "target_ref=${{ github.base_ref }}" >>$GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.base_ref }}"
+
+      - name: "Find base commit (pushes)"
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          set -x
+          # In a push workflow, 'github.event.before' is the SHA hash of the commit
+          # immediately preceding the commit being pushed. 
+          git fetch origin ${{ github.event.before }}
+          echo "base_sha=${{ github.event.before }}" >>$GITHUB_ENV
+          echo "target_ref=${{ github.ref }}" >>$GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
+
+      - name: "Find base commit (manual)"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -x
+          # In a manually triggered workflow, we don't necessarily have a base commit to compare against.
+          # We rely on inputs providing it.
+          git fetch origin ${{ inputs.comparison_base_ref }}
+          echo "base_sha=$(git rev-parse origin/${{ inputs.comparison_base_ref }})" >>$GITHUB_ENV
+          echo "target_ref=${{ github.ref }}" >>$GITHUB_ENV
+          echo "Building ${{ github.ref }} and comparing against ${{ inputs.comparison_base_ref }}"
+
+      - name: Compute tooling args
+        run: |
+          # TODO: We naively assume that this is a 3.0+ version that will have a daily build.
+          # To support older versions, some work may be required.
+          echo 'azl_extra_make_args=DAILY_BUILD_ID=lkg' >>$GITHUB_ENV
+
+      - name: Infer changed specs
+        run: |
+          set -x
+          updated_specs=$(./toolkit/scripts/detect_changes.py --since ${{ env.base_sha }} --spec-names)
+          updated_extended_specs=$(./toolkit/scripts/detect_changes.py --since ${{ env.base_sha }} --extended-spec-names)
+          echo "Specs updated: '${updated_specs}'"
+          echo "Extended specs updated: '${updated_extended_specs}'"
+          echo "updated_specs=$(echo ${updated_specs})" >>$GITHUB_ENV
+          echo "updated_extended_specs=$(echo ${updated_extended_specs})" >>$GITHUB_ENV
+
+      - name: Export outputs
+        id: export
+        run: |
+          echo "UPDATED_SPECS=${{ env.updated_specs }}" >>$GITHUB_OUTPUT
+          echo "UPDATED_EXTENDED_SPECS=${{ env.updated_extended_specs }}" >>$GITHUB_OUTPUT
+          echo "TARGET_REF=${{ env.target_ref }}" >>$GITHUB_OUTPUT
+          echo "AZL_EXTRA_MAKE_ARGS=${{ env.azl_extra_make_args }}" >>$GITHUB_OUTPUT
+
+  build:
+    name: 'Build RPMS'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.updated_specs != '' || needs.detect-changes.outputs.updated_extended_specs != '' }}
+    env:
+      updated_specs: ${{ needs.detect-changes.outputs.updated_specs }}
+      updated_extended_specs: ${{ needs.detect-changes.outputs.updated_extended_specs }}
+      azl_extra_make_args: ${{ needs.detect-changes.outputs.azl_extra_make_args }}
+
+    outputs:
+      daily_build_id: ${{ steps.find-daily-repo.outputs.DAILY_BUILD_ID }}
+      daily_build_arch: ${{ steps.find-daily-repo.outputs.DAILY_BUILD_ARCH }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies for tools
+        run: python3 -m pip install -r toolkit/scripts/requirements.txt
+
+      - name: Find daily repo
+        id: find-daily-repo
+        run: |
+          DAILY_BUILD_ID=$(toolkit/scripts/get_lkg_id.sh /tmp)
+          echo "DAILY_BUILD_ID=${DAILY_BUILD_ID}" >>$GITHUB_OUTPUT
+          echo "DAILY_BUILD_ARCH=x86-64" >>$GITHUB_OUTPUT
+
+      - name: "Build modified specs (base)"
+        id: build-specs
+        if: ${{ env.updated_specs != '' }}
+        run: |
+          sudo make -C toolkit \
+            build-packages \
+            $azl_extra_make_args \
+            -j$(nproc) \
+            REBUILD_TOOLS=y \
+            SRPM_PACK_LIST='${{ env.updated_specs }}'
+
+      - name: "Build modified specs (extended)"
+        id: build-extended-specs
+        if: ${{ env.updated_extended_specs != '' }}
+        run: |
+          sudo make -C toolkit \
+            build-packages \
+            $azl_extra_make_args \
+            -j$(nproc) \
+            REBUILD_TOOLS=y \
+            SPECS_DIR=$(pwd)/SPECS-EXTENDED \
+            SRPM_PACK_LIST='${{ env.updated_extended_specs }}'
+
+      - name: Upload built RPMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms
+          path: out/RPMS
+
+      - name: Upload build logs
+        id: upload-build-logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ github.run_attempt }}
+          path: build/logs
+
+      - name: Publish result
+        if: always()
+        run: |
+          if [[ ( ${{ steps.build-specs.outcome }} == 'success' || ${{ steps.build-specs.outcome }} == 'skipped' ) && ( ${{ steps.build-extended-specs.outcome }} == 'success' || ${{ steps.build-extended-specs.outcome }} == 'skipped' ) ]]; then
+            echo "✅ Build succeeded" >>${GITHUB_STEP_SUMMARY}
+          else
+            echo "❌ Build failed" >>${GITHUB_STEP_SUMMARY}
+          fi
+
+      - name: Advertise build logs
+        if: always() && steps.upload-build-logs.outcome == 'success'
+        run: |
+          echo "_Build logs available [for download](${{ steps.upload-build-logs.outputs.artifact-url }})_" >>${GITHUB_STEP_SUMMARY}
+
+  install:
+    name: 'Test installing RPM'
+    needs: [build, detect-changes]
+    if: ${{ needs.detect-changes.outputs.updated_specs != '' || needs.detect-changes.outputs.updated_extended_specs != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      # Use a base Azure Linux 3.0 container.
+      image: mcr.microsoft.com/azurelinux/base/core:3.0
+      env:
+        daily_build_id: ${{ needs.build.outputs.daily_build_id }}
+        daily_build_arch: ${{ needs.build.outputs.daily_build_arch }}
+
+          # Reference: https://github.com/Azure/azure-cli/issues/29835
+        GNUPGHOME: /root/.gnupg
+
+    defaults:
+      run:
+        shell: bash
+    env:
+      target_ref: ${{ needs.detect-changes.outputs.target_ref }}
+
+    steps:
+      - name: Install prerequisites
+        run: |
+          tdnf install -y ca-certificates createrepo_c jq sudo tar wget
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Download built RPMs
+        uses: actions/download-artifact@v4
+        with:
+          name: rpms
+          path: RPMS
+
+      - name: Prepare downloaded RPMs
+        run: |
+          set -euxo pipefail
+
+          # Inventory what we downloaded
+          ls -l -R RPMS
+          find RPMS -type f -name "*.rpm" ! -name "*.src.rpm" ! -name "*debuginfo*" >rpms.txt
+          cat rpms.txt
+
+      - name: "Test package install/uninstall"
+        # TODO: For now we hard-code .azl3 + use of latest daily repo
+        run: |
+          set -euxo pipefail
+
+          declare -a rpm_names=()
+          for rpm_path in $(cat rpms.txt); do
+            rpm_names+=("$(basename ${rpm_path})")
+          done
+
+          ./toolkit/scripts/test_package_install.sh -p RPMS -s "${rpm_names[@]}" -y latest -d ".azl3"

--- a/toolkit/scripts/detect_changes.py
+++ b/toolkit/scripts/detect_changes.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser(description="Detect changes in the repository")
+parser.add_argument("--display-compare-ref", dest="display_compare_ref", action="store_true", help="Display the detected comparison ref and exit")
+parser.add_argument("--since", dest="compare_ref", required=False, help="Identifies the git ref to compare against")
+parser.add_argument("-t", "--target-ref", dest="target_ref", default="HEAD", help="Identifies the target git ref with changes")
+parser.add_argument("-u", "--include-uncommitted", dest="include_uncommitted", action="store_true", help="Include uncommitted files from working tree")
+parser.add_argument("--include-untracked", dest="include_untracked", action="store_true", help="Include untracked files in working tree")
+parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Enable verbose output")
+
+spec_options = parser.add_mutually_exclusive_group()
+spec_options.add_argument("-s", "--spec-names", dest="spec_names_only", action="store_true", help="Only detect changes in SPECS .spec files and print out their base names")
+spec_options.add_argument("-e", "--extended-spec-names", dest="extended_spec_names_only", action="store_true", help="Only detect changes in SPECS-EXTENDED .spec files and print out their base names")
+
+args = parser.parse_args()
+
+if args.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.INFO
+
+logging.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
+
+def autodetect_compare_ref(target_ref: str) -> str:
+    # Find the registered remotes
+    result = subprocess.run(["git", "remote"], capture_output=True, check=True)
+    remotes = result.stdout.decode("utf-8").splitlines()
+
+    # Find all branches.
+    git_args = ["git", "for-each-ref", "refs/heads/"]
+    for remote in remotes:
+        git_args.append(f"refs/remotes/{remote}/")
+    git_args.append("--format=%(refname)")
+    result = subprocess.run(git_args, capture_output=True, check=True)
+    branch_refs = result.stdout.decode("utf-8").splitlines()    
+
+    # Find the branches that look like official release or dev branches.
+    well_known_refs = [branch_ref for branch_ref in branch_refs if is_well_known_azlinux_branch_ref(branch_ref)]
+
+    # Figure out which of these branches is our closest ancestor.
+    return get_closest_git_ancestor(target_ref, well_known_refs)
+
+def is_well_known_azlinux_branch_ref(branch_ref: str) -> bool:
+    branch_pieces = branch_ref.split("/")
+    if not branch_pieces:
+        return False
+
+    if len(branch_pieces) < 3:
+        return False
+
+    # We only look at refs/heads/* and refs/remotes/*/*.
+    if branch_pieces[0] != "refs":
+        return False
+
+    if branch_pieces[1] == "heads":
+        # Look past ref/heads prefix.
+        branch_name_pieces = branch_pieces[2:]
+    elif branch_pieces[1] == "remotes":
+        # Look past ref/remotes prefix as well as past the remote name.
+        branch_name_pieces = branch_pieces[3:]
+
+    # We only know about fasttrack/<ver>[-dev] and <ver>[-dev] named branches (and "main" as the legacy form of the 2.0 dev branch).
+    if len(branch_name_pieces) == 2 and branch_name_pieces[0] == "fasttrack":
+        name_to_check = branch_name_pieces[1]
+    elif len(branch_name_pieces) == 1:
+        name_to_check = branch_name_pieces[0]
+    else:
+        return False
+
+    return name_to_check == "main" or name_to_check.endswith(".0") or name_to_check.endswith(".0-dev")
+
+def get_closest_git_ancestor(target_ref: str, refs: Sequence[str]) -> str:
+    # First filter down to fork points.
+    fork_points = {}
+    for ref in refs:
+        result = subprocess.run(["git", "merge-base", "--fork-point", ref, target_ref], capture_output=True)
+        if result.returncode == 0:
+            fork_point_ref = result.stdout.decode("utf-8").strip()
+            fork_points[ref] = fork_point_ref
+
+    best_distance = None
+    best_candidate_ref = None
+
+    for candidate_ancestor, fork_point in fork_points.items():
+        # Find the distance in the chain.
+        result = subprocess.run(["git", "rev-list", "--count", f"{fork_point}..{target_ref}"], capture_output=True, check=True)
+        distance = int(result.stdout.decode("utf-8").strip())
+
+        if best_distance is None or distance < best_distance:
+            best_distance = distance
+            best_candidate_ref = candidate_ancestor
+        
+    return best_candidate_ref
+
+# If a comparison ref wasn't provided, then we go into auto-detect mode.
+if not args.compare_ref:
+    args.compare_ref = autodetect_compare_ref(args.target_ref)
+    if not args.compare_ref:
+        logger.error("could not autodetect comparison branch")
+        sys.exit(1)
+
+# If requested, display the comparison ref and then exit.
+if args.display_compare_ref:
+    print(args.compare_ref)
+    sys.exit(0)
+
+# Log output
+logger.debug(f"comparing against ref: {args.compare_ref}")
+
+# Try to find the files changed since the reference ref.
+if args.include_uncommitted:
+    if args.target_ref != "HEAD":
+        logger.error("cannot include uncommitted files when target ref is not HEAD")
+        sys.exit(1)
+
+    git_cmd = ["git", "diff-index", "--name-only", args.compare_ref]
+else:
+    git_cmd = ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", args.compare_ref, args.target_ref]
+
+result = subprocess.run(git_cmd, capture_output=True, check=True)
+changed_files = result.stdout.decode("utf-8").splitlines()
+
+# If requested, look for untracked files.
+if args.include_untracked:
+    # This is not compatible with a target ref other than HEAD.
+    if args.target_ref != "HEAD":
+        logger.error("cannot include untracked files when target ref is not HEAD")
+        sys.exit(1)
+
+    result = subprocess.run(["git", "ls-files", "--others", "--exclude-standard"], capture_output=True, check=True)
+    changed_files.extend(result.stdout.decode("utf-8").splitlines())
+
+# Identify any base dir filter.
+if args.spec_names_only:
+    base_dir = "SPECS/"
+elif args.extended_spec_names_only:
+    base_dir = "SPECS-EXTENDED/"
+else:
+    base_dir = None
+
+for changed_file in changed_files:
+    # If a base dir filter is provided, then apply it.
+    if base_dir is not None and not changed_file.startswith(base_dir):
+        continue
+
+    # If requested, filter out non-spec files.
+    if args.spec_names_only or args.extended_spec_names_only:
+        if not changed_file.endswith(".spec"):
+            continue
+
+        filename = os.path.basename(changed_file)
+        base_name = os.path.splitext(filename)[0]
+
+        print(base_name)
+    else:
+        print(changed_file)
+
+# Log output
+if args.verbose:
+    logger.debug(f"found {len(changed_files)} changed files")

--- a/toolkit/scripts/test_package_install.sh
+++ b/toolkit/scripts/test_package_install.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+
+set -e
+
+DAILY_BUILD_ID=""
+
+# parse script parameters:
+#
+# -p -> folder where built RPMs/SRPMs are published
+# -s -> packages to test for install and uninstall functionality
+# -i -> packages to not install
+# -u -> packages to not uninstall
+# -y -> daily build ID
+# -d -> dist tag
+# -v -> verbose output
+
+while getopts ":p:s:i:u:y:d:v" OPTIONS; do
+  case "${OPTIONS}" in
+    p ) RPM_DIRECTORY=$OPTARG;;
+    s ) RPMS_TO_INSTALL=${OPTARG//,/ } ;;
+    i ) PACKAGES_TO_NOT_INSTALL=${OPTARG//,/ } ;;
+    u ) PACKAGES_TO_NOT_UNINSTALL=${OPTARG//,/ } ;;
+    y ) DAILY_BUILD_ID=$OPTARG ;;
+    d ) DIST_TAG=$OPTARG ;;
+    v ) set -x ;;
+
+    \? )
+        echo "Error - Invalid Option: -$OPTARG" 1>&2
+        exit 1
+        ;;
+    : )
+        echo "Error - Invalid Option: -$OPTARG requires an argument" 1>&2
+        exit 1
+        ;;
+  esac
+done
+
+ARCHITECTURE=$(uname -p)
+
+# Determine LKG_BASE_URL
+if [[ -n $DAILY_BUILD_ID &&
+      $DAILY_BUILD_ID == "latest" &&
+      $DIST_TAG == ".azl3" ]]; then
+    echo "Determine LKG_BASE_URL directly from lkg-3.0-dev.json"
+    wget -nv https://mariner3dailydevrepo.blob.core.windows.net/lkg/lkg-3.0-dev.json
+    LKG_BASE_URL=$(cat lkg-3.0-dev.json | jq -r .repo.$ARCHITECTURE)
+else
+    echo "Determine LKG_BASE_URL from provided DAILY_BUILD_ID"
+    if [[ $ARCHITECTURE == "x86_64" ]]; then
+        DAILY_BUILD_ARCH="-x86-64"
+    else
+        DAILY_BUILD_ARCH="-aarch64"
+    fi
+    LKG_BASE_URL=https://mariner3dailydevrepo.blob.core.windows.net/daily-repo-$DAILY_BUILD_ID$DAILY_BUILD_ARCH
+fi
+
+echo "---------------------------------------------------------------"
+echo "-- Install packages in provided folder --"
+echo "---------------------------------------------------------------"
+echo "-- RPM_DIRECTORY                            -> $RPM_DIRECTORY"
+echo "-- RPMS_TO_INSTALL                          -> $RPMS_TO_INSTALL"
+echo "-- LKG_BASE_URL                             -> '$LKG_BASE_URL'"
+echo "-- DAILY_BUILD_ID                           -> '$DAILY_BUILD_ID'"
+echo "-- DAILY_BUILD_ARCH                         -> '$DAILY_BUILD_ARCH'"
+echo "-- DIST_TAG                                 -> '$DIST_TAG'"
+echo "-- PACKAGES_TO_NOT_INSTALL                  -> $PACKAGES_TO_NOT_INSTALL"
+echo "-- PACKAGES_TO_NOT_UNINSTALL                -> $PACKAGES_TO_NOT_UNINSTALL"
+echo ""
+
+echo "##[debug]Installing these space separated packages:"
+echo "$RPMS_TO_INSTALL"
+echo ""
+
+RPMS_TO_INSTALL=($RPMS_TO_INSTALL)
+PACKAGES_TO_NOT_INSTALL=($PACKAGES_TO_NOT_INSTALL)
+PACKAGES_TO_NOT_UNINSTALL=($PACKAGES_TO_NOT_UNINSTALL)
+
+
+exists_in_list() {
+    local VALUE=$1
+    shift
+    local LIST=("$@")
+
+    for x in "${LIST[@]}"; do
+        if [ "$x" = "$VALUE" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Add built packages as a local repo for tdnf
+sudo createrepo --compatibility "$RPM_DIRECTORY"
+
+repo_content=$(cat << EOF
+[builtpackages]
+name=Local Built Packages($ARCHITECTURE)
+baseurl=file://$RPM_DIRECTORY
+enabled=1
+priority=0
+skip_if_unavailable=True
+enabled=1
+EOF
+)
+
+# create the repo metadata file
+echo "$repo_content" | sudo tee /etc/yum.repos.d/builtpackages.repo > /dev/null
+
+echo "##[debug]Created repo file with content:"
+sudo cat /etc/yum.repos.d/builtpackages.repo
+echo ""
+
+# Add daily 3.0 repo if available
+repo_content_daily=$(cat << EOF
+[daily3]
+name=Daily 3.0 repo
+baseurl=$LKG_BASE_URL
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY file:///etc/pki/rpm-gpg/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+skip_if_unavailable=True
+sslverify=0
+EOF
+)
+
+if [[ $DIST_TAG == ".azl3" ]]; then
+    echo "$repo_content_daily" | sudo tee /etc/yum.repos.d/daily3.repo > /dev/null
+    echo "##[debug]Created daily repo file with content:"
+    sudo cat /etc/yum.repos.d/daily3.repo
+    echo ""
+else
+    echo "Mariner 3.0 was not detected, so skipping daily repo setup"
+fi
+
+# update the cached binary metadata.
+sudo tdnf makecache
+
+sudo tdnf repolist --refresh
+
+PACKAGES_FAIL_INSTALL=()
+PACKAGES_FAIL_UNINSTALL=()
+
+for rpm_to_install in "${RPMS_TO_INSTALL[@]}"; do
+    path_to_rpm=$(find $RPM_DIRECTORY -name "$rpm_to_install")
+    package_name_to_install=$(rpm -qp --queryformat "%{name}" "$path_to_rpm" 2>/dev/null)
+
+    if exists_in_list "$package_name_to_install" "${PACKAGES_TO_NOT_INSTALL[@]}"; then
+        echo "##[debug]Skipping package $package_name_to_install for installation test"
+        continue
+    fi
+
+    echo "------------------------------------------------"
+    echo "About to tdnf install package '$package_name_to_install' ('$rpm_to_install')"
+    # we are using package files instead of names to include subpackages produces with %{name}-{subpackage_name}
+    if ! sudo tdnf install -y "$path_to_rpm"; then
+        PACKAGES_FAIL_INSTALL+=("$package_name_to_install")
+        # package did not install, skip uninstall test
+        echo "The following package failed to install: '$package_name_to_install'"
+        continue
+    fi
+
+    if exists_in_list "$package_name_to_install" "${PACKAGES_TO_NOT_UNINSTALL[@]}"; then
+        echo "##[debug]Skipping package $package_name_to_install for uninstallation test"
+        continue
+    fi
+
+    # tdnf cannot accept the package rpm for uninstalling, only name. So we cannot test uninstalling of subpackages
+    echo "About to tdnf remove package '$package_name_to_install'"
+    if ! sudo tdnf remove -y "$package_name_to_install"; then
+        PACKAGES_FAIL_UNINSTALL+=("$package_name_to_install")
+    fi
+    echo ""
+    echo ""
+done
+
+echo ""
+echo "------------------------------------------------"
+echo "-- Printing install + uninstall error details --"
+echo "------------------------------------------------"
+echo ""
+
+if [ "${#PACKAGES_FAIL_INSTALL[@]}" -gt 0 ]; then
+    echo "##vso[task.logissue type=error]Error, ${#PACKAGES_FAIL_INSTALL[@]} packages failed to install, check logs to see the list"
+    echo "Failed installed packages:"
+    echo "${PACKAGES_FAIL_INSTALL[@]}"
+    echo ""
+fi
+
+if [ "${#PACKAGES_FAIL_UNINSTALL[@]}" -gt 0 ]; then
+    echo "##vso[task.logissue type=error]Error, ${#PACKAGES_FAIL_UNINSTALL[@]} packages failed to uninstall, check logs to see the list"
+    echo "Failed installed packages:"
+    echo "${PACKAGES_FAIL_UNINSTALL[@]}"
+fi
+
+if [[ "${#PACKAGES_FAIL_UNINSTALL[@]}" -gt 0 || "${#PACKAGES_FAIL_INSTALL[@]}" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
###### Summary
This is the first step toward "buddy build" validation workflows that run via GitHub actions. At present it is a manual workflow, executed via `workflow_dispatch`, and only builds changed specs and attempts to install the built packages. After its gotten some broader testing and use, I expect that the next step will be to enable it all pull requests into `3.0-dev`. Beyond that, some work may be needed to adapt it for other branches or events.

The draft PR that this came from (#11019) continues beyond this and runs and reports on package tests as well, also handling expected failures.

###### Change Log 
* Adds new 'Spec Build/Test' action (not run by default).
* Adds new helper script `detect_changes.py`, based on inline logic available in other GitHub PR checks. I further extended the logic so that it could be usable in local dev environments, both for testing and for similar functionality.
* Ports existing `test_package_install.sh` script from private repos, enabling reuse of logic to test install/uninstall of the built packages.

###### Does this affect the toolchain?
n/a

###### Test Methodology
Validated in my GitHub fork of this repo. For a sample run:

https://github.com/reubeno/azurelinux/actions/runs/12146627411

![image](https://github.com/user-attachments/assets/2f4d364f-16be-4e2c-bbad-c7f69a1621ca)

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge