### PR TITLE
Updating `toolkit/scripts/build_cargo_cache.sh`

### DIFF
--- a/toolkit/scripts/build_cargo_cache.sh
+++ b/toolkit/scripts/build_cargo_cache.sh
@@ -129,8 +129,16 @@ DIRECTORY_NAME=${DIRECTORY_NAME[0]%//}
 pushd "$DIRECTORY_NAME" &> /dev/null
 echo "Fetching dependencies to a temporary cache in $DIRECTORY_NAME."
 
-#TODO: installing rust as auto-patcher does not have it installed by default. Possibly remove if auto-patcher will be changed to have rust included.
-sudo dnf install -y rust || sudo apt install -y rustc
+echo "Installing build prerequisites for AzureLinux..."
+CURRENT_OS=$(grep '^ID=' /etc/os-release | cut -d'=' -f2-)
+echo "Current OS: $CURRENT_OS" && \
+if [ "$CURRENT_OS" = "mariner" ] || [ "$CURRENT_OS" = "azurelinux" ]; then
+    sudo dnf install -y rust
+elif [ "$$CURRENT_OS" = "ubuntu" ]; then
+    sudo apt install -y rustc
+else
+    $(call print_error,"Unsupported OS: $$CURRENT_OS") ;
+fi
 
 # assume there is only one Cargo.toml
 TOML_LOCATION=$(find . -maxdepth 2 -name "Cargo.toml" -exec dirname {} \;)

--- a/toolkit/scripts/build_cargo_cache.sh
+++ b/toolkit/scripts/build_cargo_cache.sh
@@ -2,39 +2,114 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Quit on failure
 set -e
 
-temp_dir=$(mktemp -d)
-echo "Working in temporary directory '$temp_dir'."
-function clean-up {
-    echo "Cleaning up temporary directory '$temp_dir'."
-    rm -rf "$temp_dir"
+PKG_VERSION=""
+SRC_TARBALL=""
+OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VENDOR_VERSION="1"
+
+# parameters:
+#
+# --srcTarball  : src tarball file
+#                 this file contains the 'initial' source code of the component
+#                 and should be replaced with the new/modified src code
+# --outFolder   : folder where to copy the new tarball(s)
+# --pkgVersion  : package version
+# --vendorVersion : vendor version
+
+PARAMS=""
+while (( "$#" )); do
+    case "$1" in
+        --srcTarball)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            SRC_TARBALL=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --outFolder)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            OUT_FOLDER=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --pkgVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            PKG_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --vendorVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            VENDOR_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        -*|--*=) # unsupported flags
+        echo "Error: Unsupported flag $1" >&2
+        exit 1
+        ;;
+        *) # preserve positional arguments
+        PARAMS="$PARAMS $1"
+        shift
+        ;;
+  esac
+done
+
+echo "--srcTarball      -> $SRC_TARBALL"
+echo "--outFolder       -> $OUT_FOLDER"
+echo "--pkgVersion      -> $PKG_VERSION"
+echo "--vendorVersion   -> $VENDOR_VERSION"
+
+if [ -z "$PKG_VERSION" ]; then
+    echo "--pkgVersion parameter cannot be empty"
+    exit 1
+fi
+
+if [ -z "$VENDOR_VERSION" ]; then
+    echo "--vendorVersion parameter cannot be empty"
+    exit 1
+fi
+
+echo "-- create temp folder"
+TEMP_DIR=$(mktemp -d)
+function cleanup {
+    echo "+++ cleanup -> remove $TEMP_DIR"
+    rm -rf $TEMP_DIR
 }
-trap clean-up EXIT
+trap cleanup EXIT
 
-tarball_name=$1
+pushd $TEMP_DIR > /dev/null
 
-cache_name=${tarball_name%.*}
-if [[ "$cache_name" =~ \.tar$ ]]
+TARBALL_NAME=$(basename "$SRC_TARBALL")
+
+NAME_VER=${TARBALL_NAME%.*}
+if [[ "$NAME_VER" =~ \.tar$ ]]
 then
