### PR TITLE
libguestfs: Adding guestfsd dependencies for supermin images

### DIFF
--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -25,7 +25,7 @@
 Summary:        Access and modify virtual machine disk images
 Name:           libguestfs
 Version:        1.52.0
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -850,8 +850,9 @@ extra=--with-supermin-packager-config=$(pwd)/yum.conf
 %if %{without appliances}
   --enable-appliance=no \
 %endif
-  --disable-erlang
-  $extra
+  --disable-erlang \
+  $extra \
+  --with-extra-packages="sqlite sqlite-libs sqlite-devel"
 
 # 'INSTALLDIRS' ensures that Perl and Ruby libs are installed in the
 # vendor dir, not the site dir.
@@ -1147,6 +1148,9 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
+* Mon Apr 07 2025 Kshitiz Godara <kgodara@microsoft.com> - 1.52.0-12
+- Adding support for guestfs dependencies for supermin images
+
 * Tue Feb 25 2025 Chris Co <chrco@microsoft.com> - 1.52.0-11
 - Bump to rebuild with updated glibc
 


### PR DESCRIPTION
libguestfs comes with guestfsd and a list of packages which supermin should install in its images. The listing process for dependencies has a flow where dependencies for guestfsd are listed by
```
guestfsd.deps: ../daemon/guestfsd
     /sbin/ldconfig -p > ld.so.cache.txt
     objdump -p $^ |\
```

but `objdump` doesn't list the recursive dependencies of first level dependencies.

The `guestfsd` package depends on `librpm` and currently it stops there but further recursive dependencies show that `librpm` depends on `libsqlite3` which is not copied by supermin images hence `guestfsd` running inside supermin created image fails with error that `libsqlite3 not found`.

This patch adds explicit dependencies for `sqlite packages` to ensure that `guestfsd` works fine inside supermin images.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Adding support for guestfsd dependencies


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- guestfsd depends on librpm which depends on libsqlite but currently process only lists down first level dependencies
- This patch explicitly adds dependencies for sqlite packages to ensure guestfsd works fine inside supermin images

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [781427](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=781427&view=results)
**Additional testing:**
As the test case specified in spec file requires connection with **host** libvirtd sockets but the build is sandboxed hence it cannot access the host libvirtd sockets. Additionally, `systemctl` doesn't seems to be working inside chroot as it will require full `systemd` support in chroot environment which is also not feasible (will try to take it in next revision if feasible). These changes are aimed at passing this test when binary (`libguestfs-test-tool`) is directly ran on host machine. Without these changes, `libguestfs-test-tool` gives following error when ran on host
```
sudo libguestfs-test-tool
...
guestfsd: error while loading shared libraries: libsqlite3.so.0: cannot open shared object file: No such file or directory
libguestfs: command: run: \ -rf /tmp/libguestfsMr4aQJ
```

After installing the updated binary, the test case works fine on host machine itself,
```
sudo libguestfs-test-tool
...
libguestfs: recv_from_daemon: received GUESTFS_LAUNCH_FLAG
libguestfs: appliance is up
...
libguestfs: command: run: \ -rf /tmp/libguestfsnufr4N
Guest launched OK.
...
===== TEST FINISHED OK =====
```

