### PR TITLE
[AUTO-CHERRYPICK] cf-cli, kubevirt, packer: patch CVE-2024-45337 - branch 3.0-dev

### DIFF
--- a/SPECS/cf-cli/CVE-2024-45337.patch
+++ b/SPECS/cf-cli/CVE-2024-45337.patch
@@ -1,0 +1,77 @@
+https://github.com/golang/crypto/commit/b4f1988a35dee11ec3e05d6bf3e90b695fbd8909.patch
+
+From b4f1988a35dee11ec3e05d6bf3e90b695fbd8909 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 3 Dec 2024 09:03:03 -0800
+Subject: [PATCH] ssh: make the public key cache a 1-entry FIFO cache
+
+Users of the the ssh package seem to extremely commonly misuse the
+PublicKeyCallback API, assuming that the key passed in the last call
+before a connection is established is the key used for authentication.
+Some users then make authorization decisions based on this key. This
+property is not documented, and may not be correct, due to the caching
+behavior of the package, resulting in users making incorrect
+authorization decisions about the connection.
+
+This change makes the cache a one entry FIFO cache, making the assumed
+property, that the last call to PublicKeyCallback represents the key
+actually used for authentication, actually hold.
+
+Thanks to Damien Tournoud, Patrick Dawkins, Vince Parker, and
+Jules Duvivier from the Platform.sh / Upsun engineering team
+for reporting this issue.
+
+Fixes golang/go#70779
+Fixes CVE-2024-45337
+
+Change-Id: Ife7c7b4045d8b6bcd7e3a417bdfae370c709797f
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/635315
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Nicola Murino <nicola.murino@gmail.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/crypto/ssh/server.go      | 15 ++++++++++----
+
+diff --git a/vendor/golang.org/x/crypto/ssh/server.go b/vendor/golang.org/x/crypto/ssh/server.go
+index c0d1c29e6f..5b5ccd96f4 100644
+--- a/vendor/golang.org/x/crypto/ssh/server.go
++++ b/vendor/golang.org/x/crypto/ssh/server.go
+@@ -142,7 +142,7 @@ func (s *ServerConfig) AddHostKey(key Signer) {
+ }
+
+ // cachedPubKey contains the results of querying whether a public key is
+-// acceptable for a user.
++// acceptable for a user. This is a FIFO cache.
+ type cachedPubKey struct {
+ 	user       string
+ 	pubKeyData []byte
+@@ -150,7 +150,13 @@ type cachedPubKey struct {
+ 	perms      *Permissions
+ }
+
+-const maxCachedPubKeys = 16
++// maxCachedPubKeys is the number of cache entries we store.
++//
++// Due to consistent misuse of the PublicKeyCallback API, we have reduced this
++// to 1, such that the only key in the cache is the most recently seen one. This
++// forces the behavior that the last call to PublicKeyCallback will always be
++// with the key that is used for authentication.
++const maxCachedPubKeys = 1
+
+ // pubKeyCache caches tests for public keys.  Since SSH clients
+ // will query whether a public key is acceptable before attempting to
+@@ -172,9 +178,10 @@ func (c *pubKeyCache) get(user string, pubKeyData []byte) (cachedPubKey, bool) {
+
+ // add adds the given tuple to the cache.
+ func (c *pubKeyCache) add(candidate cachedPubKey) {
+-	if len(c.keys) < maxCachedPubKeys {
+-		c.keys = append(c.keys, candidate)
++	if len(c.keys) >= maxCachedPubKeys {
++		c.keys = c.keys[1:]
+ 	}
++	c.keys = append(c.keys, candidate)
+ }
+
+ // ServerConn is an authenticated SSH connection, as seen from the

--- a/SPECS/cf-cli/cf-cli.spec
+++ b/SPECS/cf-cli/cf-cli.spec
@@ -5,7 +5,7 @@ Summary:        The official command line client for Cloud Foundry.
 Name:           cf-cli
 # Note: Upgrading the package also warrants an upgrade in the CF_BUILD_SHA
 Version:        8.7.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -33,6 +33,7 @@ Source0:        https://github.com/cloudfoundry/cli/archive/refs/tags/v%{version
 Source1:        cli-%{version}-vendor.tar.gz
 Patch0:         CVE-2023-39325.patch
 Patch1:         CVE-2024-24786.patch
+Patch2:         CVE-2024-45337.patch
 
 BuildRequires:  golang >= 1.18.3
 %global debug_package %{nil}
@@ -46,6 +47,7 @@ The official command line client for Cloud Foundry.
 tar --no-same-owner -xf %{SOURCE1}
 %patch 0 -p1
 %patch 1 -p1
+%patch 2 -p1
 
 %build
 export GOPATH=%{our_gopath}
@@ -67,6 +69,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./out/cf
 %{_bindir}/cf
 
 %changelog
+* Fri Dec 20 2024 Aurelien Bombo <abombo@microsoft.com> - 8.7.3-4
+- Add patch for CVE-2024-45337
+
 * Mon Nov 25 2024 Bala <balakumaran.kannan@microsoft.com> - 8.7.3-3
 - Fix CVE-2024-24786
 

--- a/SPECS/kubevirt/CVE-2024-45337.patch
+++ b/SPECS/kubevirt/CVE-2024-45337.patch
@@ -1,0 +1,77 @@
+https://github.com/golang/crypto/commit/b4f1988a35dee11ec3e05d6bf3e90b695fbd8909.patch
+
+From b4f1988a35dee11ec3e05d6bf3e90b695fbd8909 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 3 Dec 2024 09:03:03 -0800
+Subject: [PATCH] ssh: make the public key cache a 1-entry FIFO cache
+
+Users of the the ssh package seem to extremely commonly misuse the
+PublicKeyCallback API, assuming that the key passed in the last call
+before a connection is established is the key used for authentication.
+Some users then make authorization decisions based on this key. This
+property is not documented, and may not be correct, due to the caching
+behavior of the package, resulting in users making incorrect
+authorization decisions about the connection.
+
+This change makes the cache a one entry FIFO cache, making the assumed
+property, that the last call to PublicKeyCallback represents the key
+actually used for authentication, actually hold.
+
+Thanks to Damien Tournoud, Patrick Dawkins, Vince Parker, and
+Jules Duvivier from the Platform.sh / Upsun engineering team
+for reporting this issue.
+
+Fixes golang/go#70779
+Fixes CVE-2024-45337
+
+Change-Id: Ife7c7b4045d8b6bcd7e3a417bdfae370c709797f
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/635315
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Nicola Murino <nicola.murino@gmail.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/crypto/ssh/server.go      | 15 ++++++++++----
+
+diff --git a/vendor/golang.org/x/crypto/ssh/server.go b/vendor/golang.org/x/crypto/ssh/server.go
+index c0d1c29e6f..5b5ccd96f4 100644
+--- a/vendor/golang.org/x/crypto/ssh/server.go
++++ b/vendor/golang.org/x/crypto/ssh/server.go
+@@ -142,7 +142,7 @@ func (s *ServerConfig) AddHostKey(key Signer) {
+ }
+
+ // cachedPubKey contains the results of querying whether a public key is
+-// acceptable for a user.
++// acceptable for a user. This is a FIFO cache.
+ type cachedPubKey struct {
+ 	user       string
+ 	pubKeyData []byte
+@@ -150,7 +150,13 @@ type cachedPubKey struct {
+ 	perms      *Permissions
+ }
+
+-const maxCachedPubKeys = 16
++// maxCachedPubKeys is the number of cache entries we store.
++//
++// Due to consistent misuse of the PublicKeyCallback API, we have reduced this
++// to 1, such that the only key in the cache is the most recently seen one. This
++// forces the behavior that the last call to PublicKeyCallback will always be
++// with the key that is used for authentication.
++const maxCachedPubKeys = 1
+
+ // pubKeyCache caches tests for public keys.  Since SSH clients
+ // will query whether a public key is acceptable before attempting to
+@@ -172,9 +178,10 @@ func (c *pubKeyCache) get(user string, pubKeyData []byte) (cachedPubKey, bool) {
+
+ // add adds the given tuple to the cache.
+ func (c *pubKeyCache) add(candidate cachedPubKey) {
+-	if len(c.keys) < maxCachedPubKeys {
+-		c.keys = append(c.keys, candidate)
++	if len(c.keys) >= maxCachedPubKeys {
++		c.keys = c.keys[1:]
+ 	}
++	c.keys = append(c.keys, candidate)
+ }
+
+ // ServerConn is an authenticated SSH connection, as seen from the

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -20,7 +20,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        1.2.0
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -33,6 +33,7 @@ Source0:        https://github.com/kubevirt/kubevirt/archive/refs/tags/v%{versio
 Patch0:         Cleanup-housekeeping-cgroup-on-vm-del.patch
 Patch1:         CVE-2023-48795.patch
 Patch2:         CVE-2024-24786.patch
+Patch3:         CVE-2024-45337.patch
 %global debug_package %{nil}
 BuildRequires:  swtpm-tools
 BuildRequires:  glibc-devel
@@ -273,6 +274,9 @@ install -p -m 0644 cmd/virt-launcher/qemu.conf %{buildroot}%{_datadir}/kube-virt
 %{_bindir}/virt-tests
 
 %changelog
+* Fri Dec 20 2024 Aurelien Bombo <abombo@microsoft.com> - 1.2.0-11
+- Add patch for CVE-2024-45337
+
 * Mon Nov 25 2024 Bala <balakumaran.kannan@microsoft.com> - 1.2.0-10
 - Fix for CVE-2024-24786
 

--- a/SPECS/packer/CVE-2024-45337.patch
+++ b/SPECS/packer/CVE-2024-45337.patch
@@ -1,0 +1,77 @@
+https://github.com/golang/crypto/commit/b4f1988a35dee11ec3e05d6bf3e90b695fbd8909.patch
+
+From b4f1988a35dee11ec3e05d6bf3e90b695fbd8909 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 3 Dec 2024 09:03:03 -0800
+Subject: [PATCH] ssh: make the public key cache a 1-entry FIFO cache
+
+Users of the the ssh package seem to extremely commonly misuse the
+PublicKeyCallback API, assuming that the key passed in the last call
+before a connection is established is the key used for authentication.
+Some users then make authorization decisions based on this key. This
+property is not documented, and may not be correct, due to the caching
+behavior of the package, resulting in users making incorrect
+authorization decisions about the connection.
+
+This change makes the cache a one entry FIFO cache, making the assumed
+property, that the last call to PublicKeyCallback represents the key
+actually used for authentication, actually hold.
+
+Thanks to Damien Tournoud, Patrick Dawkins, Vince Parker, and
+Jules Duvivier from the Platform.sh / Upsun engineering team
+for reporting this issue.
+
+Fixes golang/go#70779
+Fixes CVE-2024-45337
+
+Change-Id: Ife7c7b4045d8b6bcd7e3a417bdfae370c709797f
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/635315
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Nicola Murino <nicola.murino@gmail.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/crypto/ssh/server.go      | 15 ++++++++++----
+
+diff --git a/vendor/golang.org/x/crypto/ssh/server.go b/vendor/golang.org/x/crypto/ssh/server.go
+index c0d1c29e6f..5b5ccd96f4 100644
+--- a/vendor/golang.org/x/crypto/ssh/server.go
++++ b/vendor/golang.org/x/crypto/ssh/server.go
+@@ -142,7 +142,7 @@ func (s *ServerConfig) AddHostKey(key Signer) {
+ }
+
+ // cachedPubKey contains the results of querying whether a public key is
+-// acceptable for a user.
++// acceptable for a user. This is a FIFO cache.
+ type cachedPubKey struct {
+ 	user       string
+ 	pubKeyData []byte
+@@ -150,7 +150,13 @@ type cachedPubKey struct {
+ 	perms      *Permissions
+ }
+
+-const maxCachedPubKeys = 16
++// maxCachedPubKeys is the number of cache entries we store.
++//
++// Due to consistent misuse of the PublicKeyCallback API, we have reduced this
++// to 1, such that the only key in the cache is the most recently seen one. This
++// forces the behavior that the last call to PublicKeyCallback will always be
++// with the key that is used for authentication.
++const maxCachedPubKeys = 1
+
+ // pubKeyCache caches tests for public keys.  Since SSH clients
+ // will query whether a public key is acceptable before attempting to
+@@ -172,9 +178,10 @@ func (c *pubKeyCache) get(user string, pubKeyData []byte) (cachedPubKey, bool) {
+
+ // add adds the given tuple to the cache.
+ func (c *pubKeyCache) add(candidate cachedPubKey) {
+-	if len(c.keys) < maxCachedPubKeys {
+-		c.keys = append(c.keys, candidate)
++	if len(c.keys) >= maxCachedPubKeys {
++		c.keys = c.keys[1:]
+ 	}
++	c.keys = append(c.keys, candidate)
+ }
+
+ // ServerConn is an authenticated SSH connection, as seen from the

--- a/SPECS/packer/packer.spec
+++ b/SPECS/packer/packer.spec
@@ -4,7 +4,7 @@
 Summary:        Tool for creating identical machine images for multiple platforms from a single source configuration.
 Name:           packer
 Version:        1.9.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -36,6 +36,7 @@ Patch1:         CVE-2022-3064.patch
 Patch2:         CVE-2023-49569.patch
 Patch3:         CVE-2024-6104.patch
 Patch4:         CVE-2024-24786.patch
+Patch5:         CVE-2024-45337.patch
 BuildRequires:  golang >= 1.17.1
 BuildRequires:  kernel-headers
 BuildRequires:  glibc-devel
@@ -69,6 +70,9 @@ go test -mod=vendor
 %{_bindir}/packer
 
 %changelog
+* Fri Dec 20 2024 Aurelien Bombo <abombo@microsoft.com> - 1.9.5-4
+- Add patch for CVE-2024-45337
+
 * Mon Nov 25 2024 Bala <balakumaran.kannan@microsoft.com> - 1.9.5-3
 - Patched CVE-2024-24786
 


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit 73bc2e1b27f805e6cee9e3bbd73b56af2446f0be to 3.0-dev. Original PR: #11620