### PR TITLE
Added CodeQL configuration to exclude external sources.

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,29 @@
+path_classifiers:
+  library:
+    # Treat source files for all compiled languages in the specs directories
+    # as 3rd party library sources because they are not owned by us.
+    #
+    # Extensions from https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/.
+    - "SPECS*/**/*.c"
+    - "SPECS*/**/*.c++"
+    - "SPECS*/**/*.cc"
+    - "SPECS*/**/*.cpp"
+    - "SPECS*/**/*.cs"
+    - "SPECS*/**/*.cshtml"
+    - "SPECS*/**/*.csproj"
+    - "SPECS*/**/*.cts"
+    - "SPECS*/**/*.cxx"
+    - "SPECS*/**/*.go"
+    - "SPECS*/**/*.h"
+    - "SPECS*/**/*.h++"
+    - "SPECS*/**/*.hh"
+    - "SPECS*/**/*.hpp"
+    - "SPECS*/**/*.hxx"
+    - "SPECS*/**/*.java"
+    - "SPECS*/**/*.kt"
+    - "SPECS*/**/*.mts"
+    - "SPECS*/**/*.sln"
+    - "SPECS*/**/*.swift"
+    - "SPECS*/**/*.ts"
+    - "SPECS*/**/*.tsx"
+    - "SPECS*/**/*.xaml"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

### Cherry-pick of #11809 in 2.0.

Adding CodeQL configuration to skip analyzing spec sources.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- ADO pipeline runs.