### PR TITLE
Adding SRPM duplicates check.

### DIFF
--- a/.github/workflows/check-srpm-duplicates.yml
+++ b/.github/workflows/check-srpm-duplicates.yml
@@ -43,7 +43,7 @@ jobs:
           for spec_folder in ${{ matrix.specs-dirs-groups }}; do
             echo "Generating specs.json for spec folder '$spec_folder'."
 
-            sudo make -C toolkit -j$(nproc) parse-specs REBUILD_TOOLS=y DAILY_BUILD_ID=lkg SPECS_DIR=../$spec_folder
+            sudo make -C toolkit -j$(nproc) parse-specs REBUILD_TOOLS=y SPECS_DIR=../$spec_folder
             cp -v build/pkg_artifacts/specs.json ${spec_folder}_specs.json
           done
 

--- a/.github/workflows/check-srpm-duplicates.yml
+++ b/.github/workflows/check-srpm-duplicates.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.12
 
       - name: Switch to stable toolkit
-        run: git checkout 2.0-stable -- toolkit
+        run: git fetch --all && git checkout 2.0-stable -- toolkit
 
       # Generate the specs.json files. They are the input for the duplicates check script.
       - name: Generate specs.json

--- a/.github/workflows/check-srpm-duplicates.yml
+++ b/.github/workflows/check-srpm-duplicates.yml
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This action checks that the specs in this repo
+# generate SRPMs with unique names.
+name: SRPMs duplicates check
+
+on:
+  push:
+    branches: [main, 2.0*, 3.0*, fasttrack/*]
+  pull_request:
+    branches: [main, 2.0*, 3.0*, fasttrack/*]
+
+jobs:
+  check:
+    name: SRPMs duplicates check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Each group is published to a different repo, thus we only need to check
+        # for SRPM duplicates within the group.
+        specs-dirs-groups: ["SPECS SPECS-SIGNED", "SPECS-EXTENDED"]
+
+    steps:
+      # Checkout the branch of our repo that triggered this action
+      - name: Workflow trigger checkout
+        uses: actions/checkout@v4
+
+      # For consistency, we use the same major/minor version of Python that Azure Linux ships
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Switch to stable toolkit
+        run: git checkout 2.0-stable -- toolkit
+
+      # Generate the specs.json files. They are the input for the duplicates check script.
+      - name: Generate specs.json
+        run: |
+          set -euo pipefail
+
+          for spec_folder in ${{ matrix.specs-dirs-groups }}; do
+            echo "Generating specs.json for spec folder '$spec_folder'."
+
+            sudo make -C toolkit -j$(nproc) parse-specs REBUILD_TOOLS=y DAILY_BUILD_ID=lkg SPECS_DIR=../$spec_folder
+            cp -v build/pkg_artifacts/specs.json ${spec_folder}_specs.json
+          done
+
+      - name: Check for duplicate SRPMs
+        run: python3 toolkit/scripts/check_srpm_duplicates.py *_specs.json

--- a/.github/workflows/check-srpm-duplicates.yml
+++ b/.github/workflows/check-srpm-duplicates.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@v4
 
       # For consistency, we use the same major/minor version of Python that Azure Linux ships
-      - name: Setup Python 3.12
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.9
 
       - name: Switch to stable toolkit
         run: git fetch --all && git checkout 2.0-stable -- toolkit

--- a/toolkit/scripts/check_srpm_duplicates.py
+++ b/toolkit/scripts/check_srpm_duplicates.py
@@ -58,10 +58,10 @@ if __name__ == "__main__":
     if srpm_duplicates:
         print("Error: detected specs building the same SRPM.", file=sys.stderr)
         for srpm, specs_paths in srpm_duplicates:
-            print(f"{srpm}:")
+            print(f"{srpm}:", file=sys.stderr)
             for spec_path in specs_paths:
-                print(f"  - {spec_path}")
-            print()
+                print(f"  - {spec_path}", file=sys.stderr)
+            print(file=sys.stderr)
         sys.exit(1)
 
     print("No SRPM duplicates found.")

--- a/toolkit/scripts/check_srpm_duplicates.py
+++ b/toolkit/scripts/check_srpm_duplicates.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+
+_REPO_KEY = "Repo"
+_SPEC_PATH_KEY = "SpecPath"
+_SRPM_PATH_KEY = "SrpmPath"
+
+
+def find_srpm_duplicates(specs_file_paths: list[str]) -> bool:
+    """
+    Analyze multiple specs JSON files to find specs producing the same SRPM.
+    """
+    srpm_to_specs = defaultdict(set)
+
+    for specs_file_path in specs_file_paths:
+        with open(specs_file_path, "r") as f:
+            data = json.load(f)
+
+        if _REPO_KEY not in data:
+            raise Exception(
+                f"Invalid JSON format in {specs_file_path}. Expected '{_REPO_KEY}' key."
+            )
+
+        # Process each item in the repo
+        for item in data["Repo"]:
+            if _SRPM_PATH_KEY not in item or _SPEC_PATH_KEY not in item:
+                raise Exception(
+                    f"Invalid JSON format in {specs_file_path}. Expected '{_SPEC_PATH_KEY}' and '{_SRPM_PATH_KEY}' keys in each element of '{_REPO_KEY}'."
+                )
+
+            srpm = os.path.basename(item[_SRPM_PATH_KEY])
+            srpm_to_specs[srpm].add(item[_SPEC_PATH_KEY])
+
+    return [
+        (srpm, specs_paths)
+        for srpm, specs_paths in srpm_to_specs.items()
+        if len(specs_paths) > 1
+    ]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "specs_file_paths",
+        nargs="+",
+        help="Paths to the specs JSON files to analyze.",
+    )
+    args = parser.parse_args()
+
+    srpm_duplicates = find_srpm_duplicates(args.specs_file_paths)
+    if srpm_duplicates:
+        print("Error: detected specs building the same SRPM.", file=sys.stderr)
+        for srpm, specs_paths in srpm_duplicates:
+            print(f"{srpm}:")
+            for spec_path in specs_paths:
+                print(f"  - {spec_path}")
+            print()
+        sys.exit(1)
+
+    print("No SRPM duplicates found.")

--- a/toolkit/scripts/check_srpm_duplicates.py
+++ b/toolkit/scripts/check_srpm_duplicates.py
@@ -13,7 +13,7 @@ _SPEC_PATH_KEY = "SpecPath"
 _SRPM_PATH_KEY = "SrpmPath"
 
 
-def find_srpm_duplicates(specs_file_paths: list[str]) -> bool:
+def find_srpm_duplicates(specs_file_paths: list[str]) -> list[tuple[str, set[str]]]:
     """
     Analyze multiple specs JSON files to find specs producing the same SRPM.
     """
@@ -24,14 +24,14 @@ def find_srpm_duplicates(specs_file_paths: list[str]) -> bool:
             data = json.load(f)
 
         if _REPO_KEY not in data:
-            raise Exception(
+            raise ValueError(
                 f"Invalid JSON format in {specs_file_path}. Expected '{_REPO_KEY}' key."
             )
 
         # Process each item in the repo
         for item in data["Repo"]:
             if _SRPM_PATH_KEY not in item or _SPEC_PATH_KEY not in item:
-                raise Exception(
+                raise ValueError(
                     f"Invalid JSON format in {specs_file_path}. Expected '{_SPEC_PATH_KEY}' and '{_SRPM_PATH_KEY}' keys in each element of '{_REPO_KEY}'."
                 )
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

#### Related to #13314

In 3.0 we've recently noticed that some of our specs generate SRPMs with identical names. This was causing the following issues:
- In monthly production builds we'd end up publishing only one of the SRPMs out of all specs generating the same SRPM.
- In fast-track builds we'd fail the build during the (S)RPM signing phase as it detects duplicate RPM files.

This issue is not present in 2.0, so this change only backport the duplicate SRPMs PR check.

**NOTE**
Two specs may have the same `Name` tag but still generate different SRPMs due to differences in versions. These are expected and are not considered to be duplicates. Examples:
- `golang.spec` and `golang-1.23.spec`
- the two `rdma-core.spec` - one in `SPECS` and one in `SPECS-EXTENDED`. In this case, even if the versions matched, the specs wouldn't build duplicates, because their packages are published to different PMC repositories.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR check for this PR.