### PR TITLE
fix bind postun

### DIFF
--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -10,7 +10,7 @@
 Summary:        Domain Name System software
 Name:           bind
 Version:        9.20.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -527,6 +527,9 @@ fi;
 %{_mandir}/man1/named-nzd2nzf.1*
 
 %changelog
+* Tue Feb 25 2025 Tobias Brick <tobiasb@microsoft.com> - 9.20.5-2
+- Fix warning during package uninstall.
+
 * Tue Feb 04 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.20.5-1
 - Auto-upgrade to 9.20.5 - to fix CVE-2024-12705 & CVE-2024-11187
 - Refresh nongit-fix patch to apply cleanly.

--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -360,8 +360,7 @@ if [ $1 -gt 1 ]; then \
     fi \
   done \
 fi
-Vendor:         Microsoft Corporation
-Distribution:   Azure Linux
+
 %ldconfig_scriptlets libs
 
 %post chroot


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
`bind` has a warning during uninstall:
```
# tdnf remove -y bind
<snip>

Removing: bind-9.20.5-1.azl3.x86_64
/var/tmp/rpm-tmp.o0lrpa: line 12: Vendor:: command not found
/var/tmp/rpm-tmp.o0lrpa: line 13: Distribution:: command not found
warning: %postun(bind-9.20.5-1.azl3.x86_64) scriptlet failed, exit status 127
package bind-9.20.5-1.azl3.x86_64: script warning in %postun
```

The issue is that we we're missing a new-line at the of the `%postun` scriptlet, which makes the `Vendor:` and `Distribution:` lines sneak into that script, which means `bash` tries to run them as programs. Interestingly, if you drop an executable file at, say, `/usr/bin/Vendor:`, this will run it. Fun.

This has been there for years and as it happens both the `Vendor:` and `Distribution:` lines were duplicates of the ones towards the top of the file so just deleting them and making sure we have the blank line fixes things.

###### Change Log  <!-- REQUIRED -->
- Remove spurious `Vendor:` and `Distribution:` lines.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- ADO: https://microsoft.visualstudio.com/OS/_workitems/edit/56351472/?view=edit

###### Test Methodology
- Built and installed/uninstalled locally
- Buddy Build:https://dev.azure.com/mariner-org/mariner/_build/results?buildId=747805&view=results
