### PR TITLE
Enable to tui for perf

### DIFF
--- a/SPECS-SIGNED/fwctl-signed/fwctl-signed.spec
+++ b/SPECS-SIGNED/fwctl-signed/fwctl-signed.spec
@@ -45,7 +45,7 @@
 Summary:	 %{_name} Driver
 Name:		 %{_name}
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://nvidia.com
 Group:		 System Environment/Base
@@ -112,6 +112,9 @@ fi # 1 : closed
 
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/iser-signed/iser-signed.spec
+++ b/SPECS-SIGNED/iser-signed/iser-signed.spec
@@ -41,7 +41,7 @@
 Summary:	 %{_name} Driver
 Name:		 %{_name}
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -103,6 +103,9 @@ fi # 1 : closed
 %config(noreplace) %{_sysconfdir}/depmod.d/zz02-%{name}-*.conf
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/isert-signed/isert-signed.spec
+++ b/SPECS-SIGNED/isert-signed/isert-signed.spec
@@ -41,7 +41,7 @@
 Summary:	 %{_name} Driver
 Name:		 %{_name}
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -102,6 +102,9 @@ fi # 1 : closed
 %config(noreplace) %{_sysconfdir}/depmod.d/zz02-%{name}-*.conf
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
+++ b/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
@@ -7,7 +7,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-64k-signed-%{buildarch}
 Version:        6.6.78.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,6 +105,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.78.1-2
+- Bump release to match kernel
+
 * Mon Mar 03 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.78.1-1
 - Auto-upgrade to 6.6.78.1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        6.6.78.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -145,6 +145,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.78.1-2
+- Bump release to match kernel
+
 * Mon Mar 03 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.78.1-1
 - Auto-upgrade to 6.6.78.1
 

--- a/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
+++ b/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed Unified Kernel Image for %{buildarch} systems
 Name:           kernel-uki-signed-%{buildarch}
 Version:        6.6.78.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -68,6 +68,9 @@ popd
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.78.1-2
+- Bump release to match kernel
+
 * Mon Mar 03 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.78.1-1
 - Auto-upgrade to 6.6.78.1
 

--- a/SPECS-SIGNED/knem-modules-signed/knem-modules-signed.spec
+++ b/SPECS-SIGNED/knem-modules-signed/knem-modules-signed.spec
@@ -43,7 +43,7 @@
 Summary:	 KNEM: High-Performance Intra-Node MPI Communication
 Name:		 %{_name}-modules
 Version:	 1.1.4.90mlnx3
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 Provides:	 knem-mlnx = %{version}-%{release}
 Obsoletes:	 knem-mlnx < %{version}-%{release}
 License:	 BSD and GPLv2
@@ -103,6 +103,9 @@ fi
 /lib/modules/
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 1.1.4.90mlnx3-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 1.1.4.90mlnx3-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/mft_kernel-signed/mft_kernel-signed.spec
+++ b/SPECS-SIGNED/mft_kernel-signed/mft_kernel-signed.spec
@@ -12,7 +12,7 @@
 Name:            mft_kernel
 Summary:         %{name} Kernel Module for the %{KVERSION} kernel
 Version:         4.30.0
-Release:         9%{?dist}
+Release:         10%{?dist}
 License:         Dual BSD/GPLv2
 Group:           System Environment/Kernel
 
@@ -74,6 +74,9 @@ popd
 /lib/modules/%{KVERSION}/updates/
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 4.30.0-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 4.30.0-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/mlnx-nfsrdma-signed/mlnx-nfsrdma-signed.spec
+++ b/SPECS-SIGNED/mlnx-nfsrdma-signed/mlnx-nfsrdma-signed.spec
@@ -43,7 +43,7 @@
 Summary:	 %{_name} Driver
 Name:		 %{_name}
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -111,6 +111,9 @@ fi
 %config(noreplace) %{_sysconfdir}/depmod.d/zz02-%{name}-*.conf
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/mlnx-ofa_kernel-modules-signed/mlnx-ofa_kernel-modules-signed.spec
+++ b/SPECS-SIGNED/mlnx-ofa_kernel-modules-signed/mlnx-ofa_kernel-modules-signed.spec
@@ -44,7 +44,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 %{_name}-modules
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -185,6 +185,9 @@ fi
 %license %{_datadir}/licenses/%{name}/copyright
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/srp-signed/srp-signed.spec
+++ b/SPECS-SIGNED/srp-signed/srp-signed.spec
@@ -41,7 +41,7 @@
 Summary:	 srp driver
 Name:		 srp
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -99,6 +99,9 @@ popd
 %license %{_datadir}/licenses/%{name}/copyright
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS-SIGNED/xpmem-modules-signed/xpmem-modules-signed.spec
+++ b/SPECS-SIGNED/xpmem-modules-signed/xpmem-modules-signed.spec
@@ -16,7 +16,7 @@
 Summary:	 Cross-partition memory
 Name:		 xpmem-modules
 Version:	 2.7.4
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2 and LGPLv2.1
 Group:		 System Environment/Libraries
 Vendor:          Microsoft Corporation
