### PR TITLE
Dracut: Update Dracut overlay module to correctly locate 'chcon'

### DIFF
--- a/SPECS/dracut/90overlayfs/azl-configure-selinux.sh
+++ b/SPECS/dracut/90overlayfs/azl-configure-selinux.sh
@@ -28,7 +28,8 @@ if [ -n "$overlayfs" ]; then
     echo "root folder label  : ($contextType)"
 
     # Set the type on the target folders
-    [ -e /sysroot ] && chcon -t $contextType /sysroot
-    [ -e /run/overlayfs ] && chcon -t $contextType /run/overlayfs
-    [ -e /run/ovlwork ] && chcon -t $contextType /run/ovlwork
+    CHCON_TOOL=$NEWROOT/usr/bin/chcon
+    [ -e /sysroot ] && $CHCON_TOOL -t $contextType /sysroot
+    [ -e /run/overlayfs ] && $CHCON_TOOL -t $contextType /run/overlayfs
+    [ -e /run/ovlwork ] && $CHCON_TOOL -t $contextType /run/ovlwork
 fi

--- a/SPECS/dracut/dracut.signatures.json
+++ b/SPECS/dracut/dracut.signatures.json
@@ -6,7 +6,7 @@
   "00-vrf.conf": "e2885a4b090d8ca3771e60ce6dcd8b849e28ce5002a5c7b71ff796a92deb2810",
   "00-xen.conf": "8b7a89b7716cb40a9c0d681caed6994d81ff4dfad4fe50cea15cd47b885dc5a6",
   "50-noxattr.conf": "61d95f05890ac6ee3355d0a386dd5645d82b7a4202d90305d997fd18c6d139dd",
-  "azl-configure-selinux.sh": "5f526509910fccdc2dffad4ef5070740847195510e3faefff39b831c9d28a439",
+  "azl-configure-selinux.sh": "a32da2e920348a5f991d6c418873a0a761f6e4bd926bb17a43cdb2c28b4f21d6",
   "azl-liveos-artifacts-download.service": "888be8c82297cccd510d7f963611c2360ae67559826b2b474da6d9935237de64",
   "azl-liveos-artifacts-download.sh": "f21dc68de8c81d8a8128e7a9d7be45d25978f0b5e47a4cf1a2d97b1e171ec045",
   "dracut-102.tar.gz": "601b175cbf4d2ee902bb7bda3af8826ae2ca060c1af880f6da5a833413f4ec70",

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        102
-Release:        10%{?dist}
+Release:        11%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -315,6 +315,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Mon Mar 05 2025 George Mileka <gmileka@microsoft.com> - 102-11
+- Update overlayfs selinux handling with the full path of chcon
+
 * Tue Feb 25 2025 Cameron Baird <cameronbaird@microsoft.com> - 102-10
 - Fix 0006-dracut.sh-validate-instmods patch to not break crypto module blacklisting
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [n/a] The toolchain has been rebuilt successfully (or no changes were made to it)
- [n/a] The toolchain/worker package manifests are up-to-date
- [ok] Any updated packages successfully build (or no packages were changed)
- [n/a] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ok] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ok] All package sources are available
- [ok] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ok] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ok] All source files have up-to-date hashes in the `*.signatures.json` files
- [ok] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [n/a] Documentation has been updated to match any changes to the build system
- [ok] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
LiveOS ISO utilizes an overlay file system that consists of a read-only full OS rootfs (lower dir) and an in-memory read-write file system (upper dir).

When selinux is enabled, the final root (`/`) must be labeled `root_t`. Given that the final root (`/`) is constructed from the lower dir and the upper dir, both should also be marked as such (i.e. with `root_t`). The read-only full OS rootfs is already labeled as such during build time. The in-memory file system is new, however, and still need to be labeled.

A fix was merged in December to achieve that by calling selinux `chcon` utility. At the time, the labeling was done correctly, and selinux did not report any violations in our private testing.

However, this bug report alerted us that `chcon` is not being found on the path as tested by Brian, and as a result, the labeling is not taking place, and the liveos iso does not boot when selinux is enabled.

This fix changes the dracut module responsible for the labeling to explicitly specify the full path of the `chcon` utility. This guarantees that regardless of the contents of the initrd, the command always succeeds.

When doing root cause analysis for the regression, the most likely reason it did not not show in the private testing is that the initrd had a copy of `chcon`, and it was on the path. This hid the problem that would arise if the contents of the initrd changed.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- [Unblock SELinux for ISO - Update Dracut module to correctly locate 'chcon'](https://github.com/microsoft/azurelinux/pull/11986/commits/f482913d595ee3cb3a7a5b4d10075ff2a06d3c82)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
- NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- n/a

###### Links to CVEs  <!-- optional -->
- n/a

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
**Validation**
- Locally, on dev box:
  - New enlistment of Azure Linux.
  - Build the dracut package.
  - Build the baremela image.
  - Build Prism.
  - Use Prism to build a LiveOS ISO.
  - Create a VM with the generated ISO.
  - Boot the VM.
  - Log-in.
  - Verify that no selinux denials exist in the journal logs.
    
**Automation**

- Enabled the VM tests suite in the Prism build/test pipelines.
  - Download varius Azure Linux 2.0/3.0 images.
  - Customize using Prism.
  - Ensure they all boot, get an IP, and the test can ssh and inspect the contents.
 
**Note** While we've put in automation to catch this kind of failures in the future, the downloaded images in the test are the public one which do not have the fixed Dracut package. However, once the Dracut package is published, the test will automatically pick it up and verify it boots.