### PR TITLE
kata-containers: add support for virtio-blk based kata pod sandboxing

### DIFF
--- a/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
+++ b/SPECS/kata-containers-cc/kata-containers-cc.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "kata-containers-3.2.0.azl4-cargo.tar.gz": "2a242deedddbd01b50b56d9f6d02ffd3f40cb2e91221fda4f4b4791d98404f96",
-    "kata-containers-3.2.0.azl4.tar.gz": "397749898ae5963b9d88092e1bd3aacfb2d9bdeb35373be079879fc92f7ffd71"
+    "kata-containers-3.2.0.azl4.tar.gz": "e9bb1124541152178bb642f613ab586dc7d021021b769d0548c5013ea701361d",
+    "kata-containers-3.2.0.azl4-cargo.tar.gz": "18749c417a5d0458549832237329cef2f8042fbd28fffde7d7084a2b75cc7188"
   }
 }

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -3,7 +3,7 @@
 
 Name:         kata-containers-cc
 Version:      3.2.0.azl4
-Release:      1%{?dist}
+Release:      2%{?dist}
 Summary:      Kata Confidential Containers package developed for Confidential Containers on AKS
 License:      ASL 2.0
 URL:          https://github.com/microsoft/kata-containers
@@ -43,6 +43,12 @@ Summary:        Kata Confidential Containers tools package for building the UVM
 %description tools
 This package contains the scripts and files required to build the UVM
 
+%package tardev
+Summary:        tardev-snapshotter for Kata Containers
+
+%description tardev
+This package contains the tardev-snapshotter service for Kata Containers.
+
 %prep
 %autosetup -p1 -n %{sourceName}-%{version}
 pushd %{_builddir}/%{sourceName}-%{version}
@@ -52,6 +58,7 @@ popd
 %build
 pushd %{_builddir}/%{sourceName}-%{version}/tools/osbuilder/node-builder/azure-linux
 %make_build package-confpods
+%make_build tardev
 popd
 
 %define kata_path     /opt/confidential-containers
@@ -64,15 +71,16 @@ popd
 pushd %{_builddir}/%{sourceName}-%{version}/tools/osbuilder/node-builder/azure-linux
 START_SERVICES=no PREFIX=%{buildroot} %make_build deploy-confpods-package
 PREFIX=%{buildroot} %make_build deploy-confpods-package-tools
+PREFIX=%{buildroot} %make_build deploy-tardev
 popd
 
-%preun
+%preun tardev
 %systemd_preun tardev-snapshotter.service
 
-%postun
+%postun tardev
 %systemd_postun tardev-snapshotter.service
 
-%post
+%post tardev
 %systemd_post tardev-snapshotter.service
 if [ $1 -eq 1 ]; then # Package install
 	systemctl enable tardev-snapshotter.service > /dev/null 2>&1 || :
@@ -82,9 +90,6 @@ fi
 %files
 %{_sbindir}/mount.tar
 %{_bindir}/kata-overlay
-%{_bindir}/tardev-snapshotter
-%{_unitdir}/tardev-snapshotter.service
-
 %{kata_bin}/kata-collect-data.sh
 %{kata_bin}/kata-monitor
 %{kata_bin}/kata-runtime
@@ -97,6 +102,12 @@ fi
 %license LICENSE
 %doc CONTRIBUTING.md
 %doc README.md
+
+%files tardev
+%{_bindir}/tardev-snapshotter
+%{_unitdir}/tardev-snapshotter.service
+%{_sbindir}/mount.tar
+%{_bindir}/kata-overlay
 
 %files tools
 %dir %{kata_path}
@@ -150,6 +161,9 @@ fi
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Tue Mar 18 2025 Mitch Zhu <mitchzhu@microsoft.com> - 3.2.0.azl4-2
+- Add tardev subpackage
+
 * Wed Jan 22 2025 Saul Paredes <saulparedes@microsoft.com> - 3.2.0.azl4-1
 - Upgrade to 3.2.0.azl4 release
 

--- a/SPECS/kata-containers/kata-containers.signatures.json
+++ b/SPECS/kata-containers/kata-containers.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "kata-containers-3.2.0.azl4-cargo.tar.gz": "2a242deedddbd01b50b56d9f6d02ffd3f40cb2e91221fda4f4b4791d98404f96",
-    "kata-containers-3.2.0.azl4.tar.gz": "397749898ae5963b9d88092e1bd3aacfb2d9bdeb35373be079879fc92f7ffd71"
+    "kata-containers-3.2.0.azl4.tar.gz": "e9bb1124541152178bb642f613ab586dc7d021021b769d0548c5013ea701361d",
+    "kata-containers-3.2.0.azl4-cargo.tar.gz": "18749c417a5d0458549832237329cef2f8042fbd28fffde7d7084a2b75cc7188"
   }
 }

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -2,7 +2,7 @@
 
 Name:           kata-containers
 Version:        3.2.0.azl4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Kata Containers package developed for Pod Sandboxing on AKS
 License:        ASL 2.0
 URL:            https://github.com/microsoft/kata-containers
@@ -22,8 +22,10 @@ BuildRequires:  openssl-devel
 BuildRequires:  clang
 BuildRequires:  device-mapper-devel
 BuildRequires:  cmake
+BuildRequires:  fuse-devel
 
 Requires:       kernel-uvm
+Requires:       kata-containers-cc-tardev
 # Must match the version specified by the `assets.virtiofsd.version` field in the source's versions.yaml.
 Requires:       virtiofsd = 1.8.0
 