-    cache_name=${cache_name%.*}
+    NAME_VER=${NAME_VER%.*}
 fi
 
-cache_tarball_name="$cache_name-cargo.tar.gz"
+VENDOR_TARBALL="$NAME_VER-cargovendor-v$VENDOR_VERSION.tar.gz"
 
-if [[ $# -ge 2 ]]
+if [[ -f "$TARBALL_NAME" ]]
 then
-    directory_name=$2
+    cp "$SRC_TARBALL" "$TEMP_DIR"
 else
-    directory_name=$cache_name
-fi
-
-if [[ -f "$tarball_name" ]]
-then
-    cp "$tarball_name" "$temp_dir"
-else
-    echo "Tarball '$tarball_name' doesn't exist. Will attempt to download from blobstorage."
-    if ! wget -q "https://azurelinuxsrcstorage.blob.core.windows.net/sources/core/$tarball_name" -O "$temp_dir/$tarball_name"
+    echo "Tarball '$TARBALL_NAME' doesn't exist. Will attempt to download from blobstorage."
+    if ! wget -q "https://azurelinuxsrcstorage.blob.core.windows.net/sources/core/$TARBALL_NAME" -O "$TEMP_DIR/$TARBALL_NAME"
     then
         echo "ERROR: failed to download the source tarball."
         exit 1
@@ -42,20 +117,35 @@ else
     echo "Download successful."
 fi
 
-pushd "$temp_dir" &> /dev/null
-    echo "Extracting $tarball_name."
-    tar -xf "$tarball_name"
-    
-    pushd "$directory_name" &> /dev/null
-        echo "Fetching dependencies to a temporary cache."
-        CARGO_HOME=$(pwd)/.cargo cargo fetch
+echo "Unpacking source tarball..."
+tar -xf $SRC_TARBALL
 
-        echo "Compressing the cache."
-        tar --sort=name --mtime="2021-04-26 00:00Z" --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime -cf "$cache_tarball_name" .cargo
-    popd &> /dev/null
-popd &> /dev/null
+echo "Vendor cargo ..."
+DIRECTORY_NAME=($(ls -d */))
 
-mv "$temp_dir/$directory_name/$cache_tarball_name" .
+# assume there is only one directory in the tarball
+DIRECTORY_NAME=${DIRECTORY_NAME[0]%//}
 
-echo "Done:"
-sha256sum "$cache_tarball_name"
+pushd "$DIRECTORY_NAME" &> /dev/null
+echo "Fetching dependencies to a temporary cache in $DIRECTORY_NAME."
+
+#TODO: installing rust as auto-patcher does not have it installed by default. Possibly remove if auto-patcher will be changed to have rust included.
+sudo dnf install -y rust || sudo apt install -y rustc
+
+# assume there is only one Cargo.toml
+TOML_LOCATION=$(find . -maxdepth 2 -name "Cargo.toml" -exec dirname {} \;)
+pushd $TOML_LOCATION &> /dev/null
+cargo vendor > config.toml
+
+echo ""
+echo "========================="
+echo "Tar vendored tarball"
+tar  --sort=name \
+     --mtime="2021-04-26 00:00Z" \
+     --owner=0 --group=0 --numeric-owner \
+     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+     -I pigz -cf "$VENDOR_TARBALL" vendor
+
+cp $VENDOR_TARBALL $OUT_FOLDER
+popd > /dev/null
+echo "$NAME_VER vendored modules are available at $VENDOR_TARBALL"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
I updated the `toolkit/scripts/build_cargo_cache.sh` script to improve the general cargo script, updated the `flux` script, and created a new script for `virtiofsd`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Overhauled `toolkit/scripts/build_cargo_cache.sh` to be usable for any `cargo` build
- Updated `flux` script to use the new `build_cargo_cache.sh`
- Added the script to `virtiofsd`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
