### PR TITLE
gnutls: Address CVE-2024-12133 [Medium]

### DIFF
--- a/SPECS/gnutls/CVE-2024-12133.patch
+++ b/SPECS/gnutls/CVE-2024-12133.patch
@@ -1,26 +1,23 @@
-From 869a97aa259dffa2620dabcad84e1c22545ffc3d Mon Sep 17 00:00:00 2001
-From: Daiki Ueno <ueno@gnu.org>
-Date: Fri, 8 Nov 2024 16:05:32 +0900
-Subject: [PATCH] asn1_find_node: optimize "?NUMBER" node lookup with indexing
+From 1ca74c7814f9c58929755ce5b3b66262564543d1 Mon Sep 17 00:00:00 2001
+From: Ankita Pareek <ankitapareek@microsoft.com>
+Date: Wed, 26 Feb 2025 21:28:46 +0530
+Subject: [PATCH] gnutls: Add patch for CVE-2024-12133. Upstream fix:
+ https://gitlab.com/gnutls/libtasn1/-/commit/869a97aa259dffa2620dabcad84e1c22545ffc3d
 
-To avoid linear search of named nodes, this adds a array of child
-nodes to their parent nodes as a cache.
-
-Signed-off-by: Daiki Ueno <ueno@gnu.org>
-Signed-off-by: Simon Josefsson <simon@josefsson.org>
+Signed-off-by: Ankita Pareek <ankitapareek@microsoft.com>
 ---
- lib/element.c    | 56 ++++++++++++++++++++++++++++++++++++++++++------
- lib/element.h    | 10 +++++++++
- lib/int.h        |  8 +++++++
- lib/parser_aux.c | 10 +++++++++
- lib/structure.c  | 13 +++++++++++
+ lib/minitasn1/element.c    | 56 +++++++++++++++++++++++++++++++++-----
+ lib/minitasn1/element.h    | 10 +++++++
+ lib/minitasn1/int.h        |  8 ++++++
+ lib/minitasn1/parser_aux.c | 10 +++++++
+ lib/minitasn1/structure.c  | 13 +++++++++
  5 files changed, 90 insertions(+), 7 deletions(-)
 
-diff --git a/lib/minitasn1/element.c b/lib/element.c
-index 850bef4a..528df418 100644
+diff --git a/lib/minitasn1/element.c b/lib/minitasn1/element.c
+index 550fdb2..67434a8 100644
 --- a/lib/minitasn1/element.c
 +++ b/lib/minitasn1/element.c
-@@ -33,6 +33,8 @@
+@@ -32,6 +32,8 @@
  #include "structure.h"
  #include "c-ctype.h"
  #include "element.h"
@@ -29,7 +26,7 @@ index 850bef4a..528df418 100644
  
  void
  _asn1_hierarchical_name (asn1_node_const node, char *name, int name_size)
