### PR TITLE
Fixing `generate_source_tarball.sh` for `influxdb` and `influx-cli` to match other scripts

### DIFF
--- a/SPECS/influx-cli/generate_source_tarball.sh
+++ b/SPECS/influx-cli/generate_source_tarball.sh
@@ -11,11 +11,11 @@ OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # parameters:
 #
-# --srcTarball  : src tarball file
-#                 this file contains the 'initial' source code of the component
-#                 and should be replaced with the new/modified src code
-# --outFolder   : folder where to copy the new tarball(s)
-# --pkgVersion  : package version
+# --srcTarball    : src tarball file
+#                   this file contains the 'initial' source code of the component
+#                   and should be replaced with the new/modified src code
+# --outFolder     : folder where to copy the new tarball(s)
+# --pkgVersion    : package version
 # --vendorVersion : vendor version
 #
 PARAMS=""

--- a/SPECS/influx-cli/generate_source_tarball.sh
+++ b/SPECS/influx-cli/generate_source_tarball.sh
@@ -16,6 +16,7 @@ OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #                 and should be replaced with the new/modified src code
 # --outFolder   : folder where to copy the new tarball(s)
 # --pkgVersion  : package version
+# --vendorVersion : vendor version
 #
 PARAMS=""
 while (( "$#" )); do
@@ -47,6 +48,15 @@ while (( "$#" )); do
             exit 1
         fi
         ;;
+         --vendorVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            VENDOR_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
         -*|--*=) # unsupported flags
         echo "Error: Unsupported flag $1" >&2
         exit 1
@@ -58,9 +68,10 @@ while (( "$#" )); do
   esac
 done
 
-echo "--srcTarball   -> $SRC_TARBALL"
-echo "--outFolder    -> $OUT_FOLDER"
-echo "--pkgVersion   -> $PKG_VERSION"
+echo "--srcTarball      -> $SRC_TARBALL"
+echo "--outFolder       -> $OUT_FOLDER"
+echo "--pkgVersion      -> $PKG_VERSION"
+echo "--vendorVersion   -> $VENDOR_VERSION"
 
 if [ -z "$PKG_VERSION" ]; then
     echo "--pkgVersion parameter cannot be empty"
@@ -102,4 +113,4 @@ tar  --sort=name \
      -cf "$VENDOR_TARBALL" vendor
 
 popd > /dev/null
-echo "$PKG_NAME vendored modules are available at $VENDOR_TARBALL and static assets in $STATIC_ASSETS_TARBALL"
+echo "$PKG_NAME vendored modules are available at $VENDOR_TARBALL"

--- a/SPECS/influx-cli/generate_source_tarball.sh
+++ b/SPECS/influx-cli/generate_source_tarball.sh
@@ -94,7 +94,7 @@ pushd $tmpdir > /dev/null
 
 PKG_NAME="influx-cli"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
-VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
+VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
 tar -xf $SRC_TARBALL

--- a/SPECS/influx-cli/generate_source_tarball.sh
+++ b/SPECS/influx-cli/generate_source_tarball.sh
@@ -94,7 +94,7 @@ pushd $tmpdir > /dev/null
 
 PKG_NAME="influx-cli"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
-VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-$VENDOR_VERSION.tar.gz"
+VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-v$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
 tar -xf $SRC_TARBALL

--- a/SPECS/influx-cli/influx-cli.signatures.json
+++ b/SPECS/influx-cli/influx-cli.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
       "influx-cli-2.7.3.tar.gz": "1be63bfdf39ee5e038c464b97994967183e9c6db05a3829172f0045b84e2b247",
-      "influx-cli-2.7.3-govendor.tar.gz": "8548981c0df5d6330c612ec9fd2aeaa8203aa2e86868087f9b9410dc1758d56b"
+      "influx-cli-2.7.3-govendor-v1.tar.gz": "8548981c0df5d6330c612ec9fd2aeaa8203aa2e86868087f9b9410dc1758d56b"
   }
 }

--- a/SPECS/influx-cli/influx-cli.signatures.json
+++ b/SPECS/influx-cli/influx-cli.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
       "influx-cli-2.7.3.tar.gz": "1be63bfdf39ee5e038c464b97994967183e9c6db05a3829172f0045b84e2b247",
