### PR TITLE
[3.0] Adjust dracut patch to fix fips module block list behavior

### DIFF
--- a/SPECS/dracut/0006-dracut.sh-validate-instmods-calls.patch
+++ b/SPECS/dracut/0006-dracut.sh-validate-instmods-calls.patch
@@ -61,7 +61,7 @@ index 83fcd564..3e3a7c88 100755
 +            return 1
          fi
 +        echo "$_mod" >> "${initdir}/etc/fipsmodules"
-+        echo "blacklist $_mod" >> "${initdir}/etc/modprobe.d/fips.conf"
++        echo "blacklist $_mod" >> "${initdir}/etc/fips.conf"
      done
  
      # with hostonly_default_device fs module for /boot is not installed by default

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        102
-Release:        9%{?dist}
+Release:        10%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -315,6 +315,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Tue Feb 25 2025 Cameron Baird <cameronbaird@microsoft.com> - 102-10
+- Fix 0006-dracut.sh-validate-instmods patch to not break crypto module blacklisting
+
 * Tue Feb 04 2025 Brian Fjeldstad <bfjelds@microsoft.com> - 102-9
 - Avoid mktemp folder name colliding with find filter.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
When we rebased our patches onto dracut-ng v102, block listing of crypto modules during fips module-setup.sh stopped working, throwing a series of errors due to a missing directory. This PR fixes the issue by adjusting the patch to block list the crypto modules correctly.

The theoretical purpose of this block list is to prevent unloading and loading crypto modules later on at runtime, which would then require re-running the selftests by reloading the tcrypt module

See: https://github.com/dracut-ng/dracut-ng/issues/1202 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Reformat 0006-dracut.sh-validate-instmods-calls.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Test image build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=745788&view=results 
- Booted image and observed block list is in effect, fips mode is enabled, and tcrypt self-tests successful
