### PR TITLE
Added missing `Obsoletes: dbus-x11` in `dbus.spec`

### DIFF
--- a/SPECS/dbus/dbus.spec
+++ b/SPECS/dbus/dbus.spec
@@ -2,7 +2,7 @@
 Summary:        DBus for systemd
 Name:           dbus
 Version:        1.15.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+ OR AFL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -23,7 +23,8 @@ Recommends:     systemd
 Provides:       dbus-libs = %{version}-%{release}
 # NOTE: We currently do not build with X11 support.
 # build with X11 support in the future.
-Provides:       %{name}-x11
+Provides:       %{name}-x11 = %{version}-%{release}
+Obsoletes:      %{name}-x11 <= 1.14.0-1.%{?dist}
 
 %description
 The dbus package contains dbus.
@@ -86,6 +87,9 @@ make %{?_smp_mflags} check
 %{_libdir}/*.so
 
 %changelog
+* Mon Dec 23 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.15.6-2
+- Obsolete older 'dbus-x11'.
+
 * Thu Dec 28 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 1.15.6-1
 - Update to v1.15.6 to fix CVE-2023-34969
 

--- a/SPECS/dbus/dbus.spec
+++ b/SPECS/dbus/dbus.spec
@@ -24,7 +24,7 @@ Provides:       dbus-libs = %{version}-%{release}
 # NOTE: We currently do not build with X11 support.
 # build with X11 support in the future.
 Provides:       %{name}-x11 = %{version}-%{release}
-Obsoletes:      %{name}-x11 <= 1.14.0-1.%{?dist}
+Obsoletes:      %{name}-x11 <= 1.14.0-1%{?dist}
 
 %description
 The dbus package contains dbus.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Package build of the `oddjob` extended package fails, because that package `BuildRequires: dbus-x11`. We've removed the standalone `dbus-x11` package a while ago and replaced it with a `Provides` in the `dbus.spec`. We've missed adding an `Obsoletes` to that spec, however, which caused the build to prefer the old `dbus-x11` with a dependency on an older version of `dbus`, which conflicted with a newer version required through `BuildRequires: dbus-devel`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full dev build 699550.