-      "influx-cli-2.7.3-vendor.tar.gz": "8548981c0df5d6330c612ec9fd2aeaa8203aa2e86868087f9b9410dc1758d56b"
+      "influx-cli-2.7.3-govendor.tar.gz": "8548981c0df5d6330c612ec9fd2aeaa8203aa2e86868087f9b9410dc1758d56b"
   }
 }

--- a/SPECS/influx-cli/influx-cli.spec
+++ b/SPECS/influx-cli/influx-cli.spec
@@ -25,20 +25,6 @@ Distribution:   Azure Linux
 Group:          Productivity/Databases/Servers
 URL:            https://github.com/influxdata/influx-cli
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-# Below is a manually created tarball, no download link.
-# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
-# Use generate_source_tarbbal.sh to get this generated from a source code file.
-# How to re-build this file:
-#   1. wget https://github.com/influxdata/influx-cli/archive/refs/tags/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
-#   2. tar -xf %%{name}-%%{version}.tar.gz
-#   3. cd %%{name}-%%{version}
-#   4. go mod vendor
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
-#           --owner=0 --group=0 --numeric-owner \
-#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %%{name}-%%{version}-vendor.tar.gz vendor
-#
 Source1:        %{name}-%{version}-govendor-v1.tar.gz
 BuildRequires:  golang
 BuildRequires:  systemd-rpm-macros

--- a/SPECS/influx-cli/influx-cli.spec
+++ b/SPECS/influx-cli/influx-cli.spec
@@ -18,7 +18,7 @@
 Summary:        CLI for managing resources in InfluxDB
 Name:           influx-cli
 Version:        2.7.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -39,7 +39,7 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.
 #           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 #           -cf %%{name}-%%{version}-vendor.tar.gz vendor
 #
-Source1:        %{name}-%{version}-vendor.tar.gz
+Source1:        %{name}-%{version}-govendor.tar.gz
 BuildRequires:  golang
 BuildRequires:  systemd-rpm-macros
 
@@ -81,6 +81,9 @@ bin/influx completion zsh > %{buildroot}/%{_datadir}/zsh/site-functions/_influx
 %{_datadir}/zsh
 
 %changelog
+* Wed Jan 29 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.7.3-3
+- Change vendor naming convention to match other go packages.
+
 * Thu Mar 07 2024 Andrew Phelps <anphel@microsoft.com> - 2.7.3-2
 - Remove restriction on golang BR version
 
@@ -102,7 +105,7 @@ bin/influx completion zsh > %{buildroot}/%{_datadir}/zsh/site-functions/_influx
 * Thu Jun 15 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.6.1-9
 - Bump release to rebuild with go 1.19.10
 
-* Thu May 25 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsft.com> - 2.6.1-8
+* Thu May 25 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.6.1-8
 - Removed bash-completion subpackage since the script produced is included in original bash-completion.
 
 * Wed Apr 05 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.6.1-7

--- a/SPECS/influx-cli/influx-cli.spec
+++ b/SPECS/influx-cli/influx-cli.spec
@@ -39,7 +39,7 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.
 #           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 #           -cf %%{name}-%%{version}-vendor.tar.gz vendor
 #
-Source1:        %{name}-%{version}-govendor.tar.gz
+Source1:        %{name}-%{version}-govendor-v1.tar.gz
 BuildRequires:  golang
 BuildRequires:  systemd-rpm-macros
 

--- a/SPECS/influxdb/generate_source_tarball.sh
+++ b/SPECS/influxdb/generate_source_tarball.sh
@@ -94,7 +94,7 @@ pushd $tmpdir > /dev/null
 
 PKG_NAME="influxdb"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
-VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
+VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
 tar -xf $SRC_TARBALL

--- a/SPECS/influxdb/generate_source_tarball.sh
+++ b/SPECS/influxdb/generate_source_tarball.sh
@@ -11,11 +11,12 @@ OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # parameters:
 #
-# --srcTarball  : src tarball file
-#                 this file contains the 'initial' source code of the component
-#                 and should be replaced with the new/modified src code
-# --outFolder   : folder where to copy the new tarball(s)
-# --pkgVersion  : package version
+# --srcTarball    : src tarball file
+#                   this file contains the 'initial' source code of the component
+#                   and should be replaced with the new/modified src code
+# --outFolder     : folder where to copy the new tarball(s)
+# --pkgVersion    : package version
+# --vendorVersion : vendor version
 #
 PARAMS=""
 while (( "$#" )); do
@@ -47,6 +48,15 @@ while (( "$#" )); do
             exit 1
         fi
         ;;
