### PR TITLE
[AUTO-CHERRYPICK] docker-buildx, moby-engine: patch CVE-2024-45337 - branch 3.0-dev

### DIFF
--- a/SPECS/docker-buildx/CVE-2024-45337.patch
+++ b/SPECS/docker-buildx/CVE-2024-45337.patch
@@ -1,0 +1,77 @@
+https://github.com/golang/crypto/commit/b4f1988a35dee11ec3e05d6bf3e90b695fbd8909.patch
+
+From b4f1988a35dee11ec3e05d6bf3e90b695fbd8909 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 3 Dec 2024 09:03:03 -0800
+Subject: [PATCH] ssh: make the public key cache a 1-entry FIFO cache
+
+Users of the the ssh package seem to extremely commonly misuse the
+PublicKeyCallback API, assuming that the key passed in the last call
+before a connection is established is the key used for authentication.
+Some users then make authorization decisions based on this key. This
+property is not documented, and may not be correct, due to the caching
+behavior of the package, resulting in users making incorrect
+authorization decisions about the connection.
+
+This change makes the cache a one entry FIFO cache, making the assumed
+property, that the last call to PublicKeyCallback represents the key
+actually used for authentication, actually hold.
+
+Thanks to Damien Tournoud, Patrick Dawkins, Vince Parker, and
+Jules Duvivier from the Platform.sh / Upsun engineering team
+for reporting this issue.
+
+Fixes golang/go#70779
+Fixes CVE-2024-45337
+
+Change-Id: Ife7c7b4045d8b6bcd7e3a417bdfae370c709797f
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/635315
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Nicola Murino <nicola.murino@gmail.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/crypto/ssh/server.go      | 15 ++++++++++----
+
+diff --git a/vendor/golang.org/x/crypto/ssh/server.go b/vendor/golang.org/x/crypto/ssh/server.go
+index c0d1c29e6f..5b5ccd96f4 100644
+--- a/vendor/golang.org/x/crypto/ssh/server.go
++++ b/vendor/golang.org/x/crypto/ssh/server.go
+@@ -149,7 +149,7 @@ func (s *ServerConfig) AddHostKey(key Signer) {
+ }
+
+ // cachedPubKey contains the results of querying whether a public key is
+-// acceptable for a user.
++// acceptable for a user. This is a FIFO cache.
+ type cachedPubKey struct {
+ 	user       string
+ 	pubKeyData []byte
+@@ -157,7 +157,13 @@ type cachedPubKey struct {
+ 	perms      *Permissions
+ }
+
+-const maxCachedPubKeys = 16
++// maxCachedPubKeys is the number of cache entries we store.
++//
++// Due to consistent misuse of the PublicKeyCallback API, we have reduced this
++// to 1, such that the only key in the cache is the most recently seen one. This
++// forces the behavior that the last call to PublicKeyCallback will always be
++// with the key that is used for authentication.
++const maxCachedPubKeys = 1
+
+ // pubKeyCache caches tests for public keys.  Since SSH clients
+ // will query whether a public key is acceptable before attempting to
+@@ -179,9 +185,10 @@ func (c *pubKeyCache) get(user string, pubKeyData []byte) (cachedPubKey, bool) {
+
+ // add adds the given tuple to the cache.
+ func (c *pubKeyCache) add(candidate cachedPubKey) {
+-	if len(c.keys) < maxCachedPubKeys {
+-		c.keys = append(c.keys, candidate)
++	if len(c.keys) >= maxCachedPubKeys {
++		c.keys = c.keys[1:]
+ 	}
++	c.keys = append(c.keys, candidate)
+ }
+
+ // ServerConn is an authenticated SSH connection, as seen from the

--- a/SPECS/docker-buildx/docker-buildx.spec
+++ b/SPECS/docker-buildx/docker-buildx.spec
@@ -4,13 +4,14 @@ Summary:        A Docker CLI plugin for extended build capabilities with BuildKi
 Name:           docker-buildx
 # update "commit_hash" above when upgrading version
 Version:        0.14.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Group:          Tools/Container
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://www.github.com/docker/buildx
 Source0:        https://github.com/docker/buildx/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-45337.patch
 
 BuildRequires: bash
 BuildRequires: golang
@@ -44,6 +45,9 @@ install -m 755 buildx "%{buildroot}%{_libexecdir}/docker/cli-plugins/docker-buil
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Fri Dec 20 2024 Aurelien Bombo <abombo@microsoft.com> - 0.14.0-2
+- Add patch for CVE-2024-45337
+
 * Thu May 02 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.14.0-1
 - Auto-upgrade to 0.14.0 - address CVE-2024-23653
 

--- a/SPECS/moby-engine/CVE-2024-45337.patch
+++ b/SPECS/moby-engine/CVE-2024-45337.patch
@@ -1,0 +1,77 @@
+https://github.com/golang/crypto/commit/b4f1988a35dee11ec3e05d6bf3e90b695fbd8909.patch
+
+From b4f1988a35dee11ec3e05d6bf3e90b695fbd8909 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 3 Dec 2024 09:03:03 -0800
+Subject: [PATCH] ssh: make the public key cache a 1-entry FIFO cache
+
+Users of the the ssh package seem to extremely commonly misuse the
+PublicKeyCallback API, assuming that the key passed in the last call
+before a connection is established is the key used for authentication.
+Some users then make authorization decisions based on this key. This
+property is not documented, and may not be correct, due to the caching
+behavior of the package, resulting in users making incorrect
+authorization decisions about the connection.
+
+This change makes the cache a one entry FIFO cache, making the assumed
+property, that the last call to PublicKeyCallback represents the key
+actually used for authentication, actually hold.
+
+Thanks to Damien Tournoud, Patrick Dawkins, Vince Parker, and
+Jules Duvivier from the Platform.sh / Upsun engineering team
+for reporting this issue.
+
+Fixes golang/go#70779
+Fixes CVE-2024-45337
+
+Change-Id: Ife7c7b4045d8b6bcd7e3a417bdfae370c709797f
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/635315
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Nicola Murino <nicola.murino@gmail.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/crypto/ssh/server.go      | 15 ++++++++++----
+
+diff --git a/vendor/golang.org/x/crypto/ssh/server.go b/vendor/golang.org/x/crypto/ssh/server.go
+index c0d1c29e6f..5b5ccd96f4 100644
+--- a/vendor/golang.org/x/crypto/ssh/server.go
++++ b/vendor/golang.org/x/crypto/ssh/server.go
+@@ -149,7 +149,7 @@ func (s *ServerConfig) AddHostKey(key Signer) {
+ }
+
+ // cachedPubKey contains the results of querying whether a public key is
+-// acceptable for a user.
++// acceptable for a user. This is a FIFO cache.
+ type cachedPubKey struct {
+ 	user       string
+ 	pubKeyData []byte
+@@ -157,7 +157,13 @@ type cachedPubKey struct {
+ 	perms      *Permissions
+ }
+
+-const maxCachedPubKeys = 16
++// maxCachedPubKeys is the number of cache entries we store.
++//
++// Due to consistent misuse of the PublicKeyCallback API, we have reduced this
++// to 1, such that the only key in the cache is the most recently seen one. This
++// forces the behavior that the last call to PublicKeyCallback will always be
++// with the key that is used for authentication.
++const maxCachedPubKeys = 1
+
+ // pubKeyCache caches tests for public keys.  Since SSH clients
+ // will query whether a public key is acceptable before attempting to
+@@ -179,9 +185,10 @@ func (c *pubKeyCache) get(user string, pubKeyData []byte) (cachedPubKey, bool) {
+
+ // add adds the given tuple to the cache.
+ func (c *pubKeyCache) add(candidate cachedPubKey) {
+-	if len(c.keys) < maxCachedPubKeys {
+-		c.keys = append(c.keys, candidate)
++	if len(c.keys) >= maxCachedPubKeys {
++		c.keys = c.keys[1:]
+ 	}
++	c.keys = append(c.keys, candidate)
+ }
+
+ // ServerConn is an authenticated SSH connection, as seen from the

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -3,7 +3,7 @@
 Summary: The open-source application container engine
 Name:    moby-engine
 Version: 25.0.3
-Release: 8%{?dist}
+Release: 9%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -22,6 +22,7 @@ Patch4:  CVE-2024-24786.patch
 Patch5:  CVE-2024-36621.patch
 Patch6:  CVE-2024-36620.patch
 Patch7:  CVE-2024-36623.patch
+Patch8:  CVE-2024-45337.patch
 
 %{?systemd_requires}
 
@@ -117,6 +118,9 @@ fi
 %{_unitdir}/*
 
 %changelog
+* Fri Dec 20 2024 Aurelien Bombo <abombo@microsoft.com> - 25.0.3-9
+- Add patch for CVE-2024-45337
+
 * Wed Dec 04 2024 Adit Jha <aditjha@microsoft.com> - 25.0.3-8
 - Fix CVE-2024-36620, CVE-2024-36621, and CVE-2024-36623 with patches
 


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit b83da2ac6c19b819ddc644bf7ede47aca72ca554 to 3.0-dev. Original PR: #11618