### PR TITLE
Cloud-init add module-setup.sh azure module for dracut to run

### DIFF
--- a/SPECS/cloud-init/cloud-init.signatures.json
+++ b/SPECS/cloud-init/cloud-init.signatures.json
@@ -1,6 +1,7 @@
 {
  "Signatures": {
   "10-azure-kvp.cfg": "79e0370c010be5cd4717960e4b414570c9ec6e6d29aede77ccecc43d2b03bb9a",
-  "cloud-init-23.3.tar.gz": "1a5a54369f78891b79f43061c1ff0fb31e2bd74ff9527d7150ddd6517c3e2b07"
+  "cloud-init-23.3.tar.gz": "1a5a54369f78891b79f43061c1ff0fb31e2bd74ff9527d7150ddd6517c3e2b07",
+  "module-setup.sh": "aee825f849ce35a5a178cf095c2b9c46e586d50082f681d7f8d2c5d769c2f592"
  }
 }

--- a/SPECS/cloud-init/module-setup.sh
+++ b/SPECS/cloud-init/module-setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+# called by dracut
+check() {
+   return 0
+}
+# called by dracut
+depends() {
+   return 0
+}
+# called by dracut to make sure 66-azure-ephemeral.rules is installed 
+install() {
+   inst_multiple cut readlink
+   inst_rules 66-azure-ephemeral.rules
+}
+


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add a new module-setup.sh azure module for dracut to consume to make sure 66-azure-ephemeral.rules is applied beforehand. Dracut is used to create initramfs and 66-azure-ephemeral.rules is provided by cloud-init.
This script is to prevent an intermittent issue where ephemeral disk not being formatted by cloud-init on Azure due to possibly racing condition due to ephemeral resource disk does not exist.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add module-setup.sh azure module and install it under dracut modules. Path for install: /usr/lib/dracut/modules.d/99azure-cloud


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 54009131](https://microsoft.visualstudio.com/OS/_workitems/edit/54009131)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Azure provisioning test. Verify script installed in /usr/lib/dracut/modules.d/99azure-cloud and cloud-init status is ok
- Local package and image build with RUN_CHECK=y.
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=692112&view=results
