### PR TITLE
Fixing `generate_source_tarball.sh` for `grpc` to match other scripts

### DIFF
--- a/SPECS/grpc/generate_source_tarball.sh
+++ b/SPECS/grpc/generate_source_tarball.sh
@@ -6,13 +6,12 @@ SRC_TARBALL=""
 OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PKG_VERSION=""
 
-# parameters:
-#
-# --srcTarball  : src tarball file
-#                 this file contains the 'initial' source code of the component
-#                 and should be replaced with the new/modified src code
-# --outFolder   : folder where to copy the new tarball(s)
-# --pkgVersion  : package version
+# --srcTarball    : src tarball file
+#                   this file contains the 'initial' source code of the component
+#                   and should be replaced with the new/modified src code
+# --outFolder     : folder where to copy the new tarball(s)
+# --pkgVersion    : package version
+# --vendorVersion : vendor version
 #
 PARAMS=""
 while (( "$#" )); do
@@ -44,6 +43,15 @@ while (( "$#" )); do
             exit 1
         fi
         ;;
+        --vendorVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            VENDOR_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
         -*|--*=) # unsupported flags
         echo "Error: Unsupported flag $1" >&2
         exit 1
@@ -55,9 +63,10 @@ while (( "$#" )); do
   esac
 done
 
-echo "--srcTarball   -> $SRC_TARBALL"
-echo "--outFolder    -> $OUT_FOLDER"
-echo "--pkgVersion   -> $PKG_VERSION"
+echo "--srcTarball      -> $SRC_TARBALL"
+echo "--outFolder       -> $OUT_FOLDER"
+echo "--pkgVersion      -> $PKG_VERSION"
+echo "--vendorVersion   -> $VENDOR_VERSION"
 
 if [ -z "$PKG_VERSION" ]; then
     echo "--pkgVersion parameter cannot be empty"
@@ -82,7 +91,7 @@ git submodule update --init
 popd
 mv grpc/third_party third_party
 
-TARBALL_NAME="grpc-$PKG_VERSION-submodules.tar.gz"
+TARBALL_NAME="grpc-$PKG_VERSION-submodules-v$VENDOR_VERSION.tar.gz"
 
 NEW_TARBALL="$OUT_FOLDER/$TARBALL_NAME"
 

--- a/SPECS/grpc/grpc.signatures.json
+++ b/SPECS/grpc/grpc.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "grpc-1.62.0-submodules.tar.gz": "dba5605f82b99f65f7109644cbd0b92936f29f5308d2565c9cc6cfde27e215d0",
+  "grpc-1.62.0-submodules-v1.tar.gz": "dba5605f82b99f65f7109644cbd0b92936f29f5308d2565c9cc6cfde27e215d0",
   "grpc-1.62.0.tar.gz": "f40bde4ce2f31760f65dc49a2f50876f59077026494e67dccf23992548b1b04f"
  }
 }

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -1,14 +1,14 @@
 Summary:        Open source remote procedure call (RPC) framework
 Name:           grpc
 Version:        1.62.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Applications/System
 URL:            https://www.grpc.io
 Source0:        https://github.com/grpc/grpc/archive/v%{version}/%{name}-%{version}.tar.gz
-Source1:        %{name}-%{version}-submodules.tar.gz
+Source1:        %{name}-%{version}-submodules-v1.tar.gz
 Patch0:         grpcio-cython3.patch
 Patch1:         CVE-2024-11407.patch
 BuildRequires:  abseil-cpp-devel >= 20240116.0-2
@@ -152,6 +152,9 @@ export GRPC_PYTHON_CFLAGS="%{optflags} -std=c++$CXX_VERSION"
 %{python3_sitearch}/grpcio-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Thu Jan 30 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 1.62.0-5
+- Change vendor naming convention to match other go packages.
+
 * Wed Jan 25 2024 Suresh Thelkar <sthelkar@microsoft.com> - 1.62.0-4
 - Patch CVE-2024-11407
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Following PRs like https://github.com/microsoft/azurelinux/pull/12065, this PR aims to modify existing `generate_source_tarball.sh` scripts for `grpc` to use the same parameters and behavior as other go vendored packages. So it adds new parameter to the script and modifies the vendored file name to match the naming scheme.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adds `vendorVersion` parameter to `grpc` make the scripts use it for naming to add `v1` versioning for vendored files
- Renames vendored files for `grpc` to use `govendor-v1` naming in it

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
