### PR TITLE
Patch application-gateway-kubernetes-ingress for CVE-2024-45338

### DIFF
--- a/SPECS/application-gateway-kubernetes-ingress/CVE-2024-45338.patch
+++ b/SPECS/application-gateway-kubernetes-ingress/CVE-2024-45338.patch
@@ -1,0 +1,80 @@
+From 8e66b04771e35c4e4125e8c60334b34e2423effb Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Wed, 04 Dec 2024 09:35:55 -0800
+Subject: [PATCH] html: use strings.EqualFold instead of lowering ourselves
+
+Instead of using strings.ToLower and == to check case insensitive
+equality, just use strings.EqualFold, even when the strings are only
+ASCII. This prevents us unnecessarily lowering extremely long strings,
+which can be a somewhat expensive operation, even if we're only
+attempting to compare equality with five characters.
+
+Thanks to Guido Vranken for reporting this issue.
+
+Fixes golang/go#70906
+Fixes CVE-2024-45338
+
+Change-Id: I323b919f912d60dab6a87cadfdcac3e6b54cd128
+Reviewed-on: https://go-review.googlesource.com/c/net/+/637536
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+---
+ vendor/golang.org/x/net/html/doctype.go | 2 +-
+ vendor/golang.org/x/net/html/foreign.go | 3 +--
+ vendor/golang.org/x/net/html/parse.go   | 4 ++--
+ 3 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/html/doctype.go b/vendor/golang.org/x/net/html/doctype.go
+index c484e5a..bca3ae9 100644
+--- a/vendor/golang.org/x/net/html/doctype.go
++++ b/vendor/golang.org/x/net/html/doctype.go
+@@ -87,7 +87,7 @@ func parseDoctype(s string) (n *Node, quirks bool) {
+ 			}
+ 		}
+ 		if lastAttr := n.Attr[len(n.Attr)-1]; lastAttr.Key == "system" &&
+-			strings.ToLower(lastAttr.Val) == "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd" {
++			strings.EqualFold(lastAttr.Val, "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd") {
+ 			quirks = true
+ 		}
+ 	}
+diff --git a/vendor/golang.org/x/net/html/foreign.go b/vendor/golang.org/x/net/html/foreign.go
+index 74774c4..d6aa84d 100644
+--- a/vendor/golang.org/x/net/html/foreign.go
++++ b/vendor/golang.org/x/net/html/foreign.go
+@@ -40,8 +40,7 @@ func htmlIntegrationPoint(n *Node) bool {
+ 		if n.Data == "annotation-xml" {
+ 			for _, a := range n.Attr {
+ 				if a.Key == "encoding" {
+-					val := strings.ToLower(a.Val)
+-					if val == "text/html" || val == "application/xhtml+xml" {
++					if strings.EqualFold(a.Val, "text/html") || strings.EqualFold(a.Val, "application/xhtml+xml") {
+ 						return true
+ 					}
+ 				}
+diff --git a/vendor/golang.org/x/net/html/parse.go b/vendor/golang.org/x/net/html/parse.go
+index 2cd12fc..851dc42 100644
+--- a/vendor/golang.org/x/net/html/parse.go
++++ b/vendor/golang.org/x/net/html/parse.go
+@@ -1007,7 +1007,7 @@ func inBodyIM(p *parser) bool {
+ 			if p.tok.DataAtom == a.Input {
+ 				for _, t := range p.tok.Attr {
+ 					if t.Key == "type" {
+-						if strings.ToLower(t.Val) == "hidden" {
++						if strings.EqualFold(t.Val, "hidden") {
+ 							// Skip setting framesetOK = false
+ 							return true
+ 						}
+@@ -1435,7 +1435,7 @@ func inTableIM(p *parser) bool {
+ 			return inHeadIM(p)
+ 		case a.Input:
+ 			for _, t := range p.tok.Attr {
+-				if t.Key == "type" && strings.ToLower(t.Val) == "hidden" {
++				if t.Key == "type" && strings.EqualFold(t.Val, "hidden") {
+ 					p.addElement()
+ 					p.oe.pop()
+ 					return true
+-- 
+2.25.1
+

--- a/SPECS/application-gateway-kubernetes-ingress/application-gateway-kubernetes-ingress.spec
+++ b/SPECS/application-gateway-kubernetes-ingress/application-gateway-kubernetes-ingress.spec
@@ -2,7 +2,7 @@
 Summary:        Application Gateway Ingress Controller
 Name:           application-gateway-kubernetes-ingress
 Version:        1.4.0
-Release:        23%{?dist}
+Release:        24%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -30,6 +30,7 @@ Patch0:         CVE-2022-21698.patch
 Patch1:         CVE-2023-44487.patch
 Patch2:         CVE-2021-44716.patch
 Patch3:         CVE-2022-32149.patch
+Patch4:         CVE-2024-45338.patch
 
 BuildRequires:  golang
 %if %{with_check}
@@ -68,6 +69,9 @@ cp appgw-ingress %{buildroot}%{_bindir}/
 %{_bindir}/appgw-ingress
 
 %changelog
+* Thu Jan 02 2025 Sumedh Sharma <sumsharma@microsoft.com> - 1.4.0-24
+- Add patch for CVE-2024-45338.
+
 * Mon Sep 09 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.4.0-23
 - Bump release to rebuild with go 1.22.7
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch for CVE-2024-45338

###### Change Log  <!-- REQUIRED -->
- Add patch file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-45338

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Local Build
