### PR TITLE
[Medium] Patch telegraf for CVE-2025-22870 and CVE-2024-51744

### DIFF
--- a/SPECS/telegraf/CVE-2024-51744.patch
+++ b/SPECS/telegraf/CVE-2024-51744.patch
@@ -1,0 +1,93 @@
+From d579cfcd4359e79a390ac4d166a0affdf3e263d4 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Wed, 26 Mar 2025 15:37:27 -0500
+Subject: [PATCH] Addressing CVE-2024-51744
+Upstream Patch Reference: https://github.com/golang-jwt/jwt/commit/7b1c1c00a171c6c79bbdb40e4ce7d197060c1c2c
+
+---
+ vendor/github.com/golang-jwt/jwt/v4/parser.go | 41 +++++++++----------
+ 1 file changed, 20 insertions(+), 21 deletions(-)
+
+diff --git a/vendor/github.com/golang-jwt/jwt/v4/parser.go b/vendor/github.com/golang-jwt/jwt/v4/parser.go
+index c0a6f692..9dd36e5a 100644
+--- a/vendor/github.com/golang-jwt/jwt/v4/parser.go
++++ b/vendor/github.com/golang-jwt/jwt/v4/parser.go
+@@ -36,19 +36,21 @@ func NewParser(options ...ParserOption) *Parser {
+ 	return p
+ }
+ 
+-// Parse parses, validates, verifies the signature and returns the parsed token.
+-// keyFunc will receive the parsed token and should return the key for validating.
++// Parse parses, validates, verifies the signature and returns the parsed token. keyFunc will
++// receive the parsed token and should return the key for validating.
+ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+ 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
+ }
+ 
+-// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object implementing the Claims
+-// interface. This provides default values which can be overridden and allows a caller to use their own type, rather
+-// than the default MapClaims implementation of Claims.
++// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object
++// implementing the Claims interface. This provides default values which can be overridden and
++// allows a caller to use their own type, rather than the default MapClaims implementation of
++// Claims.
+ //
+-// Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims),
+-// make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the
+-// proper memory for it before passing in the overall claims, otherwise you might run into a panic.
++// Note: If you provide a custom claim implementation that embeds one of the standard claims (such
++// as RegisteredClaims), make sure that a) you either embed a non-pointer version of the claims or
++// b) if you are using a pointer, allocate the proper memory for it before passing in the overall
++// claims, otherwise you might run into a panic.
+ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+ 	token, parts, err := p.ParseUnverified(tokenString, claims)
+ 	if err != nil {
+@@ -85,12 +87,17 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
+ 		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
+ 	}
+ 
++	// Perform validation
++	token.Signature = parts[2]
++	if err := token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
++		return token, &ValidationError{Inner: err, Errors: ValidationErrorSignatureInvalid}
++	}
++
+ 	vErr := &ValidationError{}
+ 
+ 	// Validate Claims
+ 	if !p.SkipClaimsValidation {
+ 		if err := token.Claims.Valid(); err != nil {
+-
+ 			// If the Claims Valid returned an error, check if it is a validation error,
+ 			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+ 			if e, ok := err.(*ValidationError); !ok {
+@@ -98,22 +105,14 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
+ 			} else {
+ 				vErr = e
+ 			}
++			return token, vErr
+ 		}
+ 	}
+ 
+-	// Perform validation
+-	token.Signature = parts[2]
+-	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+-		vErr.Inner = err
+-		vErr.Errors |= ValidationErrorSignatureInvalid
+-	}
+-
+-	if vErr.valid() {
+-		token.Valid = true
+-		return token, nil
+-	}
++	// No errors so far, token is valid.
++	token.Valid = true
+ 
+-	return token, vErr
++	return token, nil
+ }
+ 
+ // ParseUnverified parses the token but doesn't validate the signature.
+-- 
+2.45.2
+

--- a/SPECS/telegraf/CVE-2025-22870.patch
+++ b/SPECS/telegraf/CVE-2025-22870.patch
@@ -1,0 +1,48 @@
+From 02f7d1db9057c5a70b3267d2b5288f98035c5a64 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Wed, 26 Mar 2025 15:29:29 -0500
+Subject: [PATCH] Addressing CVE-2025-22870
+Upstream Patch Reference: https://github.com/golang/go/commit/25177ecde0922c50753c043579d17828b7ee88e7
+
+---
+ vendor/golang.org/x/net/http/httpproxy/proxy.go | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/http/httpproxy/proxy.go b/vendor/golang.org/x/net/http/httpproxy/proxy.go
+index 6404aaf1..d89c257a 100644
+--- a/vendor/golang.org/x/net/http/httpproxy/proxy.go
++++ b/vendor/golang.org/x/net/http/httpproxy/proxy.go
+@@ -14,6 +14,7 @@ import (
+ 	"errors"
+ 	"fmt"
+ 	"net"
++	"net/netip"
+ 	"net/url"
+ 	"os"
+ 	"strings"
+@@ -177,8 +178,10 @@ func (cfg *config) useProxy(addr string) bool {
+ 	if host == "localhost" {
+ 		return false
+ 	}
+-	ip := net.ParseIP(host)
+-	if ip != nil {
++	nip, err := netip.ParseAddr(host)
++	var ip net.IP
++	if err == nil {
++		ip = net.IP(nip.AsSlice())
+ 		if ip.IsLoopback() {
+ 			return false
+ 		}
+@@ -360,6 +363,9 @@ type domainMatch struct {
+ }
+ 
+ func (m domainMatch) match(host, port string, ip net.IP) bool {
++	if ip != nil {
++		return false
++	}
+ 	if strings.HasSuffix(host, m.host) || (m.matchHost && host == m.host[1:]) {
+ 		return m.port == "" || m.port == port
+ 	}
+-- 
+2.45.2
+

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.31.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -15,6 +15,8 @@ Patch1:         CVE-2024-45337.patch
 Patch2:         CVE-2024-45338.patch
 Patch3:         CVE-2025-22868.patch
 Patch4:         CVE-2025-22869.patch
+Patch5:         CVE-2025-22870.patch
+Patch6:         CVE-2024-51744.patch
 BuildRequires:  golang
 BuildRequires:  systemd-devel
 Requires:       logrotate
@@ -81,6 +83,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Tue Mar 26 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 1.31.0-6
+- Fix CVE-2025-22870, CVE-2024-51744 with an upstream patch
+
 * Wed Mar 05 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.31.0-5
 - Patch CVE-2025-22868, CVE-2025-22869
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
telegraf: Patch for CVE-2025-22870 and CVE-2024-51744

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: **SPECS/telegraf/CVE-2025-22870.patch**
- new file: **SPECS/telegraf/CVE-2024-51744.patch**
- modified: **SPECS/telegraf/telegraf.spec**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-22870
- https://nvd.nist.gov/vuln/detail/CVE-2024-51744

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
