### PR TITLE
[AUTO-CHERRYPICK] iptraf-ng: upgrade to 1.2.2 - branch main

### DIFF
--- a/SPECS/iptraf-ng/iptraf-ng.signatures.json
+++ b/SPECS/iptraf-ng/iptraf-ng.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "iptraf-ng-1.2.1.tar.gz": "9f5cef584065420dea1ba32c86126aede1fa9bd25b0f8362b0f9fd9754f00870",
+  "iptraf-ng-1.2.2.tar.gz": "75fd653745ea0705995c25e6c07b34252ecc2563c6a91b007a3a8c26f29cc252",
   "iptraf-ng-logrotate.conf": "c9c1f849fb04dceeff50aa3e2bd2c40f5e8656e00d1dabcde36e1e9dcfa7a1bb",
   "iptraf-ng-tmpfiles.conf": "cd9e13572be9836f8efe6fcea198ccffad97b1db7f97bf0133b7d477f9d65ed0"
  }

--- a/SPECS/iptraf-ng/iptraf-ng.spec
+++ b/SPECS/iptraf-ng/iptraf-ng.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Summary:        A console-based network monitoring utility
 Name:           iptraf-ng
-Version:        1.2.1
+Version:        1.2.2
 Release:        1%{?dist}
 Source0:        https://github.com/iptraf-ng/iptraf-ng/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        %{name}-logrotate.conf
@@ -70,6 +70,9 @@ install -d -m 0755 %{buildroot}/run/%{name}/
 %{_prefix}/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Thu Dec 19 2024 Andrew Phelps <anphel@microsoft.com> - 1.2.2-1
+- Upgrade to 1.2.2 to fix CVE-2024-52949
+
 * Tue Jun 21 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.2.1-1
 - Upgrading to fix build break and align with latest ncurses update.
 - License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7441,8 +7441,8 @@
         "type": "other",
         "other": {
           "name": "iptraf-ng",
-          "version": "1.2.1",
-          "downloadUrl": "https://github.com/iptraf-ng/iptraf-ng/archive/v1.2.1.tar.gz"
+          "version": "1.2.2",
+          "downloadUrl": "https://github.com/iptraf-ng/iptraf-ng/archive/v1.2.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit 574ad383aa465de5b37c9d24cf109d57c7d63cf0 to main. Original PR: #11568