### PR TITLE
flux warnings 2.0

### DIFF
--- a/SPECS/flux/flux.spec
+++ b/SPECS/flux/flux.spec
@@ -32,10 +32,10 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.
 # Below is a manually created tarball, no download link.
 # Note: the %%{name}-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
 # To update the cache and config.toml run:
-#   tar -xf %{name}-%{version}.tar.gz
-#   cd %{name}-%{version}/libflux
+#   tar -xf %%{name}-%%{version}.tar.gz
+#   cd %%{name}-%%{version}/libflux
 #   cargo vendor > config.toml
-#   tar -czf %{name}-%{version}-cargo.tar.gz vendor/
+#   tar -czf %%{name}-%%{version}-cargo.tar.gz vendor/
 #
 Source1:        %{name}-%{version}-cargo.tar.gz
 Source2:        cargo_config
@@ -88,6 +88,8 @@ patch -p2 <<EOF
 +
      Ok(())
  }
+EOF
+
 popd
 
 %build

--- a/SPECS/flux/flux.spec
+++ b/SPECS/flux/flux.spec
@@ -22,7 +22,7 @@
 Summary:        Influx data language
 Name:           flux
 Version:        0.191.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -141,6 +141,9 @@ RUSTFLAGS=%{rustflags} cargo test --release
 %{_includedir}/influxdata/flux.h
 
 %changelog
+* Mon Apr 14 2025 Tobias Brick <tobiasb@microsoft.com> - 0.191.0-4
+- Add missing EOF for inline patch call.
+
 * Thu Sep 14 2023 Muhammad Falak <mwani@microsoft.com> - 0.191.0-3
 - Introduce patch to drop warnings as build blocker
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
In the `%prep` section of the flux spec, it applies an inline patch using a heredoc with the ending token of `EOF` for the patch. This comes from upstream OpenSUSE. However, due to a copy-paste error in #4712 we don't have the ending `EOF`. This results in including the rest of the `%prep` script -- including the extra parts that `rpmbuild` itself adds that kills any outstanding jobs -- into the patch file. `patch` itself is smart enough to just ignore the "junk" at the end of a patch file, and warns about it. Fix for this is to add the `EOF`.

###### Change Log  <!-- REQUIRED -->
- Fix `EOF` issue.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- ADO: https://microsoft.visualstudio.com/OS/_queries/edit/56985288/?queryId=29c5f91d-06aa-4d7e-83f2-d78e490cac48

###### Test Methodology
I built this before and after my changes (without bumping the release, since that's used to generate build ids) and proved that all files are binary same with and without these changes.
Buddy Build with no changes: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=787149&view=results
Buddy Build with changes: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=787176&view=results
Buddy Build with changes and spec bump: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=787150&view=results
