### PR TITLE
 Patch `libxml2` for CVE-2025-24928, CVE-2025-27113 & CVE-2024-56171 [High]

### DIFF
--- a/SPECS/libxml2/CVE-2024-56171.patch
+++ b/SPECS/libxml2/CVE-2024-56171.patch
@@ -1,0 +1,38 @@
+From 5880a9a6bd97c0f9ac8fc4f30110fe023f484746 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Tue, 10 Dec 2024 16:52:05 +0100
+Subject: [PATCH] [CVE-2024-56171] Fix use-after-free after
+ xmlSchemaItemListAdd
+
+xmlSchemaItemListAdd can reallocate the items array. Update local
+variables after adding item in
+
+- xmlSchemaIDCFillNodeTables
+- xmlSchemaBubbleIDCNodeTables
+
+Fixes #828.
+---
+ xmlschemas.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/xmlschemas.c b/xmlschemas.c
+index 1b3c524f2..95be97c96 100644
+--- a/xmlschemas.c
++++ b/xmlschemas.c
+@@ -23374,6 +23374,7 @@ xmlSchemaIDCFillNodeTables(xmlSchemaValidCtxtPtr vctxt,
+ 			}
+ 			if (xmlSchemaItemListAdd(bind->dupls, bind->nodeTable[j]) == -1)
+ 			    goto internal_error;
++                        dupls = (xmlSchemaPSVIIDCNodePtr *) bind->dupls->items;
+ 			/*
+ 			* Remove the duplicate entry from the IDC node-table.
+ 			*/
+@@ -23590,6 +23591,8 @@ xmlSchemaBubbleIDCNodeTables(xmlSchemaValidCtxtPtr vctxt)
+ 				goto internal_error;
+ 			}
+ 			xmlSchemaItemListAdd(parBind->dupls, parNode);
++		        dupls = (xmlSchemaPSVIIDCNodePtr *)
++                            parBind->dupls->items;
+ 		    } else {
+ 			/*
+ 			* Add the node-table entry (node and key-sequence) of

--- a/SPECS/libxml2/CVE-2025-24928.patch
+++ b/SPECS/libxml2/CVE-2025-24928.patch
@@ -1,0 +1,57 @@
+From 29f5d2b67e31c435cbc08954a12a0267c5887d39 Mon Sep 17 00:00:00 2001
+From: Kanishk-Bansal <kbkanishk975@gmail.com>
+Date: Sat, 22 Feb 2025 18:12:41 +0000
+Subject: [PATCH] CVE-2025-24928
+
+Upstream Reference: https://github.com/GNOME/libxml2/commit/8c8753ad5280ee13aee5eec9b0f6eee2ed920f57
+
+---
+ valid.c | 25 +++++++++++++------------
+ 1 file changed, 13 insertions(+), 12 deletions(-)
+
+diff --git a/valid.c b/valid.c
+index 67e1b1d..7eb2dd3 100644
+--- a/valid.c
++++ b/valid.c
+@@ -5252,25 +5252,26 @@ xmlSnprintfElements(char *buf, int size, xmlNodePtr node, int glob) {
+ 	    return;
+ 	}
+         switch (cur->type) {
+-            case XML_ELEMENT_NODE:
++            case XML_ELEMENT_NODE: {
++                int qnameLen = xmlStrlen(cur->name);
++
++                if ((cur->ns != NULL) && (cur->ns->prefix != NULL))
++                    qnameLen += xmlStrlen(cur->ns->prefix) + 1;
++                if (size - len < qnameLen + 10) {
++                    if ((size - len > 4) && (buf[len - 1] != '.'))
++                        strcat(buf, " ...");
++                    return;
++                }
+ 		if ((cur->ns != NULL) && (cur->ns->prefix != NULL)) {
+-		    if (size - len < xmlStrlen(cur->ns->prefix) + 10) {
+-			if ((size - len > 4) && (buf[len - 1] != '.'))
+-			    strcat(buf, " ...");
+-			return;
+-		    }
+ 		    strcat(buf, (char *) cur->ns->prefix);
+ 		    strcat(buf, ":");
+ 		}
+-                if (size - len < xmlStrlen(cur->name) + 10) {
+-		    if ((size - len > 4) && (buf[len - 1] != '.'))
+-			strcat(buf, " ...");
+-		    return;
+-		}
+-	        strcat(buf, (char *) cur->name);
++                if (cur->name != NULL)
++	            strcat(buf, (char *) cur->name);
+ 		if (cur->next != NULL)
+ 		    strcat(buf, " ");
+ 		break;
++            }
+             case XML_TEXT_NODE:
+ 		if (xmlIsBlankNode(cur))
+ 		    break;
+-- 
+2.45.2
+

--- a/SPECS/libxml2/CVE-2025-27113.patch
+++ b/SPECS/libxml2/CVE-2025-27113.patch
@@ -1,0 +1,28 @@
+From 6c716d491dd2e67f08066f4dc0619efeb49e43e6 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Thu, 13 Feb 2025 16:48:53 +0100
+Subject: [PATCH] pattern: Fix compilation of explicit child axis
+
+The child axis is the default axis and should generate XML_OP_ELEM like
+the case without an axis.
+---
+ pattern.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pattern.c b/pattern.c
+index 0877fc1a0..6fa88f759 100644
+--- a/pattern.c
++++ b/pattern.c
+@@ -1035,10 +1035,10 @@ xmlCompileStepPattern(xmlPatParserContextPtr ctxt) {
+ 			    goto error;
+ 			}
+ 		    } else {
+-			PUSH(XML_OP_CHILD, token, URL);
++			PUSH(XML_OP_ELEM, token, URL);
+ 		    }
+ 		} else
+-		    PUSH(XML_OP_CHILD, name, NULL);
++		    PUSH(XML_OP_ELEM, name, NULL);
+ 		return;
+ 	    } else if (xmlStrEqual(name, (const xmlChar *) "attribute")) {
+ 		XML_PAT_FREE_STRING(ctxt, name)

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.10.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -12,6 +12,8 @@ Patch0:         CVE-2023-45322.patch
 Patch1:         CVE-2024-34459.patch
 Patch2:         CVE-2024-25062.patch
 Patch3:         CVE-2022-49043.patch
+Patch4:         CVE-2024-56171.patch
+Patch5:         CVE-2025-24928.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -82,6 +84,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Sat Feb 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.10.4-6
+- Patch CVE-2025-24928 & CVE-2024-56171
+
 * Tue Jan 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.10.4-5 
 - Fix CVE-2022-49043 with an upstream patch
 

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -14,6 +14,7 @@ Patch2:         CVE-2024-25062.patch
 Patch3:         CVE-2022-49043.patch
 Patch4:         CVE-2024-56171.patch
 Patch5:         CVE-2025-24928.patch
+Patch6:         CVE-2025-27113.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -85,7 +86,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 
 %changelog
 * Sat Feb 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.10.4-6
-- Patch CVE-2025-24928 & CVE-2024-56171
+- Patch CVE-2025-24928, CVE-2025-27113 & CVE-2024-56171
 
 * Tue Jan 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.10.4-5 
 - Fix CVE-2022-49043 with an upstream patch

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-4.cm2.aarch64.rpm
 curl-devel-8.8.0-4.cm2.aarch64.rpm
 curl-libs-8.8.0-4.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
-libxml2-2.10.4-5.cm2.aarch64.rpm
-libxml2-devel-2.10.4-5.cm2.aarch64.rpm
+libxml2-2.10.4-6.cm2.aarch64.rpm
+libxml2-devel-2.10.4-6.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-4.cm2.x86_64.rpm
 curl-devel-8.8.0-4.cm2.x86_64.rpm
 curl-libs-8.8.0-4.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
-libxml2-2.10.4-5.cm2.x86_64.rpm
-libxml2-devel-2.10.4-5.cm2.x86_64.rpm
+libxml2-2.10.4-6.cm2.x86_64.rpm
+libxml2-devel-2.10.4-6.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -209,9 +209,9 @@ libtasn1-debuginfo-4.19.0-1.cm2.aarch64.rpm
 libtasn1-devel-4.19.0-1.cm2.aarch64.rpm
 libtool-2.4.6-8.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-8.cm2.aarch64.rpm
-libxml2-2.10.4-5.cm2.aarch64.rpm
-libxml2-debuginfo-2.10.4-5.cm2.aarch64.rpm
-libxml2-devel-2.10.4-5.cm2.aarch64.rpm
+libxml2-2.10.4-6.cm2.aarch64.rpm
+libxml2-debuginfo-2.10.4-6.cm2.aarch64.rpm
+libxml2-devel-2.10.4-6.cm2.aarch64.rpm
 libxslt-1.1.34-7.cm2.aarch64.rpm
 libxslt-debuginfo-1.1.34-7.cm2.aarch64.rpm
 libxslt-devel-1.1.34-7.cm2.aarch64.rpm
@@ -521,7 +521,7 @@ python3-gpg-1.16.0-2.cm2.aarch64.rpm
 python3-jinja2-3.0.3-5.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.aarch64.rpm
 python3-libs-3.9.19-10.cm2.aarch64.rpm
-python3-libxml2-2.10.4-5.cm2.aarch64.rpm
+python3-libxml2-2.10.4-6.cm2.aarch64.rpm
 python3-lxml-4.9.1-1.cm2.aarch64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -215,9 +215,9 @@ libtasn1-debuginfo-4.19.0-1.cm2.x86_64.rpm
 libtasn1-devel-4.19.0-1.cm2.x86_64.rpm
 libtool-2.4.6-8.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-8.cm2.x86_64.rpm
-libxml2-2.10.4-5.cm2.x86_64.rpm
-libxml2-debuginfo-2.10.4-5.cm2.x86_64.rpm
-libxml2-devel-2.10.4-5.cm2.x86_64.rpm
+libxml2-2.10.4-6.cm2.x86_64.rpm
+libxml2-debuginfo-2.10.4-6.cm2.x86_64.rpm
+libxml2-devel-2.10.4-6.cm2.x86_64.rpm
 libxslt-1.1.34-7.cm2.x86_64.rpm
 libxslt-debuginfo-1.1.34-7.cm2.x86_64.rpm
 libxslt-devel-1.1.34-7.cm2.x86_64.rpm
@@ -527,7 +527,7 @@ python3-gpg-1.16.0-2.cm2.x86_64.rpm
 python3-jinja2-3.0.3-5.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.x86_64.rpm
 python3-libs-3.9.19-10.cm2.x86_64.rpm
-python3-libxml2-2.10.4-5.cm2.x86_64.rpm
+python3-libxml2-2.10.4-6.cm2.x86_64.rpm
 python3-lxml-4.9.1-1.cm2.x86_64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Address CVE-2025-24928, CVE-2025-27113 & CVE-2024-56171 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2025-24928
- CVE-2024-56171
- CVE-2025-27113

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-56171
- https://nvd.nist.gov/vuln/detail/CVE-2025-24928
- https://nvd.nist.gov/vuln/detail/CVE-2025-27113

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=743198&view=results)