### PR TITLE
Restore back influx-cli-bash-completion subpackage and remove it from bash-completion

### DIFF
--- a/SPECS/bash-completion/bash-completion.spec
+++ b/SPECS/bash-completion/bash-completion.spec
@@ -74,6 +74,7 @@ rm -f %{buildroot}%{_datadir}/bash-completion/completions/influx
 %changelog
 * Wed Mar 12 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.11-2
 - Remove influx bash completion file as it no longer works and is provided by influx-cli-bash-completion package.
+- Removed duplicated license file
 
 * Mon Jan 10 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 2.11-1
 - Upgrade to 2.11.

--- a/SPECS/bash-completion/bash-completion.spec
+++ b/SPECS/bash-completion/bash-completion.spec
@@ -63,7 +63,7 @@ rm -f %{buildroot}%{_datadir}/bash-completion/completions/influx
 %dir %{_datadir}/bash-completion/helpers
 %{_datadir}/bash-completion/helpers/perl
 %{_datadir}/bash-completion/helpers/python
-%doc AUTHORS COPYING
+%doc AUTHORS
 
 %files devel
 %defattr(-,root,root)

--- a/SPECS/bash-completion/bash-completion.spec
+++ b/SPECS/bash-completion/bash-completion.spec
@@ -1,6 +1,6 @@
 Name:          bash-completion
 Version:       2.11
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Programmable completion for bash
 Group:         Applications/Shells
 Vendor:        Microsoft Corporation
@@ -51,6 +51,9 @@ rm -f %{buildroot}%{_datadir}/bash-completion/completions/nmcli
 rm -f %{buildroot}%{_datadir}/bash-completion/completions/\
 {cal,chsh,dmesg,eject,hexdump,ionice,hwclock,ionice,look,mount,renice,rtcwake,su,umount}
 
+# does not work anymore with new versions of influx and provided by influx-cli-bash-completion
+rm -f %{buildroot}%{_datadir}/bash-completion/completions/influx
+
 %files
 %defattr(-,root,root)
 %license COPYING
@@ -69,13 +72,16 @@ rm -f %{buildroot}%{_datadir}/bash-completion/completions/\
 %{_datadir}/pkgconfig/bash-completion.pc
 
 %changelog
+* Wed Mar 12 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.11-2
+- Remove influx bash completion file as it no longer works and is provided by influx-cli-bash-completion package.
+
 * Mon Jan 10 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 2.11-1
 - Upgrade to 2.11.
 
 * Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.7-5
 - Removing the explicit %%clean stage.
 
-* Wed Oct 27 2021 Muhammad Falak <mwani@microsft.com> - 2.7-4
+* Wed Oct 27 2021 Muhammad Falak <mwani@microsoft.com> - 2.7-4
 - Remove epoch
 
 * Mon Mar 08 2021 Thomas Crain <thcrain@microsoft.com> - 2.7-3

--- a/SPECS/influx-cli/influx-cli.spec
+++ b/SPECS/influx-cli/influx-cli.spec
@@ -18,7 +18,7 @@
 Summary:        CLI for managing resources in InfluxDB
 Name:           influx-cli
 Version:        2.7.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -46,6 +46,17 @@ BuildRequires:  systemd-rpm-macros
 %description
 CLI for managing resources in InfluxDB v2.
 
+%package bash-completion
+Summary:        Bash Completion for %{name}
+Group:          Productivity/Databases/Servers
+Requires:       bash-completion
+Supplements:    (%{name} and bash-completion)
+BuildArch:      noarch
+
+%description bash-completion
+The official bash completion script for influx. It includes support
+for every argument that can currently be passed to influx.
+
 %package zsh-completion
 Summary:        ZSH Completion for %{name}
 Group:          Productivity/Databases/Servers
@@ -69,6 +80,9 @@ go build -mod vendor -ldflags="-X main.version=%{version}" -o bin/influx ./cmd/i
 mkdir -p %{buildroot}%{_bindir}
 install -D -m 0755 bin/influx %{buildroot}%{_bindir}/
 
+mkdir -p %{buildroot}/%{_datadir}/bash-completion/completions
+bin/influx completion bash > %{buildroot}/%{_datadir}/bash-completion/completions/influx
+
 mkdir -p %{buildroot}/%{_datadir}/zsh/site-functions
 bin/influx completion zsh > %{buildroot}/%{_datadir}/zsh/site-functions/_influx
 
@@ -77,10 +91,16 @@ bin/influx completion zsh > %{buildroot}/%{_datadir}/zsh/site-functions/_influx
 %doc README.md CHANGELOG.md
 %{_bindir}/influx
 
+%files bash-completion
+%{_datadir}/bash-completion
+
 %files zsh-completion
 %{_datadir}/zsh
 
 %changelog
+* Wed Mar 12 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.7.5-2
+- Add back bash-completion subpackage for influx-cli
+
 * Tue Feb 11 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.7.5-1
 - Auto-upgrade to 2.7.5 - Update influx-cli to match influxdb version for CVE-2023-44487
 
@@ -105,7 +125,7 @@ bin/influx completion zsh > %{buildroot}/%{_datadir}/zsh/site-functions/_influx
 * Thu Jun 15 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.6.1-9
 - Bump release to rebuild with go 1.19.10
 
-* Thu May 25 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsft.com> - 2.6.1-8
+* Thu May 25 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.6.1-8
 - Removed bash-completion subpackage since the script produced is included in original bash-completion.
 
 * Wed Apr 05 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.6.1-7


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR is sort of a revert of this old PR #5583 . After doing investigation I have found that the `influx` completion file shipped by `bash-completion` package doesn't not functionally work well anymore with modern version of influx-cli. So, this pr makes the file be shipped by `influx-cli-bash-completion` subpackage instead. Fixed bug https://microsoft.visualstudio.com/OS/_workitems/edit/44770292

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed `%{_datadir}/bash-completion/completions/influx` completion file in `bash-completion` package as it no longer works well for modern version of influx
- Added bash `influx-cli-bash-completion` subpackage which ships `%{_datadir}/bash-completion/completions/influx` completion file produced by influx-cli
- Fixed email spelling in changelogs for both packages
- Removes duplicated license file definition in `bash-completion` package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=761089&view=results
