### PR TITLE
[3.0] dracut: add patch for systemd-cryptsetup module to be included 

### DIFF
--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        102
-Release:        10%{?dist}
+Release:        11%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -56,6 +56,18 @@ Patch:          0014-fix-systemd-pcrphase-in-hostonly-mode-do-not-try-to-include
 Patch:          0015-fix-systemd-pcrphase-make-tpm2-tss-an-optional-dependency.patch
 Patch:          0016-Handle-SELinux-configuration-for-overlayfs-folders.patch
 Patch:          avoid-mktemp-collisions-with-find-not-path.patch
+# fix-dracut-systemd-include-systemd-cryptsetup.patch has been introduced  
+# by the Azure Linux team to ensure that the systemd-cryptsetup module is included  
+# in the initramfs when needed.  
+# In dracut version 102, the systemd-cryptsetup module was split from the crypt module  
+# and is no longer included by default in initramfs. This causes encrypted volumes  
+# defined in crypttab to not be processed during the initrd phase.  
+# This patch modifies the dracut-systemd module to explicitly include systemd-cryptsetup  
+# when required, restoring expected cryptsetup functionality.  
+# This is a temporary fix until Dracut is upgraded to 104+.  
+# - For reference, see https://github.com/dracut-ng/dracut-ng/pull/262 and
+# https://github.com/dracut-ng/dracut-ng/commit/e0e5424a7b5e387ccb70e47ffea5a59716bf7b76  
+Patch:          fix-dracut-systemd-include-systemd-cryptsetup.patch
 
 BuildRequires:  bash
 BuildRequires:  kmod-devel
@@ -315,6 +327,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Wed Mar 05 2025 Archana Choudhary <archana1@microsoft.com> - 102-11
+- Add fix for systemd-cryptsetup module to be included in initramfs when needed
+
 * Tue Feb 25 2025 Cameron Baird <cameronbaird@microsoft.com> - 102-10
 - Fix 0006-dracut.sh-validate-instmods patch to not break crypto module blacklisting
 

--- a/SPECS/dracut/fix-dracut-systemd-include-systemd-cryptsetup.patch
+++ b/SPECS/dracut/fix-dracut-systemd-include-systemd-cryptsetup.patch
@@ -1,0 +1,33 @@
+From e0e5424a7b5e387ccb70e47ffea5a59716bf7b76 Mon Sep 17 00:00:00 2001
+From: Jo Zzsi <jozzsicsataban@gmail.com>
+Date: Wed, 28 Aug 2024 23:06:08 -0400
+Subject: [PATCH] fix(dracut-systemd): include systemd-cryptsetup module when
+ needed
+
+---
+ modules.d/98dracut-systemd/module-setup.sh | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/98dracut-systemd/module-setup.sh b/modules.d/98dracut-systemd/module-setup.sh
+index 0ea26d425..6b8f42ae3 100755
+--- a/modules.d/98dracut-systemd/module-setup.sh
++++ b/modules.d/98dracut-systemd/module-setup.sh
+@@ -12,7 +12,17 @@ check() {
+ 
+ # called by dracut
+ depends() {
+-    echo "systemd-initrd systemd-ask-password"
++    local deps
++    deps="systemd-initrd systemd-ask-password"
++
++    # when systemd and crypt are both included
++    # systemd-cryptsetup is mandatory dependency
++    # see https://github.com/dracut-ng/dracut-ng/issues/563
++    if dracut_module_included "crypt"; then
++        deps+=" systemd-cryptsetup"
++    fi
++
++    echo "$deps"
+     return 0
+ }
+ 


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

## Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR fixes an issue where cryptsetup.target does not honor crypttab entries during the initrd phase due to missing systemd-cryptsetup-generator and systemd-cryptsetup binaries in the Dracut-generated initramfs.

Starting from Dracut version 102, the systemd-cryptsetup module was separated from the crypt module (as per [dracut-ng#262](https://github.com/dracut-ng/dracut-ng/pull/262)) and is no longer included by default. This change causes encrypted volumes to not be processed correctly in the early boot phase.

## Fix
This PR applies a patch to the dracut-systemd module to explicitly include the systemd-cryptsetup module when needed. The patch modifies the module-setup.sh script in `modules.d/98dracut-systemd/` to ensure that systemd-cryptsetup is installed as a dependency, restoring the expected cryptsetup functionality.

## Patch Details
- Patch Name: fix-dracut-systemd-include-systemd-cryptsetup.patch
- Modified File: `modules.d/98dracut-systemd/module-setup.sh`
- Patch Reference: [Commit e0e5424a7b5e387ccb70e47ffea5a59716bf7b76](https://github.com/dracut-ng/dracut-ng/commit/e0e5424a7b5e387ccb70e47ffea5a59716bf7b76)
- Fix: Updates the Dracut systemd module to correctly install the systemd-cryptsetup module when needed.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [[3][AzureDiskEncryption] cryptsetup.target is not honoring crypttab entries in initrd phase](https://microsoft.visualstudio.com/OS/_workitems/edit/55519424)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=754157&view=results
- Azure Disk Encryption working as expected after this fix:
![image](https://github.com/user-attachments/assets/8170e402-cf2c-44f3-94da-bcf3b121c260)
![image](https://github.com/user-attachments/assets/eaae32fb-967c-4d60-b38f-5a1a1e946fe8)
![image](https://github.com/user-attachments/assets/bee22b51-f4a8-4387-902e-6d53aa0d492f)