+        --vendorVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            VENDOR_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
         -*|--*=) # unsupported flags
         echo "Error: Unsupported flag $1" >&2
         exit 1
@@ -58,9 +68,10 @@ while (( "$#" )); do
   esac
 done
 
-echo "--srcTarball   -> $SRC_TARBALL"
-echo "--outFolder    -> $OUT_FOLDER"
-echo "--pkgVersion   -> $PKG_VERSION"
+echo "--srcTarball      -> $SRC_TARBALL"
+echo "--outFolder       -> $OUT_FOLDER"
+echo "--pkgVersion      -> $PKG_VERSION"
+echo "--vendorVersion   -> $VENDOR_VERSION"
 
 if [ -z "$PKG_VERSION" ]; then
     echo "--pkgVersion parameter cannot be empty"

--- a/SPECS/influxdb/generate_source_tarball.sh
+++ b/SPECS/influxdb/generate_source_tarball.sh
@@ -94,7 +94,7 @@ pushd $tmpdir > /dev/null
 
 PKG_NAME="influxdb"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
-VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-$VENDOR_VERSION.tar.gz"
+VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-v$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
 tar -xf $SRC_TARBALL
@@ -112,7 +112,7 @@ tar  --sort=name \
      --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
      -cf "$VENDOR_TARBALL" vendor
 
-STATIC_ASSETS_TARBALL="$OUT_FOLDER/$NAME_VER-static-data.tar.gz"
+STATIC_ASSETS_TARBALL="$OUT_FOLDER/$NAME_VER-static-data-v$VENDOR_VERSION.tar.gz"
 
 echo ""
 echo "========================="

