### PR TITLE
Add a post and postun for mariadb-connector-c, ensuring ldconfig is run

### DIFF
--- a/SPECS/mariadb-connector-c/mariadb-connector-c.spec
+++ b/SPECS/mariadb-connector-c/mariadb-connector-c.spec
@@ -3,7 +3,7 @@
 Summary:        The MariaDB Native Client library (C driver)
 Name:           mariadb-connector-c
 Version:        3.3.8
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -155,6 +155,9 @@ pushd unittest/libmariadb/
 %ctest || :
 popd
 
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
 
 %files
 %{_libdir}/libmariadb.so.3
@@ -207,6 +210,9 @@ popd
 #      NEW:         PR submitted, problem explained, waiting on upstream response
 
 %changelog
+* Thu Apr 10 2025 Andy Zaugg <azaugg@linkedin.com> - 3.3.8-3
+- Run ldconfig as part of post install to ensure new libs are in ld cache
+
 * Tue Apr 09 2024 Daniel McIlvaney <damcilva@microsoft.com> - 3.3.8-2
 - Remove multilib handling since azl doesn't support it
 


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When installing the mariadb-connector-c package, the new libraries that are installed as part of the package are not immediately known by ld. Call ldconfig as part of package installation and removal to ensure the ld cache is refreshed

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added a post and postrun script-let that calls ldconfig

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Built package
```
root [ /usr/src/azl/RPMS/x86_64 ]# ldconfig -p|grep mariadb
root [ /usr/src/azl/RPMS/x86_64 ]#
root [ /usr/src/azl/RPMS/x86_64 ]#
root [ /usr/src/azl/RPMS/x86_64 ]#
root [ /usr/src/azl/RPMS/x86_64 ]#
root [ /usr/src/azl/RPMS/x86_64 ]# tdnf  install mariadb-connector-c-3.3.8-2.azl3.x86_64.rpm
Loaded plugin: tdnfrepogpgcheck

Installing:
mariadb-connector-c-config noarch           3.3.8-2.azl3          azurelinux-official-base 497.00b        17.09k
mariadb-connector-c   x86_64           3.3.8-2.azl3          @cmdline         582.85k       229.51k

Total installed size: 583.34k
Total download size: 246.59k
Is this ok [y/N]: y
mariadb-connector-c-config               17496 100%
Testing transaction
Running transaction
Installing/Updating: mariadb-connector-c-config-3.3.8-2.azl3.noarch
Installing/Updating: mariadb-connector-c-3.3.8-2.azl3.x86_64
root [ /usr/src/azl/RPMS/x86_64 ]# ldconfig -p|grep mariadb
        libmariadb.so.3 (libc6,x86-64) => /usr/lib/libmariadb.so.3
root [ /usr/src/azl/RPMS/x86_64 ]# tdnf remove mariadb-connector-c
Loaded plugin: tdnfrepogpgcheck

Removing:
mariadb-connector-c   x86_64           3.3.8-2.azl3          @System          582.85k         0.00b

Total installed size: 582.85k
Total download size:   0.00b
Is this ok [y/N]: y
Testing transaction
Running transaction
Removing: mariadb-connector-c-3.3.8-2.azl3.x86_64
root [ /usr/src/azl/RPMS/x86_64 ]# ldconfig -p|grep mariadb
root [ /usr/src/azl/RPMS/x86_64 ]# tdnf install -y mariadb-connector-c
Loaded plugin: tdnfrepogpgcheck

Installing:
mariadb-connector-c   x86_64           3.3.8-2.azl3          azurelinux-official-base 584.41k       239.81k

Total installed size: 584.41k
Total download size: 239.81k
mariadb-connector-c                     245566 100%
Testing transaction
Running transaction
Installing/Updating: mariadb-connector-c-3.3.8-2.azl3.x86_64
root [ /usr/src/azl/RPMS/x86_64 ]# ldconfig -p|grep mariadb
root [ /usr/src/azl/RPMS/x86_64 ]#
```