### PR TITLE
kernel: add missing build deps

### DIFF
--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -55,7 +55,9 @@ BuildRequires:  elfutils-libelf-devel
 BuildRequires:  flex
 BuildRequires:  gettext
 BuildRequires:  glib-devel
+BuildRequires:  glibc-iconv
 BuildRequires:  grub2-rpm-macros
+BuildRequires:  java-devel
 BuildRequires:  kbd
 BuildRequires:  kmod-devel
 BuildRequires:  libcap-devel


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

The kernel build requires the `glibc-iconv` package and also one of the Java SDK packages (e.g. `msopenjdk-21`). This adds them as build deps.