### PR TITLE
selinux-policy: Add fix for gpg-agent use in rpm scripts for watching root's secrets dir

### DIFF
--- a/SPECS/selinux-policy/0041-rpm-Allow-gpg-agent-run-in-rpm-scripts-to-watch-secr.patch
+++ b/SPECS/selinux-policy/0041-rpm-Allow-gpg-agent-run-in-rpm-scripts-to-watch-secr.patch
@@ -1,0 +1,31 @@
+From 7cbf9bac360e62fb7bc75d43f62cceab5786eb4f Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <chpebeni@linux.microsoft.com>
+Date: Fri, 4 Apr 2025 14:17:34 -0400
+Subject: [PATCH 41/41] rpm: Allow gpg-agent run in rpm scripts to watch
+ secrets dirs.
+
+This a parallel change to the existing permission for rpm_t.
+
+Signed-off-by: Chris PeBenito <chpebeni@linux.microsoft.com>
+---
+ policy/modules/admin/rpm.te | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/policy/modules/admin/rpm.te b/policy/modules/admin/rpm.te
+index 809e8c573..d0bad2d1b 100644
+--- a/policy/modules/admin/rpm.te
++++ b/policy/modules/admin/rpm.te
+@@ -408,6 +408,10 @@ optional_policy(`
+ 	')
+ ')
+ 
++optional_policy(`
++	gpg_watch_user_secrets_dirs(rpm_script_t)
++')
++
+ optional_policy(`
+ 	lvm_run(rpm_script_t, rpm_roles)
+ ')
+-- 
+2.49.0
+

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -57,6 +57,7 @@ Patch35:        0035-rpm-Run-systemd-sysctl-from-post.patch
 Patch36:        0036-fstools-Add-additional-perms-for-cloud-utils-growpar.patch
 Patch37:        0037-docker-Fix-dockerc-typo-in-container_engine_executab.patch
 Patch38:        0038-enable-liveos-iso-flow.patch
+Patch41:        0041-rpm-Allow-gpg-agent-run-in-rpm-scripts-to-watch-secr.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -328,6 +329,9 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Fri Apr 04 2025 Chris PeBenito <chpebeni@microsoft.com> - 2.20240226-11
+- Add fix for gpg-agent use in rpm scripts for watching root's secrets dir.
+
 * Thu Mar 06 2025 Chris PeBenito <chpebeni@microsoft.com> - 2.20240226-10
 - Add tmpfs fix for cloud-utils-growpart.
 


### PR DESCRIPTION
… root's secrets dir.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add fix for gpg-agent use in rpm scripts for watching root's secrets dir

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add fix for gpg-agent use in rpm scripts for watching root's secrets dir

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 779916
