### PR TITLE
add missing CVE-2024-45337.patch for moby-engine

### DIFF
--- a/SPECS/moby-engine/CVE-2024-45337.patch
+++ b/SPECS/moby-engine/CVE-2024-45337.patch
@@ -1,0 +1,77 @@
+https://github.com/golang/crypto/commit/b4f1988a35dee11ec3e05d6bf3e90b695fbd8909.patch
+
+From b4f1988a35dee11ec3e05d6bf3e90b695fbd8909 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 3 Dec 2024 09:03:03 -0800
+Subject: [PATCH] ssh: make the public key cache a 1-entry FIFO cache
+
+Users of the the ssh package seem to extremely commonly misuse the
+PublicKeyCallback API, assuming that the key passed in the last call
+before a connection is established is the key used for authentication.
+Some users then make authorization decisions based on this key. This
+property is not documented, and may not be correct, due to the caching
+behavior of the package, resulting in users making incorrect
+authorization decisions about the connection.
+
+This change makes the cache a one entry FIFO cache, making the assumed
+property, that the last call to PublicKeyCallback represents the key
+actually used for authentication, actually hold.
+
+Thanks to Damien Tournoud, Patrick Dawkins, Vince Parker, and
+Jules Duvivier from the Platform.sh / Upsun engineering team
+for reporting this issue.
+
+Fixes golang/go#70779
+Fixes CVE-2024-45337
+
+Change-Id: Ife7c7b4045d8b6bcd7e3a417bdfae370c709797f
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/635315
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-by: Nicola Murino <nicola.murino@gmail.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ vendor/golang.org/x/crypto/ssh/server.go      | 15 ++++++++++----
+
+diff --git a/vendor/golang.org/x/crypto/ssh/server.go b/vendor/golang.org/x/crypto/ssh/server.go
+index c0d1c29e6f..5b5ccd96f4 100644
+--- a/vendor/golang.org/x/crypto/ssh/server.go
++++ b/vendor/golang.org/x/crypto/ssh/server.go
+@@ -149,7 +149,7 @@ func (s *ServerConfig) AddHostKey(key Signer) {
+ }
+ 
+ // cachedPubKey contains the results of querying whether a public key is
+-// acceptable for a user.
++// acceptable for a user. This is a FIFO cache.
+ type cachedPubKey struct {
+ 	user       string
+ 	pubKeyData []byte
+@@ -157,7 +157,13 @@ type cachedPubKey struct {
+ 	perms      *Permissions
+ }
+ 
+-const maxCachedPubKeys = 16
++// maxCachedPubKeys is the number of cache entries we store.
++//
++// Due to consistent misuse of the PublicKeyCallback API, we have reduced this
++// to 1, such that the only key in the cache is the most recently seen one. This
++// forces the behavior that the last call to PublicKeyCallback will always be
++// with the key that is used for authentication.
++const maxCachedPubKeys = 1
+ 
+ // pubKeyCache caches tests for public keys.  Since SSH clients
+ // will query whether a public key is acceptable before attempting to
+@@ -179,9 +185,10 @@ func (c *pubKeyCache) get(user string, pubKeyData []byte) (cachedPubKey, bool) {
+ 
+ // add adds the given tuple to the cache.
+ func (c *pubKeyCache) add(candidate cachedPubKey) {
+-	if len(c.keys) < maxCachedPubKeys {
+-		c.keys = append(c.keys, candidate)
++	if len(c.keys) >= maxCachedPubKeys {
++		c.keys = c.keys[1:]
+ 	}
++	c.keys = append(c.keys, candidate)
+ }
+ 
+ // ServerConn is an authenticated SSH connection, as seen from the


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix build break: [link](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=698527&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=460b7289-1832-5507-1175-ad5f30576086)
```
ERRO[0016][srpmpacker] Failed to pack (/specs/moby-engine/moby-engine.spec). Cancelling outstanding workers. Error: unable to hydrate files: [CVE-2024-45337.patch] 
PANI[0029][srpmpacker] unable to hydrate files: [CVE-2024-45337.patch] 
```


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add missing patch for moby-engine

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=698780&view=results
