### PR TITLE
Fix issue when version pinning packages that are checked by the configvalidator tool

### DIFF
--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -115,6 +115,7 @@ func validatePackages(config configuration.Config) (err error) {
 
 	const (
 		validateError     = "failed to validate package lists in config"
+		kernelPkgName     = "kernel"
 		dracutFipsPkgName = "dracut-fips"
 		fipsKernelCmdLine = "fips=1"
 		userAddPkgName    = "shadow-utils"
@@ -141,6 +142,10 @@ func validatePackages(config configuration.Config) (err error) {
 			pkgVer, err := pkgjson.PackageStringToPackageVer(pkg)
 			if err != nil {
 				return fmt.Errorf("%s: %w", validateError, err)
+			}
+
+			if pkgVer.Name == kernelPkgName {
+				return fmt.Errorf("%s: kernel should not be included in a package list, add via config file's [KernelOptions] entry", validateError)
 			}
 			if pkgVer.Name == dracutFipsPkgName {
 				foundDracutFipsPackage = true

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
@@ -164,6 +164,20 @@ func TestValidationAgainstTestConfig(t *testing.T) {
 			expectedError1: "failed to validate package lists in config: the 'shadow-utils' package must be included in the package lists when the image is configured to add users or groups",
 			expectedError2: "",
 		},
+
+		{
+			name:          "Shadowutils pinned version with whitespace",
+			extraListPath: "./testdata/pinned-shadowutils-ws-list.json",
+			configModifier: func(config *configuration.Config) {
+				config.SystemConfigs[0].Users = []configuration.User{
+					{
+						Name: "testuser",
+					},
+				}
+			},
+			expectedError1: "failed to validate package lists in config: the 'shadow-utils' package must be included in the package lists when the image is configured to add users or groups",
+			expectedError2: "",
+		},
 		{
 			name:           "missing package list",
 			extraListPath:  "./testdata/not-a-real-list.json",

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator_test.go
@@ -74,7 +74,7 @@ func TestShouldFailEmptySystemConfig(t *testing.T) {
 	assert.Equal(t, "invalid [SystemConfigs]:\nmissing [Name] field", err.Error())
 }
 
-func TestSELinuxRequiresSELinuxPacakgeInline(t *testing.T) {
+func TestSELinuxRequiresSELinuxPackageInline(t *testing.T) {
 	const (
 		configDirectory = "./testdata/"
 		targetConfig    = "test-config.json"

--- a/toolkit/tools/imageconfigvalidator/testdata/bogus-list.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/bogus-list.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "bad package = bad < version"
+    ]
+}

--- a/toolkit/tools/imageconfigvalidator/testdata/dummy-list.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/dummy-list.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "words"
+    ]
+}

--- a/toolkit/tools/imageconfigvalidator/testdata/fips-list.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/fips-list.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "dracut-fips"
+    ]
+}

--- a/toolkit/tools/imageconfigvalidator/testdata/pinned-shadowutils-list.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/pinned-shadowutils-list.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "shadow-utils=some-version"
+    ]
+}

--- a/toolkit/tools/imageconfigvalidator/testdata/pinned-shadowutils-ws-list.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/pinned-shadowutils-ws-list.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "shadow-utils = some-version"
+    ]
+}

--- a/toolkit/tools/imageconfigvalidator/testdata/selinux-policy-list.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/selinux-policy-list.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "selinux-policy"
+    ]
+}

--- a/toolkit/tools/imageconfigvalidator/testdata/shadowutils-list.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/shadowutils-list.json
@@ -1,0 +1,5 @@
+{
+    "packages": [
+        "shadow-utils"
+    ]
+}

--- a/toolkit/tools/imageconfigvalidator/testdata/test-config.json
+++ b/toolkit/tools/imageconfigvalidator/testdata/test-config.json
@@ -1,0 +1,59 @@
+{
+
+    "_comment": "Based on core-efi.json",
+
+    "Disks": [
+        {
+            "PartitionTableType": "gpt",
+            "MaxSize": 4096,
+            "Artifacts": [
+                {
+                    "Name": "test",
+                    "Type": "vhdx"
+                }
+            ],
+            "Partitions": [
+                {
+                    "ID": "boot",
+                    "Flags": [
+                        "esp",
+                        "boot"
+                    ],
+                    "Start": 1,
+                    "End": 9,
+                    "FsType": "fat32"
+                },
+                {
+                    "ID": "rootfs",
+                    "Start": 9,
+                    "End": 0,
+                    "FsType": "ext4"
+                }
+            ]
+        }
+    ],
+    "SystemConfigs": [
+        {
+            "Name": "Standard",
+            "BootType": "efi",
+            "PartitionSettings": [
+                {
+                    "ID": "boot",
+                    "MountPoint": "/boot/efi",
+                    "MountOptions" : "umask=0077"
+                },
+                {
+                    "ID": "rootfs",
+                    "MountPoint": "/"
+                }
+            ],
+            "PackageLists": [
+                "dummy-list.json"
+            ],
+            "KernelOptions": {
+                "default": "kernel"
+            },
+            "Hostname": "azurelinux"
+        }
+    ]
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Several features require specific packages also be installed to function (selinux, fips, etc.). One of these is `shadow-utils` which is needed for user changes.

We also have an undocumented feature where you can pin packages to specific versions in a package list via "pkg-name = 1.2.3-4". These two features conflict with each other since the validator assumed only basic package names would be used.

Also flesh out the unit tests a bit for the validator and rely less on using the built-in configs and instead use a dedicated test config file.

There is a limitation however, we cannot distinguish between `pkg-long-name` and `pkg-version-release` even though tdnf will accept that, so that will still be passed to the check verbatim and will fail. The form `pkg = version-release` should be used instead.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Support version pinning in image configs for validated packages (selinux, fips, shadow-utils).
- Fix up the validator unit tests

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_queries/edit/55399616/?triage=true

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local testing, including against customer's config
- pipeline https://dev.azure.com/mariner-org/mariner/_build/results?buildId=695490&view=results