@@ -76,6 +76,9 @@ popd
 
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 2.7.4-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 2.7.4-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/fwctl/fwctl.spec
+++ b/SPECS/fwctl/fwctl.spec
@@ -67,7 +67,7 @@
 Summary:	 %{_name} Driver
 Name:		 fwctl
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://nvidia.com
 Group:		 System Environment/Base
@@ -250,6 +250,9 @@ fi # 1 : closed
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/iser/iser.spec
+++ b/SPECS/iser/iser.spec
@@ -64,7 +64,7 @@
 Summary:	 %{_name} Driver
 Name:		 iser
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -247,6 +247,9 @@ fi # 1 : closed
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/isert/isert.spec
+++ b/SPECS/isert/isert.spec
@@ -64,7 +64,7 @@
 Summary:	 %{_name} Driver
 Name:		 isert
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -247,6 +247,9 @@ fi # 1 : closed
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/kernel-64k/kernel-64k.spec
+++ b/SPECS/kernel-64k/kernel-64k.spec
@@ -25,7 +25,7 @@
 Summary:        Linux Kernel
 Name:           kernel-64k
 Version:        6.6.78.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -65,6 +65,7 @@ BuildRequires:  pam-devel
 BuildRequires:  procps-ng-devel
 BuildRequires:  python3-devel
 BuildRequires:  sed
+BuildRequires:  slang-devel
 BuildRequires:  systemd-bootstrap-rpm-macros
 Requires:       filesystem
 Requires:       kmod
@@ -371,6 +372,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.78.1-2
+- Add slang as BuildRequires, enabling tui on perf
+
 * Mon Mar 03 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.78.1-1
 - Auto-upgrade to 6.6.78.1
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.6.78.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +75,9 @@ done
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.78.1-2
+- Bump release to match kernel
+
 * Mon Mar 03 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.78.1-1
 - Auto-upgrade to 6.6.78.1
 

--- a/SPECS/kernel/kernel-uki.spec
+++ b/SPECS/kernel/kernel-uki.spec
@@ -13,7 +13,7 @@
 Summary:        Unified Kernel Image
 Name:           kernel-uki
 Version:        6.6.78.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -70,6 +70,9 @@ cp %{buildroot}/boot/vmlinuz-uki-%{kernelver}.efi %{buildroot}/boot/efi/EFI/Linu
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.78.1-2
+- Bump release to match kernel
+
 * Mon Mar 03 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.78.1-1
 - Auto-upgrade to 6.6.78.1
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -30,7 +30,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.78.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -69,6 +69,7 @@ BuildRequires:  pam-devel
 BuildRequires:  procps-ng-devel
 BuildRequires:  python3-devel
 BuildRequires:  sed
+BuildRequires:  slang-devel
 BuildRequires:  systemd-bootstrap-rpm-macros
 %ifarch x86_64
 BuildRequires:  pciutils-devel
@@ -428,6 +429,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Mar 03 2025 Andy Zaugg <azaugg@linkedin.com> - 6.6.78.1-2
+- Add slang as BuildRequires, enabling tui on perf
+
 * Mon Mar 03 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.78.1-1
 - Auto-upgrade to 6.6.78.1
 

