### PR TITLE
cdi: Renaming binaries in the SPEC file to align with upstream naming conventions

### DIFF
--- a/.pipelines/containerSourceData/cdi/Dockerfile-cdi-apiserver
+++ b/.pipelines/containerSourceData/cdi/Dockerfile-cdi-apiserver
@@ -10,9 +10,6 @@ ARG USER
 
 @INCLUDE_MAIN_RUN_INSTRUCTION@
 
-# workaround till binaries rename is merged
-RUN [ -f /usr/bin/virt-cdi-apiserver ] && mv -f /usr/bin/virt-cdi-apiserver /usr/bin/cdi-apiserver
-
 #simple smoke test
 RUN ls /usr/bin/cdi-apiserver
 

--- a/.pipelines/containerSourceData/cdi/Dockerfile-cdi-controller
+++ b/.pipelines/containerSourceData/cdi/Dockerfile-cdi-controller
@@ -10,9 +10,6 @@ ARG USER
 
 @INCLUDE_MAIN_RUN_INSTRUCTION@
 
-# workaround till binaries rename is merged
-RUN [ -f /usr/bin/virt-cdi-controller ] && mv -f /usr/bin/virt-cdi-controller /usr/bin/cdi-controller
-
 #simple smoke test
 RUN ls /usr/bin/cdi-controller
 

--- a/.pipelines/containerSourceData/cdi/Dockerfile-cdi-importer
+++ b/.pipelines/containerSourceData/cdi/Dockerfile-cdi-importer
@@ -10,9 +10,6 @@ ARG USER
 
 @INCLUDE_MAIN_RUN_INSTRUCTION@
 
-# workaround till binaries rename is merged
-RUN [ -f /usr/bin/virt-cdi-importer ] && mv -f /usr/bin/virt-cdi-importer /usr/bin/cdi-importer
-
 #simple smoke test
 RUN ls /usr/bin/cdi-importer
 

--- a/.pipelines/containerSourceData/cdi/Dockerfile-cdi-operator
+++ b/.pipelines/containerSourceData/cdi/Dockerfile-cdi-operator
@@ -10,9 +10,6 @@ ARG USER
 
 @INCLUDE_MAIN_RUN_INSTRUCTION@
 
-# workaround till binaries rename is merged
-RUN [ -f /usr/bin/virt-cdi-operator ] && mv -f /usr/bin/virt-cdi-operator /usr/bin/cdi-operator
-
 #simple smoke test
 RUN ls /usr/bin/cdi-operator
 

--- a/.pipelines/containerSourceData/cdi/Dockerfile-cdi-uploadproxy
+++ b/.pipelines/containerSourceData/cdi/Dockerfile-cdi-uploadproxy
@@ -10,9 +10,6 @@ ARG USER
 
 @INCLUDE_MAIN_RUN_INSTRUCTION@
 
-# workaround till binaries rename is merged
-RUN [ -f /usr/bin/virt-cdi-uploadproxy ] && mv -f /usr/bin/virt-cdi-uploadproxy /usr/bin/cdi-uploadproxy
-
 #simple smoke test
 RUN ls /usr/bin/cdi-uploadproxy
 

--- a/.pipelines/containerSourceData/cdi/Dockerfile-cdi-uploadserver
+++ b/.pipelines/containerSourceData/cdi/Dockerfile-cdi-uploadserver
@@ -10,9 +10,6 @@ ARG USER
 
 @INCLUDE_MAIN_RUN_INSTRUCTION@
 
-# workaround till binaries rename is merged
-RUN [ -f /usr/bin/virt-cdi-uploadserver ] && mv -f /usr/bin/virt-cdi-uploadserver /usr/bin/cdi-uploadserver
-
 #simple smoke test
 RUN ls /usr/bin/cdi-uploadserver
 

--- a/SPECS/containerized-data-importer/containerized-data-importer.spec
+++ b/SPECS/containerized-data-importer/containerized-data-importer.spec
@@ -18,7 +18,7 @@
 Summary:        Container native virtualization
 Name:           containerized-data-importer
 Version:        1.57.0
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -149,20 +149,20 @@ CGO_ENABLED=0 ./hack/build/build-go.sh build \
 %install
 mkdir -p %{buildroot}%{_bindir}
 
