### PR TITLE
[Medium] Patch keda for CVE-2025-22870 and CVE-2024-51744

### DIFF
--- a/SPECS/keda/CVE-2024-51744.patch
+++ b/SPECS/keda/CVE-2024-51744.patch
@@ -1,0 +1,86 @@
+From da9cc2fcfc075958f3bd728992dce97ba53e5c71 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Thu, 13 Mar 2025 22:49:38 -0500
+Subject: [PATCH] Addressing CVE-2024-51744
+
+---
+ .../github.com/form3tech-oss/jwt-go/parser.go | 36 +++++++++++--------
+ 1 file changed, 21 insertions(+), 15 deletions(-)
+
+diff --git a/vendor/github.com/form3tech-oss/jwt-go/parser.go b/vendor/github.com/form3tech-oss/jwt-go/parser.go
+index d6901d9..bfb480c 100644
+--- a/vendor/github.com/form3tech-oss/jwt-go/parser.go
++++ b/vendor/github.com/form3tech-oss/jwt-go/parser.go
+@@ -14,12 +14,21 @@ type Parser struct {
+ }
+ 
+ // Parse, validate, and return a token.
+-// keyFunc will receive the parsed token and should return the key for validating.
+-// If everything is kosher, err will be nil
++// Parse parses, validates, verifies the signature and returns the parsed token. keyFunc will
++// receive the parsed token and should return the key for validating.
+ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+ 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
+ }
+ 
++// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object
++// implementing the Claims interface. This provides default values which can be overridden and
++// allows a caller to use their own type, rather than the default MapClaims implementation of
++// Claims.
++//
++// Note: If you provide a custom claim implementation that embeds one of the standard claims (such
++// as RegisteredClaims), make sure that a) you either embed a non-pointer version of the claims or
++// b) if you are using a pointer, allocate the proper memory for it before passing in the overall
++// claims, otherwise you might run into a panic.
+ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+ 	token, parts, err := p.ParseUnverified(tokenString, claims)
+ 	if err != nil {
+@@ -56,12 +65,17 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
+ 		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
+ 	}
+ 
++	// Perform validation
++	token.Signature = parts[2]
++	if err := token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
++		return token, &ValidationError{Inner: err, Errors: ValidationErrorSignatureInvalid}
++	}
++
+ 	vErr := &ValidationError{}
+ 
+ 	// Validate Claims
+ 	if !p.SkipClaimsValidation {
+ 		if err := token.Claims.Valid(); err != nil {
+-
+ 			// If the Claims Valid returned an error, check if it is a validation error,
+ 			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+ 			if e, ok := err.(*ValidationError); !ok {
+@@ -69,22 +83,14 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
+ 			} else {
+ 				vErr = e
+ 			}
++			return token, vErr
+ 		}
+ 	}
+ 
+-	// Perform validation
+-	token.Signature = parts[2]
+-	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+-		vErr.Inner = err
+-		vErr.Errors |= ValidationErrorSignatureInvalid
+-	}
+-
+-	if vErr.valid() {
+-		token.Valid = true
+-		return token, nil
+-	}
++	// No errors so far, token is valid.
++	token.Valid = true
+ 
+-	return token, vErr
++	return token, nil
+ }
+ 
+ // WARNING: Don't use this method unless you know what you're doing
+-- 
+2.45.2
+

--- a/SPECS/keda/CVE-2025-22870.patch
+++ b/SPECS/keda/CVE-2025-22870.patch
@@ -1,0 +1,47 @@
+From 52c84a42ef05c1de656c2aa9f92ca1b3b4df4918 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Thu, 13 Mar 2025 22:16:59 -0500
+Subject: [PATCH] Patching CVE-2025-22870
+
+---
+ vendor/golang.org/x/net/http/httpproxy/proxy.go | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/http/httpproxy/proxy.go b/vendor/golang.org/x/net/http/httpproxy/proxy.go
+index 1415b07..0d23a10 100644
+--- a/vendor/golang.org/x/net/http/httpproxy/proxy.go
++++ b/vendor/golang.org/x/net/http/httpproxy/proxy.go
+@@ -14,6 +14,7 @@ import (
+ 	"errors"
+ 	"fmt"
+ 	"net"
++	"net/netip"
+ 	"net/url"
+ 	"os"
+ 	"strings"
+@@ -181,8 +182,10 @@ func (cfg *config) useProxy(addr string) bool {
+ 	if host == "localhost" {
+ 		return false
+ 	}
+-	ip := net.ParseIP(host)
+-	if ip != nil {
++	nip, err := netip.ParseAddr(host)
++	var ip net.IP
++	if err == nil {
++		ip = net.IP(nip.AsSlice())
+ 		if ip.IsLoopback() {
+ 			return false
+ 		}
+@@ -361,6 +364,9 @@ type domainMatch struct {
+ }
+ 
+ func (m domainMatch) match(host, port string, ip net.IP) bool {
++	if ip != nil {
++		return false
++	}
+ 	if strings.HasSuffix(host, m.host) || (m.matchHost && host == m.host[1:]) {
+ 		return m.port == "" || m.port == port
+ 	}
+-- 
+2.45.2
+

--- a/SPECS/keda/keda.spec
+++ b/SPECS/keda/keda.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes-based Event Driven Autoscaling
 Name:           keda
 Version:        2.4.0
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,8 @@ Patch4:         CVE-2024-6104.patch
 Patch5:         CVE-2024-45338.patch
 Patch6:         CVE-2024-28180.patch
 Patch7:         CVE-2025-27144.patch
+Patch8:         CVE-2025-22870.patch
+Patch9:         CVE-2024-51744.patch
 
 BuildRequires:  golang
 
@@ -71,6 +73,9 @@ cp ./bin/keda-adapter %{buildroot}%{_bindir}
 %{_bindir}/%{name}-adapter
 
 %changelog
+* Fri Mar 14 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.4.0-28
+- Patch to fix CVE-2025-22870, CVE-2024-51744 with an upstream patch
+
 * Fri Feb 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.4.0-27
 - Fix CVE-2025-27144 with an upstream patch
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
keda: Patch for CVE-2025-22870 and CVE-2024-51744

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: **SPECS/keda/CVE-2025-22870.patch**
- new file: **SPECS/keda/CVE-2024-51744.patch**
- modified: **SPECS/keda/keda.spec**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-22870
- https://nvd.nist.gov/vuln/detail/CVE-2024-51744

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx

