### PR TITLE
Fix shadow-utils detection in imager as well as validator

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -197,3 +197,50 @@ func TestAddImageIDFileGuardClause(t *testing.T) {
 	err = AddImageIDFile(chroot.RootDir(), "")
 	assert.Error(t, err)
 }
+
+func TestPackagelistContainsPackage(t *testing.T) {
+	packageList := []string{
+		"package1",
+		"package2",
+		"package3",
+	}
+
+	found, err := PackagelistContainsPackage(packageList, "package2")
+	assert.NoError(t, err)
+	assert.True(t, found)
+
+	found, err = PackagelistContainsPackage(packageList, "package4")
+	assert.NoError(t, err)
+	assert.False(t, found)
+
+	found, err = PackagelistContainsPackage(nil, "package4")
+	assert.NoError(t, err)
+	assert.False(t, found)
+
+	found, err = PackagelistContainsPackage(packageList, "")
+	assert.Error(t, err)
+	assert.False(t, found)
+}
+
+func TestPackagelistContainsPackageBadVersion(t *testing.T) {
+	packageList := []string{
+		"bad package = bad < version",
+	}
+
+	found, err := PackagelistContainsPackage(packageList, "package2")
+	assert.Error(t, err)
+	assert.False(t, found)
+}
+
+func TestPackagelistContainsPackageVersions(t *testing.T) {
+	packageList := []string{
+		"package1",
+		"package2",
+		"package3",
+		"package4 = 1.2.3",
+	}
+
+	found, err := PackagelistContainsPackage(packageList, "package4")
+	assert.NoError(t, err)
+	assert.True(t, found)
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
#11442 was only a partial fix, we had similar logic inside the imager tool itself. Make a common function both tools can use to validate the shadow-utils package.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `installutils.PackagelistContainsPackage()`
- Use new function in both `imageconfigvalidator` and `imager`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_queries/edit/55399616/?triage=true

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of customer's config with version issues, including a full image build
