### PR TITLE
[3.0] Fix NVIDIA GPU driver container build errors

### DIFF
--- a/.pipelines/containerSourceData/cuda/core.pkg
+++ b/.pipelines/containerSourceData/cuda/core.pkg
@@ -2,3 +2,5 @@ util-linux
 ca-certificates
 kernel
 kernel-drivers-gpu
+mlnx-ofa_kernel
+mlnx-ofa_kernel-modules

--- a/.pipelines/containerSourceData/scripts/BuildNvidiaDriverContainers.sh
+++ b/.pipelines/containerSourceData/scripts/BuildNvidiaDriverContainers.sh
@@ -238,7 +238,7 @@ function prepare_docker_directory {
 function prepare_docker_build_args {
     echo "+++ Prepare NVIDIA docker build arguments"
     KERNEL_VERSION=$(rpm -q --qf '%{VERSION}-%{release}\n' -p $HOST_MOUNTED_DIR/RPMS/x86_64/kernel-devel*)
-    DRIVER_VERSION=$(rpm -q --qf '%{VERSION}' -p $HOST_MOUNTED_DIR/RPMS/x86_64/$IMAGE*)
+    DRIVER_VERSION=$(rpm -q --qf '%{VERSION}' -p $HOST_MOUNTED_DIR/RPMS/x86_64/$IMAGE-[0-9]*)
     DRIVER_BRANCH="${DRIVER_VERSION%%.*}"
 
     DOCKER_BUILD_ARGS="--build-arg KERNEL_VERSION=$KERNEL_VERSION --build-arg DRIVER_VERSION=$DRIVER_VERSION --build-arg AZURE_LINUX_VERSION=$AZURE_LINUX_VERSION"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

This PR resolves the following two issues due to recent changes to cuda:
- Add mlnx-ofa_kernel and mlnx-ofa_kernel-modules, which are recently onboarded as runtime dependencies for cuda
- Fix the logic to set DRIVER_VERSION due to the introduction of cuda-open, which caused the existing logic to match both cuda and cuda-open and thus return the driver version repeated twice

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Local testing
