### PR TITLE
Backport grub xfs large extent counters feature

### DIFF
--- a/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
@@ -13,7 +13,7 @@
 Summary:        Signed GRand Unified Bootloader for %{buildarch} systems
 Name:           grub2-efi-binary-signed-%{buildarch}
 Version:        2.06
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -84,6 +84,9 @@ cp %{SOURCE3} %{buildroot}/boot/efi/EFI/%{efidir}/%{grubpxeefiname}
 /boot/efi/EFI/%{efidir}/%{grubpxeefiname}
 
 %changelog
+* Mon Mar 17 2025 Andy Zaugg <azaugg@linkedin.com> - 2.06-23
+- Bump release number to match grub release
+
 * Sun Nov 10 2024 Chris Co <chrco@microsoft.com> - 2.06-22
 - Set efidir location to BOOT for eventual use in changing to "azurelinux"
 

--- a/SPECS/grub2/0203-fs-xfs-Fix-nrext64-support.patch
+++ b/SPECS/grub2/0203-fs-xfs-Fix-nrext64-support.patch
@@ -1,0 +1,88 @@
+diff --git a/grub-core/fs/xfs.c b/grub-core/fs/xfs.c
+index 0f524c3a8..e94f1b936 100644
+--- a/grub-core/fs/xfs.c
++++ b/grub-core/fs/xfs.c
+@@ -79,6 +79,8 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ /* Inode flags2 flags */
+ #define XFS_DIFLAG2_BIGTIME_BIT	3
+ #define XFS_DIFLAG2_BIGTIME		(1 << XFS_DIFLAG2_BIGTIME_BIT)
++#define XFS_DIFLAG2_NREXT64_BIT        4
++#define XFS_DIFLAG2_NREXT64            (1 << XFS_DIFLAG2_NREXT64_BIT)
+
+ /* incompat feature flags */
+ #define XFS_SB_FEAT_INCOMPAT_FTYPE      (1 << 0)        /* filetype in dirent */
+@@ -86,6 +88,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ #define XFS_SB_FEAT_INCOMPAT_META_UUID  (1 << 2)        /* metadata UUID */
+ #define XFS_SB_FEAT_INCOMPAT_BIGTIME    (1 << 3)        /* large timestamps */
+ #define XFS_SB_FEAT_INCOMPAT_NEEDSREPAIR (1 << 4)       /* needs xfs_repair */
++#define XFS_SB_FEAT_INCOMPAT_NREXT64 (1 << 5)           /* large extent counters */
+
+ /*
+  * Directory entries with ftype are explicitly handled by GRUB code.
+@@ -101,7 +104,8 @@ GRUB_MOD_LICENSE ("GPLv3+");
+	 XFS_SB_FEAT_INCOMPAT_SPINODES | \
+	 XFS_SB_FEAT_INCOMPAT_META_UUID | \
+	 XFS_SB_FEAT_INCOMPAT_BIGTIME | \
+-	 XFS_SB_FEAT_INCOMPAT_NEEDSREPAIR)
++        XFS_SB_FEAT_INCOMPAT_NEEDSREPAIR | \
++        XFS_SB_FEAT_INCOMPAT_NREXT64)
+
+ struct grub_xfs_sblock
+ {
+@@ -198,7 +202,8 @@ struct grub_xfs_inode
+   grub_uint16_t mode;
+   grub_uint8_t version;
+   grub_uint8_t format;
+-  grub_uint8_t unused2[26];
++  grub_uint8_t unused2[18];
++  grub_uint64_t nextents_big;
+   grub_uint64_t atime;
+   grub_uint64_t mtime;
+   grub_uint64_t ctime;
+@@ -532,11 +537,27 @@ get_fsb (const void *keys, int idx)
+   return grub_be_to_cpu64 (grub_get_unaligned64 (p));
+ }
+
++static int
++grub_xfs_inode_has_large_extent_counts (const struct grub_xfs_inode *inode)
++{
++  return inode->version >= 3 &&
++        (inode->flags2 & grub_cpu_to_be64_compile_time (XFS_DIFLAG2_NREXT64));
++}
++
++static grub_uint64_t
++grub_xfs_get_inode_nextents (struct grub_xfs_inode *inode)
++{
++  return (grub_xfs_inode_has_large_extent_counts (inode)) ?
++         grub_be_to_cpu64 (inode->nextents_big) :
++         grub_be_to_cpu32 (inode->nextents);
++}
++
++
+ static grub_disk_addr_t
+ grub_xfs_read_block (grub_fshelp_node_t node, grub_disk_addr_t fileblock)
+ {
+   struct grub_xfs_btree_node *leaf = 0;
+-  int ex, nrec;
++  grub_uint64_t ex, nrec;
+   struct grub_xfs_extent *exts;
+   grub_uint64_t ret = 0;
+
+@@ -561,7 +582,7 @@ grub_xfs_read_block (grub_fshelp_node_t node, grub_disk_addr_t fileblock)
+				/ (2 * sizeof (grub_uint64_t));
+       do
+         {
+-          int i;
++          grub_uint64_t i;
+
+           for (i = 0; i < nrec; i++)
+             {
+@@ -602,7 +623,7 @@ grub_xfs_read_block (grub_fshelp_node_t node, grub_disk_addr_t fileblock)
+     }
+   else if (node->inode.format == XFS_INODE_FORMAT_EXT)
+     {
+-      nrec = grub_be_to_cpu32 (node->inode.nextents);
++      nrec = grub_xfs_get_inode_nextents (&node->inode);
+       exts = (struct grub_xfs_extent *) grub_xfs_inode_data(&node->inode);
+     }
+   else

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -7,7 +7,7 @@
 Summary:        GRand Unified Bootloader
 Name:           grub2
 Version:        2.06
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -85,6 +85,7 @@ Patch0199:      0199-fs-f2fs-Do-not-copy-file-names-that-are-too-long.patch
 Patch0200:      0200-fs-btrfs-Fix-several-fuzz-issues-with-invalid-dir-it.patch
 Patch0201:      0201-fs-btrfs-Fix-more-ASAN-and-SEGV-issues-found-with-fu.patch
 Patch0202:      0202-fs-btrfs-Fix-more-fuzz-issues-related-to-chunks.patch
+Patch0203:      0203-fs-xfs-Fix-nrext64-support.patch
 # Required to reach SBAT 3
 Patch:          sbat-3-0001-font-Reject-glyphs-exceeds-font-max_glyph_width-or-f.patch
 Patch:          sbat-3-0004-font-Remove-grub_font_dup_glyph.patch
@@ -566,6 +567,9 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 - Fix CVE-2020-14311
 - Fix CVE-2020-15706
 - Fix CVE-2020-15707
+
+* Mon Mar 17 2025 Andy Zaugg <azaugg@linkedin.com> - 2.02-23
+- Backport grub patch from 2.12 allowing support for nrext64(large extent counts)
 
 * Wed Jul 22 2020 Joe Schmitt <joschmit@microsoft.com> - 2.02-22
 - Always include Patch100, but conditionally apply it.


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backport upstream feature from grub2-12 allowing filesystems formatted with large extent count support(nrext64=1) to be recognisable by grub2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Back ported commit from [upstream](https://git.savannah.gnu.org/cgit/grub.git/commit/?id=aa7c1322671eef48ba72d3b733da37e63eb37328) 2.12 . I was not able to get a clean cherry-pick, so i reformatted the patch to get it apply to your 2.06 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Applied patch and created my own version of grub2
```
root [ / ]# rpm -qa | grep grub2
grub2-configuration-2.06-23.azl3.x86_64
grub2-tools-minimal-2.06-23.azl3.x86_64
grub2-2.06-23.azl3.x86_64
grub2-efi-2.06-23.azl3.x86_64
grub2-pc-2.06-23.azl3.x86_64
grub2-efi-binary-noprefix-2.06-23.azl3.x86_64
grub2-efi-binary-2.06-23.azl3.x86_64
grub2-efi-unsigned-2.06-23.azl3.x86_64
root [ / ]# xfs_info /dev/sda3 | grep nrext64=1
     =           reflink=1  bigtime=1 inobtcount=1 nrext64=1
root [ / ]# /usr/sbin/grub2-install /dev/sda
Installing for i386-pc platform.
Installation finished. No error reported.
```

