### PR TITLE
Set unique names for subpackages in kernel-rt spec

### DIFF
--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -4,6 +4,7 @@
 %define uname_r %{version}-%{rt_version}-%{release}
 %define mariner_version 3
 %define version_upstream %(echo %{version} | rev | cut -d'.' -f2- | rev)
+%define short_name rt
 
 # find_debuginfo.sh arguments are set by default in rpm's macros.
 # The default arguments regenerate the build-id for vmlinux in the
@@ -24,7 +25,7 @@
 Summary:        Realtime Linux Kernel
 Name:           kernel-rt
 Version:        6.6.77.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -144,17 +145,19 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package -n     python3-perf-%{short_name}
 Summary:        Python 3 extension for perf tools
+Requires:       %{name} = %{version}-%{release}
 Requires:       python3
 
-%description -n python3-perf
+%description -n python3-perf-%{short_name}
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     bpftool
+%package -n     bpftool-%{short_name}
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Requires:       %{name} = %{version}-%{release}
 
-%description -n bpftool
+%description -n bpftool-%{short_name}
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -406,14 +409,17 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_unitdir}/cpupower.service
 %config(noreplace) %{_sysconfdir}/sysconfig/cpupower
 
-%files -n python3-perf
+%files -n python3-perf-%{short_name}
 %{python3_sitearch}/*
 
-%files -n bpftool
+%files -n bpftool-%{short_name}
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Thu Mar 20 2025 Harshit Gupta <guptaharshit@microsoft.com> - 6.6.77.1-2
+- Rename bpftool and python3-perf to be kernel specific
+
 * Mon Feb 24 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.77.1-1
 - Auto-upgrade to 6.6.77.1
 

--- a/SPECS/tuned/tuned.spec
+++ b/SPECS/tuned/tuned.spec
@@ -7,7 +7,7 @@
 Summary:      A dynamic adaptive system tuning daemon
 Name:         tuned
 Version:      2.21.0
-Release:      2%{?dist}
+Release:      3%{?dist}
 License:      GPLv2+
 Vendor:       Microsoft Corporation
 Distribution:   Azure Linux
@@ -36,7 +36,7 @@ Requires: python3-configobj
 Requires: python3-dbus 
 Requires: python3-decorator
 Requires: python3-linux-procfs
-Requires: python3-perf
+Requires: (python3-perf or python3-perf-rt)
 Requires: python3-gobject
 Requires: python3-pyudev
 Requires: python3-schedutils
@@ -429,6 +429,9 @@ fi
 %{_mandir}/man7/tuned-profiles-openshift.7*
 
 %changelog
+* Thu Mar 20 2025 Harshit Gupta <guptaharshit@microsoft.com> 2.21.0-3
+- Set boolean dependency on python3-perf or python3-perf-rt
+
 * Wed Dec 11 2024 Sandeep Karambelkar <skarambelkar@microsoft.com> 2.21.0-2
 - Fix CVEs - CVE-2024-52336 CVE-2024-52337
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Currently, the subpackages `python3-perf` and `bpftools` are being built both by the kernel-rt and kernel specs. However, they have the same name - irrespective of which spec file they are built from. This causes the `python3-perf` RPM built against kernel-rt source-code to override the RPM built against kernel source-code (same for `bpftools` RPM).

###### Change Log  <!-- REQUIRED -->
- Rename the `bpftool` and `python3-perf` subpackages to be kernel specific in the `kernel-rt` spec file.
- Since `tuned` is the only package that uses `python3-perf`, change its Requires field to use either `python3-perf` (built from kernel spec) or `python3-perf-rt` (built from kernel-rt spec).

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
