### PR TITLE
Patch `libcap` for CVE-2025-1390 [Medium] (#12558)

### DIFF
--- a/SPECS/libcap/CVE-2025-1390.patch
+++ b/SPECS/libcap/CVE-2025-1390.patch
@@ -1,0 +1,31 @@
+From 1ad42b66c3567481cc5fa22fc1ba1556a316d878 Mon Sep 17 00:00:00 2001
+From: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>
+Date: Mon, 17 Feb 2025 10:31:55 +0800
+Subject: pam_cap: Fix potential configuration parsing error
+
+The current configuration parsing does not actually skip user names
+that do not start with @, but instead treats the name as a group
+name for further parsing, which can result in matching unexpected
+capability sets and may trigger potential security issues.  Only
+names starting with @ should be parsed as group names.
+
+Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>
+Signed-off-by: Andrew G. Morgan <morgan@kernel.org>
+---
+ pam_cap/pam_cap.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pam_cap/pam_cap.c b/pam_cap/pam_cap.c
+index 24de329..3ec99bb 100644
+--- a/pam_cap/pam_cap.c
++++ b/pam_cap/pam_cap.c
+@@ -166,6 +166,7 @@ static char *read_capabilities_for_user(const char *user, const char *source)
+ 
+ 	    if (line[0] != '@') {
+ 		D(("user [%s] is not [%s] - skipping", user, line));
++		continue;
+ 	    }
+ 
+ 	    int i;
+-- 
+cgit 1.2.3-korg

--- a/SPECS/libcap/libcap.spec
+++ b/SPECS/libcap/libcap.spec
@@ -1,11 +1,12 @@
 Summary:        Libcap
 Name:           libcap
 Version:        2.69
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+
 Group:          System Environment/Security
 URL:            https://www.gnu.org/software/hurd/community/gsoc/project_ideas/libcap.html
 Source0:        https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/%{name}-%{version}.tar.xz
+Patch0:         CVE-2025-1390.patch
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 
@@ -58,6 +59,9 @@ sed -i "s|pass_capsh --chroot=\$(/bin/pwd) ==||g" quicktest.sh
 %{_mandir}/man3/*
 
 %changelog
+* Sun Feb 23 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.69-2
+- Patch CVE-2025-1390
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.69-1
 - Auto-upgrade to 2.69 - Azure Linux 3.0 - package upgrades
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -175,8 +175,8 @@ openssl-devel-3.3.2-2.azl3.aarch64.rpm
 openssl-libs-3.3.2-2.azl3.aarch64.rpm
 openssl-perl-3.3.2-2.azl3.aarch64.rpm
 openssl-static-3.3.2-2.azl3.aarch64.rpm
-libcap-2.69-1.azl3.aarch64.rpm
-libcap-devel-2.69-1.azl3.aarch64.rpm
+libcap-2.69-2.azl3.aarch64.rpm
+libcap-devel-2.69-2.azl3.aarch64.rpm
 debugedit-5.0-2.azl3.aarch64.rpm
 libarchive-3.7.7-1.azl3.aarch64.rpm
 libarchive-devel-3.7.7-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -175,8 +175,8 @@ openssl-devel-3.3.2-2.azl3.x86_64.rpm
 openssl-libs-3.3.2-2.azl3.x86_64.rpm
 openssl-perl-3.3.2-2.azl3.x86_64.rpm
 openssl-static-3.3.2-2.azl3.x86_64.rpm
-libcap-2.69-1.azl3.x86_64.rpm
-libcap-devel-2.69-1.azl3.x86_64.rpm
+libcap-2.69-2.azl3.x86_64.rpm
+libcap-devel-2.69-2.azl3.x86_64.rpm
 debugedit-5.0-2.azl3.x86_64.rpm
 libarchive-3.7.7-1.azl3.x86_64.rpm
 libarchive-devel-3.7.7-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -175,9 +175,9 @@ libassuan-devel-2.5.6-1.azl3.aarch64.rpm
 libattr-2.5.2-1.azl3.aarch64.rpm
 libattr-devel-2.5.2-1.azl3.aarch64.rpm
 libbacktrace-static-13.2.0-7.azl3.aarch64.rpm
-libcap-2.69-1.azl3.aarch64.rpm
-libcap-debuginfo-2.69-1.azl3.aarch64.rpm
-libcap-devel-2.69-1.azl3.aarch64.rpm
+libcap-2.69-2.azl3.aarch64.rpm
+libcap-debuginfo-2.69-2.azl3.aarch64.rpm
+libcap-devel-2.69-2.azl3.aarch64.rpm
 libcap-ng-0.8.4-1.azl3.aarch64.rpm
 libcap-ng-debuginfo-0.8.4-1.azl3.aarch64.rpm
 libcap-ng-devel-0.8.4-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -183,9 +183,9 @@ libassuan-devel-2.5.6-1.azl3.x86_64.rpm
 libattr-2.5.2-1.azl3.x86_64.rpm
 libattr-devel-2.5.2-1.azl3.x86_64.rpm
 libbacktrace-static-13.2.0-7.azl3.x86_64.rpm
-libcap-2.69-1.azl3.x86_64.rpm
-libcap-debuginfo-2.69-1.azl3.x86_64.rpm
-libcap-devel-2.69-1.azl3.x86_64.rpm
+libcap-2.69-2.azl3.x86_64.rpm
+libcap-debuginfo-2.69-2.azl3.x86_64.rpm
+libcap-devel-2.69-2.azl3.x86_64.rpm
 libcap-ng-0.8.4-1.azl3.x86_64.rpm
 libcap-ng-debuginfo-0.8.4-1.azl3.x86_64.rpm
 libcap-ng-devel-0.8.4-1.azl3.x86_64.rpm


### PR DESCRIPTION
Cherry Pick of https://github.com/microsoft/azurelinux/commit/9c3e6fd109bd04945a4cce474c412db1cb223a82 to 3.0-dev