### PR TITLE
Fixing `generate_source_tarball.sh` for `helm` to match other scripts 

### DIFF
--- a/SPECS/helm/generate_source_tarball.sh
+++ b/SPECS/helm/generate_source_tarball.sh
@@ -9,14 +9,12 @@ PKG_VERSION=""
 SRC_TARBALL=""
 OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# parameters:
-#
-# --srcTarball  : src tarball file
-#                 this file contains the 'initial' source code of the component
-#                 and should be replaced with the new/modified src code
-# --outFolder   : folder where to copy the new tarball(s)
-# --pkgVersion  : package version
-#
+# --srcTarball    : src tarball file
+#                   this file contains the 'initial' source code of the component
+#                   and should be replaced with the new/modified src code
+# --outFolder     : folder where to copy the new tarball(s)
+# --pkgVersion    : package version
+# --vendorVersion : vendor version
 PARAMS=""
 while (( "$#" )); do
     case "$1" in
@@ -47,6 +45,15 @@ while (( "$#" )); do
             exit 1
         fi
         ;;
+        --vendorVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            VENDOR_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
         -*|--*=) # unsupported flags
         echo "Error: Unsupported flag $1" >&2
         exit 1
@@ -58,9 +65,10 @@ while (( "$#" )); do
   esac
 done
 
-echo "--srcTarball   -> $SRC_TARBALL"
-echo "--outFolder    -> $OUT_FOLDER"
-echo "--pkgVersion   -> $PKG_VERSION"
+echo "--srcTarball      -> $SRC_TARBALL"
+echo "--outFolder       -> $OUT_FOLDER"
+echo "--pkgVersion      -> $PKG_VERSION"
+echo "--vendorVersion   -> $VENDOR_VERSION"
 
 if [ -z "$PKG_VERSION" ]; then
     echo "--pkgVersion parameter cannot be empty"
@@ -79,7 +87,7 @@ pushd $tmpdir > /dev/null
 
 NAME="helm"
 NAME_VER="$NAME-$PKG_VERSION"
-VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
+VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-v$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
 tar -xf $SRC_TARBALL

--- a/SPECS/helm/helm.signatures.json
+++ b/SPECS/helm/helm.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "helm-3.15.2-vendor.tar.gz": "b7b805732765d0976a0cc9e37ba4ce1c0a92a03c6c6257330ebfd50f860896dc",
+  "helm-3.15.2-govendor-v1.tar.gz": "b7b805732765d0976a0cc9e37ba4ce1c0a92a03c6c6257330ebfd50f860896dc",
   "helm-3.15.2.tar.gz": "c26b74f855cd403183729f24be5a60ed6ed018d2855f0d9caf99cacb127f34b2"
  }
 }

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -2,7 +2,7 @@
 
 Name:          helm
 Version:       3.15.2
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       The Kubernetes Package Manager
 Group:         Applications/Networking
 License:       Apache 2.0
@@ -23,7 +23,7 @@ Source0:       https://github.com/helm/helm/archive/refs/tags/v%{version}.tar.gz
 #           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 #           -cf %%{name}-%%{version}-vendor.tar.gz vendor
 #
-Source1:       %{name}-%{version}-vendor.tar.gz
+Source1:       %{name}-%{version}-govendor-v1.tar.gz
 Patch0:        CVE-2024-45338.patch
 BuildRequires: golang
 
@@ -55,6 +55,9 @@ install -m 755 ./helm %{buildroot}%{_bindir}
 go test -v ./cmd/helm
 
 %changelog
+* Wed Jan 29 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 3.15.2-3
+- Change vendor naming convention to match other go packages.
+
 * Tue Dec 31 2024 Rohit Rawat <rohitrawat@microsoft.com> - 3.15.2-2
 - Add patch for CVE-2024-45338
 

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -10,19 +10,6 @@ Vendor:        Microsoft Corporation
 Distribution:  Azure Linux
 Url:           https://helm.sh/
 Source0:       https://github.com/helm/helm/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-# Below is a manually created tarball, no download link.
-# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
-# How to re-build this file:
-#   1. wget https://github.com/helm/helm/archive/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
-#   2. tar -xf %%{name}-%%{version}.tar.gz
-#   3. cd %%{name}-%%{version}
-#   4. go mod vendor
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
-#           --owner=0 --group=0 --numeric-owner \
-#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %%{name}-%%{version}-vendor.tar.gz vendor
-#
 Source1:       %{name}-%{version}-govendor-v1.tar.gz
 Patch0:        CVE-2024-45338.patch
 BuildRequires: golang


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Following PRs like https://github.com/microsoft/azurelinux/pull/12065, this PR aims to modify existing `generate_source_tarball.sh` scripts for `helm` to use the same parameters and behavior as other go vendored packages. So it adds new parameter to the script and modifies the vendored file name to match the naming scheme.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adds `vendorVersion` parameter to `helm` make the scripts use it for naming to add `v1` versioning for vendored files
- Renames vendored files for `helm` to use `govendor-v1` naming in it

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
