### PR TITLE
avoid dracut collision between [mktemp] and [find -not -path '*.ko*']

### DIFF
--- a/SPECS/dracut/avoid-mktemp-collisions-with-find-not-path.patch
+++ b/SPECS/dracut/avoid-mktemp-collisions-with-find-not-path.patch
@@ -1,0 +1,28 @@
+From 192a4908594d0080072dd4aaf3417a926003083b Mon Sep 17 00:00:00 2001
+From: Brian Fjeldstad <bfjelds@microsoft.com>
+Date: Tue, 4 Feb 2025 21:48:52 +0000
+Subject: [PATCH] avoid mktemp collisions with [find -not -path '*.ko*']
+
+---
+ dracut.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dracut.sh b/dracut.sh
+index cc6d6f28..06e7ce8e 100755
+--- a/dracut.sh
++++ b/dracut.sh
+@@ -1253,9 +1253,9 @@ if findmnt --raw -n --target "$tmpdir" --output=options | grep -q noexec; then
+ fi
+ 
+ # shellcheck disable=SC2155
+-readonly DRACUT_TMPDIR="$(mktemp -p "$TMPDIR/" -d -t dracut.XXXXXX)"
++readonly DRACUT_TMPDIR="$(mktemp -p "$TMPDIR/" -d -t dracut.dXXXXXX)"
+ [ -d "$DRACUT_TMPDIR" ] || {
+-    printf "%s\n" "dracut[F]: mktemp -p '$TMPDIR/' -d -t dracut.XXXXXX failed." >&2
++    printf "%s\n" "dracut[F]: mktemp -p '$TMPDIR/' -d -t dracut.dXXXXXX failed." >&2
+     exit 1
+ }
+ 
+-- 
+2.34.1
+

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        102
-Release:        8%{?dist}
+Release:        9%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -315,6 +315,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Tue Feb 04 2025 Brian Fjeldstad <bfjelds@microsoft.com> - 102-9
+- Avoid mktemp folder name colliding with find filter.
+
 * Mon Dec 09 2024 George Mileka <gmileka@microsoft.com> - 102-8
 - Augment overlayfs with selinux handling.
 

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -55,6 +55,7 @@ Patch:          0013-revert-fix-crypt-unlock-encrypted-devices-by-default.patch
 Patch:          0014-fix-systemd-pcrphase-in-hostonly-mode-do-not-try-to-include-systemd-pcrphase.patch
 Patch:          0015-fix-systemd-pcrphase-make-tpm2-tss-an-optional-dependency.patch
 Patch:          0016-Handle-SELinux-configuration-for-overlayfs-folders.patch
+Patch:          avoid-mktemp-collisions-with-find-not-path.patch
 
 BuildRequires:  bash
 BuildRequires:  kmod-devel


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
dracut.sh uses mktemp to create temporary workspace.  The pattern provided is dracut.XXXXXX.  Rarely, the temporary folder is dracut.ko*.  This conflicts with a find filter used in dracut.sh: `-not -path '*.ko*'`.   When the conflict occurs, dracut fails to install many required modules (including systemd-core), resulting in an initramfs that cannot be booted.

The patch prevents this conflict by prepending `d` to the mktemp substitution.

The matching upstream PR: https://github.com/dracut-ng/dracut-ng/pull/1198

###### Change Log  <!-- REQUIRED -->
- add patch to modify dracut.sh

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=727939&view=results
