### PR TITLE
add license checker exceptions for openssl

### DIFF
--- a/toolkit/resources/manifests/package/license_file_exceptions.json
+++ b/toolkit/resources/manifests/package/license_file_exceptions.json
@@ -30,6 +30,14 @@
             "IgnoredFilesRegexList": [
                 "^/usr/share/doc/tar-[0-9\\.]+/tar\\.html/GNU-Free-Documentation-License\\.html$"
             ]
+        },
+        {
+            "_comment1": "OpenSSL has multiple structs, constants and procedures that have the word 'NOTICE' in them, like 'NOTICEREF_free'.",
+            "_comment2": "These man pages are for those items, not actual license notices.",
+            "PackageName": "openssl-devel",
+            "IgnoredFilesRegexList": [
+                "^/usr/share/man/man3/.*NOTICE.*\\.3ossl\\.gz$"
+            ]
         }
     ],
     "GlobalExceptionsRegexList": [


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
The license checker found several potential mishandled license files in `openssl-devel`. However, after looking at them, all of them are false positives that refer to APIs, not licenses.

###### Change Log  <!-- REQUIRED -->
- Update the license checker exception file to ignore these files.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- ADO: https://microsoft.visualstudio.com/OS/_workitems/edit/56749229

###### Test Methodology
- Manually ran `make license-check` on openssl rpms to verify these are now ignored.
- Manually tested the regex against the contents of `openssl-devel` to make sure it didn't exclude anything I didn't want excluded.
- Buddy Build shows no license check issues: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=767826&view=results
(TODO: Check arm64 build once it's done)