-@@ -129,6 +131,41 @@ _asn1_convert_integer (const unsigned char *value, unsigned char *value_out,
+@@ -128,6 +130,41 @@ _asn1_convert_integer (const unsigned char *value, unsigned char *value_out,
    return ASN1_SUCCESS;
  }
  
@@ -71,15 +68,15 @@ index 850bef4a..528df418 100644
  /* Appends a new element into the sequence (or set) defined by this
   * node. The new element will have a name of '?number', where number
   * is a monotonically increased serial number.
-@@ -145,6 +182,7 @@ _asn1_append_sequence_set (asn1_node node, struct node_tail_cache_st *pcache)
+@@ -144,6 +181,7 @@ _asn1_append_sequence_set (asn1_node node, struct node_tail_cache_st *pcache)
    asn1_node p, p2;
-   char temp[LTOSTR_MAX_SIZE + 1];
+   char temp[LTOSTR_MAX_SIZE+1];
    long n;
 +  int result;
  
    if (!node || !(node->down))
      return ASN1_GENERIC_ERROR;
-@@ -177,17 +215,21 @@ _asn1_append_sequence_set (asn1_node node, struct node_tail_cache_st *pcache)
+@@ -176,17 +214,21 @@ _asn1_append_sequence_set (asn1_node node, struct node_tail_cache_st *pcache)
        pcache->tail = p2;
      }
  
@@ -109,12 +106,12 @@ index 850bef4a..528df418 100644
    return ASN1_SUCCESS;
  }
 diff --git a/lib/minitasn1/element.h b/lib/minitasn1/element.h
-index 732054e9..b84e3a27 100644
+index 717bfaf..0ff92bd 100644
 --- a/lib/minitasn1/element.h
 +++ b/lib/minitasn1/element.h
-@@ -38,4 +38,14 @@ int _asn1_convert_integer (const unsigned char *value,
- void _asn1_hierarchical_name (asn1_node_const node, char *name,
- 			      int name_size);
+@@ -37,4 +37,14 @@ int _asn1_convert_integer (const unsigned char *value,
+ 
+ void _asn1_hierarchical_name (asn1_node_const node, char *name, int name_size);
  
 +static inline asn1_node_const
 +_asn1_node_array_get (const struct asn1_node_array_st *array, size_t position)
@@ -127,13 +124,13 @@ index 732054e9..b84e3a27 100644
 +		      asn1_node node);
 +
  #endif
-diff --git a/lib/minitasn1/int.h b/minitasn1/lib/int.h
-index 4f2d98d1..41b12b0b 100644
+diff --git a/lib/minitasn1/int.h b/lib/minitasn1/int.h
+index 57f1efd..163a423 100644
 --- a/lib/minitasn1/int.h
 +++ b/lib/minitasn1/int.h
-@@ -31,6 +31,12 @@
+@@ -39,6 +39,12 @@
  
- # define ASN1_SMALL_VALUE_SIZE 16
+ #define ASN1_SMALL_VALUE_SIZE 16
  
 +struct asn1_node_array_st
 +{
@@ -144,7 +141,7 @@ index 4f2d98d1..41b12b0b 100644
  /* This structure is also in libtasn1.h, but then contains less
     fields.  You cannot make any modifications to these first fields
     without breaking ABI.  */
-@@ -47,6 +53,8 @@ struct asn1_node_st
+@@ -55,6 +61,8 @@ struct asn1_node_st
    asn1_node left;		/* Pointer to the next list element */
    /* private fields: */
    unsigned char small_value[ASN1_SMALL_VALUE_SIZE];	/* For small values */
@@ -154,10 +151,10 @@ index 4f2d98d1..41b12b0b 100644
    /* values used during decoding/coding */
    int tmp_ival;
 diff --git a/lib/minitasn1/parser_aux.c b/lib/minitasn1/parser_aux.c
-index 415905a0..4281cc97 100644
+index bb88ab9..d6764d7 100644
 --- a/lib/minitasn1/parser_aux.c
 +++ b/lib/minitasn1/parser_aux.c
-@@ -126,6 +126,7 @@ asn1_find_node (asn1_node_const pointer, const char *name)
+@@ -127,6 +127,7 @@ asn1_find_node (asn1_node_const pointer, const char *name)
    const char *n_start;
    unsigned int nsize;
    unsigned int nhash;
@@ -165,15 +162,15 @@ index 415905a0..4281cc97 100644
  
    if (pointer == NULL)
      return NULL;
-@@ -209,6 +210,7 @@ asn1_find_node (asn1_node_const pointer, const char *name)
+@@ -210,6 +211,7 @@ asn1_find_node (asn1_node_const pointer, const char *name)
        if (p->down == NULL)
  	return NULL;
  
 +      numbered_children = &p->numbered_children;
        p = p->down;
        if (p == NULL)
- 	return NULL;
-@@ -222,6 +224,12 @@ asn1_find_node (asn1_node_const pointer, const char *name)
+         return NULL;
+@@ -223,6 +225,12 @@ asn1_find_node (asn1_node_const pointer, const char *name)
  	}
        else
  	{			/* no "?LAST" */
@@ -186,9 +183,9 @@ index 415905a0..4281cc97 100644
  	  while (p)
  	    {
  	      if (p->name_hash == nhash && !strcmp (p->name, n))
-@@ -509,6 +517,8 @@ _asn1_remove_node (asn1_node node, unsigned int flags)
+@@ -510,6 +518,8 @@ _asn1_remove_node (asn1_node node, unsigned int flags)
        if (node->value != node->small_value)
- 	free (node->value);
+         free (node->value);
      }
 +
 +  free (node->numbered_children.nodes);
@@ -196,7 +193,7 @@ index 415905a0..4281cc97 100644
  }
  
 diff --git a/lib/minitasn1/structure.c b/lib/minitasn1/structure.c
