### PR TITLE
fix: ISO installer encrypted root doesn't boot

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -32,6 +32,8 @@ var (
 	DefaultMkfsOptions = map[string][]string{
 		"ext2": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr"},
 		"ext3": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal"},
+		// grub2 doesn't recognize ext4 with metadata_csum_seed enabled
+		// ^metadata_csum_seed disables filesystem to store the metadata checksum seed in the superblock, hence disables changing uuid of mounted filesystem
 		"ext4": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize,^metadata_csum_seed"},
 	}
 

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -32,7 +32,7 @@ var (
 	DefaultMkfsOptions = map[string][]string{
 		"ext2": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr"},
 		"ext3": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal"},
-		"ext4": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize"},
+		"ext4": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize,^metadata_csum_seed"},
 	}
 
 	partedVersionRegex = regexp.MustCompile(`^parted \(GNU parted\) (\d+)\.(\d+)`)

--- a/toolkit/tools/imagegen/diskutils/encryption.go
+++ b/toolkit/tools/imagegen/diskutils/encryption.go
@@ -173,8 +173,16 @@ func encryptRootPartition(partDevPath string, partition configuration.Partition,
 		return
 	}
 
+	mkfsOptions, ok := DefaultMkfsOptions[partition.FsType]
+	if !ok {
+		mkfsOptions = []string{}
+	}
+	mkfsArgs := []string{"-t", partition.FsType}
+	mkfsArgs = append(mkfsArgs, mkfsOptions...)
+	mkfsArgs = append(mkfsArgs, fullMappedPath)
+
 	// Create the file system
-	_, stderr, err = shell.Execute("mkfs", "-t", partition.FsType, fullMappedPath)
+	_, stderr, err = shell.Execute("mkfs", mkfsArgs...)
 	if err != nil {
 		err = fmt.Errorf("failed to mkfs for partition (%v):\n%v\n%w", partDevPath, stderr, err)
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Resolves [[Core][ISO][3.0] ISO installer encrypted root doesn't boot](https://microsoft.visualstudio.com/OS/_workitems/edit/54417272)
Cause: [Grub does not recognize ext4 partition with certain features enabled](https://badrpc.net/20230728-grub-does-not-recognise-ext4/)
![image](https://github.com/user-attachments/assets/ef75fd9b-03da-4d45-9b3f-a54051c906c1)
![image](https://github.com/user-attachments/assets/1edc2b33-2abc-4507-8e48-50ba74393727)
![image](https://github.com/user-attachments/assets/0e102b98-35a4-4532-9cb1-ed0445c51c45)


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disable unsupported mkfs option for creating partitions

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=688906&view=results
- Fixed ISO Link for testing (use with disabled secure boot, this is not prod image): https://artprodwus21.artifacts.visualstudio.com/A4e58110d-cc16-4704-a98b-bec4860aaa10/36d030d6-1d99-4ebd-878b-09af1f4f722f/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL21hcmluZXItb3JnL3Byb2plY3RJZC8zNmQwMzBkNi0xZDk5LTRlYmQtODc4Yi0wOWFmMWY0ZjcyMmYvYnVpbGRJZC82ODg5MDYvYXJ0aWZhY3ROYW1lL2Ryb3BfYnVpbGRfcnBtc19idWlsZA2/content?format=file&subPath=%2Fbuild-artifacts%2Ffull_iso%2Ffull-3.0.20241205.iso