--- a/SPECS/knem/knem.spec
+++ b/SPECS/knem/knem.spec
@@ -53,7 +53,7 @@
 Summary:	 KNEM: High-Performance Intra-Node MPI Communication
 Name:		 knem
 Version:	 1.1.4.90mlnx3
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 Provides:	 knem-mlnx = %{version}-%{release}
 Obsoletes:	 knem-mlnx < %{version}-%{release}
 License:	 BSD and GPLv2
@@ -116,7 +116,7 @@ EOF)
 %global flavors_to_build default
 
 %package -n %{non_kmp_pname}
-Release: 9%{?dist}
+Release: 10%{?dist}
 Summary: KNEM: High-Performance Intra-Node MPI Communication
 Group: System Environment/Libraries
 %description -n %{non_kmp_pname}
@@ -282,6 +282,9 @@ fi
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 1.1.4.90mlnx3-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 1.1.4.90mlnx3-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/mft_kernel/mft_kernel.spec
+++ b/SPECS/mft_kernel/mft_kernel.spec
@@ -33,7 +33,7 @@
 Name:		 mft_kernel
 Summary:	 %{name} Kernel Module for the %{KVERSION} kernel
 Version:	 4.30.0
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 Dual BSD/GPLv2
 Group:		 System Environment/Kernel
 BuildRoot:	 /var/tmp/%{name}-%{version}-build
@@ -228,6 +228,9 @@ find %{buildroot} -type f -name \*.ko -exec %{__strip} -p --strip-debug --discar
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 4.30.0-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 4.30.0-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/mlnx-nfsrdma/mlnx-nfsrdma.spec
+++ b/SPECS/mlnx-nfsrdma/mlnx-nfsrdma.spec
@@ -65,7 +65,7 @@
 Summary:	 %{_name} Driver
 Name:		 mlnx-nfsrdma
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -248,6 +248,9 @@ fi
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
+++ b/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
@@ -99,7 +99,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 mlnx-ofa_kernel
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -191,7 +191,7 @@ Obsoletes: mlnx-en-debuginfo
 Obsoletes: mlnx-en-sources
 Obsoletes: mlnx-rdma-rxe
 Version: %{_version}
-Release: 9%{?dist}
+Release: 10%{?dist}
 Summary: Infiniband Driver and ULPs kernel modules
 Group: System Environment/Libraries
 %description -n %{non_kmp_pname}
@@ -203,7 +203,7 @@ The driver sources are located at: http://www.mellanox.com/downloads/ofed/mlnx-o
 %package -n %{devel_pname}
 Version: %{_version}
 # build KMP rpms?
-Release: 9%{?dist}
+Release: 10%{?dist}
 Obsoletes: kernel-ib-devel
 Obsoletes: kernel-ib
 Obsoletes: mlnx-en
@@ -739,6 +739,9 @@ update-alternatives --remove \
 %{_prefix}/src/mlnx-ofa_kernel-%version
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/srp/srp.spec
+++ b/SPECS/srp/srp.spec
@@ -64,7 +64,7 @@
 Summary:	 srp driver
 Name:		 srp
 Version:	 24.10
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com
 Group:		 System Environment/Base
@@ -253,6 +253,9 @@ fi
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 24.10-9
 - Bump release to rebuild for new kernel release
 

--- a/SPECS/xpmem/xpmem.spec
+++ b/SPECS/xpmem/xpmem.spec
@@ -39,7 +39,7 @@
 Summary:	 Cross-partition memory
 Name:		 xpmem
 Version:	 2.7.4
-Release:	 9%{?dist}
+Release:	 10%{?dist}
 License:	 GPLv2 and LGPLv2.1
 Group:		 System Environment/Libraries
 Vendor:          Microsoft Corporation
@@ -125,7 +125,7 @@ EOF)
 %package modules
 # %{nil}: to avoid having the script that build OFED-internal
 # munge the release version here as well:
-Release: 9%{?dist}
+Release: 10%{?dist}
 Summary: XPMEM: kernel modules
 Group: System Environment/Libraries
 %description modules
@@ -247,6 +247,9 @@ fi
 %endif
 
 %changelog