-index 9c95b9e2..32692ad2 100644
+index 4f43335..4138c61 100644
 --- a/lib/minitasn1/structure.c
 +++ b/lib/minitasn1/structure.c
 @@ -31,6 +31,9 @@
@@ -209,7 +206,7 @@ index 9c95b9e2..32692ad2 100644
  
  
  extern char _asn1_identifierMissing[];
-@@ -391,6 +394,16 @@ asn1_delete_element (asn1_node structure, const char *element_name)
+@@ -390,6 +393,16 @@ asn1_delete_element (asn1_node structure, const char *element_name)
    if (source_node == NULL)
      return ASN1_ELEMENT_NOT_FOUND;
  
@@ -227,5 +224,5 @@ index 9c95b9e2..32692ad2 100644
    p3 = _asn1_find_left (source_node);
    if (!p3)
 -- 
-GitLab
+2.34.1
 

--- a/SPECS/gnutls/CVE-2024-12133.patch
+++ b/SPECS/gnutls/CVE-2024-12133.patch
@@ -1,0 +1,231 @@
+From 869a97aa259dffa2620dabcad84e1c22545ffc3d Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Fri, 8 Nov 2024 16:05:32 +0900
+Subject: [PATCH] asn1_find_node: optimize "?NUMBER" node lookup with indexing
+
+To avoid linear search of named nodes, this adds a array of child
+nodes to their parent nodes as a cache.
+
+Signed-off-by: Daiki Ueno <ueno@gnu.org>
+Signed-off-by: Simon Josefsson <simon@josefsson.org>
+---
+ lib/element.c    | 56 ++++++++++++++++++++++++++++++++++++++++++------
+ lib/element.h    | 10 +++++++++
+ lib/int.h        |  8 +++++++
+ lib/parser_aux.c | 10 +++++++++
+ lib/structure.c  | 13 +++++++++++
+ 5 files changed, 90 insertions(+), 7 deletions(-)
+
+diff --git a/lib/minitasn1/element.c b/lib/element.c
+index 850bef4a..528df418 100644
+--- a/lib/minitasn1/element.c
++++ b/lib/minitasn1/element.c
+@@ -33,6 +33,8 @@
+ #include "structure.h"
+ #include "c-ctype.h"
+ #include "element.h"
++#include <limits.h>
++#include "intprops.h"
+ 
+ void
+ _asn1_hierarchical_name (asn1_node_const node, char *name, int name_size)
+@@ -129,6 +131,41 @@ _asn1_convert_integer (const unsigned char *value, unsigned char *value_out,
+   return ASN1_SUCCESS;
+ }
+ 
++int
++_asn1_node_array_set (struct asn1_node_array_st *array, size_t position,
++		      asn1_node node)
++{
++  if (position >= array->size)
++    {
++      size_t new_size = position, i;
++      asn1_node *new_nodes;
++
++      if (INT_MULTIPLY_OVERFLOW (new_size, 2))
++	return ASN1_GENERIC_ERROR;
++      new_size *= 2;
++
++      if (INT_ADD_OVERFLOW (new_size, 1))
++	return ASN1_GENERIC_ERROR;
++      new_size += 1;
++
++      if (INT_MULTIPLY_OVERFLOW (new_size, sizeof (*new_nodes)))
++	return ASN1_GENERIC_ERROR;
++
++      new_nodes = realloc (array->nodes, new_size * sizeof (*new_nodes));
++      if (!new_nodes)
++	return ASN1_MEM_ALLOC_ERROR;
++
++      for (i = array->size; i < new_size; i++)
++	new_nodes[i] = NULL;
++
++      array->nodes = new_nodes;
++      array->size = new_size;
++    }
++
++  array->nodes[position] = node;
++  return ASN1_SUCCESS;
++}
++
+ /* Appends a new element into the sequence (or set) defined by this
+  * node. The new element will have a name of '?number', where number
+  * is a monotonically increased serial number.
+@@ -145,6 +182,7 @@ _asn1_append_sequence_set (asn1_node node, struct node_tail_cache_st *pcache)
+   asn1_node p, p2;
+   char temp[LTOSTR_MAX_SIZE + 1];
+   long n;
++  int result;
+ 
+   if (!node || !(node->down))
+     return ASN1_GENERIC_ERROR;
+@@ -177,17 +215,21 @@ _asn1_append_sequence_set (asn1_node node, struct node_tail_cache_st *pcache)
+       pcache->tail = p2;
+     }
+ 
+-  if (p->name[0] == 0)
+-    _asn1_str_cpy (temp, sizeof (temp), "?1");
+-  else
++  n = 0;
++  if (p->name[0] != 0)
+     {
+-      n = strtol (p->name + 1, NULL, 0);
+-      n++;
+-      temp[0] = '?';
+-      _asn1_ltostr (n, temp + 1);
++      n = strtol (p->name + 1, NULL, 10);
++      if (n <= 0 || n >= LONG_MAX - 1)
++	return ASN1_GENERIC_ERROR;
+     }
++  temp[0] = '?';
++  _asn1_ltostr (n + 1, temp + 1);
+   _asn1_set_name (p2, temp);
+   /*  p2->type |= CONST_OPTION; */
++  result = _asn1_node_array_set (&node->numbered_children, n, p2);
++  if (result != ASN1_SUCCESS)
++    return result;
++  p2->parent = node;
+ 
+   return ASN1_SUCCESS;
+ }
+diff --git a/lib/minitasn1/element.h b/lib/minitasn1/element.h
+index 732054e9..b84e3a27 100644
+--- a/lib/minitasn1/element.h
++++ b/lib/minitasn1/element.h
+@@ -38,4 +38,14 @@ int _asn1_convert_integer (const unsigned char *value,
+ void _asn1_hierarchical_name (asn1_node_const node, char *name,
+ 			      int name_size);
+ 
++static inline asn1_node_const
++_asn1_node_array_get (const struct asn1_node_array_st *array, size_t position)
++{
++  return position < array->size ? array->nodes[position] : NULL;
++}
++
++int
++_asn1_node_array_set (struct asn1_node_array_st *array, size_t position,
++		      asn1_node node);
++
+ #endif
+diff --git a/lib/minitasn1/int.h b/minitasn1/lib/int.h
+index 4f2d98d1..41b12b0b 100644
+--- a/lib/minitasn1/int.h
++++ b/lib/minitasn1/int.h
+@@ -31,6 +31,12 @@
+ 
+ # define ASN1_SMALL_VALUE_SIZE 16
+ 
++struct asn1_node_array_st
++{
++  asn1_node *nodes;
++  size_t size;
++};
++
+ /* This structure is also in libtasn1.h, but then contains less
+    fields.  You cannot make any modifications to these first fields
+    without breaking ABI.  */
+@@ -47,6 +53,8 @@ struct asn1_node_st
+   asn1_node left;		/* Pointer to the next list element */
+   /* private fields: */
+   unsigned char small_value[ASN1_SMALL_VALUE_SIZE];	/* For small values */
++  asn1_node parent;		/* Pointer to the parent node */
++  struct asn1_node_array_st numbered_children; /* Array of unnamed child nodes for caching */
+ 
+   /* values used during decoding/coding */
+   int tmp_ival;
+diff --git a/lib/minitasn1/parser_aux.c b/lib/minitasn1/parser_aux.c
+index 415905a0..4281cc97 100644
+--- a/lib/minitasn1/parser_aux.c
++++ b/lib/minitasn1/parser_aux.c
+@@ -126,6 +126,7 @@ asn1_find_node (asn1_node_const pointer, const char *name)
+   const char *n_start;
+   unsigned int nsize;
+   unsigned int nhash;
++  const struct asn1_node_array_st *numbered_children;
+ 
+   if (pointer == NULL)
+     return NULL;
+@@ -209,6 +210,7 @@ asn1_find_node (asn1_node_const pointer, const char *name)
+       if (p->down == NULL)
+ 	return NULL;
+ 
++      numbered_children = &p->numbered_children;
+       p = p->down;
+       if (p == NULL)
+ 	return NULL;
+@@ -222,6 +224,12 @@ asn1_find_node (asn1_node_const pointer, const char *name)
+ 	}
+       else
+ 	{			/* no "?LAST" */
++	  if (n[0] == '?' && c_isdigit (n[1]))
++	    {
++	      long position = strtol (n + 1, NULL, 10);
++	      if (position > 0 && position < LONG_MAX)
++		p = _asn1_node_array_get (numbered_children, position - 1);
++	    }
+ 	  while (p)
+ 	    {
+ 	      if (p->name_hash == nhash && !strcmp (p->name, n))
+@@ -509,6 +517,8 @@ _asn1_remove_node (asn1_node node, unsigned int flags)
+       if (node->value != node->small_value)
+ 	free (node->value);
+     }
++
++  free (node->numbered_children.nodes);
+   free (node);
+ }
+ 
+diff --git a/lib/minitasn1/structure.c b/lib/minitasn1/structure.c
+index 9c95b9e2..32692ad2 100644
+--- a/lib/minitasn1/structure.c
++++ b/lib/minitasn1/structure.c
+@@ -31,6 +31,9 @@
+ #include <structure.h>
+ #include "parser_aux.h"
+ #include <gstr.h>
++#include "c-ctype.h"
++#include "element.h"
++#include <limits.h>
+ 
+ 
+ extern char _asn1_identifierMissing[];
+@@ -391,6 +394,16 @@ asn1_delete_element (asn1_node structure, const char *element_name)
+   if (source_node == NULL)
+     return ASN1_ELEMENT_NOT_FOUND;
+ 
++  if (source_node->parent
++      && source_node->name[0] == '?'
++      && c_isdigit (source_node->name[1]))
++    {
++      long position = strtol (source_node->name + 1, NULL, 10);
++      if (position > 0 && position < LONG_MAX)
++	_asn1_node_array_set (&source_node->parent->numbered_children,
++			      position - 1, NULL);
++    }
++
+   p2 = source_node->right;
+   p3 = _asn1_find_left (source_node);
+   if (!p3)
+-- 
+GitLab
+

