### PR TITLE
[3.0] Introduce debug and metapackage and reduce size of non-debug metapackage

### DIFF
--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -12,15 +12,15 @@ ExclusiveArch:  x86_64
 
 Requires:       ca-certificates
 Requires:       chrony
+# Required for confidential storage functionality
 Requires:       cryptsetup
 Requires:       dbus
+# Required for confidential storage functionality
+Requires:       e2fsprogs
 Requires:       elfutils-libelf
 Requires:       filesystem
 Requires:       iptables
-Requires:       iproute
 Requires:       irqbalance
-Requires:       lz4
-Requires:       sed
 # Note: We currently only support using systemd for our init process, not the kata-agent.
 # When we go to add support for AGENT_INIT=yes, can drop this.
 # https://github.com/microsoft/kata-containers/blob/msft-main/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh#L10
@@ -36,11 +36,16 @@ Summary:        Metapackage to install the set of packages inside a Kata confide
 Requires:       %{name} = %{version}-%{release}
 Requires:       curl
 Requires:       cpio
+# Provides find
 Requires:       findutils
 Requires:       gzip
+Requires:       iproute
+# Provides ping, tracepath, etc for debugging net
 Requires:       iputils
-Requires:       lvm2
+Requires:       lz4
+Requires:       sed
 Requires:       tar
+# Provides free, kill, pgrep, ps, etc
 Requires:       procps-ng
 
 %description    debug

--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -12,6 +12,7 @@ ExclusiveArch:  x86_64
 
 Requires:       ca-certificates
 Requires:       chrony
+Requires:       cryptsetup
 Requires:       dbus
 Requires:       elfutils-libelf
 Requires:       filesystem
@@ -33,7 +34,6 @@ Metapackage to install the set of packages inside a Kata containers UVM
 %package        debug
 Summary:        Metapackage to install the set of packages inside a Kata confidential containers debug UVM.
 Requires:       %{name} = %{version}-%{release}
-Requires:       cryptsetup
 Requires:       curl
 Requires:       cpio
 Requires:       findutils
@@ -110,7 +110,7 @@ Requires:       golang
 %changelog
 * Tue Feb 11 2025 Cameron Baird <cameronbaird@microsoft.com> - 1.0.0-8
 - Introduce debug metapackage
-- Move cryptsetup, curl, cpio, gzip, iputils, lvm2, tar, procps-ng to debug metapackage
+- Move curl, cpio, gzip, iputils, lvm2, tar, procps-ng to debug metapackage
 - Remove bash, grep, readline, util-linux from all metapackages (implicit deps of existing requirements)
 - Add findutils to debug metapackage
 

--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -55,7 +55,6 @@ Requires:       device-mapper
 Requires:       systemd-udev
 
 %description    coco
-Metapackage to install the set of packages inside a Kata containers coco UVM
 
 %package        build
 Summary:        Metapackage to install the set of packages for building a Kata UVM.

--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage for Kata UVM components
 Name:           kata-packages-uvm
 Version:        1.0.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -10,37 +10,41 @@ URL:            https://aka.ms/mariner
 
 ExclusiveArch:  x86_64
 
-Requires:       bash
 Requires:       ca-certificates
 Requires:       chrony
-Requires:       cpio
-Requires:       cryptsetup
-Requires:       curl
 Requires:       dbus
 Requires:       elfutils-libelf
 Requires:       filesystem
-Requires:       grep
-Requires:       gzip
 Requires:       iptables
 Requires:       iproute
-Requires:       iputils
 Requires:       irqbalance
-Requires:       lvm2
 Requires:       lz4
-Requires:       procps-ng
-Requires:       readline
 Requires:       sed
 # Note: We currently only support using systemd for our init process, not the kata-agent.
 # When we go to add support for AGENT_INIT=yes, can drop this.
 # https://github.com/microsoft/kata-containers/blob/msft-main/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh#L10
 Requires:       systemd
-Requires:       tar
 Requires:       tzdata
-Requires:       util-linux
 Requires:       zlib
 
 %description
 Metapackage to install the set of packages inside a Kata containers UVM
+
+%package        debug
+Summary:        Metapackage to install the set of packages inside a Kata confidential containers debug UVM.
+Requires:       %{name} = %{version}-%{release}
+Requires:       cryptsetup
+Requires:       curl
+Requires:       cpio
+Requires:       findutils
+Requires:       gzip
+Requires:       iputils
+Requires:       lvm2
+Requires:       tar
+Requires:       procps-ng
+
+%description    debug
+Metapackage to install the set of packages inside a Kata containers UVM, includes extra debug utilities.
 
 %package        coco
 Summary:        Metapackage to install the set of packages inside a Kata confidential containers UVM.
@@ -51,6 +55,7 @@ Requires:       device-mapper
 Requires:       systemd-udev
 
 %description    coco
+Metapackage to install the set of packages inside a Kata containers coco UVM
 
 %package        build
 Summary:        Metapackage to install the set of packages for building a Kata UVM.
@@ -95,6 +100,8 @@ Requires:       golang
 
 %files
 
+%files debug
+
 %files coco
 
 %files build
@@ -102,6 +109,12 @@ Requires:       golang
 %files coco-sign
 
 %changelog
+* Tue Feb 11 2025 Cameron Baird <cameronbaird@microsoft.com> - 1.0.0-8
+- Introduce debug metapackage
+- Move cryptsetup, curl, cpio, gzip, iputils, lvm2, tar, procps-ng to debug metapackage
+- Remove bash, grep, readline, util-linux from all metapackages (implicit deps of existing requirements)
+- Add findutils to debug metapackage
+
 * Mon Nov 25 2024 Manuel Huber <mahuber@microsoft.com> - 1.0.0-7
 - Add explicit make dependency for UVM build
 - Remove commented package dependencies

--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -12,11 +12,8 @@ ExclusiveArch:  x86_64
 
 Requires:       ca-certificates
 Requires:       chrony
-# Required for confidential storage functionality
 Requires:       cryptsetup
 Requires:       dbus
-# Required for confidential storage functionality
-Requires:       e2fsprogs
 Requires:       elfutils-libelf
 Requires:       filesystem
 Requires:       iptables


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Introduce kata-packages-uvm-debug metapackage

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Introduce kata-packages-uvm-debug metapackage
- Move curl, cpio, gzip, iputils, lvm2, tar, procps-ng to debug metapackage
- Remove bash, grep, readline, util-linux from all metapackages (implicit deps of existing requirements)
- Add findutils to debug metapackage

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested via kata image build, kata conformance tests pass https://dev.azure.com/mariner-org/mariner/_build/results?buildId=760112&view=results 
- Deployed dev image, inspected the new set of images. Noted a net saving of ~8Mb in image size for the release UVM image 
![image](https://github.com/user-attachments/assets/f0179b0f-052e-4b37-9c54-f12b8e32553a)

