### PR TITLE
cmake: patch CVE-2024-11053

### DIFF
--- a/SPECS/cmake/CVE-2024-11053.patch
+++ b/SPECS/cmake/CVE-2024-11053.patch
@@ -1,0 +1,304 @@
+From c67d69ef80e6d91d4124c704aceb667859d6a0df Mon Sep 17 00:00:00 2001
+From: Henry Beberman <henry.beberman@microsoft.com>
+Date: Wed, 15 Jan 2025 21:26:44 +0000
+Subject: [PATCH] Backport patch for CVE-2024-11053
+
+Backport fix for CVE-2024-11053 from upstream commit to vendored libcurl 8.8.0
+
+From e9b9bbac22c26cf67316fa8e6c6b9e831af31949 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 15 Nov 2024 11:06:36 +0100
+Subject: [PATCH] netrc: address several netrc parser flaws
+
+- make sure that a match that returns a username also returns a
+  password, that should be blank if no password is found
+
+- fix handling of multiple logins for same host where the password/login
+  order might be reversed.
+
+- reject credentials provided in the .netrc if they contain ASCII control
+  codes - if the used protocol does not support such (like HTTP and WS do)
+
+---
+ lib/netrc.c | 205 +++++++++++++++++++++++++++++-----------------------
+ lib/url.c   |   2 +
+ 2 files changed, 116 insertions(+), 91 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/netrc.c b/Utilities/cmcurl/lib/netrc.c
+index cd2a284..83dd9eb 100644
+--- a/Utilities/cmcurl/lib/netrc.c
++++ b/Utilities/cmcurl/lib/netrc.c
+@@ -49,6 +49,15 @@ enum host_lookup_state {
+   MACDEF
+ };
+ 
++enum found_state {
++  NONE,
++  LOGIN,
++  PASSWORD
++};
++
++#define FOUND_LOGIN    1
++#define FOUND_PASSWORD 2
++
+ #define NETRC_FILE_MISSING 1
+ #define NETRC_FAILED -1
+ #define NETRC_SUCCESS 0
+@@ -66,11 +75,13 @@ static int parsenetrc(const char *host,
+   FILE *file;
+   int retcode = NETRC_FILE_MISSING;
+   char *login = *loginp;
+-  char *password = *passwordp;
++  char *password = NULL;
+   bool specific_login = (login && *login != 0);
+-  bool login_alloc = FALSE;
+-  bool password_alloc = FALSE;
+   enum host_lookup_state state = NOTHING;
++  enum found_state keyword = NONE;
++  unsigned char found = 0; /* login + password found bits, as they can come in
++                              any order */
++  bool our_login = FALSE;  /* found our login name */
+ 
+   char state_login = 0;      /* Found a login keyword */
+   char state_password = 0;   /* Found a password keyword */
+@@ -156,117 +167,129 @@ static int parsenetrc(const char *host,
+           }
+         }
+ 
+-        if((login && *login) && (password && *password)) {
+-          done = TRUE;
+-          break;
+-        }
+-
+         switch(state) {
+-        case NOTHING:
+-          if(strcasecompare("macdef", tok)) {
+-            /* Define a macro. A macro is defined with the specified name; its
+-               contents begin with the next .netrc line and continue until a
+-               null line (consecutive new-line characters) is encountered. */
+-            state = MACDEF;
+-          }
+-          else if(strcasecompare("machine", tok)) {
+-            /* the next tok is the machine name, this is in itself the
+-               delimiter that starts the stuff entered for this machine,
+-               after this we need to search for 'login' and
+-               'password'. */
+-            state = HOSTFOUND;
+-          }
+-          else if(strcasecompare("default", tok)) {
+-            state = HOSTVALID;
+-            retcode = NETRC_SUCCESS; /* we did find our host */
+-          }
+-          break;
+-        case MACDEF:
+-          if(!strlen(tok)) {
+-            state = NOTHING;
+-          }
+-          break;
+-        case HOSTFOUND:
+-          if(strcasecompare(host, tok)) {
+-            /* and yes, this is our host! */
+-            state = HOSTVALID;
+-            retcode = NETRC_SUCCESS; /* we did find our host */
+-          }
+-          else
+-            /* not our host */
+-            state = NOTHING;
+-          break;
+-        case HOSTVALID:
+-          /* we are now parsing sub-keywords concerning "our" host */
+-          if(state_login) {
+-            if(specific_login) {
+-              state_our_login = !Curl_timestrcmp(login, tok);
++          case NOTHING:
++            if(strcasecompare("macdef", tok))
++              /* Define a macro. A macro is defined with the specified name; its
++                 contents begin with the next .netrc line and continue until a
++                 null line (consecutive new-line characters) is encountered. */
++              state = MACDEF;
++            else if(strcasecompare("machine", tok)) {
++              /* the next tok is the machine name, this is in itself the delimiter
++                 that starts the stuff entered for this machine, after this we
++                 need to search for 'login' and 'password'. */
++              state = HOSTFOUND;
++              keyword = NONE;
++              found = 0;
++              our_login = FALSE;
++              Curl_safefree(password);
++              if(!specific_login)
++                Curl_safefree(login);
+             }
+-            else if(!login || Curl_timestrcmp(login, tok)) {
+-              if(login_alloc) {
++            else if(strcasecompare("default", tok)) {
++              state = HOSTVALID;
++              retcode = NETRC_SUCCESS; /* we did find our host */
++            }
++            break;
++          case MACDEF:
++            if(!*tok)
++              state = NOTHING;
++            break;
++          case HOSTFOUND:
++            if(strcasecompare(host, tok)) {
++              /* and yes, this is our host! */
++              state = HOSTVALID;
++              retcode = NETRC_SUCCESS; /* we did find our host */
++            }
++            else
++              /* not our host */
++              state = NOTHING;
++            break;
++          case HOSTVALID:
++            /* we are now parsing sub-keywords concerning "our" host */
++            if(keyword == LOGIN) {
++              if(specific_login)
++                our_login = !Curl_timestrcmp(login, tok);
++              else {
++                our_login = TRUE;
+                 free(login);
+-                login_alloc = FALSE;
++                login = strdup(tok);
++                if(!login) {
++                  retcode = NETRC_FAILED; /* allocation failed */
++                  goto out;
++                }
+               }
+-              login = strdup(tok);
+-              if(!login) {
+-                retcode = NETRC_FAILED; /* allocation failed */
+-                goto out;
+-              }
+-              login_alloc = TRUE;
++              found |= FOUND_LOGIN;
++              keyword = NONE;
+             }
+-            state_login = 0;
+-          }
+-          else if(state_password) {
+-            if((state_our_login || !specific_login)
+-               && (!password || Curl_timestrcmp(password, tok))) {
+-              if(password_alloc) {
+-                free(password);
+-                password_alloc = FALSE;
+-              }
++            else if(keyword == PASSWORD) {
++              free(password);
+               password = strdup(tok);
+               if(!password) {
+                 retcode = NETRC_FAILED; /* allocation failed */
+                 goto out;
+               }
+-              password_alloc = TRUE;
++              if(!specific_login || our_login)
++                found |= FOUND_PASSWORD;
++              keyword = NONE;
+             }
+-            state_password = 0;
+-          }
+-          else if(strcasecompare("login", tok))
+-            state_login = 1;
+-          else if(strcasecompare("password", tok))
+-            state_password = 1;
+-          else if(strcasecompare("machine", tok)) {
+-            /* ok, there's machine here go => */
+-            state = HOSTFOUND;
+-            state_our_login = FALSE;
+-          }
+-          break;
+-        } /* switch (state) */
++            else if(strcasecompare("login", tok))
++              keyword = LOGIN;
++            else if(strcasecompare("password", tok))
++              keyword = PASSWORD;
++            else if(strcasecompare("machine", tok)) {
++              /* a new machine here */
++              if(found & FOUND_PASSWORD) {
++                done = TRUE;
++                break;
++              }
++              state = HOSTFOUND;
++              keyword = NONE;
++              found = 0;
++              Curl_safefree(password);
++              if(!specific_login)
++                Curl_safefree(login);
++            }
++            else if(strcasecompare("default", tok)) {
++              state = HOSTVALID;
++              retcode = NETRC_SUCCESS; /* we did find our host */
++              Curl_safefree(password);
++              if(!specific_login)
++                Curl_safefree(login);
++            }
++            if((found == (FOUND_PASSWORD|FOUND_LOGIN)) && our_login) {
++              done = TRUE;
++              break;
++            }
++            break;
++          } /* switch (state) */
+         tok = ++tok_end;
+       }
+     } /* while Curl_get_line() */
+ 
+ out:
+     Curl_dyn_free(&buf);
++    if(!retcode) {
++      if(!password && our_login) {
++        /* success without a password, set a blank one */
++        password = strdup("");
++        if(!password)
++          retcode = 1; /* out of memory */
++      }
++      else if(!login && !password)
++        /* a default with no credentials */
++        retcode = NETRC_FILE_MISSING;
++    }
+     if(!retcode) {
+       /* success */
+-      if(login_alloc) {
+-        if(*loginp)
+-          free(*loginp);
++      if(!specific_login)
+         *loginp = login;
+-      }
+-      if(password_alloc) {
+-        if(*passwordp)
+-          free(*passwordp);
+-        *passwordp = password;
+-      }
++      *passwordp = password;
+     }
+     else {
+-      if(login_alloc)
++      if(!specific_login)
+         free(login);
+-      if(password_alloc)
+-        free(password);
++      free(password);
+     }
+     fclose(file);
+   }
+diff --git a/Utilities/cmcurl/lib/url.c b/Utilities/cmcurl/lib/url.c
+index 2814d31..51c7f88 100644
+--- a/Utilities/cmcurl/lib/url.c
++++ b/Utilities/cmcurl/lib/url.c
+@@ -2698,6 +2698,7 @@ static CURLcode override_login(struct Curl_easy *data,
+       url_provided = TRUE;
+     }
+ 
++    if(!*passwdp) {
+     ret = Curl_parsenetrc(conn->host.name,
+                           userp, passwdp,
+                           data->set.str[STRING_NETRC_FILE]);
+@@ -2729,6 +2730,7 @@ static CURLcode override_login(struct Curl_easy *data,
+       if(!*userp)
+         return CURLE_OUT_OF_MEMORY;
+     }
++    }
+   }
+ #endif
+ 
+-- 
+2.45.2
+

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -2,7 +2,7 @@
 Summary:        Cmake
 Name:           cmake
 Version:        3.30.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -14,6 +14,7 @@ Patch0:         0001-manually-recreating-patches.patch
 Patch1:         CVE-2024-6197.patch
 Patch2:         CVE-2024-6874.patch
 Patch3:         CVE-2024-8096.patch
