### PR TITLE
Adding `generate_source_tarball.sh` and vendor tarball to `docker-buildx`

### DIFF
--- a/SPECS/docker-buildx/docker-buildx.signatures.json
+++ b/SPECS/docker-buildx/docker-buildx.signatures.json
@@ -1,5 +1,6 @@
 {
   "Signatures": {
+    "docker-buildx-0.14.0-govendor-v1.tar.gz": "49d195b123d9857dc0530cbd797d290e3106e11a158d92fbb30720875626b42d",
     "docker-buildx-0.14.0.tar.gz": "9ed27d47b728288500ba2535366792d9b006354e02178688360919663f92b63e"
   }
 }

--- a/SPECS/docker-buildx/docker-buildx.spec
+++ b/SPECS/docker-buildx/docker-buildx.spec
@@ -4,7 +4,7 @@ Summary:        A Docker CLI plugin for extended build capabilities with BuildKi
 Name:           docker-buildx
 # update "commit_hash" above when upgrading version
 Version:        0.14.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Group:          Tools/Container
 Vendor:         Microsoft Corporation
@@ -46,6 +46,9 @@ install -m 755 buildx "%{buildroot}%{_libexecdir}/docker/cli-plugins/docker-buil
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Mon Jan 27 2025 Osama Esmail <osamaesmail@microsoft.com> - 0.14.0-3
+- Added "generate_source_tarball.sh" and vendor tarball
+
 * Fri Dec 20 2024 Aurelien Bombo <abombo@microsoft.com> - 0.14.0-2
 - Add patch for CVE-2024-45337
 

--- a/SPECS/docker-buildx/docker-buildx.spec
+++ b/SPECS/docker-buildx/docker-buildx.spec
@@ -11,6 +11,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://www.github.com/docker/buildx
 Source0:        https://github.com/docker/buildx/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-govendor-v1.tar.gz
 Patch0:         CVE-2024-45337.patch
 
 BuildRequires: bash

--- a/SPECS/docker-buildx/docker-buildx.spec
+++ b/SPECS/docker-buildx/docker-buildx.spec
@@ -29,6 +29,8 @@ A Docker CLI plugin for extended build capabilities with BuildKit
 
 %prep
 %autosetup -p1 -n buildx-%{version}
+rm -rf vendor
+tar -xf %{SOURCE1}
 
 %build
 export CGO_ENABLED=0

--- a/SPECS/docker-buildx/generate_source_tarball.sh
+++ b/SPECS/docker-buildx/generate_source_tarball.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Quit on failure
+set -e
+
+PKG_VERSION=""
+SRC_TARBALL=""
+VENDOR_VERSION="1"
+OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# parameters:
+#
+# --srcTarball    : src tarball file
+#                   this file contains the 'initial' source code of the component
+#                   and should be replaced with the new/modified src code
+# --outFolder     : folder where to copy the new tarball(s)
+# --pkgVersion    : package version
+# --vendorVersion : vendor version
+#
+PARAMS=""
+while (( "$#" )); do
+    case "$1" in
+        --srcTarball)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            SRC_TARBALL=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --outFolder)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            OUT_FOLDER=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --pkgVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            PKG_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --vendorVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            VENDOR_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        -*|--*=) # unsupported flags
+        echo "Error: Unsupported flag $1" >&2
+        exit 1
+        ;;
+        *) # preserve positional arguments
+        PARAMS="$PARAMS $1"
+        shift
+        ;;
+  esac
+done
+
+echo "--srcTarball      -> $SRC_TARBALL"
+echo "--outFolder       -> $OUT_FOLDER"
+echo "--pkgVersion      -> $PKG_VERSION"
+echo "--vendorVersion   -> $VENDOR_VERSION"
+
+if [ -z "$PKG_VERSION" ]; then
+    echo "--pkgVersion parameter cannot be empty"
+    exit 1
+fi
+
+echo "-- create temp folder"
+tmpdir=$(mktemp -d)
+function cleanup {
+    echo "+++ cleanup -> remove $tmpdir"
+    rm -rf $tmpdir
+}
+trap cleanup EXIT
+
+TARBALL_FOLDER="$tmpdir/tarballFolder"
+mkdir -p $TARBALL_FOLDER
+cp $SRC_TARBALL $tmpdir
+
+pushd $tmpdir > /dev/null
+
+PKG_NAME="docker-buildx"
+NAME_VER="$PKG_NAME-$PKG_VERSION"
+VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-v$VENDOR_VERSION.tar.gz"
+
+echo "Unpacking source tarball..."
+tar -xf $SRC_TARBALL
+
+echo "Vendor go modules..."
+cd "buildx-$PKG_VERSION"
+go mod tidy
+go mod vendor
+
+echo ""
+echo "========================="
+echo "Tar vendored tarball"
+tar  --sort=name \
+     --mtime="2021-04-26 00:00Z" \
+     --owner=0 --group=0 --numeric-owner \
+     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+     -czf "$VENDOR_TARBALL" vendor
+
+popd > /dev/null
+echo "$PKG_NAME vendored modules are available at $VENDOR_TARBALL"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Change log has details

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added `generate_source_tarball.sh` to `SPECS/docker-buildx` for the `vendor` folder to be a separate tarball
- Added vendor tarball and updated spec / signatures to match.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [721846](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=721846&view=results)
