### PR TITLE
Removed outdated `blacklist` folders from `ca-certificates`.

### DIFF
--- a/SPECS/ca-certificates/ca-certificates.signatures.json
+++ b/SPECS/ca-certificates/ca-certificates.signatures.json
@@ -17,6 +17,6 @@
     "pem2bundle.sh": "f96a2f0071fb80e30332c0bd95853183f2f49a3c98d5e9fc4716aeeb001e3426",
     "trust-fixes": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
     "update-ca-trust": "0c0c0600587db7f59ba5e399666152ea6de6059f37408f3946c43438d607efdd",
-    "update-ca-trust.8.txt": "2470551bd11cc393ddf4cf43cf101c29d9f308c15469ee5e78908cfcf2437579"
+    "update-ca-trust.8.txt": "d69b6335c5ba99872a3d693c08d598f1ddef947aaa6b2432d93e86f20870743c"
   }
 }

--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -47,7 +47,7 @@ Name:           ca-certificates
 # When updating, "Epoch, "Version", AND "Release" tags must be updated in the "prebuilt-ca-certificates*" packages as well.
 Epoch:          1
 Version:        %{azl}.0.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -163,7 +163,7 @@ mkdir -p -m 755 %{buildroot}%{pkidir}/java
 mkdir -p -m 755 %{buildroot}%{_sysconfdir}/ssl
 mkdir -p -m 755 %{buildroot}%{catrustdir}/source
 mkdir -p -m 755 %{buildroot}%{catrustdir}/source/anchors
-mkdir -p -m 755 %{buildroot}%{catrustdir}/source/blacklist
+mkdir -p -m 755 %{buildroot}%{catrustdir}/source/blocklist
 mkdir -p -m 755 %{buildroot}%{catrustdir}/extracted
 mkdir -p -m 755 %{buildroot}%{catrustdir}/extracted/pem
 mkdir -p -m 755 %{buildroot}%{catrustdir}/extracted/openssl
@@ -171,7 +171,7 @@ mkdir -p -m 755 %{buildroot}%{catrustdir}/extracted/java
 mkdir -p -m 755 %{buildroot}%{catrustdir}/extracted/edk2
 mkdir -p -m 755 %{buildroot}%{_datadir}/pki/ca-trust-source
 mkdir -p -m 755 %{buildroot}%{_datadir}/pki/ca-trust-source/anchors
-mkdir -p -m 755 %{buildroot}%{_datadir}/pki/ca-trust-source/blacklist
+mkdir -p -m 755 %{buildroot}%{_datadir}/pki/ca-trust-source/blocklist
 mkdir -p -m 755 %{buildroot}%{_bindir}
 mkdir -p -m 755 %{buildroot}%{_mandir}/man8
 
@@ -232,10 +232,6 @@ ln -s %{catrustdir}/extracted/openssl/%{openssl_format_trust_bundle} \
 ln -s %{catrustdir}/extracted/%{java_bundle} \
     %{buildroot}%{pkidir}/%{java_bundle}
 
-# Supporting p11-kit's directory re-name in version 0.24.0.
-ln -s blacklist %{buildroot}%{_datadir}/pki/ca-trust-source/blocklist
-ln -s blacklist %{buildroot}%{catrustdir}/source/blocklist
-
 %post
 %{refresh_bundles}
 
@@ -285,10 +281,8 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %{pkidir}/%{java_bundle}
 
 # symlink directory
-%{_datadir}/pki/ca-trust-source/blocklist
 %{_sysconfdir}/ssl/certs
 %{_libdir}/ssl/certs
-%{catrustdir}/source/blocklist
 
 # README files
 %{_datadir}/pki/ca-trust-source/README
@@ -303,7 +297,7 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %dir %{_datadir}/pki
 %dir %{_datadir}/pki/ca-trust-source
 %dir %{_datadir}/pki/ca-trust-source/anchors
-%dir %{_datadir}/pki/ca-trust-source/blacklist
+%dir %{_datadir}/pki/ca-trust-source/blocklist
 %dir %{_sysconfdir}/ssl
 %dir %{catrustdir}
 %dir %{catrustdir}/extracted
@@ -313,7 +307,7 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %dir %{catrustdir}/extracted/openssl
 %dir %{catrustdir}/source
 %dir %{catrustdir}/source/anchors
-%dir %{catrustdir}/source/blacklist
+%dir %{catrustdir}/source/blocklist
 %dir %{pkidir}/java
 %dir %{pkidir}/tls
 %dir %{pkidir}/tls/certs
@@ -340,6 +334,9 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %{_bindir}/bundle2pem.sh
 
 %changelog
