### PR TITLE
Fix binutils CVE-2025-1176 CVE-2025-1181 CVE-2025-1182

### DIFF
--- a/SPECS/binutils/CVE-2025-1176.patch
+++ b/SPECS/binutils/CVE-2025-1176.patch
@@ -5,17 +5,19 @@ Subject: [PATCH] Prevent illegal memory access when indexing into the
  sym_hashes array of the elf bfd cookie structure.
 
 PR 32636
+
+Source:  https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=f9978defb6fab0bd8583942d97c112b0932ac814
 ---
  bfd/elflink.c | 90 +++++++++++++++++++++++++--------------------------
  1 file changed, 45 insertions(+), 45 deletions(-)
 
 diff --git a/bfd/elflink.c b/bfd/elflink.c
-index a31e4092a16..1f1263007c0 100644
+index 9a052082..9acfe8b8 100644
 --- a/bfd/elflink.c
 +++ b/bfd/elflink.c
-@@ -96,22 +96,37 @@ _bfd_elf_link_keep_memory (struct bfd_link_info *info)
-   return true;
- }
+@@ -62,22 +62,37 @@ struct elf_find_verdep_info
+ static bool _bfd_elf_fix_symbol_flags
+   (struct elf_link_hash_entry *, struct elf_info_failed *);
  
 -asection *
 -_bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
@@ -59,7 +61,7 @@ index a31e4092a16..1f1263007c0 100644
        if ((h->root.type == bfd_link_hash_defined
  	   || h->root.type == bfd_link_hash_defweak)
  	   && discarded_section (h->root.u.def.section))
-@@ -119,21 +134,20 @@ _bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
+@@ -85,21 +100,20 @@ _bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
        else
  	return NULL;
      }
@@ -94,7 +96,7 @@ index a31e4092a16..1f1263007c0 100644
    return NULL;
  }
  