--- a/SPECS/gnutls/gnutls.spec
+++ b/SPECS/gnutls/gnutls.spec
@@ -1,13 +1,14 @@
 Summary:        The GnuTLS Transport Layer Security Library
 Name:           gnutls
 Version:        3.7.11
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3+ AND LGPLv2.1+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://www.gnutls.org
 Source0:        https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/%{name}-%{version}.tar.xz
+Patch0:         CVE-2024-12133.patch
 BuildRequires:  autogen-libopts-devel
 BuildRequires:  gc-devel
 BuildRequires:  guile-devel
@@ -94,6 +95,9 @@ sed -i 's/TESTS += test-ciphers-openssl.sh//'  tests/slow/Makefile.am
 %{_mandir}/man3/*
 
 %changelog
+* Wed Feb 26 2025 Ankita Pareek <ankitapareek@microsoft.com> - 3.7.11-2
+- Address CVE-2024-12133 with a patch
+
 * Mon Sep 30 2024 Muhammad Falak <mwani@microsoft.com> - 3.7.11-1
 - Upgrade to v3.7.11 to address CVE-2023-5981, CVE-2024-28835, CVE-2024-28834, CVE-2024-0553
 - Drop patches which are already included in the source.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2024-12133 in gnutls package

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for CVE-2024-12133 in gnutls package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-12133

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
-Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=746473&view=results