+* Mon Apr 07 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.0-9
+- Remove outdated 'blacklist' folders.
+
 * Wed Dec 11 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.0-8
 - Update adding Microsoft distrusted CAs.
 - Explicitly set default file ownership to root:root.

--- a/SPECS/ca-certificates/update-ca-trust.8.txt
+++ b/SPECS/ca-certificates/update-ca-trust.8.txt
@@ -98,13 +98,13 @@ subdirectory in the /etc hierarchy.
 * add it as a new file to directory /etc/pki/ca-trust/source/anchors/
 * run 'update-ca-trust extract'
 
-.*QUICK HELP 2*: If your certificate is in the extended BEGIN TRUSTED file format (which may contain distrust/blacklist trust flags, or trust flags for usages other than TLS) then:
+.*QUICK HELP 2*: If your certificate is in the extended BEGIN TRUSTED file format (which may contain distrust/blocklist trust flags, or trust flags for usages other than TLS) then:
 * add it as a new file to directory /etc/pki/ca-trust/source/
 * run 'update-ca-trust extract'
 
 .In order to offer simplicity and flexibility, the way certificate files are treated depends on the subdirectory they are installed to.
 * simple trust anchors subdirectory: /usr/share/pki/ca-trust-source/anchors/ or /etc/pki/ca-trust/source/anchors/
-* simple blacklist (distrust) subdirectory: /usr/share/pki/ca-trust-source/blacklist/ or /etc/pki/ca-trust/source/blacklist/
+* simple blocklist (distrust) subdirectory: /usr/share/pki/ca-trust-source/blocklist/ or /etc/pki/ca-trust/source/blocklist/
 * extended format directory: /usr/share/pki/ca-trust-source/ or /etc/pki/ca-trust/source/
 
 .In the main directories /usr/share/pki/ca-trust-source/ or /etc/pki/ca-trust/source/ you may install one or multiple files in the following file formats:
@@ -134,7 +134,7 @@ you may install one or multiple certificates in either the DER file
 format or in the PEM (BEGIN/END CERTIFICATE) file format.
 Each certificate will be treated as *trusted* for all purposes.
 
-In the blacklist subdirectories /usr/share/pki/ca-trust-source/blacklist/ or /etc/pki/ca-trust/source/blacklist/
+In the blocklist subdirectories /usr/share/pki/ca-trust-source/blocklist/ or /etc/pki/ca-trust/source/blocklist/
 you may install one or multiple certificates in either the DER file
 format or in the PEM (BEGIN/END CERTIFICATE) file format.
 Each certificate will be treated as *distrusted* for all purposes.

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -3,7 +3,7 @@ Name:           prebuilt-ca-certificates-base
 # When updating, "Epoch, "Version", AND "Release" tags must be updated in the "ca-certificates" package as well.
 Epoch:          1
 Version:        %{azl}.0.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -46,6 +46,9 @@ find %{buildroot} -name README -delete
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
+* Mon Apr 07 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.0-9
+- Making 'Release' match with 'ca-certificates'
+
 * Wed Dec 11 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.0-8
 - Update adding Microsoft distrusted CAs.
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -3,7 +3,7 @@ Name:           prebuilt-ca-certificates
 # When updating, "Epoch, "Version", AND "Release" tags must be updated in the "ca-certificates" package as well.
 Epoch:          1
 Version:        %{azl}.0.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -49,6 +49,9 @@ find %{buildroot} -name README -delete
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
+* Mon Apr 07 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.0-9
+- Making 'Release' match with 'ca-certificates'
+
 * Wed Dec 11 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0.0-8
 - Update adding Microsoft distrusted CAs.
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -238,10 +238,10 @@ libffi-devel-3.4.4-1.azl3.aarch64.rpm
 libtasn1-4.19.0-2.azl3.aarch64.rpm
 p11-kit-0.25.0-1.azl3.aarch64.rpm
 p11-kit-trust-0.25.0-1.azl3.aarch64.rpm
-ca-certificates-shared-3.0.0-8.azl3.noarch.rpm
-ca-certificates-tools-3.0.0-8.azl3.noarch.rpm
-ca-certificates-base-3.0.0-8.azl3.noarch.rpm
-ca-certificates-3.0.0-8.azl3.noarch.rpm
+ca-certificates-shared-3.0.0-9.azl3.noarch.rpm
+ca-certificates-tools-3.0.0-9.azl3.noarch.rpm
+ca-certificates-base-3.0.0-9.azl3.noarch.rpm
+ca-certificates-3.0.0-9.azl3.noarch.rpm
 dwz-0.14-2.azl3.aarch64.rpm
 unzip-6.0-21.azl3.aarch64.rpm
 python3-3.12.9-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -238,10 +238,10 @@ libffi-devel-3.4.4-1.azl3.x86_64.rpm
 libtasn1-4.19.0-2.azl3.x86_64.rpm
 p11-kit-0.25.0-1.azl3.x86_64.rpm
 p11-kit-trust-0.25.0-1.azl3.x86_64.rpm
