### PR TITLE
[AUTO-CHERRYPICK] Upgrade DPDK for CVE-2024-11614 - branch 3.0-dev

### DIFF
--- a/SPECS/dpdk/dpdk.signatures.json
+++ b/SPECS/dpdk/dpdk.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "dpdk-23.11.tar.xz": "64fa58fdfc9e9510e8e414e3bedd165bd3d4ca465a231b280323f83cd53fd865"
+  "dpdk-23.11.3.tar.xz": "8e51836bc6524e0512f89eeca27532021fe0ccc7f764cf238ee283e7f416c185"
  }
 }

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -29,8 +29,8 @@
 %bcond_without tools
 Summary:        Set of libraries and drivers for fast packet processing
 Name:           dpdk
-Version:        23.11
-Release:        2%{?dist}
+Version:        23.11.3
+Release:        1%{?dist}
 License:        BSD AND LGPLv2 AND GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -106,7 +106,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 
 %prep
-%autosetup -p1 -n dpdk-%{version}
+%autosetup -p1 -n dpdk-stable-%{version}
 
 %build
 CFLAGS="$(echo %{optflags} -fcommon)" \
@@ -179,6 +179,9 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 %endif
 
 %changelog
+* Fri Dec 20 2024 Jon Slobodzian <joslobo@microsoft.com> - 23.11.3-1
+- Updgrade to 23.11.3 to resolve CVE-2024-11614.
+
 * Thu Feb 22 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 23.11-2
 - Updating naming for 3.0 version of Azure Linux.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2968,8 +2968,8 @@
         "type": "other",
         "other": {
           "name": "dpdk",
-          "version": "23.11",
-          "downloadUrl": "https://fast.dpdk.org/rel/dpdk-23.11.tar.xz"
+          "version": "23.11.3",
+          "downloadUrl": "https://fast.dpdk.org/rel/dpdk-23.11.3.tar.xz"
         }
       }
     },


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit 674e0763a633d836b373e98987b1ef6aed0de69c to 3.0-dev. Original PR: #11631