### PR TITLE
Add nil error trapping to licensecheck.go to allow for chroot cleanup on failure and exit gracefully

### DIFF
--- a/toolkit/tools/licensecheck/licensecheck.go
+++ b/toolkit/tools/licensecheck/licensecheck.go
@@ -106,7 +106,7 @@ func printSummary(numFailures, numWarnings int) {
 Errors/warnings fall into three buckets:
 	1. 'bad %doc files': A %doc documentation file that the tool believes to be a license file.
 	2. 'bad general file': A file that is placed into '/usr/share/licenses/' that is not flagged as
-		a license file. These files should use %license instead of %doc. Ideally whey should also
+		a license file. These files should use %license instead of %doc. Ideally, they should also
 		not be placed in a directory manually. (e.g. prefer '%license COPYING' over
 		'%license %{_docdir}/%{name}/COPYING')
 	3. 'duplicated license files': A license file that is both a %license and a %doc file, pick one.")

--- a/toolkit/tools/pkg/licensecheck/licensecheck.go
+++ b/toolkit/tools/pkg/licensecheck/licensecheck.go
@@ -77,7 +77,7 @@ func New(buildDirPath, workerTarPath, rpmDirPath, nameFilePath, exceptionFilePat
 	err = newLicenseChecker.simpleToolChroot.InitializeChroot(buildDirPath, chrootName, workerTarPath, rpmDirPath)
 	if err != nil {
 		err = fmt.Errorf("failed to initialize chroot:\n%w", err)
-		return nil, err
+		return newLicenseChecker, err
 	}
 	defer func() {
 		if err != nil {
@@ -86,20 +86,22 @@ func New(buildDirPath, workerTarPath, rpmDirPath, nameFilePath, exceptionFilePat
 				// Append the cleanup error to the existing error
 				err = fmt.Errorf("%w\nfailed to cleanup after failing to create a new LicenseChecker:\n%w", err, cleanupErr)
 			}
+			// set newLicenseChecker to nil after chroot cleanup to avoid loss of reference
+			newLicenseChecker = nil
 		}
 	}()
 
 	newLicenseChecker.licenseNames, err = LoadLicenseNames(nameFilePath)
 	if err != nil {
 		err = fmt.Errorf("failed to load license names:\n%w", err)
-		return nil, err
+		return newLicenseChecker, err
 	}
 
 	if exceptionFilePath != "" {
 		newLicenseChecker.exceptions, err = LoadLicenseExceptions(exceptionFilePath)
 		if err != nil {
 			err = fmt.Errorf("failed to load license exceptions:\n%w", err)
-			return nil, err
+			return newLicenseChecker, err
 		}
 	}
 

--- a/toolkit/tools/pkg/licensecheck/testdata/not_a_json.json
+++ b/toolkit/tools/pkg/licensecheck/testdata/not_a_json.json
@@ -1,0 +1,4 @@
+I'm definitely not a json file :)
+{
+    "an_attribute": "Hello World!"
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
See this ADO bug: https://microsoft.visualstudio.com/OS/_workitems/edit/56788175
nil was being passed as the value of named return newLicenseChecker, which was being dereferenced within the cleanup function to do chroot cleanup. This caused the tool to break if malformed json files were used for names or exceptions.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- set newLicenseChecker to nil only after chroot cleanup has occurred if needed.
- fix a typo "whey" -> "they"
- add 2 new unit tests for the identified bad json scenarios

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- sudo make build-packages REBUILD_TOOLS=y REBUILD_TOOLCHAIN=n DAILY_BUILD_ID=lkg SRPM_PACK_LIST=vim LICENSE_CHECK_MODE=warn -j100
![image](https://github.com/user-attachments/assets/f93cb2dd-c2ba-4feb-ad0f-9e2c4d1bbf95)

- sudo make go-test-coverage REBUILD_TOOLS=y
![image](https://github.com/user-attachments/assets/4749e1e0-09f4-47cd-b75a-417dfdbc2024)