-install -p -m 0755 _out/cmd/cdi-apiserver/cdi-apiserver %{buildroot}%{_bindir}/virt-cdi-apiserver
+install -p -m 0755 _out/cmd/cdi-apiserver/cdi-apiserver %{buildroot}%{_bindir}/cdi-apiserver
 
 install -p -m 0755 cmd/cdi-cloner/cloner_startup.sh %{buildroot}%{_bindir}/
 install -p -m 0755 _out/cmd/cdi-cloner/cdi-cloner %{buildroot}%{_bindir}/
 
-install -p -m 0755 _out/cmd/cdi-controller/cdi-controller %{buildroot}%{_bindir}/virt-cdi-controller
+install -p -m 0755 _out/cmd/cdi-controller/cdi-controller %{buildroot}%{_bindir}/cdi-controller
 
-install -p -m 0755 _out/cmd/cdi-importer/cdi-importer %{buildroot}%{_bindir}/virt-cdi-importer
+install -p -m 0755 _out/cmd/cdi-importer/cdi-importer %{buildroot}%{_bindir}/cdi-importer
 
-install -p -m 0755 _out/cmd/cdi-operator/cdi-operator %{buildroot}%{_bindir}/virt-cdi-operator
+install -p -m 0755 _out/cmd/cdi-operator/cdi-operator %{buildroot}%{_bindir}/cdi-operator
 
-install -p -m 0755 _out/cmd/cdi-uploadproxy/cdi-uploadproxy %{buildroot}%{_bindir}/virt-cdi-uploadproxy
+install -p -m 0755 _out/cmd/cdi-uploadproxy/cdi-uploadproxy %{buildroot}%{_bindir}/cdi-uploadproxy
 
-install -p -m 0755 _out/cmd/cdi-uploadserver/cdi-uploadserver %{buildroot}%{_bindir}/virt-cdi-uploadserver
+install -p -m 0755 _out/cmd/cdi-uploadserver/cdi-uploadserver %{buildroot}%{_bindir}/cdi-uploadserver
 
 install -p -m 0755 _out/tools/cdi-containerimage-server/cdi-containerimage-server %{buildroot}%{_bindir}/cdi-containerimage-server
 
@@ -180,7 +180,7 @@ install -m 0644 _out/manifests/release/cdi-cr.yaml %{buildroot}%{_datadir}/cdi/m
 %files api
 %license LICENSE
 %doc README.md
-%{_bindir}/virt-cdi-apiserver
+%{_bindir}/cdi-apiserver
 
 %files cloner
 %license LICENSE
@@ -191,12 +191,12 @@ install -m 0644 _out/manifests/release/cdi-cr.yaml %{buildroot}%{_datadir}/cdi/m
 %files controller
 %license LICENSE
 %doc README.md
-%{_bindir}/virt-cdi-controller
+%{_bindir}/cdi-controller
 
 %files importer
 %license LICENSE
 %doc README.md
-%{_bindir}/virt-cdi-importer
+%{_bindir}/cdi-importer
 %{_bindir}/cdi-containerimage-server
 %{_bindir}/cdi-image-size-detection
 %{_bindir}/cdi-source-update-poller
@@ -204,18 +204,18 @@ install -m 0644 _out/manifests/release/cdi-cr.yaml %{buildroot}%{_datadir}/cdi/m
 %files operator
 %license LICENSE
 %doc README.md
-%{_bindir}/virt-cdi-operator
+%{_bindir}/cdi-operator
 %{_bindir}/csv-generator
 
 %files uploadproxy
 %license LICENSE
 %doc README.md
-%{_bindir}/virt-cdi-uploadproxy
+%{_bindir}/cdi-uploadproxy
 
 %files uploadserver
 %license LICENSE
 %doc README.md
-%{_bindir}/virt-cdi-uploadserver
+%{_bindir}/cdi-uploadserver
 
 %files manifests
 %license LICENSE
@@ -226,6 +226,9 @@ install -m 0644 _out/manifests/release/cdi-cr.yaml %{buildroot}%{_datadir}/cdi/m
 %{_datadir}/cdi/manifests
 
 %changelog
