### PR TITLE
Patch cri-o for CVE-2023-6476 & CVE-2023-0778 [MEDIUM]

### DIFF
--- a/SPECS/cri-o/CVE-2023-0778.patch
+++ b/SPECS/cri-o/CVE-2023-0778.patch
@@ -1,0 +1,54 @@
+Modified Patch to apply only for container export. The utils.go file
+does not have the volume export code in the vendored podman version.
+Modified by: Sumedh Sharma <sumsharma@microsoft.com>
+
+From 6ca857feb07a5fdc96fd947afef03916291673d8 Mon Sep 17 00:00:00 2001
+From: Aditya R <arajan@redhat.com>
+Date: Fri, 10 Feb 2023 15:16:27 +0530
+Subject: [PATCH] volume,container: chroot to source before exporting content
+
+* Utils must support higher level API to create Tar with chrooted into
+  directory
+* Volume export: use TarwithChroot instead of Tar so we can make sure no
+  symlink can be exported by tar if it exists outside of the source
+directory.
+* container export: use chroot and Tar instead of Tar so we can make sure no
+  symlink can be exported by tar if it exists outside of the mointPoint.
+
+[NO NEW TESTS NEEDED]
+[NO TESTS NEEDED]
+Race needs combination of external/in-container mechanism which is hard to repro in CI.
+
+Closes: BZ:#2168256
+CVE: https://access.redhat.com/security/cve/CVE-2023-0778
+
+Signed-off-by: Aditya R <arajan@redhat.com>
+---
+ .../containers/podman/v3/libpod/container_internal.go         | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/github.com/containers/podman/v3/libpod/container_internal.go b/vendor/github.com/containers/podman/v3/libpod/container_internal.go
+index 8ffcccf..42cb682 100644
+--- a/vendor/github.com/containers/podman/v3/libpod/container_internal.go
++++ b/vendor/github.com/containers/podman/v3/libpod/container_internal.go
+@@ -26,7 +26,7 @@ import (
+ 	"github.com/containers/podman/v3/pkg/selinux"
+ 	"github.com/containers/podman/v3/pkg/util"
+ 	"github.com/containers/storage"
+-	"github.com/containers/storage/pkg/archive"
++	"github.com/containers/storage/pkg/chrootarchive"
+ 	"github.com/containers/storage/pkg/idtools"
+ 	"github.com/containers/storage/pkg/mount"
+ 	"github.com/coreos/go-systemd/v22/daemon"
+@@ -757,7 +757,7 @@ func (c *Container) export(path string) error {
+ 		}()
+ 	}
+ 
+-	input, err := archive.Tar(mountPoint, archive.Uncompressed)
++	input, err := chrootarchive.Tar(mountPoint, nil, mountPoint)
+ 	if err != nil {
+ 		return errors.Wrapf(err, "error reading container directory %q", c.ID())
+ 	}
+-- 
+2.25.1
+

--- a/SPECS/cri-o/CVE-2023-6476.patch
+++ b/SPECS/cri-o/CVE-2023-6476.patch
@@ -1,0 +1,32 @@
+From 5faee5d82556a6bf4dd1144d2a86e70d097ab200 Mon Sep 17 00:00:00 2001
+From: Peter Hunt <pehunt@redhat.com>
+Date: Thu, 7 Dec 2023 16:07:12 -0500
+Subject: [PATCH] allowed annotations: correctly filter prefixed annotations
+
+without this fix, a pod is able to gain access to experimental annotations that are prefixes of container names.
+The most problematic of these is io.kubernetes.cri-o.UnifiedCgroup, which allows a user to arbitrarily
+change the resources of the pod, potentially leading to OOM.
+
+Fixes CVE-2023-6476
+
+Signed-off-by: Peter Hunt <pehunt@redhat.com>
+---
+ internal/oci/oci.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/internal/oci/oci.go b/internal/oci/oci.go
+index 89ecfb2..b56b6d9 100644
+--- a/internal/oci/oci.go
++++ b/internal/oci/oci.go
+@@ -216,7 +216,7 @@ func (r *Runtime) FilterDisallowedAnnotations(handler string, annotations map[st
+ 	for ann := range annotations {
+ 		for _, disallowed := range rh.DisallowedAnnotations {
+ 			if strings.HasPrefix(ann, disallowed) {
+-				delete(annotations, disallowed)
++				delete(annotations, ann)
+ 			}
+ 		}
+ 	}
+-- 
+2.25.1
+

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.22.3
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -71,6 +71,8 @@ Patch15:        CVE-2022-32149.patch
 Patch16:        CVE-2022-4318.patch
 Patch17:        CVE-2024-9341.patch
 Patch18:        CVE-2024-45338.patch
+Patch19:        CVE-2023-0778.patch
+Patch20:        CVE-2023-6476.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  fdupes
@@ -223,6 +225,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Thu Jan 23 2025 Sumedh Sharma <sumsharma@microsoft.com> - 1.22.3-10
+- Add patch for CVE-2023-0778 & CVE-2023-6476.
+
 * Mon Jan 06 2025 Sumedh Sharma <sumsharma@microsoft.com> - 1.22.3-9
 - Apply patch after extracting the vendor sources.
 - Fix patches with compilation errors.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Patch CVE-2023-6476 & CVE-2023-0778

###### Change Log  <!-- REQUIRED -->
- Add patch file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-6476
- https://nvd.nist.gov/vuln/detail/CVE-2023-0778

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Local Build
