### PR TITLE
Print errors when creating directories in Makefile

### DIFF
--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -20,9 +20,14 @@ no_repo_acl = $(STATUS_FLAGS_DIR)/no_repo_acl.flag
 # Creates a folder if it doesn't exist. Also sets the timestamp to 0 if it is
 # created.
 #
+# To allow output to be printed, we use the $(eval) function to create a new
+# variable _out which will contain the output of the shell command. If the output
+# is not empty, we print it to the console.
+#
 # $1 - Folder path
 define create_folder
-$(call shell_real_build_only, if [ ! -d $1 ]; then mkdir -p $1 && touch -d @0 $1 ; fi )
+$(eval _out := $(call shell_real_build_only, if [ ! -d $1 ]; then mkdir -p $1 2>&1 && touch -d @0 $1 ; fi ))
+$(if $(strip $(_out)),$(info $(_out)))
 endef
 
 # Runs a shell commannd only if we are actually doing a build rather than parsing the makefile for tab-completion etc

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -27,7 +27,7 @@ no_repo_acl = $(STATUS_FLAGS_DIR)/no_repo_acl.flag
 # $1 - Folder path
 define create_folder
 $(eval _out := $(call shell_real_build_only, if [ ! -d $1 ]; then mkdir -p $1 2>&1 && touch -d @0 $1 ; fi ))
-$(if $(strip $(_out)),$(info $(_out)))
+$(if $(strip $(_out)),$(warning $(_out)))
 endef
 
 # Runs a shell commannd only if we are actually doing a build rather than parsing the makefile for tab-completion etc


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We are seeing very occasional failures in the toolkit. The symptoms are generally go tools reporting directories are not present. The way the Makefile is setup this should never be possible. Unfortunately we do not print any errors from the directory creation process currently, so it is not possible to debug further.

This adds a print for any stderr output from the mkdir commands. Hopefully this will give more insight into this failure if it occurs again.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update the Makefile's `create_folder` function to print `stderr` if any is generated by `mkdir`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/56157284

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Multiple runs of the sanity test, e.g.: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=734250&view=results
- Full build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=734270&view=results