+* Wed Mar 05 2025 Rachel Menge <rachelmenge@microsoft.com> - 2.7.4-10
+- Bump release to rebuild for new kernel release
+
 * Tue Mar 04 2025 Rachel Menge <rachelmenge@microsoft.com> - 2.7.4-9
 - Bump release to rebuild for new kernel release
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
-kernel-headers-6.6.78.1-1.azl3.noarch.rpm
+kernel-headers-6.6.78.1-2.azl3.noarch.rpm
 glibc-2.38-9.azl3.aarch64.rpm
 glibc-devel-2.38-9.azl3.aarch64.rpm
 glibc-i18n-2.38-9.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
-kernel-headers-6.6.78.1-1.azl3.noarch.rpm
+kernel-headers-6.6.78.1-2.azl3.noarch.rpm
 glibc-2.38-9.azl3.x86_64.rpm
 glibc-devel-2.38-9.azl3.x86_64.rpm
 glibc-i18n-2.38-9.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -156,7 +156,7 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.aarch64.rpm
 kbd-debuginfo-2.2.0-2.azl3.aarch64.rpm
-kernel-headers-6.6.78.1-1.azl3.noarch.rpm
+kernel-headers-6.6.78.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -163,8 +163,8 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.x86_64.rpm
 kbd-debuginfo-2.2.0-2.azl3.x86_64.rpm
-kernel-cross-headers-6.6.78.1-1.azl3.noarch.rpm
-kernel-headers-6.6.78.1-1.azl3.noarch.rpm
+kernel-cross-headers-6.6.78.1-2.azl3.noarch.rpm
+kernel-headers-6.6.78.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adding slang-devel to kernel spec, enabling perf tui

Perf's Makefile has a slang-devel check, which enables tui when slang is detected. (https://github.com/microsoft/CBL-Mariner-Linux-Kernel/blob/rolling-lts/mariner-3/6.6.78.1/tools/perf/Makefile.config#L765). Adding this package at built time will allow
perf --tui support

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add slang-devel as a BR to enable tui for perf

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/53509572

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
[Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=753668&view=results)
Validate fix
```
sudo tdnf install -y  kernel-tools-6.6.78.1-2.azl3.x86_64.rpm
# May need sudo sysctl -w kernel.perf_event_paranoid=-1
perf record -e cycles -a -- ls
# perf report will default to tui if available otherwise will print data
perf report
```
Example without tui
![image](https://github.com/user-attachments/assets/0e88ebcc-e8d6-41ea-a4ad-a7f852d56dcd)
Example of tui:
![image](https://github.com/user-attachments/assets/257212c2-04f7-4cd9-8aca-66724c773535)

Smoke Tests
AMD
```
*** Smoke Testing Kernel 6.6.78.1-2.azl3 (est. < 1 min) ***
PASS: Kernel version matches the running kernel version.
PASS: eth0 interface is up.
PASS: iptables service is running.
Boot times:
Startup finished in 1.884s (kernel) + 1.347s (initrd) + 8.864s (userspace) = 12.095s 
graphical.target reached after 8.465s in userspace.
Kernel size:
-rw------- 1 root root 15044608 Mar  5 02:13 /boot/vmlinuz-6.6.78.1-2.azl3
30916	/lib/modules/6.6.78.1-2.azl3
kernel memory:
MemTotal:       32874296 kB
MemFree:        32515432 kB
MemAvailable:   32338676 kB
Total memory:
               total        used        free      shared  buff/cache   available
Mem:           32103         523       31753           8         123       31580
Swap:              0           0           0
```
ARM
```
*** Smoke Testing Kernel 6.6.78.1-2.azl3 (est. < 1 min) ***
PASS: Kernel version matches the running kernel version.
PASS: eth0 interface is up.
PASS: iptables service is running.
Boot times:
Startup finished in 2.225s (kernel) + 1.410s (initrd) + 5.308s (userspace) = 8.944s 
graphical.target reached after 5.051s in userspace.
Kernel size:
-rw------- 1 root root 48718336 Mar  5 02:48 /boot/vmlinuz-6.6.78.1-2.azl3
49204	/lib/modules/6.6.78.1-2.azl3
kernel memory:
MemTotal:       395447188 kB
MemFree:        392640772 kB
MemAvailable:   391088544 kB
Total memory:
               total        used        free      shared  buff/cache   available
Mem:          386178        4256      383438           1         172      381922
Swap:              0           0           0
```
