### PR TITLE
Patch cri-o for CVE-2025-27144 [medium]

### DIFF
--- a/SPECS/cri-o/CVE-2025-27144.patch
+++ b/SPECS/cri-o/CVE-2025-27144.patch
@@ -1,0 +1,50 @@
+From fa324fa38481f9d2da9109cb5983326f62ff7507 Mon Sep 17 00:00:00 2001
+From: Kanishk-Bansal <kbkanishk975@gmail.com>
+Date: Fri, 28 Feb 2025 07:45:53 +0000
+Subject: [PATCH] CVE-2025-27144
+Upstream Ref: https://github.com/go-jose/go-jose/commit/c9ed84d8f0cfadcfad817150158caca6fcbc518b
+
+---
+ vendor/gopkg.in/square/go-jose.v2/jwe.go | 5 +++--
+ vendor/gopkg.in/square/go-jose.v2/jws.go | 5 +++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/vendor/gopkg.in/square/go-jose.v2/jwe.go b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+index b5a6dcd..cd1de9e 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/jwe.go
++++ b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+@@ -201,10 +201,11 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
+ 
+ // parseEncryptedCompact parses a message in compact format.
+ func parseEncryptedCompact(input string) (*JSONWebEncryption, error) {
+-	parts := strings.Split(input, ".")
+-	if len(parts) != 5 {
++	// Five parts is four separators
++	if strings.Count(input, ".") != 4 {
+ 		return nil, fmt.Errorf("square/go-jose: compact JWE format must have five parts")
+ 	}
++	parts := strings.SplitN(input, ".", 5)
+ 
+ 	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
+ 	if err != nil {
+diff --git a/vendor/gopkg.in/square/go-jose.v2/jws.go b/vendor/gopkg.in/square/go-jose.v2/jws.go
+index 7e261f9..a8d55fb 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/jws.go
++++ b/vendor/gopkg.in/square/go-jose.v2/jws.go
+@@ -275,10 +275,11 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
+ 
+ // parseSignedCompact parses a message in compact format.
+ func parseSignedCompact(input string, payload []byte) (*JSONWebSignature, error) {
+-	parts := strings.Split(input, ".")
+-	if len(parts) != 3 {
++	// Three parts is two separators
++	if strings.Count(input, ".") != 2 {
+ 		return nil, fmt.Errorf("square/go-jose: compact JWS format must have three parts")
+ 	}
++	parts := strings.SplitN(input, ".", 3)
+ 
+ 	if parts[1] != "" && payload != nil {
+ 		return nil, fmt.Errorf("square/go-jose: payload is not detached")
+-- 
+2.45.2
+

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.22.3
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -73,6 +73,7 @@ Patch17:        CVE-2024-9341.patch
 Patch18:        CVE-2024-45338.patch
 Patch19:        CVE-2023-0778.patch
 Patch20:        CVE-2023-6476.patch
+Patch21:        CVE-2025-27144.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  fdupes
@@ -225,6 +226,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Fri Mar 21 2025 Dallas Delaney <dadelan@microsoft.com> - 1.22.3-11
+- Add patch for CVE-2025-27144
+
 * Thu Jan 23 2025 Sumedh Sharma <sumsharma@microsoft.com> - 1.22.3-10
 - Add patch for CVE-2023-0778 & CVE-2023-6476.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch cri-o for CVE-2025-27144

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2025-27144

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-27144

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=768750&view=results
