### PR TITLE
Patch containerd and containerd2 for CVE-2025-27144 [medium]

### DIFF
--- a/SPECS/containerd/CVE-2025-27144.patch
+++ b/SPECS/containerd/CVE-2025-27144.patch
@@ -1,0 +1,50 @@
+From fa324fa38481f9d2da9109cb5983326f62ff7507 Mon Sep 17 00:00:00 2001
+From: Kanishk-Bansal <kbkanishk975@gmail.com>
+Date: Fri, 28 Feb 2025 07:45:53 +0000
+Subject: [PATCH] CVE-2025-27144
+Upstream Ref: https://github.com/go-jose/go-jose/commit/c9ed84d8f0cfadcfad817150158caca6fcbc518b
+
+---
+ vendor/gopkg.in/square/go-jose.v2/jwe.go | 5 +++--
+ vendor/gopkg.in/square/go-jose.v2/jws.go | 5 +++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/vendor/gopkg.in/square/go-jose.v2/jwe.go b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+index b5a6dcd..cd1de9e 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/jwe.go
++++ b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+@@ -201,10 +201,11 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
+ 
+ // parseEncryptedCompact parses a message in compact format.
+ func parseEncryptedCompact(input string) (*JSONWebEncryption, error) {
+-	parts := strings.Split(input, ".")
+-	if len(parts) != 5 {
++	// Five parts is four separators
++	if strings.Count(input, ".") != 4 {
+ 		return nil, fmt.Errorf("square/go-jose: compact JWE format must have five parts")
+ 	}
++	parts := strings.SplitN(input, ".", 5)
+ 
+ 	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
+ 	if err != nil {
+diff --git a/vendor/gopkg.in/square/go-jose.v2/jws.go b/vendor/gopkg.in/square/go-jose.v2/jws.go
+index 7e261f9..a8d55fb 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/jws.go
++++ b/vendor/gopkg.in/square/go-jose.v2/jws.go
+@@ -275,10 +275,11 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
+ 
+ // parseSignedCompact parses a message in compact format.
+ func parseSignedCompact(input string, payload []byte) (*JSONWebSignature, error) {
+-	parts := strings.Split(input, ".")
+-	if len(parts) != 3 {
++	// Three parts is two separators
++	if strings.Count(input, ".") != 2 {
+ 		return nil, fmt.Errorf("square/go-jose: compact JWS format must have three parts")
+ 	}
++	parts := strings.SplitN(input, ".", 3)
+ 
+ 	if parts[1] != "" && payload != nil {
+ 		return nil, fmt.Errorf("square/go-jose: payload is not detached")
+-- 
+2.45.2
+

--- a/SPECS/containerd/containerd.spec
+++ b/SPECS/containerd/containerd.spec
@@ -4,7 +4,7 @@
 Summary: Industry-standard container runtime
 Name: containerd
 Version: 1.7.13
-Release: 6%{?dist}
+Release: 7%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -21,6 +21,7 @@ Patch3:  CVE-2023-47108.patch
 Patch4:  CVE-2024-24786.patch
 Patch5:  CVE-2024-28180.patch
 Patch6:  CVE-2023-45288.patch
+Patch7:  CVE-2025-27144.patch
 
 %{?systemd_requires}
 
@@ -90,6 +91,9 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Fri Mar 21 2025 Dallas Delaney <dadelan@microsoft.com> - 1.7.13-7
+- Fix CVE-2025-27144
+
 * Fri Feb 14 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.7.13-6
 - Fix CVE-2024-28180, CVE-2023-45288
 

--- a/SPECS/containerd2/CVE-2025-27144.patch
+++ b/SPECS/containerd2/CVE-2025-27144.patch
@@ -1,0 +1,50 @@
+From fa324fa38481f9d2da9109cb5983326f62ff7507 Mon Sep 17 00:00:00 2001
+From: Kanishk-Bansal <kbkanishk975@gmail.com>
+Date: Fri, 28 Feb 2025 07:45:53 +0000
+Subject: [PATCH] CVE-2025-27144
+Upstream Ref: https://github.com/go-jose/go-jose/commit/c9ed84d8f0cfadcfad817150158caca6fcbc518b
+
+---
+ vendor/gopkg.in/square/go-jose.v2/jwe.go | 5 +++--
+ vendor/gopkg.in/square/go-jose.v2/jws.go | 5 +++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/vendor/gopkg.in/square/go-jose.v2/jwe.go b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+index b5a6dcd..cd1de9e 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/jwe.go
++++ b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+@@ -201,10 +201,11 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
+ 
+ // parseEncryptedCompact parses a message in compact format.
+ func parseEncryptedCompact(input string) (*JSONWebEncryption, error) {
+-	parts := strings.Split(input, ".")
+-	if len(parts) != 5 {
++	// Five parts is four separators
++	if strings.Count(input, ".") != 4 {
+ 		return nil, fmt.Errorf("square/go-jose: compact JWE format must have five parts")
+ 	}
++	parts := strings.SplitN(input, ".", 5)
+ 
+ 	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
+ 	if err != nil {
+diff --git a/vendor/gopkg.in/square/go-jose.v2/jws.go b/vendor/gopkg.in/square/go-jose.v2/jws.go
+index 7e261f9..a8d55fb 100644
+--- a/vendor/gopkg.in/square/go-jose.v2/jws.go
++++ b/vendor/gopkg.in/square/go-jose.v2/jws.go
+@@ -275,10 +275,11 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
+ 
+ // parseSignedCompact parses a message in compact format.
+ func parseSignedCompact(input string, payload []byte) (*JSONWebSignature, error) {
+-	parts := strings.Split(input, ".")
+-	if len(parts) != 3 {
++	// Three parts is two separators
++	if strings.Count(input, ".") != 2 {
+ 		return nil, fmt.Errorf("square/go-jose: compact JWS format must have three parts")
+ 	}
++	parts := strings.SplitN(input, ".", 3)
+ 
+ 	if parts[1] != "" && payload != nil {
+ 		return nil, fmt.Errorf("square/go-jose: payload is not detached")
+-- 
+2.45.2
+

--- a/SPECS/containerd2/CVE-2025-27144.patch
+++ b/SPECS/containerd2/CVE-2025-27144.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] CVE-2025-27144
 Upstream Ref: https://github.com/go-jose/go-jose/commit/c9ed84d8f0cfadcfad817150158caca6fcbc518b
 
 ---
- vendor/gopkg.in/square/go-jose.v2/jwe.go | 5 +++--
- vendor/gopkg.in/square/go-jose.v2/jws.go | 5 +++--
+ vendor/github.com/go-jose/go-jose/v4/jwe.go | 5 +++--
+ vendor/github.com/go-jose/go-jose/v4/jws.go | 5 +++--
  2 files changed, 6 insertions(+), 4 deletions(-)
 
-diff --git a/vendor/gopkg.in/square/go-jose.v2/jwe.go b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+diff --git a/vendor/github.com/go-jose/go-jose/v4/jwe.go b/vendor/github.com/go-jose/go-jose/v4/jwe.go
 index b5a6dcd..cd1de9e 100644
---- a/vendor/gopkg.in/square/go-jose.v2/jwe.go
-+++ b/vendor/gopkg.in/square/go-jose.v2/jwe.go
+--- a/vendor/github.com/go-jose/go-jose/v4/jwe.go
++++ b/vendor/github.com/go-jose/go-jose/v4/jwe.go
 @@ -201,10 +201,11 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
  
  // parseEncryptedCompact parses a message in compact format.
@@ -27,10 +27,10 @@ index b5a6dcd..cd1de9e 100644
  
  	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
  	if err != nil {
-diff --git a/vendor/gopkg.in/square/go-jose.v2/jws.go b/vendor/gopkg.in/square/go-jose.v2/jws.go
+diff --git a/vendor/github.com/go-jose/go-jose/v4/jws.go b/vendor/github.com/go-jose/go-jose/v4/jws.go
 index 7e261f9..a8d55fb 100644
---- a/vendor/gopkg.in/square/go-jose.v2/jws.go
-+++ b/vendor/gopkg.in/square/go-jose.v2/jws.go
+--- a/vendor/github.com/go-jose/go-jose/v4/jws.go
++++ b/vendor/github.com/go-jose/go-jose/v4/jws.go
 @@ -275,10 +275,11 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
  
  // parseSignedCompact parses a message in compact format.
@@ -47,4 +47,3 @@ index 7e261f9..a8d55fb 100644
  		return nil, fmt.Errorf("square/go-jose: payload is not detached")
 -- 
 2.45.2
-

--- a/SPECS/containerd2/CVE-2025-27144.patch
+++ b/SPECS/containerd2/CVE-2025-27144.patch
@@ -10,40 +10,40 @@ Upstream Ref: https://github.com/go-jose/go-jose/commit/c9ed84d8f0cfadcfad817150
  2 files changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/vendor/github.com/go-jose/go-jose/v4/jwe.go b/vendor/github.com/go-jose/go-jose/v4/jwe.go
-index b5a6dcd..cd1de9e 100644
+index 89f03ee..9f1322d 100644
 --- a/vendor/github.com/go-jose/go-jose/v4/jwe.go
 +++ b/vendor/github.com/go-jose/go-jose/v4/jwe.go
-@@ -201,10 +201,11 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
- 
- // parseEncryptedCompact parses a message in compact format.
- func parseEncryptedCompact(input string) (*JSONWebEncryption, error) {
+@@ -288,10 +288,11 @@ func ParseEncryptedCompact(
+ 	keyAlgorithms []KeyAlgorithm,
+ 	contentEncryption []ContentEncryption,
+ ) (*JSONWebEncryption, error) {
 -	parts := strings.Split(input, ".")
 -	if len(parts) != 5 {
 +	// Five parts is four separators
 +	if strings.Count(input, ".") != 4 {
- 		return nil, fmt.Errorf("square/go-jose: compact JWE format must have five parts")
+ 		return nil, fmt.Errorf("go-jose/go-jose: compact JWE format must have five parts")
  	}
 +	parts := strings.SplitN(input, ".", 5)
  
  	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
  	if err != nil {
 diff --git a/vendor/github.com/go-jose/go-jose/v4/jws.go b/vendor/github.com/go-jose/go-jose/v4/jws.go
-index 7e261f9..a8d55fb 100644
+index 3a91230..d09d8ba 100644
 --- a/vendor/github.com/go-jose/go-jose/v4/jws.go
 +++ b/vendor/github.com/go-jose/go-jose/v4/jws.go
-@@ -275,10 +275,11 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
- 
- // parseSignedCompact parses a message in compact format.
- func parseSignedCompact(input string, payload []byte) (*JSONWebSignature, error) {
+@@ -327,10 +327,11 @@ func parseSignedCompact(
+ 	payload []byte,
+ 	signatureAlgorithms []SignatureAlgorithm,
+ ) (*JSONWebSignature, error) {
 -	parts := strings.Split(input, ".")
 -	if len(parts) != 3 {
 +	// Three parts is two separators
 +	if strings.Count(input, ".") != 2 {
- 		return nil, fmt.Errorf("square/go-jose: compact JWS format must have three parts")
+ 		return nil, fmt.Errorf("go-jose/go-jose: compact JWS format must have three parts")
  	}
 +	parts := strings.SplitN(input, ".", 3)
  
  	if parts[1] != "" && payload != nil {
- 		return nil, fmt.Errorf("square/go-jose: payload is not detached")
+ 		return nil, fmt.Errorf("go-jose/go-jose: payload is not detached")
 -- 
-2.45.2
+2.34.1

--- a/SPECS/containerd2/containerd2.spec
+++ b/SPECS/containerd2/containerd2.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: %{upstream_name}2
 Version: 2.0.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -18,6 +18,7 @@ Source2: containerd.toml
 # Added patch to support tardev-snapshotter for Kata CC
 Patch0:	CVE-2024-45338.patch
 Patch1:  add-tardev-support.patch
+Patch2:	CVE-2025-27144.patch
 %{?systemd_requires}
 
 BuildRequires: golang
@@ -89,6 +90,9 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Fri Mar 21 2025 Dallas Delaney <dadelan@microsoft.com> - 2.0.0-6
+- Fix CVE-2025-27144
+
 * Mon Mar 03 2025 Nan Liu <liunan@microsoft.com> - 2.0.0-5
 - Add "Provides/Obsoletes:" to shift all installs of containerd and moby-containerd to containerd2
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch containerd and containerd2 for CVE-2025-27144

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2025-27144

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-27144

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=769020&view=results