+Patch4:         CVE-2024-11053.patch
 BuildRequires:  bzip2
 BuildRequires:  bzip2-devel
 BuildRequires:  curl
@@ -93,6 +94,9 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_libdir}/rpm/macros.d/macros.cmake
 
 %changelog
+* Wed Jan 15 2025 Henry Beberman <henry.beberman@microsoft.com> - 3.30.3-3
+- Patch vendored curl for CVE-2024-11053
+
 * Thu Sep 26 2024 Jonathan Behrens <jbehrens@microsoft.com> - 3.30.3-2
 - Fix CVE-2024-6197, CVE-2024-6874, and CVE-2024-8096
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -49,8 +49,8 @@ check-debuginfo-0.15.2-1.azl3.aarch64.rpm
 chkconfig-1.25-1.azl3.aarch64.rpm
 chkconfig-debuginfo-1.25-1.azl3.aarch64.rpm
 chkconfig-lang-1.25-1.azl3.aarch64.rpm
-cmake-3.30.3-2.azl3.aarch64.rpm
-cmake-debuginfo-3.30.3-2.azl3.aarch64.rpm
+cmake-3.30.3-3.azl3.aarch64.rpm
+cmake-debuginfo-3.30.3-3.azl3.aarch64.rpm
 coreutils-9.4-6.azl3.aarch64.rpm
 coreutils-debuginfo-9.4-6.azl3.aarch64.rpm
 coreutils-lang-9.4-6.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -52,8 +52,8 @@ check-debuginfo-0.15.2-1.azl3.x86_64.rpm
 chkconfig-1.25-1.azl3.x86_64.rpm
 chkconfig-debuginfo-1.25-1.azl3.x86_64.rpm
 chkconfig-lang-1.25-1.azl3.x86_64.rpm
-cmake-3.30.3-2.azl3.x86_64.rpm
-cmake-debuginfo-3.30.3-2.azl3.x86_64.rpm
+cmake-3.30.3-3.azl3.x86_64.rpm
+cmake-debuginfo-3.30.3-3.azl3.x86_64.rpm
 coreutils-9.4-6.azl3.x86_64.rpm
 coreutils-debuginfo-9.4-6.azl3.x86_64.rpm
 coreutils-lang-9.4-6.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fix CVE-2024-11053 in vendored curl in cmake

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport upstream fix for CVE-2024-11053 to vendored curl 8.8.0 in cmake

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-11053

###### Test Methodology
- Patched 8.8.0 curl standalone, passed existing and new netrc unit tests then applied patch to vendored cmake
- Built cmake package locally and check section succeeded
- Pipeline build id: 712153
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=712153&view=results