--- a/SPECS/influxdb/influxdb.signatures.json
+++ b/SPECS/influxdb/influxdb.signatures.json
@@ -1,7 +1,7 @@
 {
     "Signatures": {
         "influxdb-2.7.3.tar.gz": "b1bc78feff1940774f3d017d292b9fd4187ce2041ceaf94fa5fa7ff7546d8944",
-        "influxdb-2.7.3-vendor.tar.gz": "d59a7652ffac6b108fd4815289dd65148bedaa747a932b9a52b76b1628ab9d4c",
+        "influxdb-2.7.3-govendor.tar.gz": "d59a7652ffac6b108fd4815289dd65148bedaa747a932b9a52b76b1628ab9d4c",
         "influxdb-2.7.3-static-data.tar.gz": "23e0f0503368bae46d41840934f3c907f3978cdbbc9a1f8f250e396b2d004842",
         "config.yaml": "f0eb56d58d2685bdfc16ee73d835f022c2df6905458381a972375449fde6170c",
         "influxdb.service": "570fdbb685c8468f3c4e75b7f482bbc5c0ab4382ad2259a595e7839244747645",

--- a/SPECS/influxdb/influxdb.signatures.json
+++ b/SPECS/influxdb/influxdb.signatures.json
@@ -1,8 +1,8 @@
 {
     "Signatures": {
         "influxdb-2.7.3.tar.gz": "b1bc78feff1940774f3d017d292b9fd4187ce2041ceaf94fa5fa7ff7546d8944",
-        "influxdb-2.7.3-govendor.tar.gz": "d59a7652ffac6b108fd4815289dd65148bedaa747a932b9a52b76b1628ab9d4c",
-        "influxdb-2.7.3-static-data.tar.gz": "23e0f0503368bae46d41840934f3c907f3978cdbbc9a1f8f250e396b2d004842",
+        "influxdb-2.7.3-govendor-v1.tar.gz": "d59a7652ffac6b108fd4815289dd65148bedaa747a932b9a52b76b1628ab9d4c",
+        "influxdb-2.7.3-static-data-v1.tar.gz": "23e0f0503368bae46d41840934f3c907f3978cdbbc9a1f8f250e396b2d004842",
         "config.yaml": "f0eb56d58d2685bdfc16ee73d835f022c2df6905458381a972375449fde6170c",
         "influxdb.service": "570fdbb685c8468f3c4e75b7f482bbc5c0ab4382ad2259a595e7839244747645",
         "influxdb-user.conf": "ca5a50bb6ca9f4fcb91d745d552e70af934fdad86196c535c4eb8699a20e7aa0",

--- a/SPECS/influxdb/influxdb.spec
+++ b/SPECS/influxdb/influxdb.spec
@@ -25,32 +25,8 @@ Distribution:   Azure Linux
 Group:          Productivity/Databases/Servers
 URL:            https://github.com/influxdata/influxdb
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-# Below is a manually created tarball, no download link.
-# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
-# Use generate_source_tarbbal.sh to get this generated from a source code file.
-# How to re-build this file:
-#   1. wget https://github.com/influxdata/influxdb/archive/refs/tags/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
-#   2. tar -xf %%{name}-%%{version}.tar.gz
-#   3. cd %%{name}-%%{version}
-#   4. go mod vendor
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
-#           --owner=0 --group=0 --numeric-owner \
-#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %%{name}-%%{version}-vendor.tar.gz vendor
-#
 Source1:        %{name}-%{version}-govendor-v1.tar.gz
-# Below is a manually created tarball, no download link.
-# predownloaded assets include ui assets and swager json. Used to replace fetch-assets and fetch-swagger script.
-# Use generate_source_tarbbal.sh to get this generated from a source code file.
-# How to rebuild this file:
-#   1. wget https://github.com/influxdata/influxdb/archive/refs/tags/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
-#   2. tar -xf %%{name}-%%{version}.tar.gz
-#   3. cd %%{name}-%%{version}
-#   4. make generate-web-assets
-#   5. cd static
-#   6. tar -cvf %%{name}-%%{version}-static-data.tar.gz data/
-Source2:        %{name}-%{version}-static-data.tar.gz
+Source2:        %{name}-%{version}-static-data-v1.tar.gz
 Source3:        influxdb.service
 Source4:        influxdb.tmpfiles
 Source5:        config.yaml

--- a/SPECS/influxdb/influxdb.spec
+++ b/SPECS/influxdb/influxdb.spec
@@ -18,7 +18,7 @@
 Summary:        Scalable datastore for metrics, events, and real-time analytics
 Name:           influxdb
 Version:        2.7.3
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -39,7 +39,7 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.
 #           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 #           -cf %%{name}-%%{version}-vendor.tar.gz vendor
 #
-Source1:        %{name}-%{version}-vendor.tar.gz
+Source1:        %{name}-%{version}-govendor.tar.gz
 # Below is a manually created tarball, no download link.
 # predownloaded assets include ui assets and swager json. Used to replace fetch-assets and fetch-swagger script.
 # Use generate_source_tarbbal.sh to get this generated from a source code file.
@@ -151,13 +151,16 @@ go test ./...
 %{_tmpfilesdir}/influxdb.conf
 
 %changelog
+* Wed Jan 29 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.7.3-10
+- Change vendor naming convention to match other go packages.
+
 * Wed Jan 27 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 2.7.3-9
 - Fix CVE-2024-28180
 
 * Tue Dec 31 2024 Rohit Rawat <rohitrawat@microsoft.com> - 2.7.3-8
 - Add patch for CVE-2024-45338
 
-- Mon Nov 25 2024 Bala <balakumaran.kannan@microsoft.com> - 2.7.3-7
+* Mon Nov 25 2024 Bala <balakumaran.kannan@microsoft.com> - 2.7.3-7
 - Fix CVE-2024-24786
 
 * Thu Oct 10 2024 Sumedh Sharma <sumsharma@microsoft.com> - 2.7.3-6

--- a/SPECS/influxdb/influxdb.spec
+++ b/SPECS/influxdb/influxdb.spec
@@ -39,7 +39,7 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.
 #           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 #           -cf %%{name}-%%{version}-vendor.tar.gz vendor
 #
-Source1:        %{name}-%{version}-govendor.tar.gz
+Source1:        %{name}-%{version}-govendor-v1.tar.gz
 # Below is a manually created tarball, no download link.
 # predownloaded assets include ui assets and swager json. Used to replace fetch-assets and fetch-swagger script.
 # Use generate_source_tarbbal.sh to get this generated from a source code file.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Following PRs like https://github.com/microsoft/azurelinux/pull/12065, this PR aims to modify existing `generate_source_tarball.sh` scripts for `influxdb` and `influx-cli` to use the same parameters and behavior as other go vendored packages. So it adds new parameter to the script and modifies the vendored file name to match the naming scheme.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adds `vendorVersion` parameter to `influxdb` and `influx-cli` scripts as well as make the scripts use it for naming to add `v1` versioning for vendored files
- Renames vendored files for `influxdb` and `influxcli` to use `govendor-v1` naming in it
- Fixes changelog typos and mistakes in `influxdb` and `influx-cli`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
