### PR TITLE
[2.0] add msopenjdk rpm hash verification

### DIFF
--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -346,7 +346,7 @@ case $(uname -m) in
     x86_64)  MSOPENJDK_EXPECTED_HASH="556ffa796970d913e4dc7ed6b28a0ac6e9dab5b8eae6063f1f060b2819857957" ;;
     aarch64) MSOPENJDK_EXPECTED_HASH="535bce10952ae9421ee7d9ccdcb6430f683f7448633430e3ff7d6ca8c586f0bc" ;;
 esac
-wget -nv --server-response --no-clobber --timeout=30 $MSOPENJDK_URL --directory-prefix=$CHROOT_RPMS_DIR_ARCH
+wget -nv --server-response --no-clobber --timeout=30 --tries=3 --waitretry=10 --retry-connrefused $MSOPENJDK_URL --directory-prefix=$CHROOT_RPMS_DIR_ARCH
 MSOPENJDK_ACTUAL_HASH=$(sha256sum "$CHROOT_RPMS_DIR_ARCH/$MSOPENJDK_FILENAME" | awk '{print $1}')
 if [[ "$MSOPENJDK_EXPECTED_HASH" != "$MSOPENJDK_ACTUAL_HASH" ]]; then
     echo "Error, incorrect msopenjdk hash: '$MSOPENJDK_ACTUAL_HASH'. Expected hash: '$MSOPENJDK_EXPECTED_HASH'"

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -343,8 +343,8 @@ echo "Downloading MsOpenJDK rpm"
 MSOPENJDK_FILENAME="msopenjdk-11-11.0.18-1.$(uname -m).rpm"
 MSOPENJDK_URL="https://packages.microsoft.com/cbl-mariner/2.0/prod/Microsoft/$(uname -m)/$MSOPENJDK_FILENAME"
 case $(uname -m) in
-    x86_64)  MSOPENJDK_EXPECTED_HASH="535bce10952ae9421ee7d9ccdcb6430f683f7448633430e3ff7d6ca8c586f0bc" ;;
-    aarch64) MSOPENJDK_EXPECTED_HASH="556ffa796970d913e4dc7ed6b28a0ac6e9dab5b8eae6063f1f060b2819857957" ;;
+    x86_64)  MSOPENJDK_EXPECTED_HASH="556ffa796970d913e4dc7ed6b28a0ac6e9dab5b8eae6063f1f060b2819857957" ;;
+    aarch64) MSOPENJDK_EXPECTED_HASH="535bce10952ae9421ee7d9ccdcb6430f683f7448633430e3ff7d6ca8c586f0bc" ;;
 esac
 wget -nv --server-response --no-clobber --timeout=30 $MSOPENJDK_URL --directory-prefix=$CHROOT_RPMS_DIR_ARCH
 MSOPENJDK_ACTUAL_HASH=$(sha256sum "$CHROOT_RPMS_DIR_ARCH/$MSOPENJDK_FILENAME" | awk '{print $1}')

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -338,6 +338,22 @@ start_record_timestamp "build packages"
 start_record_timestamp "build packages/build"
 start_record_timestamp "build packages/install"
 
+# Download JDK rpm
+echo "Downloading MsOpenJDK rpm"
+MSOPENJDK_FILENAME="msopenjdk-11-11.0.18-1.$(uname -m).rpm"
+MSOPENJDK_URL="https://packages.microsoft.com/cbl-mariner/2.0/prod/Microsoft/$(uname -m)/$MSOPENJDK_FILENAME"
+case $(uname -m) in
+    x86_64)  MSOPENJDK_EXPECTED_HASH="535bce10952ae9421ee7d9ccdcb6430f683f7448633430e3ff7d6ca8c586f0bc" ;;
+    aarch64) MSOPENJDK_EXPECTED_HASH="556ffa796970d913e4dc7ed6b28a0ac6e9dab5b8eae6063f1f060b2819857957" ;;
+esac
+wget -nv --server-response --no-clobber --timeout=30 $MSOPENJDK_URL --directory-prefix=$CHROOT_RPMS_DIR_ARCH
+MSOPENJDK_ACTUAL_HASH=$(sha256sum "$CHROOT_RPMS_DIR_ARCH/$MSOPENJDK_FILENAME" | awk '{print $1}')
+if [[ "$MSOPENJDK_EXPECTED_HASH" != "$MSOPENJDK_ACTUAL_HASH" ]]; then
+    echo "Error, incorrect msopenjdk hash: '$MSOPENJDK_ACTUAL_HASH'. Expected hash: '$MSOPENJDK_EXPECTED_HASH'"
+    rm -vf "$CHROOT_RPMS_DIR_ARCH/$MSOPENJDK_FILENAME"
+    exit 1
+fi
+
 echo Building final list of toolchain RPMs
 build_rpm_in_chroot_no_install mariner-rpm-macros
 chroot_and_install_rpms mariner-rpm-macros
@@ -451,17 +467,6 @@ chroot_and_install_rpms python3 python3
 # libxml2 is required for at least: libxslt, createrepo_c
 build_rpm_in_chroot_no_install libxml2
 chroot_and_install_rpms libxml2
-
-# Download JDK rpms
-echo Download JDK rpms
-case $(uname -m) in
-    x86_64)
-        wget -nv --no-clobber --timeout=30 https://packages.microsoft.com/cbl-mariner/2.0/prod/Microsoft/x86_64/msopenjdk-11-11.0.18-1.x86_64.rpm --directory-prefix=$CHROOT_RPMS_DIR_ARCH
-    ;;
-    aarch64)
-        wget -nv --no-clobber --timeout=30 https://packages.microsoft.com/cbl-mariner/2.0/prod/Microsoft/aarch64/msopenjdk-11-11.0.18-1.aarch64.rpm --directory-prefix=$CHROOT_RPMS_DIR_ARCH
-    ;;
-esac
 
 # PCRE needs to be installed (above) for grep to build with perl regexp support
 build_rpm_in_chroot_no_install grep


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add hash verification for msopenjdk RPM downloaded during toolchain build process. This is a backport of the similar change for 3.0 in PR #10019 
Prevents error seen in the following buildRPMS pipeline when a corrupted file was downloaded: [link](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=740797&view=logs&j=4e0f61e4-1b30-550f-20e5-747c73e9a1b3&t=e7762c05-aed0-53b0-82ec-2fcc69be9c17)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change toolchain script to hash verify and retry msopenjdk RPM download

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/56349003

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=747504&view=results
