### PR TITLE
Autofs bugfix backport deadlock

### DIFF
--- a/SPECS/autofs/autofs.spec
+++ b/SPECS/autofs/autofs.spec
@@ -2,13 +2,14 @@
 Summary:        A kernel-based automounter for Linux
 Name:           autofs
 Version:        5.1.8
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Daemons
 URL:            https://git.kernel.org/pub/scm/linux/storage/autofs/autofs.git/
 Source0:        https://www.kernel.org/pub/linux/daemons/%{name}/v5/%{name}-%{version}.tar.xz
+Patch0:         fix-deadlock-write-cache.patch
 BuildRequires:  libtirpc-devel
 BuildRequires:  rpcsvc-proto-devel
 BuildRequires:  systemd-devel
@@ -19,7 +20,7 @@ Requires:       systemd
 Automounting is the process of automatically mounting and unmounting of file systems by a daemon. Autofs includes both a user-space daemon and code in the kernel that assists the daemon.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 %configure \
@@ -66,6 +67,9 @@ rm -rf %{buildroot}%{_sysconfdir}/{init.d,rc.d}
 /lib/systemd/system/autofs.service
 
 %changelog
+* Mon Mar 24 2025 Andy Zaugg <azaugg@linkedin.com> - 5.1.8-5
+- Backport patch from 5.1.9 to address deadlock issue
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 5.1.8-4
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/SPECS/autofs/fix-deadlock-write-cache.patch
+++ b/SPECS/autofs/fix-deadlock-write-cache.patch
@@ -1,0 +1,58 @@
+commit ad518262e9294ad465120cdb6fd29fdd4ccb179d
+Author: Ian Kent <raven@themaw.net>
+Date:   Tue Dec 5 13:25:49 2023 +0800
+
+    autofs-5.1.9 - fix deadlock in remount
+    
+    If we're starting up or trying to re-connect to an existing direct mount
+    we could be iterating through the map entries with the cache readlock
+    held so we can't just take the writelock for direct mounts. But when
+    trying to re-connect to an existing mount at startup there won't be any
+    other process updating the map entry cache.
+    
+    Signed-off-by: Ian Kent <raven@themaw.net>
+
+diff --git a/modules/parse_sun.c b/modules/parse_sun.c
+index a5351fd..b16ebe8 100644
+--- a/modules/parse_sun.c
++++ b/modules/parse_sun.c
+@@ -889,7 +889,18 @@ update_offset_entry(struct autofs_point *ap,
+ 			strcpy(m_mapent, loc);
+ 	}
+ 
+-	cache_writelock(mc);
++	/*
++	 * If we're starting up or trying to re-connect to an existing
++	 * direct mount we could be iterating through the map entries
++	 * with the readlock held so we can't just take the writelock
++	 * for direct mounts. But at when trying to re-connect to an
++	 * existing mount at startup there won't be any other process
++	 * updating the map entry cache.
++	 */
++	if (ap->state == ST_INIT && ap->flags & MOUNT_FLAG_REMOUNT)
++		cache_readlock(mc);
++	else
++		cache_writelock(mc);
+ 	ret = cache_update_offset(mc, name, m_key, m_mapent, age);
+ 
+ 	me = cache_lookup_distinct(mc, m_key);
+@@ -1581,7 +1592,18 @@ dont_expand:
+ 			free(myoptions);
+ 		} while (*p == '/' || (*p == '"' && *(p + 1) == '/'));
+ 
+-		cache_writelock(mc);
++		/*
++		 * If we're starting up or trying to re-connect to an existing
++		 * direct mount we could be iterating through the map entries
++		 * with the readlock held so we can't just take the writelock
++		 * for direct mounts. But at when trying to re-connect to an
++		 * existing mount at startup there won't be any other process
++		 * updating the map entry cache.
++		 */
++		if (ap->state == ST_INIT && ap->flags & MOUNT_FLAG_REMOUNT)
++			cache_readlock(mc);
++		else
++			cache_writelock(mc);
+ 		me = cache_lookup_distinct(mc, name);
+ 		if (!me) {
+ 			cache_unlock(mc);


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We are seeing autofs hang after NFS servers upstream fail IP addresses. Autofs seems stuck and timing out on futex, ran the patched version of autofs over the last 3 days and have not seen a reoccurrence of a stuck automount process

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport a fix from [5.1.9](https://web.git.kernel.org/pub/scm/linux/storage/autofs/autofs.git/commit/?id=ad518262e9294ad465120cdb6fd29fdd4ccb179d) which addresses a deadlock with autofs in the event of a remount.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
