### PR TITLE
libsepol: Install chkcon tool in libsepol-devel.

### DIFF
--- a/SPECS/libsepol/libsepol.spec
+++ b/SPECS/libsepol/libsepol.spec
@@ -1,7 +1,7 @@
 Summary:        SELinux binary policy manipulation library
 Name:           libsepol
 Version:        3.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -62,8 +62,7 @@ mkdir -p %{buildroot}%{_mandir}/man8
 
 rm -f %{buildroot}%{_bindir}/genpolbools
 rm -f %{buildroot}%{_bindir}/genpolusers
-rm -f %{buildroot}%{_bindir}/chkcon
-rm -rf %{buildroot}%{_mandir}/man8
+rm -rf %{buildroot}%{_mandir}/man8/genpol*
 rm -rf %{buildroot}%{_mandir}/ru/man8
 
 %post
@@ -94,8 +93,14 @@ exit 0
 %{_includedir}/sepol/*.h
 %{_includedir}/sepol/cil/*.h
 %{_mandir}/man3/*.3.gz
+%{_mandir}/man8/*.8.gz
+%{_bindir}/chkcon
 
 %changelog
+* Wed Apr 02 2025 Chris PeBenito <chpebeni@microsoft.com> - 3.6-2
+- Install the chkcon binary into the devel package as it is needed by selinux-policy
+  builds starting with 2.20250213.
+
 * Tue Feb 06 2024 Cameron Baird <cameronbaird@microsoft.com> - 3.6-1
 - Upgrade to version 3.6
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -207,7 +207,7 @@ libxml2-2.11.5-4.azl3.aarch64.rpm
 libxml2-devel-2.11.5-4.azl3.aarch64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
-libsepol-3.6-1.azl3.aarch64.rpm
+libsepol-3.6-2.azl3.aarch64.rpm
 glib-2.78.6-1.azl3.aarch64.rpm
 libltdl-2.4.7-1.azl3.aarch64.rpm
 libltdl-devel-2.4.7-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -207,7 +207,7 @@ libxml2-2.11.5-4.azl3.x86_64.rpm
 libxml2-devel-2.11.5-4.azl3.x86_64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
-libsepol-3.6-1.azl3.x86_64.rpm
+libsepol-3.6-2.azl3.x86_64.rpm
 glib-2.78.6-1.azl3.x86_64.rpm
 libltdl-2.4.7-1.azl3.x86_64.rpm
 libltdl-devel-2.4.7-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -222,9 +222,9 @@ libselinux-debuginfo-3.6-3.azl3.aarch64.rpm
 libselinux-devel-3.6-3.azl3.aarch64.rpm
 libselinux-python3-3.6-3.azl3.aarch64.rpm
 libselinux-utils-3.6-3.azl3.aarch64.rpm
-libsepol-3.6-1.azl3.aarch64.rpm
-libsepol-debuginfo-3.6-1.azl3.aarch64.rpm
-libsepol-devel-3.6-1.azl3.aarch64.rpm
+libsepol-3.6-2.azl3.aarch64.rpm
+libsepol-debuginfo-3.6-2.azl3.aarch64.rpm
+libsepol-devel-3.6-2.azl3.aarch64.rpm
 libsolv-0.7.28-2.azl3.aarch64.rpm
 libsolv-debuginfo-0.7.28-2.azl3.aarch64.rpm
 libsolv-devel-0.7.28-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -230,9 +230,9 @@ libselinux-debuginfo-3.6-3.azl3.x86_64.rpm
 libselinux-devel-3.6-3.azl3.x86_64.rpm
 libselinux-python3-3.6-3.azl3.x86_64.rpm
 libselinux-utils-3.6-3.azl3.x86_64.rpm
-libsepol-3.6-1.azl3.x86_64.rpm
-libsepol-debuginfo-3.6-1.azl3.x86_64.rpm
-libsepol-devel-3.6-1.azl3.x86_64.rpm
+libsepol-3.6-2.azl3.x86_64.rpm
+libsepol-debuginfo-3.6-2.azl3.x86_64.rpm
+libsepol-devel-3.6-2.azl3.x86_64.rpm
 libsolv-0.7.28-2.azl3.x86_64.rpm
 libsolv-debuginfo-0.7.28-2.azl3.x86_64.rpm
 libsolv-devel-0.7.28-2.azl3.x86_64.rpm


### PR DESCRIPTION
It is needed by selinux-policy builds starting with 2.20250213.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Restore the chkcon tool in the libsepol-devel package.

###### Change Log  <!-- REQUIRED -->
- Restore the chkcon tool in the libsepol-devel package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES** but only the libsepol-devel subpackage

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 778807
