### PR TITLE
ldns fix intermittent build failure

### DIFF
--- a/SPECS/ldns/fix-intermittent-build-failure-with-milti-job-build.patch
+++ b/SPECS/ldns/fix-intermittent-build-failure-with-milti-job-build.patch
@@ -1,0 +1,83 @@
+From 9303f1876b660d18118cd5b09ba616d01bc31610 Mon Sep 17 00:00:00 2001
+From: "W.C.A. Wijngaards" <wouter@nlnetlabs.nl>
+Date: Thu, 20 Feb 2025 10:28:40 +0100
+Subject: [PATCH] * Fix #271: Intermittent build failure with multi-job builds
+ (make -j).
+
+---
+ Makefile.in | 54 ++++++++++++++++++++++++++---------------------------
+ 1 file changed, 27 insertions(+), 27 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 57957d0..e89d4b0 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -566,9 +566,9 @@ depend:
+ 		done; \
+ 	done
+ 	for p in $(EXAMPLE_PROGS) $(LDNS_DPA) $(LDNS_DANE) $(EX_SSL_PROGS); do \
+-		echo "$$p: $$p.lo $$p.o \$$(LIB)" >> $(DEPEND_TMP) ; done
++		echo "$$p: $$p.lo \$$(LIB)" >> $(DEPEND_TMP) ; done
+ 	echo "$(TESTNS): `for o in $(TESTNS_LOBJS) ; do \
+-				echo -n "$$o $${o%lo}o " ; done` \$$(LIB)" \
++				echo -n "$$o " ; done`\$$(LIB)" \
+ 			       	>> $(DEPEND_TMP)
+ 	cp $(DEPEND_TARGET) $(DEPEND_TMP2)
+ 	head -`egrep -n "# Dependencies" $(DEPEND_TARGET) | tail -1 | sed -e 's/:.*$$//'` $(DEPEND_TMP2) > $(DEPEND_TARGET)
+@@ -1108,28 +1108,28 @@ drill/work.lo drill/work.o: $(srcdir)/drill/work.c $(srcdir)/drill/drill.h ldns/
+  $(srcdir)/ldns/host2wire.h ldns/net.h $(srcdir)/ldns/str2host.h $(srcdir)/ldns/update.h \
+  $(srcdir)/ldns/wire2host.h $(srcdir)/ldns/rr_functions.h $(srcdir)/ldns/parse.h $(srcdir)/ldns/radix.h \
+  $(srcdir)/ldns/sha1.h $(srcdir)/ldns/sha2.h
+-examples/ldns-chaos: examples/ldns-chaos.lo examples/ldns-chaos.o $(LIB)
+-examples/ldns-compare-zones: examples/ldns-compare-zones.lo examples/ldns-compare-zones.o $(LIB)
+-examples/ldnsd: examples/ldnsd.lo examples/ldnsd.o $(LIB)
+-examples/ldns-gen-zone: examples/ldns-gen-zone.lo examples/ldns-gen-zone.o $(LIB)
+-examples/ldns-key2ds: examples/ldns-key2ds.lo examples/ldns-key2ds.o $(LIB)
+-examples/ldns-keyfetcher: examples/ldns-keyfetcher.lo examples/ldns-keyfetcher.o $(LIB)
+-examples/ldns-keygen: examples/ldns-keygen.lo examples/ldns-keygen.o $(LIB)
+-examples/ldns-mx: examples/ldns-mx.lo examples/ldns-mx.o $(LIB)
+-examples/ldns-notify: examples/ldns-notify.lo examples/ldns-notify.o $(LIB)
+-examples/ldns-read-zone: examples/ldns-read-zone.lo examples/ldns-read-zone.o $(LIB)
+-examples/ldns-resolver: examples/ldns-resolver.lo examples/ldns-resolver.o $(LIB)
+-examples/ldns-rrsig: examples/ldns-rrsig.lo examples/ldns-rrsig.o $(LIB)
+-examples/ldns-test-edns: examples/ldns-test-edns.lo examples/ldns-test-edns.o $(LIB)
+-examples/ldns-update: examples/ldns-update.lo examples/ldns-update.o $(LIB)
+-examples/ldns-version: examples/ldns-version.lo examples/ldns-version.o $(LIB)
+-examples/ldns-walk: examples/ldns-walk.lo examples/ldns-walk.o $(LIB)
+-examples/ldns-zcat: examples/ldns-zcat.lo examples/ldns-zcat.o $(LIB)
+-examples/ldns-zsplit: examples/ldns-zsplit.lo examples/ldns-zsplit.o $(LIB)
+-examples/ldns-dpa: examples/ldns-dpa.lo examples/ldns-dpa.o $(LIB)
+-examples/ldns-dane: examples/ldns-dane.lo examples/ldns-dane.o $(LIB)
+-examples/ldns-nsec3-hash: examples/ldns-nsec3-hash.lo examples/ldns-nsec3-hash.o $(LIB)
+-examples/ldns-revoke: examples/ldns-revoke.lo examples/ldns-revoke.o $(LIB)
+-examples/ldns-signzone: examples/ldns-signzone.lo examples/ldns-signzone.o $(LIB)
+-examples/ldns-verify-zone: examples/ldns-verify-zone.lo examples/ldns-verify-zone.o $(LIB)
+-examples/ldns-testns: examples/ldns-testns.lo examples/ldns-testns.o examples/ldns-testpkts.lo examples/ldns-testpkts.o  $(LIB)
++examples/ldns-chaos: examples/ldns-chaos.lo $(LIB)
++examples/ldns-compare-zones: examples/ldns-compare-zones.lo $(LIB)
++examples/ldnsd: examples/ldnsd.lo $(LIB)
++examples/ldns-gen-zone: examples/ldns-gen-zone.lo $(LIB)
++examples/ldns-key2ds: examples/ldns-key2ds.lo $(LIB)
++examples/ldns-keyfetcher: examples/ldns-keyfetcher.lo $(LIB)
++examples/ldns-keygen: examples/ldns-keygen.lo $(LIB)
++examples/ldns-mx: examples/ldns-mx.lo $(LIB)
++examples/ldns-notify: examples/ldns-notify.lo $(LIB)
++examples/ldns-read-zone: examples/ldns-read-zone.lo $(LIB)
++examples/ldns-resolver: examples/ldns-resolver.lo $(LIB)
++examples/ldns-rrsig: examples/ldns-rrsig.lo $(LIB)
++examples/ldns-test-edns: examples/ldns-test-edns.lo $(LIB)
++examples/ldns-update: examples/ldns-update.lo $(LIB)
++examples/ldns-version: examples/ldns-version.lo $(LIB)
++examples/ldns-walk: examples/ldns-walk.lo $(LIB)
++examples/ldns-zcat: examples/ldns-zcat.lo $(LIB)
++examples/ldns-zsplit: examples/ldns-zsplit.lo $(LIB)
++examples/ldns-dpa: examples/ldns-dpa.lo $(LIB)
++examples/ldns-dane: examples/ldns-dane.lo $(LIB)
++examples/ldns-nsec3-hash: examples/ldns-nsec3-hash.lo $(LIB)
++examples/ldns-revoke: examples/ldns-revoke.lo $(LIB)
++examples/ldns-signzone: examples/ldns-signzone.lo $(LIB)
++examples/ldns-verify-zone: examples/ldns-verify-zone.lo $(LIB)
++examples/ldns-testns: examples/ldns-testns.lo examples/ldns-testpkts.lo $(LIB)
+-- 
+2.45.3
+

--- a/SPECS/ldns/ldns.spec
+++ b/SPECS/ldns/ldns.spec
@@ -40,6 +40,7 @@ Url:            http://www.nlnetlabs.nl/%{name}/
 Source0:        http://www.nlnetlabs.nl/downloads/%{name}/%{name}-%{version}.tar.gz
 
 Patch1:         ldns-swig-4.2.patch
+Patch2:         fix-intermittent-build-failure-with-milti-job-build.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake

--- a/SPECS/ldns/ldns.spec
+++ b/SPECS/ldns/ldns.spec
@@ -31,7 +31,7 @@
 Summary:        Low-level DNS(SEC) library with API
 Name:           ldns
 Version:        1.8.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -279,6 +279,10 @@ rm -rf doc/man
 %doc doc
 
 %changelog
+* Tue Feb 25 2025 Tobias Brick <tobiasb@microsoft.com> - 1.8.3-2
+- Patch to fix multi-job builds.
+- Also removed comment that caused rpmbuild warning.
+
 * Thu Jan 25 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.8.3-1
 - Auto-upgrade to 1.8.3 - Upgrade for Azure Linux 3.0
 - Removed unsupported multilib patch (azl only supports 64bit)

--- a/SPECS/ldns/ldns.spec
+++ b/SPECS/ldns/ldns.spec
@@ -170,7 +170,7 @@ export CFLAGS CXXFLAGS LDFLAGS
 pushd %{pkgname}_python3
 %else
 pushd %{pkgname}
-%endif # with python3
+%endif
 
 %configure \
   --disable-rpath \


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
`ldns` fails to build intermittently due to a problem with parallel builds.
[Upstream issue](https://github.com/NLnetLabs/ldns/issues/271).

This change applies the fix to the above issue.

###### Change Log  <!-- REQUIRED -->
- Apply upstream patch to fix `make -j` issues.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
ADO: https://microsoft.visualstudio.com/OS/_workitems/edit/56322679

###### Test Methodology
- Built locally in a loop 10 times with 0 failures.
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=745639&view=results
