### PR TITLE
[AUTO-CHERRYPICK] telegraf: patch CVE-2024-45337 - branch 3.0-dev

### DIFF
--- a/SPECS/telegraf/CVE-2024-45337.patch
+++ b/SPECS/telegraf/CVE-2024-45337.patch
@@ -1,0 +1,77 @@
+https://github.com/golang/crypto/commit/b4f1988a35dee11ec3e05d6bf3e90b695fbd8909.patch
+
+From b4f1988a35dee11ec3e05d6bf3e90b695fbd8909 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 3 Dec 2024 09:03:03 -0800
+Subject: [PATCH] ssh: make the public key cache a 1-entry FIFO cache
+
+Users of the the ssh package seem to extremely commonly misuse the
+PublicKeyCallback API, assuming that the key passed in the last call
+before a connection is established is the key used for authentication.
+Some users then make authorization decisions based on this key. This
+property is not documented, and may not be correct, due to the caching
+behavior of the package, resulting in users making incorrect
+authorization decisions about the connection.
+
+This change makes the cache a one entry FIFO cache, making the assumed
+property, that the last call to PublicKeyCallback represents the key
+actually used for authentication, actually hold.
+
+Thanks to Damien Tournoud, Patrick Dawkins, Vince Parker, and
+Jules Duvivier from the Platform.sh / Upsun engineering team
+for reporting this issue.
+
+Fixes golang/go#70779
+Fixes CVE-2024-45337
+
+Change-Id: Ife7c7b4045d8b6bcd7e3a417bdfae370c709797f
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/635315
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Nicola Murino <nicola.murino@gmail.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/crypto/ssh/server.go      | 15 ++++++++++----
+
+diff --git a/vendor/golang.org/x/crypto/ssh/server.go b/vendor/golang.org/x/crypto/ssh/server.go
+index c0d1c29e6f..5b5ccd96f4 100644
+--- a/vendor/golang.org/x/crypto/ssh/server.go
++++ b/vendor/golang.org/x/crypto/ssh/server.go
+@@ -149,7 +149,7 @@ func (s *ServerConfig) AddHostKey(key Signer) {
+ }
+
+ // cachedPubKey contains the results of querying whether a public key is
+-// acceptable for a user.
++// acceptable for a user. This is a FIFO cache.
+ type cachedPubKey struct {
+ 	user       string
+ 	pubKeyData []byte
+@@ -157,7 +157,13 @@ type cachedPubKey struct {
+ 	perms      *Permissions
+ }
+
+-const maxCachedPubKeys = 16
++// maxCachedPubKeys is the number of cache entries we store.
++//
++// Due to consistent misuse of the PublicKeyCallback API, we have reduced this
++// to 1, such that the only key in the cache is the most recently seen one. This
++// forces the behavior that the last call to PublicKeyCallback will always be
++// with the key that is used for authentication.
++const maxCachedPubKeys = 1
+
+ // pubKeyCache caches tests for public keys.  Since SSH clients
+ // will query whether a public key is acceptable before attempting to
+@@ -179,9 +185,10 @@ func (c *pubKeyCache) get(user string, pubKeyData []byte) (cachedPubKey, bool) {
+
+ // add adds the given tuple to the cache.
+ func (c *pubKeyCache) add(candidate cachedPubKey) {
+-	if len(c.keys) < maxCachedPubKeys {
+-		c.keys = append(c.keys, candidate)
++	if len(c.keys) >= maxCachedPubKeys {
++		c.keys = c.keys[1:]
+ 	}
++	c.keys = append(c.keys, candidate)
+ }
+
+ // ServerConn is an authenticated SSH connection, as seen from the

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.31.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,7 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.
 # Use the generate_source_tarbbal.sh script to get the vendored sources.
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2024-37298.patch
+Patch1:         CVE-2024-45337.patch
 BuildRequires:  golang
 BuildRequires:  systemd-devel
 Requires:       logrotate
@@ -77,6 +78,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Wed Dec 18 2024 Aurelien Bombo <abombo@microsoft.com> - 1.31.0-3
+- Patch CVE-2024-45337
+
 * Thu Jul 11 2024 Sumedh Sharma <sumsharma@microsoft.com> - 1.31.0-2
 - Add patch for CVE-2024-37298
 


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit f2ca49d0e57ff86d1ff5d03fed700214362d3a84 to 3.0-dev. Original PR: #11526