-@@ -13997,22 +14011,12 @@ _bfd_elf_gc_mark_rsec (struct bfd_link_info *info, asection *sec,
+@@ -13442,22 +13456,12 @@ _bfd_elf_gc_mark_rsec (struct bfd_link_info *info, asection *sec,
    if (r_symndx == STN_UNDEF)
      return NULL;
  
@@ -120,7 +122,7 @@ index a31e4092a16..1f1263007c0 100644
        was_marked = h->mark;
        h->mark = 1;
        /* Keep all aliases of the symbol too.  If an object symbol
-@@ -15067,17 +15071,12 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
+@@ -14491,17 +14495,12 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
        if (r_symndx == STN_UNDEF)
  	return true;
  
@@ -143,7 +145,7 @@ index a31e4092a16..1f1263007c0 100644
  	  if ((h->root.type == bfd_link_hash_defined
  	       || h->root.type == bfd_link_hash_defweak)
  	      && (h->root.u.def.section->owner != rcookie->abfd
-@@ -15101,6 +15100,7 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
+@@ -14525,6 +14524,7 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
  		  || discarded_section (isec)))
  	    return true;
  	}
@@ -152,4 +154,4 @@ index a31e4092a16..1f1263007c0 100644
      }
    return false;
 -- 
-2.43.5
+2.33.8

--- a/SPECS/binutils/CVE-2025-1176.patch
+++ b/SPECS/binutils/CVE-2025-1176.patch
@@ -1,0 +1,155 @@
+From f9978defb6fab0bd8583942d97c112b0932ac814 Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Wed, 5 Feb 2025 11:15:11 +0000
+Subject: [PATCH] Prevent illegal memory access when indexing into the
+ sym_hashes array of the elf bfd cookie structure.
+
+PR 32636
+---
+ bfd/elflink.c | 90 +++++++++++++++++++++++++--------------------------
+ 1 file changed, 45 insertions(+), 45 deletions(-)
+
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index a31e4092a16..1f1263007c0 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -96,22 +96,37 @@ _bfd_elf_link_keep_memory (struct bfd_link_info *info)
+   return true;
+ }
+ 
+-asection *
+-_bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
+-			     unsigned long r_symndx,
+-			     bool discard)
++static struct elf_link_hash_entry *
++get_ext_sym_hash (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
+ {
+-  if (r_symndx >= cookie->locsymcount
+-      || ELF_ST_BIND (cookie->locsyms[r_symndx].st_info) != STB_LOCAL)
+-    {
+-      struct elf_link_hash_entry *h;
++  struct elf_link_hash_entry *h = NULL;
+ 
++  if ((r_symndx >= cookie->locsymcount
++       || ELF_ST_BIND (cookie->locsyms[r_symndx].st_info) != STB_LOCAL)
++      /* Guard against corrupt input.  See PR 32636 for an example.  */
++      && r_symndx >= cookie->extsymoff)
++    {
+       h = cookie->sym_hashes[r_symndx - cookie->extsymoff];
+ 
+       while (h->root.type == bfd_link_hash_indirect
+ 	     || h->root.type == bfd_link_hash_warning)
+ 	h = (struct elf_link_hash_entry *) h->root.u.i.link;
++    }
++
++  return h;
++}
+ 
++asection *
++_bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
++			     unsigned long r_symndx,
++			     bool discard)
++{
++  struct elf_link_hash_entry *h;
++
++  h = get_ext_sym_hash (cookie, r_symndx);
++  
++  if (h != NULL)
++    {
+       if ((h->root.type == bfd_link_hash_defined
+ 	   || h->root.type == bfd_link_hash_defweak)
+ 	   && discarded_section (h->root.u.def.section))
+@@ -119,21 +134,20 @@ _bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
+       else
+ 	return NULL;
+     }
+-  else
+-    {
+-      /* It's not a relocation against a global symbol,
+-	 but it could be a relocation against a local
+-	 symbol for a discarded section.  */
+-      asection *isec;
+-      Elf_Internal_Sym *isym;
+ 
+-      /* Need to: get the symbol; get the section.  */
+-      isym = &cookie->locsyms[r_symndx];
+-      isec = bfd_section_from_elf_index (cookie->abfd, isym->st_shndx);
+-      if (isec != NULL
+-	  && discard ? discarded_section (isec) : 1)
+-	return isec;
+-     }
++  /* It's not a relocation against a global symbol,
++     but it could be a relocation against a local
++     symbol for a discarded section.  */
++  asection *isec;
++  Elf_Internal_Sym *isym;
++
++  /* Need to: get the symbol; get the section.  */
++  isym = &cookie->locsyms[r_symndx];
++  isec = bfd_section_from_elf_index (cookie->abfd, isym->st_shndx);
++  if (isec != NULL
++      && discard ? discarded_section (isec) : 1)
++    return isec;
++
+   return NULL;
+ }
+ 
+@@ -13997,22 +14011,12 @@ _bfd_elf_gc_mark_rsec (struct bfd_link_info *info, asection *sec,
+   if (r_symndx == STN_UNDEF)
+     return NULL;
+ 
+-  if (r_symndx >= cookie->locsymcount
+-      || ELF_ST_BIND (cookie->locsyms[r_symndx].st_info) != STB_LOCAL)
++  h = get_ext_sym_hash (cookie, r_symndx);
++  
++  if (h != NULL)
+     {
+       bool was_marked;
+ 
+-      h = cookie->sym_hashes[r_symndx - cookie->extsymoff];
+-      if (h == NULL)
+-	{
+-	  info->callbacks->einfo (_("%F%P: corrupt input: %pB\n"),
+-				  sec->owner);
+-	  return NULL;
+-	}
+-      while (h->root.type == bfd_link_hash_indirect
+-	     || h->root.type == bfd_link_hash_warning)
+-	h = (struct elf_link_hash_entry *) h->root.u.i.link;
+-
+       was_marked = h->mark;
+       h->mark = 1;
+       /* Keep all aliases of the symbol too.  If an object symbol
+@@ -15067,17 +15071,12 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
+       if (r_symndx == STN_UNDEF)
+ 	return true;
+ 
+-      if (r_symndx >= rcookie->locsymcount
+-	  || ELF_ST_BIND (rcookie->locsyms[r_symndx].st_info) != STB_LOCAL)
+-	{
+-	  struct elf_link_hash_entry *h;
+-
+-	  h = rcookie->sym_hashes[r_symndx - rcookie->extsymoff];
+-
+-	  while (h->root.type == bfd_link_hash_indirect
+-		 || h->root.type == bfd_link_hash_warning)
+-	    h = (struct elf_link_hash_entry *) h->root.u.i.link;
++      struct elf_link_hash_entry *h;
+ 
++      h = get_ext_sym_hash (rcookie, r_symndx);
++      
++      if (h != NULL)
++	{
+ 	  if ((h->root.type == bfd_link_hash_defined
+ 	       || h->root.type == bfd_link_hash_defweak)
+ 	      && (h->root.u.def.section->owner != rcookie->abfd
+@@ -15101,6 +15100,7 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
+ 		  || discarded_section (isec)))
+ 	    return true;
+ 	}
++
+       return false;
+     }
+   return false;
+-- 
+2.43.5

--- a/SPECS/binutils/CVE-2025-1181.patch
+++ b/SPECS/binutils/CVE-2025-1181.patch
@@ -4,23 +4,23 @@ Date: Wed, 5 Feb 2025 14:31:10 +0000
 Subject: [PATCH] Prevent illegal memory access when checking relocs in a
  corrupt ELF binary.
 This patch is added as a prerequisite to apply the actual CVE fix
-changes in bfd/elfxx-x86.c are dropped as they are not required in the current version of the code
+Changes in bfd/elfxx-x86.c are dropped as they are not required in the current version of the code
+Source: https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=18cc11a2771d9e40180485da9a4fb660c03efac3
 
 PR 32641
 ---
  bfd/elf-bfd.h      |  3 +++
  bfd/elf64-x86-64.c | 10 +++++-----
  bfd/elflink.c      | 24 ++++++++++++++++++++++++
- bfd/elfxx-x86.c    | 20 +++++++-------------
- 4 files changed, 39 insertions(+), 18 deletions(-)
+ 3 files changed, 32 insertions(+), 5 deletions(-)
 
 diff --git a/bfd/elf-bfd.h b/bfd/elf-bfd.h
-index 785a37dd7fd..d2bf8e5cbae 100644
+index 8f985ab8..14e0fa01 100644
 --- a/bfd/elf-bfd.h
 +++ b/bfd/elf-bfd.h
-@@ -3153,6 +3153,9 @@ extern bool _bfd_elf_link_mmap_section_contents
- extern void _bfd_elf_link_munmap_section_contents
-   (asection *);
+@@ -2979,6 +2979,9 @@ extern bool _bfd_elf_maybe_set_textrel
+ extern bool _bfd_elf_add_dynamic_tags
+   (bfd *, struct bfd_link_info *, bool);
  
 +extern struct elf_link_hash_entry * _bfd_elf_get_link_hash_entry
 +  (struct elf_link_hash_entry **, unsigned int, Elf_Internal_Shdr *);
@@ -29,10 +29,10 @@ index 785a37dd7fd..d2bf8e5cbae 100644
  extern asection _bfd_elf_large_com_section;
  
 diff --git a/bfd/elf64-x86-64.c b/bfd/elf64-x86-64.c
-index 32db254ba6c..2d82c6583c3 100644
+index 4b6489b9..c10f41e0 100644
 --- a/bfd/elf64-x86-64.c
 +++ b/bfd/elf64-x86-64.c
-@@ -1784,7 +1784,7 @@ elf_x86_64_convert_load_reloc (bfd *abfd,
+@@ -1499,7 +1499,7 @@ elf_x86_64_convert_load_reloc (bfd *abfd,
    bool to_reloc_pc32;
    bool abs_symbol;
    bool local_ref;
@@ -41,7 +41,7 @@ index 32db254ba6c..2d82c6583c3 100644
    bfd_signed_vma raddend;
    unsigned int opcode;
    unsigned int modrm;
-@@ -1999,6 +1999,9 @@ elf_x86_64_convert_load_reloc (bfd *abfd,
+@@ -1654,6 +1654,9 @@ elf_x86_64_convert_load_reloc (bfd *abfd,
  	return true;
      }
  
@@ -51,7 +51,7 @@ index 32db254ba6c..2d82c6583c3 100644
    /* Don't convert GOTPCREL relocation against large section.  */
    if (elf_section_data (tsec) !=  NULL
        && (elf_section_flags (tsec) & SHF_X86_64_LARGE) != 0)
-@@ -2408,10 +2411,7 @@ elf_x86_64_scan_relocs (bfd *abfd, struct bfd_link_info *info,
+@@ -1933,10 +1936,7 @@ elf_x86_64_check_relocs (bfd *abfd, struct bfd_link_info *info,
        else
  	{
  	  isym = NULL;
@@ -64,12 +64,12 @@ index 32db254ba6c..2d82c6583c3 100644
  
        /* Check invalid x32 relocations.  */
 diff --git a/bfd/elflink.c b/bfd/elflink.c
-index 1f1263007c0..eafbd133ff5 100644
+index 9acfe8b8..a157d846 100644
 --- a/bfd/elflink.c
 +++ b/bfd/elflink.c
-@@ -96,6 +96,27 @@ _bfd_elf_link_keep_memory (struct bfd_link_info *info)
-   return true;
- }
+@@ -62,6 +62,27 @@ struct elf_find_verdep_info
+ static bool _bfd_elf_fix_symbol_flags
+   (struct elf_link_hash_entry *, struct elf_info_failed *);
  
 +struct elf_link_hash_entry *
 +_bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
@@ -95,7 +95,7 @@ index 1f1263007c0..eafbd133ff5 100644
  static struct elf_link_hash_entry *
  get_ext_sym_hash (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
  {
-@@ -108,6 +129,9 @@ get_ext_sym_hash (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
+@@ -74,6 +95,9 @@ get_ext_sym_hash (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
      {
        h = cookie->sym_hashes[r_symndx - cookie->extsymoff];
  
@@ -105,6 +105,9 @@ index 1f1263007c0..eafbd133ff5 100644
        while (h->root.type == bfd_link_hash_indirect
  	     || h->root.type == bfd_link_hash_warning)
  	h = (struct elf_link_hash_entry *) h->root.u.i.link;
+--
+2.33.8
+
 From 931494c9a89558acb36a03a340c01726545eef24 Mon Sep 17 00:00:00 2001
 From: Nick Clifton <nickc@redhat.com>
 Date: Wed, 5 Feb 2025 15:43:04 +0000
@@ -117,12 +120,12 @@ PR 32643
  1 file changed, 106 insertions(+), 100 deletions(-)
 
 diff --git a/bfd/elflink.c b/bfd/elflink.c
-index eafbd133ff5..bf940942ec3 100644
+index a157d846..bc2d01eb 100644
 --- a/bfd/elflink.c
 +++ b/bfd/elflink.c
-@@ -96,15 +96,17 @@ _bfd_elf_link_keep_memory (struct bfd_link_info *info)
-   return true;
- }
+@@ -62,15 +62,17 @@ struct elf_find_verdep_info
+ static bool _bfd_elf_fix_symbol_flags
+   (struct elf_link_hash_entry *, struct elf_info_failed *);
  
 -struct elf_link_hash_entry *
 -_bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
@@ -144,7 +147,7 @@ index eafbd133ff5..bf940942ec3 100644
  
    /* The hash might be empty.  See PR 32641 for an example of this.  */
    if (h == NULL)
-@@ -117,27 +119,28 @@ _bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
+@@ -83,27 +85,28 @@ _bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
    return h;
  }
  
@@ -190,7 +193,7 @@ index eafbd133ff5..bf940942ec3 100644
  }
  
  asection *
-@@ -147,7 +150,7 @@ _bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
+@@ -113,7 +116,7 @@ _bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
  {
    struct elf_link_hash_entry *h;
  
@@ -199,7 +202,7 @@ index eafbd133ff5..bf940942ec3 100644
    
    if (h != NULL)
      {
-@@ -9108,7 +9111,6 @@ set_symbol_value (bfd *bfd_with_globals,
+@@ -8627,7 +8630,6 @@ set_symbol_value (bfd *bfd_with_globals,
  		  size_t symidx,
  		  bfd_vma val)
  {
@@ -207,7 +210,7 @@ index eafbd133ff5..bf940942ec3 100644
    struct elf_link_hash_entry *h;
    size_t extsymoff = locsymcount;
  
-@@ -9131,12 +9133,12 @@ set_symbol_value (bfd *bfd_with_globals,
+@@ -8650,12 +8652,12 @@ set_symbol_value (bfd *bfd_with_globals,
  
    /* It is a global symbol: set its link type
       to "defined" and give it a value.  */
@@ -226,7 +229,7 @@ index eafbd133ff5..bf940942ec3 100644
    h->root.type = bfd_link_hash_defined;
    h->root.u.def.value = val;
    h->root.u.def.section = bfd_abs_section_ptr;
-@@ -11614,10 +11616,19 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+@@ -11129,10 +11131,19 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
  	      || (elf_bad_symtab (input_bfd)
  		  && flinfo->sections[symndx] == NULL))
  	    {
@@ -250,7 +253,7 @@ index eafbd133ff5..bf940942ec3 100644
  	      /* Arrange for symbol to be output.  */
  	      h->indx = -2;
  	      elf_section_data (osec)->this_hdr.sh_info = -2;
-@@ -11752,7 +11763,7 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+@@ -11282,7 +11293,7 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
  		  || (elf_bad_symtab (input_bfd)
  		      && flinfo->sections[r_symndx] == NULL))
  		{
@@ -259,7 +262,7 @@ index eafbd133ff5..bf940942ec3 100644
  
  		  /* Badly formatted input files can contain relocs that
  		     reference non-existant symbols.  Check here so that
-@@ -11761,17 +11772,13 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+@@ -11291,17 +11302,13 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
  		    {
  		      _bfd_error_handler
  			/* xgettext:c-format */
@@ -278,7 +281,7 @@ index eafbd133ff5..bf940942ec3 100644
  		  s_type = h->type;
  
  		  /* If a plugin symbol is referenced from a non-IR file,
-@@ -11987,7 +11994,6 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+@@ -11517,7 +11524,6 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
  			  && flinfo->sections[r_symndx] == NULL))
  		    {
  		      struct elf_link_hash_entry *rh;
@@ -286,7 +289,7 @@ index eafbd133ff5..bf940942ec3 100644
  
  		      /* This is a reloc against a global symbol.  We
  			 have not yet output all the local symbols, so
-@@ -11996,15 +12002,16 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+@@ -11526,15 +11532,16 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
  			 reloc to point to the global hash table entry
  			 for this symbol.  The symbol index is then
  			 set at the end of bfd_elf_final_link.  */
@@ -312,7 +315,7 @@ index eafbd133ff5..bf940942ec3 100644
  		      BFD_ASSERT (rh->indx < 0);
  		      rh->indx = -2;
  		      *rel_hash = rh;
-@@ -13968,25 +13975,21 @@ _bfd_elf_gc_mark_hook (asection *sec,
+@@ -13413,25 +13420,21 @@ _bfd_elf_gc_mark_hook (asection *sec,
  		       struct elf_link_hash_entry *h,
  		       Elf_Internal_Sym *sym)
  {
@@ -349,7 +352,7 @@ index eafbd133ff5..bf940942ec3 100644
  }
  
  /* Return the debug definition section.  */
-@@ -14035,46 +14038,49 @@ _bfd_elf_gc_mark_rsec (struct bfd_link_info *info, asection *sec,
+@@ -13480,46 +13483,49 @@ _bfd_elf_gc_mark_rsec (struct bfd_link_info *info, asection *sec,
    if (r_symndx == STN_UNDEF)
      return NULL;
  
@@ -432,7 +435,7 @@ index eafbd133ff5..bf940942ec3 100644
  }
  
  /* COOKIE->rel describes a relocation against section SEC, which is
-@@ -15097,7 +15103,7 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
+@@ -14521,7 +14527,7 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
  
        struct elf_link_hash_entry *h;
  
@@ -442,4 +445,4 @@ index eafbd133ff5..bf940942ec3 100644
        if (h != NULL)
  	{
 -- 
-2.43.5
+2.33.8

--- a/SPECS/binutils/CVE-2025-1181.patch
+++ b/SPECS/binutils/CVE-2025-1181.patch
@@ -1,0 +1,445 @@
+From 18cc11a2771d9e40180485da9a4fb660c03efac3 Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Wed, 5 Feb 2025 14:31:10 +0000
+Subject: [PATCH] Prevent illegal memory access when checking relocs in a
+ corrupt ELF binary.
+This patch is added as a prerequisite to apply the actual CVE fix
+changes in bfd/elfxx-x86.c are dropped as they are not required in the current version of the code
+
+PR 32641
+---
+ bfd/elf-bfd.h      |  3 +++
+ bfd/elf64-x86-64.c | 10 +++++-----
+ bfd/elflink.c      | 24 ++++++++++++++++++++++++
+ bfd/elfxx-x86.c    | 20 +++++++-------------
+ 4 files changed, 39 insertions(+), 18 deletions(-)
+
+diff --git a/bfd/elf-bfd.h b/bfd/elf-bfd.h
+index 785a37dd7fd..d2bf8e5cbae 100644
+--- a/bfd/elf-bfd.h
++++ b/bfd/elf-bfd.h
+@@ -3153,6 +3153,9 @@ extern bool _bfd_elf_link_mmap_section_contents
+ extern void _bfd_elf_link_munmap_section_contents
+   (asection *);
+ 
++extern struct elf_link_hash_entry * _bfd_elf_get_link_hash_entry
++  (struct elf_link_hash_entry **, unsigned int, Elf_Internal_Shdr *);
++
+ /* Large common section.  */
+ extern asection _bfd_elf_large_com_section;
+ 
+diff --git a/bfd/elf64-x86-64.c b/bfd/elf64-x86-64.c
+index 32db254ba6c..2d82c6583c3 100644
+--- a/bfd/elf64-x86-64.c
++++ b/bfd/elf64-x86-64.c
+@@ -1784,7 +1784,7 @@ elf_x86_64_convert_load_reloc (bfd *abfd,
+   bool to_reloc_pc32;
+   bool abs_symbol;
+   bool local_ref;
+-  asection *tsec;
++  asection *tsec = NULL;
+   bfd_signed_vma raddend;
+   unsigned int opcode;
+   unsigned int modrm;
+@@ -1999,6 +1999,9 @@ elf_x86_64_convert_load_reloc (bfd *abfd,
+ 	return true;
+     }
+ 
++  if (tsec == NULL)
++    return false;
++
+   /* Don't convert GOTPCREL relocation against large section.  */
+   if (elf_section_data (tsec) !=  NULL
+       && (elf_section_flags (tsec) & SHF_X86_64_LARGE) != 0)
+@@ -2408,10 +2411,7 @@ elf_x86_64_scan_relocs (bfd *abfd, struct bfd_link_info *info,
+       else
+ 	{
+ 	  isym = NULL;
+-	  h = sym_hashes[r_symndx - symtab_hdr->sh_info];
+-	  while (h->root.type == bfd_link_hash_indirect
+-		 || h->root.type == bfd_link_hash_warning)
+-	    h = (struct elf_link_hash_entry *) h->root.u.i.link;
++	  h = _bfd_elf_get_link_hash_entry (sym_hashes, r_symndx, symtab_hdr);
+ 	}
+ 
+       /* Check invalid x32 relocations.  */
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 1f1263007c0..eafbd133ff5 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -96,6 +96,27 @@ _bfd_elf_link_keep_memory (struct bfd_link_info *info)
+   return true;
+ }
+ 
++struct elf_link_hash_entry *
++_bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
++			      unsigned int                   symndx,
++			      Elf_Internal_Shdr *            symtab_hdr)
++{
++  if (symndx < symtab_hdr->sh_info)
++    return NULL;
++
++  struct elf_link_hash_entry *h = sym_hashes[symndx - symtab_hdr->sh_info];
++
++  /* The hash might be empty.  See PR 32641 for an example of this.  */
++  if (h == NULL)
++    return NULL;
++
++  while (h->root.type == bfd_link_hash_indirect
++	 || h->root.type == bfd_link_hash_warning)
++    h = (struct elf_link_hash_entry *) h->root.u.i.link;
++
++  return h;
++}
++
+ static struct elf_link_hash_entry *
+ get_ext_sym_hash (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
+ {
+@@ -108,6 +129,9 @@ get_ext_sym_hash (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
+     {
+       h = cookie->sym_hashes[r_symndx - cookie->extsymoff];
+ 
++      if (h == NULL)
++	return NULL;
++
+       while (h->root.type == bfd_link_hash_indirect
+ 	     || h->root.type == bfd_link_hash_warning)
+ 	h = (struct elf_link_hash_entry *) h->root.u.i.link;
+From 931494c9a89558acb36a03a340c01726545eef24 Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Wed, 5 Feb 2025 15:43:04 +0000
+Subject: [PATCH] Add even more checks for corrupt input when processing
+ relocations for ELF files.
+
+PR 32643
+---
+ bfd/elflink.c | 206 ++++++++++++++++++++++++++------------------------
+ 1 file changed, 106 insertions(+), 100 deletions(-)
+
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index eafbd133ff5..bf940942ec3 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -96,15 +96,17 @@ _bfd_elf_link_keep_memory (struct bfd_link_info *info)
+   return true;
+ }
+ 
+-struct elf_link_hash_entry *
+-_bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
+-			      unsigned int                   symndx,
+-			      Elf_Internal_Shdr *            symtab_hdr)
++static struct elf_link_hash_entry *
++get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
++		     unsigned int                   symndx,
++		     unsigned int                   ext_sym_start)
+ {
+-  if (symndx < symtab_hdr->sh_info)
++  if (sym_hashes == NULL
++      /* Guard against corrupt input.  See PR 32636 for an example.  */
++      || symndx < ext_sym_start)
+     return NULL;
+ 
+-  struct elf_link_hash_entry *h = sym_hashes[symndx - symtab_hdr->sh_info];
++  struct elf_link_hash_entry *h = sym_hashes[symndx - ext_sym_start];
+ 
+   /* The hash might be empty.  See PR 32641 for an example of this.  */
+   if (h == NULL)
+@@ -117,27 +119,28 @@ _bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
+   return h;
+ }
+ 
+-static struct elf_link_hash_entry *
+-get_ext_sym_hash (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
++struct elf_link_hash_entry *
++_bfd_elf_get_link_hash_entry (struct elf_link_hash_entry **  sym_hashes,
++			      unsigned int                   symndx,
++			      Elf_Internal_Shdr *            symtab_hdr)
+ {
+-  struct elf_link_hash_entry *h = NULL;
+-
+-  if ((r_symndx >= cookie->locsymcount
+-       || ELF_ST_BIND (cookie->locsyms[r_symndx].st_info) != STB_LOCAL)
+-      /* Guard against corrupt input.  See PR 32636 for an example.  */
+-      && r_symndx >= cookie->extsymoff)
+-    {
+-      h = cookie->sym_hashes[r_symndx - cookie->extsymoff];
++  if (symtab_hdr == NULL)
++    return NULL;
+ 
+-      if (h == NULL)
+-	return NULL;
++  return get_link_hash_entry (sym_hashes, symndx, symtab_hdr->sh_info);
++}
+ 
+-      while (h->root.type == bfd_link_hash_indirect
+-	     || h->root.type == bfd_link_hash_warning)
+-	h = (struct elf_link_hash_entry *) h->root.u.i.link;
+-    }
++static struct elf_link_hash_entry *
++get_ext_sym_hash_from_cookie (struct elf_reloc_cookie *cookie, unsigned long r_symndx)
++{
++  if (cookie == NULL || cookie->sym_hashes == NULL)
++    return NULL;
++  
++  if (r_symndx >= cookie->locsymcount
++      || ELF_ST_BIND (cookie->locsyms[r_symndx].st_info) != STB_LOCAL)
++    return get_link_hash_entry (cookie->sym_hashes, r_symndx, cookie->extsymoff);
+ 
+-  return h;
++  return NULL;
+ }
+ 
+ asection *
+@@ -147,7 +150,7 @@ _bfd_elf_section_for_symbol (struct elf_reloc_cookie *cookie,
+ {
+   struct elf_link_hash_entry *h;
+ 
+-  h = get_ext_sym_hash (cookie, r_symndx);
++  h = get_ext_sym_hash_from_cookie (cookie, r_symndx);
+   
+   if (h != NULL)
+     {
+@@ -9108,7 +9111,6 @@ set_symbol_value (bfd *bfd_with_globals,
+ 		  size_t symidx,
+ 		  bfd_vma val)
+ {
+-  struct elf_link_hash_entry **sym_hashes;
+   struct elf_link_hash_entry *h;
+   size_t extsymoff = locsymcount;
+ 
+@@ -9131,12 +9133,12 @@ set_symbol_value (bfd *bfd_with_globals,
+ 
+   /* It is a global symbol: set its link type
+      to "defined" and give it a value.  */
+-
+-  sym_hashes = elf_sym_hashes (bfd_with_globals);
+-  h = sym_hashes [symidx - extsymoff];
+-  while (h->root.type == bfd_link_hash_indirect
+-	 || h->root.type == bfd_link_hash_warning)
+-    h = (struct elf_link_hash_entry *) h->root.u.i.link;
++  h = get_link_hash_entry (elf_sym_hashes (bfd_with_globals), symidx, extsymoff);
++  if (h == NULL)
++    {
++      /* FIXMEL What should we do ?  */
++      return;
++    }
+   h->root.type = bfd_link_hash_defined;
+   h->root.u.def.value = val;
+   h->root.u.def.section = bfd_abs_section_ptr;
+@@ -11614,10 +11616,19 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+ 	      || (elf_bad_symtab (input_bfd)
+ 		  && flinfo->sections[symndx] == NULL))
+ 	    {
+-	      struct elf_link_hash_entry *h = sym_hashes[symndx - extsymoff];
+-	      while (h->root.type == bfd_link_hash_indirect
+-		     || h->root.type == bfd_link_hash_warning)
+-		h = (struct elf_link_hash_entry *) h->root.u.i.link;
++	      struct elf_link_hash_entry *h;
++
++	      h = get_link_hash_entry (sym_hashes, symndx, extsymoff);
++	      if (h == NULL)
++		{
++		  _bfd_error_handler
++		    /* xgettext:c-format */
++		    (_("error: %pB: unable to create group section symbol"),
++		     input_bfd);
++		  bfd_set_error (bfd_error_bad_value);
++		  return false;
++		}	      
++
+ 	      /* Arrange for symbol to be output.  */
+ 	      h->indx = -2;
+ 	      elf_section_data (osec)->this_hdr.sh_info = -2;
+@@ -11752,7 +11763,7 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+ 		  || (elf_bad_symtab (input_bfd)
+ 		      && flinfo->sections[r_symndx] == NULL))
+ 		{
+-		  h = sym_hashes[r_symndx - extsymoff];
++		  h = get_link_hash_entry (sym_hashes, r_symndx, extsymoff);
+ 
+ 		  /* Badly formatted input files can contain relocs that
+ 		     reference non-existant symbols.  Check here so that
+@@ -11761,17 +11772,13 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+ 		    {
+ 		      _bfd_error_handler
+ 			/* xgettext:c-format */
+-			(_("error: %pB contains a reloc (%#" PRIx64 ") for section %pA "
++			(_("error: %pB contains a reloc (%#" PRIx64 ") for section '%pA' "
+ 			   "that references a non-existent global symbol"),
+ 			 input_bfd, (uint64_t) rel->r_info, o);
+ 		      bfd_set_error (bfd_error_bad_value);
+ 		      return false;
+ 		    }
+ 
+-		  while (h->root.type == bfd_link_hash_indirect
+-			 || h->root.type == bfd_link_hash_warning)
+-		    h = (struct elf_link_hash_entry *) h->root.u.i.link;
+-
+ 		  s_type = h->type;
+ 
+ 		  /* If a plugin symbol is referenced from a non-IR file,
+@@ -11987,7 +11994,6 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+ 			  && flinfo->sections[r_symndx] == NULL))
+ 		    {
+ 		      struct elf_link_hash_entry *rh;
+-		      unsigned long indx;
+ 
+ 		      /* This is a reloc against a global symbol.  We
+ 			 have not yet output all the local symbols, so
+@@ -11996,15 +12002,16 @@ elf_link_input_bfd (struct elf_final_link_info *flinfo, bfd *input_bfd)
+ 			 reloc to point to the global hash table entry
+ 			 for this symbol.  The symbol index is then
+ 			 set at the end of bfd_elf_final_link.  */
+-		      indx = r_symndx - extsymoff;
+-		      rh = elf_sym_hashes (input_bfd)[indx];
+-		      while (rh->root.type == bfd_link_hash_indirect
+-			     || rh->root.type == bfd_link_hash_warning)
+-			rh = (struct elf_link_hash_entry *) rh->root.u.i.link;
+-
+-		      /* Setting the index to -2 tells
+-			 elf_link_output_extsym that this symbol is
+-			 used by a reloc.  */
++		      rh = get_link_hash_entry (elf_sym_hashes (input_bfd),
++						r_symndx, extsymoff);
++		      if (rh == NULL)
++			{
++			  /* FIXME: Generate an error ?  */
++			  continue;
++			}
++
++		      /* Setting the index to -2 tells elf_link_output_extsym
++			 that this symbol is used by a reloc.  */
+ 		      BFD_ASSERT (rh->indx < 0);
+ 		      rh->indx = -2;
+ 		      *rel_hash = rh;
+@@ -13968,25 +13975,21 @@ _bfd_elf_gc_mark_hook (asection *sec,
+ 		       struct elf_link_hash_entry *h,
+ 		       Elf_Internal_Sym *sym)
+ {
+-  if (h != NULL)
++  if (h == NULL)
++    return bfd_section_from_elf_index (sec->owner, sym->st_shndx);
++
++  switch (h->root.type)
+     {
+-      switch (h->root.type)
+-	{
+-	case bfd_link_hash_defined:
+-	case bfd_link_hash_defweak:
+-	  return h->root.u.def.section;
++    case bfd_link_hash_defined:
++    case bfd_link_hash_defweak:
++      return h->root.u.def.section;
+ 
+-	case bfd_link_hash_common:
+-	  return h->root.u.c.p->section;
++    case bfd_link_hash_common:
++      return h->root.u.c.p->section;
+ 
+-	default:
+-	  break;
+-	}
++    default:
++      return NULL;
+     }
+-  else
+-    return bfd_section_from_elf_index (sec->owner, sym->st_shndx);
+-
+-  return NULL;
+ }
+ 
+ /* Return the debug definition section.  */
+@@ -14035,46 +14038,49 @@ _bfd_elf_gc_mark_rsec (struct bfd_link_info *info, asection *sec,
+   if (r_symndx == STN_UNDEF)
+     return NULL;
+ 
+-  h = get_ext_sym_hash (cookie, r_symndx);
+-  
+-  if (h != NULL)
++  h = get_ext_sym_hash_from_cookie (cookie, r_symndx);
++  if (h == NULL)
+     {
+-      bool was_marked;
++      /* A corrup tinput file can lead to a situation where the index
++	 does not reference either a local or an external symbol.  */
++      if (r_symndx >= cookie->locsymcount)
++	return NULL;
+ 
+-      was_marked = h->mark;
+-      h->mark = 1;
+-      /* Keep all aliases of the symbol too.  If an object symbol
+-	 needs to be copied into .dynbss then all of its aliases
+-	 should be present as dynamic symbols, not just the one used
+-	 on the copy relocation.  */
+-      hw = h;
+-      while (hw->is_weakalias)
+-	{
+-	  hw = hw->u.alias;
+-	  hw->mark = 1;
+-	}
++      return (*gc_mark_hook) (sec, info, cookie->rel, NULL,
++			      &cookie->locsyms[r_symndx]);
++    }
+ 
+-      if (!was_marked && h->start_stop && !h->root.ldscript_def)
+-	{
+-	  if (info->start_stop_gc)
+-	    return NULL;
++  bool was_marked = h->mark;
+ 
+-	  /* To work around a glibc bug, mark XXX input sections
+-	     when there is a reference to __start_XXX or __stop_XXX
+-	     symbols.  */
+-	  else if (start_stop != NULL)
+-	    {
+-	      asection *s = h->u2.start_stop_section;
+-	      *start_stop = true;
+-	      return s;
+-	    }
+-	}
++  h->mark = 1;
++  /* Keep all aliases of the symbol too.  If an object symbol
++     needs to be copied into .dynbss then all of its aliases
++     should be present as dynamic symbols, not just the one used
++     on the copy relocation.  */
++  hw = h;
++  while (hw->is_weakalias)
++    {
++      hw = hw->u.alias;
++      hw->mark = 1;
++    }
+ 
+-      return (*gc_mark_hook) (sec, info, cookie->rel, h, NULL);
++  if (!was_marked && h->start_stop && !h->root.ldscript_def)
++    {
++      if (info->start_stop_gc)
++	return NULL;
++
++      /* To work around a glibc bug, mark XXX input sections
++	 when there is a reference to __start_XXX or __stop_XXX
++	 symbols.  */
++      else if (start_stop != NULL)
++	{
++	  asection *s = h->u2.start_stop_section;
++	  *start_stop = true;
++	  return s;
++	}
+     }
+ 
+-  return (*gc_mark_hook) (sec, info, cookie->rel, NULL,
+-			  &cookie->locsyms[r_symndx]);
++  return (*gc_mark_hook) (sec, info, cookie->rel, h, NULL);
+ }
+ 
+ /* COOKIE->rel describes a relocation against section SEC, which is
+@@ -15097,7 +15103,7 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
+ 
+       struct elf_link_hash_entry *h;
+ 
+-      h = get_ext_sym_hash (rcookie, r_symndx);
++      h = get_ext_sym_hash_from_cookie (rcookie, r_symndx);
+       
+       if (h != NULL)
+ 	{
+-- 
+2.43.5

--- a/SPECS/binutils/CVE-2025-1182.patch
+++ b/SPECS/binutils/CVE-2025-1182.patch
@@ -1,0 +1,28 @@
+From b425859021d17adf62f06fb904797cf8642986ad Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Wed, 5 Feb 2025 16:27:38 +0000
+Subject: [PATCH] Fix another illegal memory access triggered by corrupt ELF
+ input files.
+
+PR 32644
+---
+ bfd/elflink.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index bf940942ec3..df6eb250961 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -15116,6 +15116,10 @@ bfd_elf_reloc_symbol_deleted_p (bfd_vma offset, void *cookie)
+ 	}
+       else
+ 	{
++	  if (r_symndx >= rcookie->locsymcount)
++	    /* This can happen with corrupt input.  */
++	    return false;
++
+ 	  /* It's not a relocation against a global symbol,
+ 	     but it could be a relocation against a local
+ 	     symbol for a discarded section.  */
+-- 
+2.43.5

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -21,7 +21,7 @@
 Summary:        Contains a linker, an assembler, and other tools
 Name:           binutils
 Version:        2.37
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -46,6 +46,9 @@ Patch11:         CVE-2022-48063.patch
 Patch12:         CVE-2023-1972.patch
 Patch13:         CVE-2022-35205.patch
 Patch14:         CVE-2025-0840.patch
+Patch15:         CVE-2025-1176.patch
+Patch16:         CVE-2025-1181.patch
+Patch17:         CVE-2025-1182.patch
 Provides:       bundled(libiberty)
 
 # Moving macro before the "SourceX" tags breaks PR checks parsing the specs.
@@ -302,6 +305,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %do_files aarch64-linux-gnu %{build_aarch64}
 
 %changelog
+* Fri Feb 14 2025 Sindhu Karri <lakarri@microsoft.com> - 2.37-12
+- Fix CVE-2025-1176, CVE-2025-1181, CVE-2025-1182
+
 * Tue Feb 04 2025 Sudipta Pandit <sudpandit@microsoft.com> - 2.37-11
 - Backport patch to fix CVE-2025-0840
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.13-2.cm2.aarch64.rpm
 file-5.40-3.cm2.aarch64.rpm
 file-devel-5.40-3.cm2.aarch64.rpm
 file-libs-5.40-3.cm2.aarch64.rpm
-binutils-2.37-11.cm2.aarch64.rpm
-binutils-devel-2.37-11.cm2.aarch64.rpm
+binutils-2.37-12.cm2.aarch64.rpm
+binutils-devel-2.37-12.cm2.aarch64.rpm
 gmp-6.2.1-4.cm2.aarch64.rpm
 gmp-devel-6.2.1-4.cm2.aarch64.rpm
 mpfr-4.1.0-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.13-2.cm2.x86_64.rpm
 file-5.40-3.cm2.x86_64.rpm
 file-devel-5.40-3.cm2.x86_64.rpm
 file-libs-5.40-3.cm2.x86_64.rpm
-binutils-2.37-11.cm2.x86_64.rpm
-binutils-devel-2.37-11.cm2.x86_64.rpm
+binutils-2.37-12.cm2.x86_64.rpm
+binutils-devel-2.37-12.cm2.x86_64.rpm
 gmp-6.2.1-4.cm2.x86_64.rpm
 gmp-devel-6.2.1-4.cm2.x86_64.rpm
 mpfr-4.1.0-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -9,9 +9,9 @@ bash-5.1.8-4.cm2.aarch64.rpm
 bash-debuginfo-5.1.8-4.cm2.aarch64.rpm
 bash-devel-5.1.8-4.cm2.aarch64.rpm
 bash-lang-5.1.8-4.cm2.aarch64.rpm
-binutils-2.37-11.cm2.aarch64.rpm
-binutils-debuginfo-2.37-11.cm2.aarch64.rpm
-binutils-devel-2.37-11.cm2.aarch64.rpm
+binutils-2.37-12.cm2.aarch64.rpm
+binutils-debuginfo-2.37-12.cm2.aarch64.rpm
+binutils-devel-2.37-12.cm2.aarch64.rpm
 bison-3.7.6-2.cm2.aarch64.rpm
 bison-debuginfo-3.7.6-2.cm2.aarch64.rpm
 bzip2-1.0.8-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -9,10 +9,10 @@ bash-5.1.8-4.cm2.x86_64.rpm
 bash-debuginfo-5.1.8-4.cm2.x86_64.rpm
 bash-devel-5.1.8-4.cm2.x86_64.rpm
 bash-lang-5.1.8-4.cm2.x86_64.rpm
-binutils-2.37-11.cm2.x86_64.rpm
-binutils-aarch64-linux-gnu-2.37-11.cm2.x86_64.rpm
-binutils-debuginfo-2.37-11.cm2.x86_64.rpm
-binutils-devel-2.37-11.cm2.x86_64.rpm
+binutils-2.37-12.cm2.x86_64.rpm
+binutils-aarch64-linux-gnu-2.37-12.cm2.x86_64.rpm
+binutils-debuginfo-2.37-12.cm2.x86_64.rpm
+binutils-devel-2.37-12.cm2.x86_64.rpm
 bison-3.7.6-2.cm2.x86_64.rpm
 bison-debuginfo-3.7.6-2.cm2.x86_64.rpm
 bzip2-1.0.8-1.cm2.x86_64.rpm
@@ -47,7 +47,7 @@ cracklib-lang-2.9.7-5.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-devel-0.17.5-1.cm2.x86_64.rpm
-cross-binutils-common-2.37-11.cm2.noarch.rpm
+cross-binutils-common-2.37-12.cm2.noarch.rpm
 cross-gcc-common-11.2.0-8.cm2.noarch.rpm
 curl-8.8.0-3.cm2.x86_64.rpm
 curl-debuginfo-8.8.0-3.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix binutils CVEs CVE-2025-1176 CVE-2025-1181 CVE-2025-1182

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix binutils CVE-2025-1176 CVE-2025-1181 CVE-2025-1182

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-1176
- https://nvd.nist.gov/vuln/detail/CVE-2025-1181
- https://nvd.nist.gov/vuln/detail/CVE-2025-1182

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=736132&view=results