@@ -67,6 +69,8 @@ popd
 %{kata_bin}/kata-runtime
 
 %{defaults_kata}/configuration.toml
+%{defaults_kata}/configuration-clh-debug.toml
+%{defaults_kata}/configuration-blk.toml
 
 %{kata_shim_bin}/containerd-shim-kata-v2
 
@@ -80,6 +84,13 @@ popd
 %dir %{tools_pkg}/tools
 %dir %{tools_pkg}/tools/osbuilder
 %{tools_pkg}/tools/osbuilder/Makefile
+
+%dir %{tools_pkg}/src
+%dir %{tools_pkg}/src/kata-opa
+%{tools_pkg}/src/kata-opa/allow-all.rego
+%dir %{tools_pkg}/src/tarfs
+%{tools_pkg}/src/tarfs/Makefile
+%{tools_pkg}/src/tarfs/tarfs.c
 
 %dir %{tools_pkg}/tools/osbuilder/scripts
 %{tools_pkg}/tools/osbuilder/scripts/lib.sh
@@ -112,6 +123,11 @@ popd
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Tue Mar 18 2025 Mitch Zhu <mitchzhu@microsoft.com> - 3.2.0.azl4-2
+- Add systemd-udev, tarfs, and tardev-snapshotter to enable virtio-blk with pod sandboxing
+- Add new config for virtio-blk based pod sandboxing
+- Set AGENT_POLICY=yes for UVM and kata-agent
+
 * Wed Jan 22 2025 Saul Paredes <saulparedes@microsoft.com> - 3.2.0.azl4-1
 - Upgrade to 3.2.0.azl4 release
 

--- a/SPECS/kata-packages-uvm/kata-packages-uvm.spec
+++ b/SPECS/kata-packages-uvm/kata-packages-uvm.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage for Kata UVM components
 Name:           kata-packages-uvm
 Version:        1.0.0
-Release:        7%{?dist}
+Release:        9%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -14,33 +14,49 @@ Requires:       bash
 Requires:       ca-certificates
 Requires:       chrony
 Requires:       cpio
+# Required for confidential storage functionality
 Requires:       cryptsetup
 Requires:       curl
 Requires:       dbus
+# Required for confidential storage functionality
+Requires:       e2fsprogs
 Requires:       elfutils-libelf
 Requires:       filesystem
-Requires:       grep
-Requires:       gzip
 Requires:       iptables
-Requires:       iproute
-Requires:       iputils
 Requires:       irqbalance
-Requires:       lvm2
-Requires:       lz4
-Requires:       procps-ng
-Requires:       readline
-Requires:       sed
 # Note: We currently only support using systemd for our init process, not the kata-agent.
 # When we go to add support for AGENT_INIT=yes, can drop this.
 # https://github.com/microsoft/kata-containers/blob/msft-main/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh#L10
 Requires:       systemd
-Requires:       tar
 Requires:       tzdata
-Requires:       util-linux
 Requires:       zlib
+Requires:       cifs-utils
+Requires:       device-mapper
+# Note: This assumes we are using systemd which may not always be the case when we support AGENT_INIT=yes
+Requires:       systemd-udev
 
 %description
 Metapackage to install the set of packages inside a Kata containers UVM
+
+%package        debug
+Summary:        Metapackage to install the set of packages inside a Kata confidential containers debug UVM.
+Requires:       %{name} = %{version}-%{release}
+Requires:       curl
+Requires:       cpio
+# Provides find
+Requires:       findutils
+Requires:       gzip
+Requires:       iproute
+# Provides ping, tracepath, etc for debugging net
+Requires:       iputils
+Requires:       lz4
+Requires:       sed
+Requires:       tar
+# Provides free, kill, pgrep, ps, etc
+Requires:       procps-ng
+
+%description    debug
+Metapackage to install the set of packages inside a Kata containers UVM, includes extra debug utilities.
 
 %package        coco
 Summary:        Metapackage to install the set of packages inside a Kata confidential containers UVM.
@@ -95,6 +111,8 @@ Requires:       golang
 
 %files
 
+%files debug
+
 %files coco
 
 %files build
@@ -102,6 +120,15 @@ Requires:       golang
 %files coco-sign
 
 %changelog
+* Mon Feb 24 2025 Mitch Zhu <mitchzhu@microsoft.com> - 1.0.0-9
+- Add cifs-utils, device-mapper, and systemd-udev to kata pod sandboxing.
+
+* Tue Feb 11 2025 Cameron Baird <cameronbaird@microsoft.com> - 1.0.0-8
+- Introduce debug metapackage
+- Move curl, cpio, gzip, iputils, lvm2, tar, procps-ng to debug metapackage
+- Remove bash, grep, readline, util-linux from all metapackages (implicit deps of existing requirements)
+- Add findutils to debug metapackage
+
 * Mon Nov 25 2024 Manuel Huber <mahuber@microsoft.com> - 1.0.0-7
 - Add explicit make dependency for UVM build
 - Remove commented package dependencies


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR adds changes to support virtio-blk based kata pod sandboxing solution.
Matching kata-containers change: https://github.com/microsoft/kata-containers/pull/324

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Extract the tardev package from kata-containers-cc and set it up as a proper dependency in kata-containers
- Add necessary virtio-blk dependencies to the vanilla Kata Containers UVM

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- buddybuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=766429&view=results
- imagebuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=766526&view=results
- kata conf test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=766880&view=results