+* Mon Feb 03 2025 Sharath Srikanth Chellappa <sharathsr@microsoft.com> - 1.57.0-10
+- Rename cdi binaries to be inline with upstream.
+
 * Wed Jan 29 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.57.0-9
 - Fix CVE-2024-28180 with an upstream patch
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

The cdi binaries are misnamed in the SPEC file leading to additional Dockerfile commands to rename the binaries. Changing the SPEC file naming conventions to align with upstream and removing Dockerfile workarounds.


###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

The cdi binaries are misnamed in the SPEC file leading to additional Dockerfile commands to rename the binaries. Changing the SPEC file naming conventions to align with upstream and removing Dockerfile workarounds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #56050776

###### Links to CVEs  <!-- optional -->


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=727053&view=results
- Container Pipeline Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=728225&view=results

```
(base) sharath@sharath-2:~$ sudo trivy image  --exit-code 1 --severity HIGH,CRITICAL,MEDIUM "acrafoimages.azurecr.io/base/kubevirt/cdi-uploadserver:1.57.0-10.3.0.20250204-amd64" --ignore-unfixed --quiet
[sudo] password for sharath:

acrafoimages.azurecr.io/base/kubevirt/cdi-uploadserver:1.57.0-10.3.0.20250204-amd64 (azurelinux 3.0)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)

(base) sharath@sharath-2:~$ sudo trivy image  --exit-code 1 --severity HIGH,CRITICAL,MEDIUM "acrafoimages.azurecr.io/base/kubevirt/cdi-uploadproxy:1.57.0-10.3.0.20250204-amd64" --ignore-unfixed --quiet

acrafoimages.azurecr.io/base/kubevirt/cdi-uploadproxy:1.57.0-10.3.0.20250204-amd64 (azurelinux 3.0)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)

(base) sharath@sharath-2:~$ sudo trivy image  --exit-code 1 --severity HIGH,CRITICAL,MEDIUM "acrafoimages.azurecr.io/base/kubevirt/cdi-operator:1.57.0-10.3.0.20250204-amd64" --ignore-unfixed --quiet

acrafoimages.azurecr.io/base/kubevirt/cdi-operator:1.57.0-10.3.0.20250204-amd64 (azurelinux 3.0)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)

(base) sharath@sharath-2:~$ sudo trivy image  --exit-code 1 --severity HIGH,CRITICAL,MEDIUM "acrafoimages.azurecr.io/base/kubevirt/cdi-importer:1.57.0-10.3.0.20250204-amd64" --ignore-unfixed --quiet

acrafoimages.azurecr.io/base/kubevirt/cdi-importer:1.57.0-10.3.0.20250204-amd64 (azurelinux 3.0)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)

(base) sharath@sharath-2:~$ sudo trivy image  --exit-code 1 --severity HIGH,CRITICAL,MEDIUM "acrafoimages.azurecr.io/base/kubevirt/cdi-controller:1.57.0-10.3.0.20250204-amd64" --ignore-unfixed --quiet

acrafoimages.azurecr.io/base/kubevirt/cdi-controller:1.57.0-10.3.0.20250204-amd64 (azurelinux 3.0)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)

(base) sharath@sharath-2:~$ sudo trivy image  --exit-code 1 --severity HIGH,CRITICAL,MEDIUM "acrafoimages.azurecr.io/base/kubevirt/cdi-cloner:1.57.0-10.3.0.20250204-amd64" --ignore-unfixed --quiet

acrafoimages.azurecr.io/base/kubevirt/cdi-cloner:1.57.0-10.3.0.20250204-amd64 (azurelinux 3.0)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)

(base) sharath@sharath-2:~$ sudo trivy image  --exit-code 1 --severity HIGH,CRITICAL,MEDIUM "acrafoimages.azurecr.io/base/kubevirt/cdi-apiserver:1.57.0-10.3.0.20250204-amd64" --ignore-unfixed --quiet

acrafoimages.azurecr.io/base/kubevirt/cdi-apiserver:1.57.0-10.3.0.20250204-amd64 (azurelinux 3.0)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
