### PR TITLE
fix golang post install and post uninstall sriptlets

### DIFF
--- a/SPECS/golang/golang-1.22.spec
+++ b/SPECS/golang/golang-1.22.spec
@@ -2,7 +2,6 @@
 %global gopath          %{_datadir}/gocode
 %global ms_go_filename  go1.22.10-20241203.4.src.tar.gz
 %global ms_go_revision  1
-%global go_priority %(echo %{version}.%{ms_go_revision} | tr -d .)
 %ifarch aarch64
 %global gohostarch      arm64
 %else
@@ -16,7 +15,7 @@
 Summary:        Go
 Name:           golang
 Version:        1.22.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -134,17 +133,10 @@ EOF
 
 %post -p /sbin/ldconfig
 
-alternatives --install %{_bindir}/go go %{goroot}/bin/go %{go_priority}
-alternatives --install %{_bindir}/gofmt gofmt %{goroot}/bin/gofmt %{go_priority}
-
 %postun
 /sbin/ldconfig
 if [ $1 -eq 0 ]; then
   # This is uninstall
-  alternatives --remove go %{goroot}/bin/go
-  alternatives --remove gofmt %{goroot}/bin/gofmt
-
-  rm %{_sysconfdir}/profile.d/go-exports.sh
   rm -rf /opt/go
   exit 0
 fi
@@ -162,6 +154,11 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Feb 04 2025 Tobias Brick <tobiasb@microsoft.com> - 1.22.10-2
+- Fix post scriptlet
+- Remove calls to alternatives
+- Don't manually delete go-exports.sh
+
 * Wed Dec 04 2024 Microsoft Golang Bot <microsoft-golang-bot@users.noreply.github.com> - 1.22.10-1
 - Bump version to 1.22.10-1
 
@@ -186,7 +183,7 @@ fi
 * Tue Jun 04 2024 Davis Goodin <dagood@microsoft.com> - 1.22.4-1
 - Bump version to 1.22.4-1
 
-* Tue May 07 2024 Davis Goodin <dagood@microsoft.com> - 1.22.3-1
+* Mon May 27 2024 Davis Goodin <dagood@microsoft.com> - 1.22.3-1
 - Bump version to 1.22.3-1
 
 * Wed May 08 2024 Davis Goodin <dagood@microsoft.com> - 1.21.9-2

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -2,7 +2,6 @@
 %global gopath          %{_datadir}/gocode
 %global ms_go_filename  go1.23.3-20241202.3.src.tar.gz
 %global ms_go_revision  2
-%global go_priority %(echo %{version}.%{ms_go_revision} | tr -d .)
 %ifarch aarch64
 %global gohostarch      arm64
 %else
@@ -16,7 +15,7 @@
 Summary:        Go
 Name:           golang
 Version:        1.23.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -134,17 +133,10 @@ EOF
 
 %post -p /sbin/ldconfig
 
-alternatives --install %{_bindir}/go go %{goroot}/bin/go %{go_priority}
-alternatives --install %{_bindir}/gofmt gofmt %{goroot}/bin/gofmt %{go_priority}
-
 %postun
 /sbin/ldconfig
 if [ $1 -eq 0 ]; then
   # This is uninstall
-  alternatives --remove go %{goroot}/bin/go
-  alternatives --remove gofmt %{goroot}/bin/gofmt
-
-  rm %{_sysconfdir}/profile.d/go-exports.sh
   rm -rf /opt/go
   exit 0
 fi
@@ -162,6 +154,11 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Feb 04 2025 Tobias Brick <tobiasb@microsoft.com> - 1.23.3-3
+- Fix post scriptlet
+- Remove calls to alternatives
+- Don't manually delete go-exports.sh
+
 * Tue Dec 03 2024 Microsoft Golang Bot <microsoft-golang-bot@users.noreply.github.com> - 1.23.3-2
 - Bump version to 1.23.3-2
 
@@ -186,7 +183,7 @@ fi
 * Tue Jun 04 2024 Davis Goodin <dagood@microsoft.com> - 1.22.4-1
 - Bump version to 1.22.4-1
 
-* Tue May 07 2024 Davis Goodin <dagood@microsoft.com> - 1.22.3-1
+* Mon May 27 2024 Davis Goodin <dagood@microsoft.com> - 1.22.3-1
 - Bump version to 1.22.3-1
 
 * Wed May 08 2024 Davis Goodin <dagood@microsoft.com> - 1.21.9-2


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
NOTE: This change obviates #11343

`golang` -- both the [primary (1.23) package](https://github.com/microsoft/azurelinux/blob/3.0-dev/SPECS/golang/golang.spec) and the [1.22 package](https://github.com/microsoft/azurelinux/blob/3.0-dev/SPECS/golang/golang-1.22.spec) -- has warnings during both package install and package uninstall.

For package install, we things like:
```
Installing/Updating: golang-1.23.3-2.azl3.x86_64
/sbin/ldconfig: relative path `1' used to build cache
warning: %post(golang-1.23.3-2.azl3.x86_64) scriptlet failed, exit status 1
package golang-1.23.3-2.azl3.x86_64: script warning in %postin
```
This is caused by #10654, which added the use of `alternatives` in both the post install and post uninstall scriptlets. The issue is:
```
%post -p /sbin/ldconfig

alternatives --install %{_bindir}/go go %{goroot}/bin/go %{go_priority}
alternatives --install %{_bindir}/gofmt gofmt %{goroot}/bin/gofmt %{go_priority}
```

By putting an executable in the `%post` line, it makes the scriptlet be run with that executable rather than `sh`. But because there's then a script after the `%post` line, it means the parameters are totally wrong for `ldconfig` -- it ends up being a temporary file containing those lines and an extra, special parameter used in the scriptlet. This causes `ldconfig` to fail, which gives us that warning.

This isn't the end of the world -- linkers will still work and everything, but it's definitely wrong and looks bad.

One may think that we could fix this by moving `ldconfig` into the script, like this:
```
%post
/sbin/ldconfig

alternatives --install %{_bindir}/go go %{goroot}/bin/go %{go_priority}
alternatives --install %{_bindir}/gofmt gofmt %{goroot}/bin/gofmt %{go_priority}
```

However, this exposes a bug in how `go_priority` is set -- it uses `version` before it's declared, which results in a completely wrong string. The good news is that we don't realistically need `alternatives`. And since it isn't actually being called now, we can safely remove it and if we ever think we do need it, we can add it back correctly.

So to fix this, we remove all uses of `alternatives` and the `go_priority` variable, which is now unused.


The warning during uninstall seems to have been there "forever":
```
Removing: golang-1.23.3-2.azl3.x86_64
rm: cannot remove '/etc/profile.d/go-exports.sh': No such file or directory
```

This happens because `%postun` calls `rm %{_sysconfdir}/profile.d/go-exports.sh`. However, that file is in the `%files` section, so the package manager itself removes it -- there's no reason to have this statement. Fix is to remove it.

###### Change Log  <!-- REQUIRED -->
- Remove all uses of `alternatives`, which also makes the `%post -p /sbin/ldconfig` run as expected.
- Don't manually remove `go-exports.sh`

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues
- [ADO Bug](https://microsoft.visualstudio.com/OS/_queries/edit/55368831/?queryId=29c5f91d-06aa-4d7e-83f2-d78e490cac48)

###### Test Methodology
- Built manually and tested install and uninstall.
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=716645&view=results
- Root of "big build": https://dev.azure.com/mariner-org/mariner/_build/results?buildId=727724&view=results
