### PR TITLE
Bumped `gcr` to 3.38.1 to fix a build break.

### DIFF
--- a/SPECS-EXTENDED/gcr/gcr.signatures.json
+++ b/SPECS-EXTENDED/gcr/gcr.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "gcr-3.36.0.tar.xz": "aaf9bed017a2263c6145c89a1a84178f9f40f238426463e4ae486694ef5f6601"
+  "gcr-3.38.1.tar.xz": "17fcaf9c4a93a65fb1c72b82643bb102c13344084687d5886ea66313868d9ec9"
  }
 }

--- a/SPECS-EXTENDED/gcr/gcr.spec
+++ b/SPECS-EXTENDED/gcr/gcr.spec
@@ -1,3 +1,5 @@
+%define majmin %(echo %{version} | cut -d. -f1-2)
+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 %ifarch %{valgrind_arches}
@@ -5,13 +7,13 @@ Distribution:   Mariner
 %endif
 
 Name:           gcr
-Version:        3.36.0
-Release:        3%{?dist}
+Version:        3.38.1
+Release:        1%{?dist}
 Summary:        A library for bits of crypto UI and parsing
 
 License:        GPLv2
 URL:            https://wiki.gnome.org/Projects/CryptoGlue
-Source0:        https://download.gnome.org/sources/%{name}/3.36/%{name}-%{version}.tar.xz
+Source0:        https://download.gnome.org/sources/%{name}/%{majmin}/%{name}-%{version}.tar.xz
 
 BuildRequires:  gettext
 BuildRequires:  gtk-doc
@@ -113,6 +115,9 @@ desktop-file-validate $RPM_BUILD_ROOT%{_datadir}/applications/gcr-viewer.desktop
 %{_libdir}/libgcr-base-3.so.*
 
 %changelog
+* Mon Dec 30 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.38.1-1
+- Bump to 3.38.1 to fix missing OID header bug (GCR issue #48).
+
 * Mon Mar 21 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.36.0-3
 - Adding BR on "python3-pygments".
 - License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4100,8 +4100,8 @@
         "type": "other",
         "other": {
           "name": "gcr",
-          "version": "3.36.0",
-          "downloadUrl": "https://download.gnome.org/sources/gcr/3.36/gcr-3.36.0.tar.xz"
+          "version": "3.38.1",
+          "downloadUrl": "https://download.gnome.org/sources/gcr/3.38/gcr-3.38.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've recently hit a build break in `gcr` [reported upstream](https://gitlab.gnome.org/GNOME/gcr/-/issues/48). Bumping `gcr` to 3.38.1, where the fix was added.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=702860&view=results).