-ca-certificates-shared-3.0.0-8.azl3.noarch.rpm
-ca-certificates-tools-3.0.0-8.azl3.noarch.rpm
-ca-certificates-base-3.0.0-8.azl3.noarch.rpm
-ca-certificates-3.0.0-8.azl3.noarch.rpm
+ca-certificates-shared-3.0.0-9.azl3.noarch.rpm
+ca-certificates-tools-3.0.0-9.azl3.noarch.rpm
+ca-certificates-base-3.0.0-9.azl3.noarch.rpm
+ca-certificates-3.0.0-9.azl3.noarch.rpm
 dwz-0.14-2.azl3.x86_64.rpm
 unzip-6.0-21.azl3.x86_64.rpm
 python3-3.12.9-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -39,11 +39,11 @@ bzip2-1.0.8-1.azl3.aarch64.rpm
 bzip2-debuginfo-1.0.8-1.azl3.aarch64.rpm
 bzip2-devel-1.0.8-1.azl3.aarch64.rpm
 bzip2-libs-1.0.8-1.azl3.aarch64.rpm
-ca-certificates-3.0.0-8.azl3.noarch.rpm
-ca-certificates-base-3.0.0-8.azl3.noarch.rpm
-ca-certificates-legacy-3.0.0-8.azl3.noarch.rpm
-ca-certificates-shared-3.0.0-8.azl3.noarch.rpm
-ca-certificates-tools-3.0.0-8.azl3.noarch.rpm
+ca-certificates-3.0.0-9.azl3.noarch.rpm
+ca-certificates-base-3.0.0-9.azl3.noarch.rpm
+ca-certificates-legacy-3.0.0-9.azl3.noarch.rpm
+ca-certificates-shared-3.0.0-9.azl3.noarch.rpm
+ca-certificates-tools-3.0.0-9.azl3.noarch.rpm
 ccache-4.8.3-3.azl3.aarch64.rpm
 ccache-debuginfo-4.8.3-3.azl3.aarch64.rpm
 check-0.15.2-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -42,11 +42,11 @@ bzip2-1.0.8-1.azl3.x86_64.rpm
 bzip2-debuginfo-1.0.8-1.azl3.x86_64.rpm
 bzip2-devel-1.0.8-1.azl3.x86_64.rpm
 bzip2-libs-1.0.8-1.azl3.x86_64.rpm
-ca-certificates-3.0.0-8.azl3.noarch.rpm
-ca-certificates-base-3.0.0-8.azl3.noarch.rpm
-ca-certificates-legacy-3.0.0-8.azl3.noarch.rpm
-ca-certificates-shared-3.0.0-8.azl3.noarch.rpm
-ca-certificates-tools-3.0.0-8.azl3.noarch.rpm
+ca-certificates-3.0.0-9.azl3.noarch.rpm
+ca-certificates-base-3.0.0-9.azl3.noarch.rpm
+ca-certificates-legacy-3.0.0-9.azl3.noarch.rpm
+ca-certificates-shared-3.0.0-9.azl3.noarch.rpm
+ca-certificates-tools-3.0.0-9.azl3.noarch.rpm
 ccache-4.8.3-3.azl3.x86_64.rpm
 ccache-debuginfo-4.8.3-3.azl3.x86_64.rpm
 check-0.15.2-1.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In 2.0 we were impacted by `p11-kit` [changing the names](https://github.com/p11-glue/p11-kit/commit/47fabc2366d917e255241c41a6cfc179af372644) of the folders it would scan to look for blocked certificates. For the sake of being backward compatible with older versions of `p11-kit` and anyone using these folders in 2.0, we've created symlinks for the new folders (see: #5121).

Reasons to make the change:
- This workaround is no longer needed in 3.0.
- The symlinks break AZL integration with `mock`, which creates the new folders as part of its set-up, which then prevents installation of `ca-certificates` as it tries to create symlinks on top of these already-created folders. We're planning to open a discussion with `mock` about the potential to disable the current hard-coded creation of these folders as a parallel task.
- The oldest supported version of `p11-kit` in 3.0 AZL already uses the new folder names.
- We didn't find any 3.0 package making use of the old folders.
- This change aligns AZL better with Microsoft's inclusive language policies.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #5121

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
- Fast-track dev build.