### PR TITLE
Upgrade libssh2 to 1.11.1 for CVE-2023-48795 [Medium]

### DIFF
--- a/SPECS/libssh2/libssh2.signatures.json
+++ b/SPECS/libssh2/libssh2.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libssh2-1.11.0.tar.gz": "3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461"
+  "libssh2-1.11.1.tar.gz": "d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7"
  }
 }

--- a/SPECS/libssh2/libssh2.spec
+++ b/SPECS/libssh2/libssh2.spec
@@ -2,7 +2,7 @@
 
 Summary:        libssh2 is a library implementing the SSH2 protocol.
 Name:           libssh2
-Version:        1.11.0
+Version:        1.11.1
 Release:        1%{?dist}
 License:        BSD
 URL:            https://www.libssh2.org/
@@ -57,6 +57,9 @@ find %{buildroot} -name '*.la' -exec rm -f {} ';'
 %{_mandir}/man3/*
 
 %changelog
+* Fri Apr 04 2025 Sumedh Sharma <sumsharma@microsoft.com> - 1.11.1-1
+- Bump patch version to fix CVE-2023-48795.
+
 * Tue Nov 21 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.11.0-1
 - Auto-upgrade to 1.11.0 - Azure Linux 3.0 - package upgrades
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11161,8 +11161,8 @@
         "type": "other",
         "other": {
           "name": "libssh2",
-          "version": "1.11.0",
-          "downloadUrl": "https://www.libssh2.org/download/libssh2-1.11.0.tar.gz"
+          "version": "1.11.1",
+          "downloadUrl": "https://www.libssh2.org/download/libssh2-1.11.1.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -193,8 +193,8 @@ e2fsprogs-1.47.0-2.azl3.aarch64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.aarch64.rpm
 libsolv-0.7.28-2.azl3.aarch64.rpm
 libsolv-devel-0.7.28-2.azl3.aarch64.rpm
-libssh2-1.11.0-1.azl3.aarch64.rpm
-libssh2-devel-1.11.0-1.azl3.aarch64.rpm
+libssh2-1.11.1-1.azl3.aarch64.rpm
+libssh2-devel-1.11.1-1.azl3.aarch64.rpm
 krb5-1.21.3-2.azl3.aarch64.rpm
 krb5-devel-1.21.3-2.azl3.aarch64.rpm
 nghttp2-1.61.0-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -193,8 +193,8 @@ e2fsprogs-1.47.0-2.azl3.x86_64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.x86_64.rpm
 libsolv-0.7.28-2.azl3.x86_64.rpm
 libsolv-devel-0.7.28-2.azl3.x86_64.rpm
-libssh2-1.11.0-1.azl3.x86_64.rpm
-libssh2-devel-1.11.0-1.azl3.x86_64.rpm
+libssh2-1.11.1-1.azl3.x86_64.rpm
+libssh2-devel-1.11.1-1.azl3.x86_64.rpm
 krb5-1.21.3-2.azl3.x86_64.rpm
 krb5-devel-1.21.3-2.azl3.x86_64.rpm
 nghttp2-1.61.0-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -227,9 +227,9 @@ libsolv-0.7.28-2.azl3.aarch64.rpm
 libsolv-debuginfo-0.7.28-2.azl3.aarch64.rpm
 libsolv-devel-0.7.28-2.azl3.aarch64.rpm
 libsolv-tools-0.7.28-2.azl3.aarch64.rpm
-libssh2-1.11.0-1.azl3.aarch64.rpm
-libssh2-debuginfo-1.11.0-1.azl3.aarch64.rpm
-libssh2-devel-1.11.0-1.azl3.aarch64.rpm
+libssh2-1.11.1-1.azl3.aarch64.rpm
+libssh2-debuginfo-1.11.1-1.azl3.aarch64.rpm
+libssh2-devel-1.11.1-1.azl3.aarch64.rpm
 libstdc++-13.2.0-7.azl3.aarch64.rpm
 libstdc++-devel-13.2.0-7.azl3.aarch64.rpm
 libtasn1-4.19.0-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -235,9 +235,9 @@ libsolv-0.7.28-2.azl3.x86_64.rpm
 libsolv-debuginfo-0.7.28-2.azl3.x86_64.rpm
 libsolv-devel-0.7.28-2.azl3.x86_64.rpm
 libsolv-tools-0.7.28-2.azl3.x86_64.rpm
-libssh2-1.11.0-1.azl3.x86_64.rpm
-libssh2-debuginfo-1.11.0-1.azl3.x86_64.rpm
-libssh2-devel-1.11.0-1.azl3.x86_64.rpm
+libssh2-1.11.1-1.azl3.x86_64.rpm
+libssh2-debuginfo-1.11.1-1.azl3.x86_64.rpm
+libssh2-devel-1.11.1-1.azl3.x86_64.rpm
 libstdc++-13.2.0-7.azl3.x86_64.rpm
 libstdc++-devel-13.2.0-7.azl3.x86_64.rpm
 libtasn1-4.19.0-2.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Bump to version 1.11.1 to fix CVE-2023-48795

###### Change Log  <!-- REQUIRED -->
- Bump version
- update cgmanifest
- update toolchain & package manifests

###### Does this affect the toolchain?  <!-- REQUIRED -->
YES

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-48795

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Full Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=779562&view=results)
