### PR TITLE
Made `PackageBuild.yml` accept arbitrary input sources.

### DIFF
--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -80,9 +80,11 @@ extends:
                       # GCC fails to build as a regular package.
                       ignoredSpecs: ["gcc"]
 
-                  - script: echo "##vso[task.setvariable variable=toolchainArtifactName;isOutput=true]$(ob_artifactBaseName)"
+                  - script: |
+                      echo "##vso[task.setvariable variable=toolchainArtifactName;isOutput=true]$(ob_artifactBaseName)"
+                      echo "##vso[task.setvariable variable=toolchainTarballName;isOutput=true]toolchain_built_rpms_all.tar.gz"
                     name: "ToolchainArtifactName"
-                    displayName: "Set variable for published artifact name"
+                    displayName: "Set variables for published toolchain tarball"
 
                   # 1. Automatic publishing won't work if 'isCustom: true' is set on the pool. We cannot do 'isCustom: false' because
                   #    then OneBranch attempts to perform additional actions (adding build tags for instance), which require additional permissions
@@ -107,11 +109,20 @@ extends:
                   ob_artifactBaseName: $(rpmsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   toolchainArtifactName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainArtifactName'] ]
+                  toolchainTarballName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainTarballName'] ]
                 steps:
+                  - task: DownloadPipelineArtifact@2
+                    displayName: "Download toolchain"
+                    inputs:
+                      artifact: $(toolchainArtifactName)
+                      patterns: "**/$(toolchainTarballName)"
+                      targetPath: $(Agent.TempDirectory)
+
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
                       checkBuildRetries: "1"
-                      customToolchainArtifactName: $(toolchainArtifactName)
+                      customToolchainTarballName: $(toolchainTarballName)
+                      inputArtifactsFolder: $(Agent.TempDirectory)
                       isCheckBuild: true
                       isQuickRebuildPackages: true
                       isUseCCache: true
@@ -146,11 +157,20 @@ extends:
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
                   toolchainArtifactName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainArtifactName'] ]
+                  toolchainTarballName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainTarballName'] ]
                 steps:
+                  - task: DownloadPipelineArtifact@2
+                    displayName: "Download toolchain"
+                    inputs:
+                      artifact: $(toolchainArtifactName)
+                      patterns: "**/$(toolchainTarballName)"
+                      targetPath: $(Agent.TempDirectory)
+
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
                       checkBuildRetries: "1"
-                      customToolchainArtifactName: $(toolchainArtifactName)
+                      customToolchainTarballName: $(toolchainTarballName)
+                      inputArtifactsFolder: $(Agent.TempDirectory)
                       isAllowToolchainRebuilds: true
                       isCheckBuild: true
                       isQuickRebuildPackages: true

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -106,6 +106,7 @@ extends:
                   isCustom: true
                   name: ${{ configuration.agentPool }}
                 variables:
+                  inputArtifactsLocation: $(Agent.TempDirectory)
                   ob_artifactBaseName: $(rpmsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   outputRPMsTarballName: "rpms.tar.gz"
@@ -117,13 +118,13 @@ extends:
                     inputs:
                       artifact: $(toolchainArtifactName)
                       patterns: "**/$(toolchainTarballName)"
-                      targetPath: $(Agent.TempDirectory)
+                      targetPath: $(inputArtifactsLocation)
 
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
                       checkBuildRetries: "1"
                       customToolchainTarballName: $(toolchainTarballName)
-                      inputArtifactsFolder: $(Agent.TempDirectory)
+                      inputArtifactsFolder: $(inputArtifactsLocation)
                       isCheckBuild: true
                       isQuickRebuildPackages: true
                       isUseCCache: true
@@ -157,6 +158,7 @@ extends:
                   isCustom: true
                   name: ${{ configuration.agentPool }}
                 variables:
+                  inputArtifactsLocation: $(Agent.TempDirectory)
                   ob_artifactBaseName: $(toolchainTestsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                   testListFromToolchain: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['CalculateToolchainPackageRetestList.toolchainPackageRetestList'] ]
@@ -168,13 +170,13 @@ extends:
                     inputs:
                       artifact: $(toolchainArtifactName)
                       patterns: "**/$(toolchainTarballName)"
-                      targetPath: $(Agent.TempDirectory)
+                      targetPath: $(inputArtifactsLocation)
 
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
                       checkBuildRetries: "1"
                       customToolchainTarballName: $(toolchainTarballName)
-                      inputArtifactsFolder: $(Agent.TempDirectory)
+                      inputArtifactsFolder: $(inputArtifactsLocation)
                       isAllowToolchainRebuilds: true
                       isCheckBuild: true
                       isQuickRebuildPackages: true

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -108,6 +108,7 @@ extends:
                 variables:
                   ob_artifactBaseName: $(rpmsArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
+                  outputRPMsTarballName: "rpms.tar.gz"
                   toolchainArtifactName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainArtifactName'] ]
                   toolchainTarballName: $[ stageDependencies.Toolchain_${{ configuration.name }}.Build.outputs['ToolchainArtifactName.toolchainTarballName'] ]
                 steps:
@@ -128,11 +129,14 @@ extends:
                       isUseCCache: true
                       maxCPU: "${{ configuration.maxCPUs }}"
                       outputArtifactsFolder: $(ob_outputDirectory)
+                      outputRPMsTarballName: $(outputRPMsTarballName)
                       pipArtifactFeeds: "mariner/Mariner-Pypi-Feed"
                       selfRepoName: self
                       testSuiteName: "[${{ configuration.name }}] Package test"
 
-                  - script: echo "##vso[task.setvariable variable=rpmsArtifactName;isOutput=true]$(ob_artifactBaseName)"
+                  - script: |
+                      echo "##vso[task.setvariable variable=rpmsArtifactName;isOutput=true]$(ob_artifactBaseName)"
+                      echo "##vso[task.setvariable variable=rpmsTarballName;isOutput=true]$(outputRPMsTarballName)"
                     name: "RPMsArtifactName"
                     displayName: "Set variable for published artifact name"
 
@@ -199,8 +203,18 @@ extends:
                   isCustom: true
                   name: ${{ configuration.agentPool }}
                 variables:
+                  inputArtifactsLocation: $(Agent.TempDirectory)
                   rpmsArtifactName: $[ stageDependencies.RPMs_${{ configuration.name }}.BuildAndTest.outputs['RPMsArtifactName.rpmsArtifactName'] ]
+                  rpmsTarballName: $[ stageDependencies.RPMs_${{ configuration.name }}.BuildAndTest.outputs['RPMsArtifactName.rpmsTarballName'] ]
                 steps:
+                  - task: DownloadPipelineArtifact@2
+                    displayName: "Download RPMs tarball"
+                    inputs:
+                      artifact: $(rpmsArtifactName)
+                      patterns: "**/$(rpmsTarballName)"
+                      targetPath: $(inputArtifactsLocation)
+
                   - template: .pipelines/templatesWithCheckout/SodiffCheck.yml@self
                     parameters:
-                      inputArtifactName: $(rpmsArtifactName)
+                      inputArtifactsFolder: $(inputArtifactsLocation)
+                      inputRPMsTarballName: $(rpmsTarballName)

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -14,13 +14,9 @@ parameters:
     type: number
     default: 12
 
-  - name: customToolchainArtifactName
-    type: string
-    default: ""
-
   - name: customToolchainTarballName
     type: string
-    default: "toolchain_built_rpms_all.tar.gz"
+    default: ""
 
   - name: extraPackageRepos
     type: string
@@ -30,12 +26,16 @@ parameters:
     type: boolean
     default: true
 
-  - name: inputCacheArtifacts
+  - name: inputArtifactsFolder
+    type: string
+    default: "$(Agent.TempDirectory)"
+
+  - name: inputCacheRPMsTarballs
     type: object
     default: []
     # Sample:
-    # - name: build-artifacts
-    #   rpmsTarball: cache.tar.gz
+    #   - cache.tar.gz
+    #   - cache2.tar.gz
 
   - name: isAllowToolchainRebuilds
     type: string
@@ -160,15 +160,9 @@ steps:
           artifactFeeds: "${{ parameters.pipArtifactFeeds }}"
         displayName: "Authenticate to custom pip artifact feeds"
 
-  - ${{ if parameters.customToolchainArtifactName }}:
-      - task: DownloadPipelineArtifact@2
-        displayName: "Download toolchain"
-        inputs:
-          artifact: "${{ parameters.customToolchainArtifactName }}"
-          patterns: "**/${{ parameters.customToolchainTarballName }}"
-
+  - ${{ if parameters.customToolchainTarballName }}:
       - script: |
-          toolchain_archive="$(find "$(Pipeline.Workspace)" -name "${{ parameters.customToolchainTarballName }}" -print -quit)"
+          toolchain_archive="$(find "${{ parameters.inputArtifactsFolder }}" -name "${{ parameters.customToolchainTarballName }}" -print -quit)"
           if [[ ! -f "$toolchain_archive" ]]; then
             echo "ERROR: toolchain archive not found!" >&2
             exit 1
@@ -178,17 +172,11 @@ steps:
           sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" toolchain TOOLCHAIN_ARCHIVE="$toolchain_archive"
         displayName: "Populate toolchain"
 
-  - ${{ each inputCacheArtifact in parameters.inputCacheArtifacts }}:
-      - task: DownloadPipelineArtifact@2
-        displayName: "Download input cache RPM from ${{ inputCacheArtifact.name }}"
-        inputs:
-          artifact: "${{ inputCacheArtifact.name }}"
-          patterns: "**/${{ inputCacheArtifact.rpmsTarball }}"
-
+  - ${{ each inputCacheRPMsTarball in parameters.inputCacheRPMsTarballs }}:
       - script: |
-          rpms_archive="$(find "$(Pipeline.Workspace)" -name "${{ inputCacheArtifact.rpmsTarball }}" -print -quit)"
+          rpms_archive="$(find "${{ parameters.inputArtifactsFolder }}" -name "${{ inputCacheRPMsTarball }}" -print -quit)"
           if [[ ! -f "$rpms_archive" ]]; then
-            echo "ERROR: cache RPMs archive '${{ inputCacheArtifact.rpmsTarball }}' not found!" >&2
+            echo "ERROR: cache RPMs archive '${{ inputCacheRPMsTarball }}' not found!" >&2
             exit 1
           fi
 
@@ -200,7 +188,7 @@ steps:
         check_build_retries_arg="CHECK_BUILD_RETRIES=${{ parameters.checkBuildRetries }}"
       fi
 
-      if [[ -n "${{ parameters.customToolchainArtifactName }}" ]]; then
+      if [[ -n "${{ parameters.customToolchainTarballName }}" ]]; then
         toolchain_archive_arg="TOOLCHAIN_ARCHIVE=$(toolchainArchive)"
       fi
 

--- a/.pipelines/templatesWithCheckout/SodiffCheck.yml
+++ b/.pipelines/templatesWithCheckout/SodiffCheck.yml
@@ -6,8 +6,9 @@ parameters:
     type: string
     default: "$(Build.SourcesDirectory)"
 
-  - name: inputArtifactName
+  - name: inputArtifactsFolder
     type: string
+    default: "$(Agent.TempDirectory)"
 
   - name: inputRPMsTarballName
     type: string
@@ -26,19 +27,11 @@ parameters:
     default: "$(Agent.TempDirectory)/SourcesWorkspace"
 
 steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: "Download sources for signing"
-    inputs:
-      artifact: ${{ parameters.inputArtifactName }}
-      patterns: |
-        **/${{ parameters.inputRPMsTarballName }}
-      targetPath: "$(Agent.TempDirectory)"
-
   - script: |
       set -e
 
       mkdir -p "${{ parameters.sourcesWorkspace }}"
-      find "$(Agent.TempDirectory)" -name "${{ parameters.inputRPMsTarballName }}" -print0 | xargs -0 -n 1 tar -C "${{ parameters.sourcesWorkspace }}" -xkf
+      find "${{ parameters.inputArtifactsFolder }}" -name "${{ parameters.inputRPMsTarballName }}" -print0 | xargs -0 -n 1 tar -C "${{ parameters.sourcesWorkspace }}" -xkf
     displayName: "Extract sources tarball"
 
   - script: |


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Updating the `PackageBuild.yml` template to be agnostic about the source of the input tarballs. This way the callers have the freedom to store them as they see fit.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [PR check pipeline build.](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=704531&view=results)
- ADO fast-track dev builds.