### PR TITLE
patch bind uninitialized memory error

### DIFF
--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -10,7 +10,7 @@
 Summary:        Domain Name System software
 Name:           bind
 Version:        9.20.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -529,6 +529,9 @@ fi;
 %{_mandir}/man1/named-nzd2nzf.1*
 
 %changelog
+* Thu Feb 27 2025 Tobias Brick <tobiasb@microsoft.com> - 9.20.5-3
+- Fix uninitialized memory warning.
+
 * Tue Feb 25 2025 Tobias Brick <tobiasb@microsoft.com> - 9.20.5-2
 - Fix warning during package uninstall.
 

--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -33,6 +33,7 @@ Source14:       named-chroot.files
 Source15:       https://gitlab.isc.org/isc-projects/dlz-modules/-/archive/main/dlz-modules-main.tar.gz
 
 Patch0:         nongit-fix.patch
+Patch1:         fix-maybe-uninitialized-warning-in-dlz_mysqldyn_mod.patch
 
 BuildRequires:  gcc
 BuildRequires:  git
@@ -190,7 +191,15 @@ Summary:        BIND utilities
 
 %prep
 %setup -q
-%patch 0 -p1
+
+# DLZ modules do not support oot builds. Copy files into build
+mkdir -p build/contrib/dlz
+pushd build/contrib/dlz
+tar --no-same-owner -xf %{SOURCE15}
+mv dlz-modules-main/modules ./
+popd
+
+%autopatch -p1
 
 # Copying auxiliary files with libtoolize. Some files will be replaced by libtoolize -c -f.
 # The files "compile", "depcomp", and "missing" will be deleted by this process, as some
@@ -203,13 +212,6 @@ mv backup/* .
 rmdir backup
 
 %build
-# DLZ modules do not support oot builds. Copy files into build
-mkdir -p build/contrib/dlz
-pushd build/contrib/dlz
-tar --no-same-owner -xf %{SOURCE15}
-mv dlz-modules-main/modules ./
-popd
-
 ./configure \
     --prefix=%{_prefix} \
     --localstatedir=%{_var} \

--- a/SPECS/bind/fix-maybe-uninitialized-warning-in-dlz_mysqldyn_mod.patch
+++ b/SPECS/bind/fix-maybe-uninitialized-warning-in-dlz_mysqldyn_mod.patch
@@ -1,0 +1,34 @@
+From daa392c65a4a578985fb3188ee81b1e80ee1791c Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Mon, 24 Feb 2025 18:17:20 +0000
+Subject: [PATCH] fix maybe-uninitialized warning in dlz_mysqldyn_mod.c
+
+---
+ build/contrib/dlz/modules/mysqldyn/dlz_mysqldyn_mod.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/build/contrib/dlz/modules/mysqldyn/dlz_mysqldyn_mod.c b/build/contrib/dlz/modules/mysqldyn/dlz_mysqldyn_mod.c
+index bdd0bcc..4488b94 100644
+--- a/build/contrib/dlz/modules/mysqldyn/dlz_mysqldyn_mod.c
++++ b/build/contrib/dlz/modules/mysqldyn/dlz_mysqldyn_mod.c
+@@ -375,6 +375,9 @@ build_query(mysql_data_t *state, mysql_instance_t *dbi, const char *command,
+ 	size_t len = 0;
+ 	va_list ap1;
+ 
++	/* Initialize arglist before anything else so we can safely free it if we fail out. */
++	DLZ_LIST_INIT(arglist);
++
+ 	/* Get a DB instance if needed */
+ 	if (dbi == NULL) {
+ 		dbi = get_dbi(state);
+@@ -390,7 +393,6 @@ build_query(mysql_data_t *state, mysql_instance_t *dbi, const char *command,
+ 	}
+ 
+ 	va_start(ap1, command);
+-	DLZ_LIST_INIT(arglist);
+ 	q = querystr = strdup(command);
+ 	if (querystr == NULL) {
+ 		goto fail;
+-- 
+2.45.3
+


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
When building bind, we see a warning like this:
```
cc -fPIC -I../include -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/azl/default-hardened-cc1    -fcommon -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/azl/default-hardened-ld  -shared -o dlz_mysqldyn_mod.so \
	dlz_mysqldyn_mod.c dlz_dbi.o -L/usr/lib/ -lmariadb
dlz_mysqldyn_mod.c: In function 'build_query':
dlz_mysqldyn_mod.c:464:22: warning: 'arglist.head' may be used uninitialized [-Wmaybe-uninitialized]
  464 |         while ((item = DLZ_LIST_HEAD(arglist)) != NULL) {
      |                ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
dlz_mysqldyn_mod.c:371:25: note: 'arglist' declared here
  371 |         mysql_arglist_t arglist;
      |                         ^~~~~~~
```

I looked at the code and this appears to be real -- I was able to repro use of uninitialized memory by copy-pasting the flagged code into a toy progrm.

Upstream code appears to be here: [ISC Open Source Projects / dlz-modules · GitLab](https://gitlab.isc.org/isc-projects/dlz-modules).

###### Change Log  <!-- REQUIRED -->
- Add patch to properly initialize variable.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- ADO: https://microsoft.visualstudio.com/OS/_workitems/edit/56381681

###### Test Methodology
- Built locally
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=747902&view=results
