### PR TITLE
ig: Bump to v0.38.0.

### DIFF
--- a/SPECS/ig/ig.signatures.json
+++ b/SPECS/ig/ig.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "ig-0.37.0-govendor-v1.tar.gz": "bc05262d7dc5a4585e8d9f8cac81577046312d5a7361c57c8280b826b81196ba",
-  "ig-0.37.0.tar.gz": "dde011c72ac3ccd4943b58bd9d240dcd6311c82a6c89904ecb77b86f727fe420"
+  "ig-0.38.0-govendor-v1.tar.gz": "dd95697fc906bde7dcc0765adf34f4eed9d547f49c5bd4549ae88506434b1813",
+  "ig-0.38.0.tar.gz": "64223d2b9655eb1c14977e586b0b7e656af75bb2095e5631b044c35c23088c18"
  }
 }

--- a/SPECS/ig/ig.spec
+++ b/SPECS/ig/ig.spec
@@ -1,6 +1,6 @@
 Summary:        The eBPF tool and systems inspection framework for Kubernetes, containers and Linux hosts.
 Name:           ig
-Version:        0.37.0
+Version:        0.38.0
 Release:        1%{?dist}
 License:        Apache 2.0 and GPL 2.0 for eBPF code
 Vendor:         Microsoft Corporation
@@ -65,6 +65,9 @@ fi
 %{_bindir}/ig
 
 %changelog
+* Tue Mar 04 2025 Francis Laniel <flaniel@linux.microsoft.com> - 0.38.0-1
+- Bump to version 0.38.0
+
 * Mon Feb 03 2025 Francis Laniel <flaniel@linux.microsoft.com> - 0.37.0-1
 - Bump to version 0.37.0
 - Drop patch for CVE-2024-45338 as it was fixed in golang.org/x/net 0.33.0 and ig uses 0.34.0.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7201,8 +7201,8 @@
         "type": "other",
         "other": {
           "name": "ig",
-          "version": "0.37.0",
-          "downloadUrl": "https://github.com/inspektor-gadget/inspektor-gadget/archive/refs/tags/v0.37.0.tar.gz"
+          "version": "0.38.0",
+          "downloadUrl": "https://github.com/inspektor-gadget/inspektor-gadget/archive/refs/tags/v0.38.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Changelog: https://github.com/inspektor-gadget/inspektor-gadget/releases/tag/v0.38.0
