### PR TITLE
[Medium] edk2 openssl CVE-2024-13176

### DIFF
--- a/SPECS-SIGNED/edk2-hvloader-signed/edk2-hvloader-signed.spec
+++ b/SPECS-SIGNED/edk2-hvloader-signed/edk2-hvloader-signed.spec
@@ -11,7 +11,7 @@
 Summary:        Signed HvLoader.efi for %{buildarch} systems
 Name:           edk2-hvloader-signed-%{buildarch}
 Version:        %{GITDATE}git%{GITCOMMIT}
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -74,6 +74,9 @@ popd
 /boot/efi/HvLoader.efi
 
 %changelog
+* Tue Apr 15 2025 Tobias Brick <tobiasb@microsoft.com> - 20240524git3e722403cd16-6
+- Bump release for consistency with edk2 spec.
+
 * Wed Mar 26 2025 Tobias Brick <tobiasb@microsoft.com> - 20240524git3e722403cd16-5
 - Bump release for consistency with edk2 spec.
 

--- a/SPECS/edk2/CVE-2024-13176.patch
+++ b/SPECS/edk2/CVE-2024-13176.patch
@@ -1,0 +1,121 @@
+From 07272b05b04836a762b4baa874958af51d513844 Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Wed, 15 Jan 2025 18:27:02 +0100
+Subject: [PATCH] Fix timing side-channel in ECDSA signature computation
+
+There is a timing signal of around 300 nanoseconds when the top word of
+the inverted ECDSA nonce value is zero. This can happen with significant
+probability only for some of the supported elliptic curves. In particular
+the NIST P-521 curve is affected. To be able to measure this leak, the
+attacker process must either be located in the same physical computer or
+must have a very fast network connection with low latency.
+
+Attacks on ECDSA nonce are also known as Minerva attack.
+
+Fixes CVE-2024-13176
+
+Reviewed-by: Tim Hudson <tjh@openssl.org>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Paul Dale <ppzgs1@gmail.com>
+(Merged from https://github.com/openssl/openssl/pull/26429)
+
+(cherry picked from commit 63c40a66c5dc287485705d06122d3a6e74a6a203)
+---
+ CryptoPkg/Library/OpensslLib/openssl/crypto/bn/bn_exp.c  | 21 +++++++++++++++------
+ CryptoPkg/Library/OpensslLib/openssl/crypto/ec/ec_lib.c  |  7 ++++---
+ include/CryptoPkg/Library/OpensslLib/openssl/crypto/bn.h |  3 +++
+ 3 files changed, 22 insertions(+), 9 deletions(-)
+
+diff --git a/CryptoPkg/Library/OpensslLib/openssl/crypto/bn/bn_exp.c b/CryptoPkg/Library/OpensslLib/openssl/crypto/bn/bn_exp.c
+index 598a592ca1397..d84c7de18a6b6 100644
+--- a/CryptoPkg/Library/OpensslLib/openssl/crypto/bn/bn_exp.c
++++ b/CryptoPkg/Library/OpensslLib/openssl/crypto/bn/bn_exp.c
+@@ -606,7 +606,7 @@ static int MOD_EXP_CTIME_COPY_FROM_PREBUF(BIGNUM *b, int top,
+  * out by Colin Percival,
+  * http://www.daemonology.net/hyperthreading-considered-harmful/)
+  */
+-int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
++int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                               const BIGNUM *m, BN_CTX *ctx,
+                               BN_MONT_CTX *in_mont)
+ {
+@@ -623,10 +623,6 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+     unsigned int t4 = 0;
+ #endif
+ 
+-    bn_check_top(a);
+-    bn_check_top(p);
+-    bn_check_top(m);
+-
+     if (!BN_is_odd(m)) {
+         ERR_raise(ERR_LIB_BN, BN_R_CALLED_WITH_EVEN_MODULUS);
+         return 0;
+@@ -1146,7 +1142,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+             goto err;
+     } else
+ #endif
+-    if (!BN_from_montgomery(rr, &tmp, mont, ctx))
++    if (!bn_from_mont_fixed_top(rr, &tmp, mont, ctx))
+         goto err;
+     ret = 1;
+  err:
+@@ -1160,6 +1156,19 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+     return ret;
+ }
+ 
++int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
++                              const BIGNUM *m, BN_CTX *ctx,
++                              BN_MONT_CTX *in_mont)
++{
++    bn_check_top(a);
++    bn_check_top(p);
++    bn_check_top(m);
++    if (!bn_mod_exp_mont_fixed_top(rr, a, p, m, ctx, in_mont))
++        return 0;
++    bn_correct_top(rr);
++    return 1;
++}
++
+ int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,
+                          const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *in_mont)
+ {
+diff --git a/CryptoPkg/Library/OpensslLib/openssl/crypto/ec/ec_lib.c b/CryptoPkg/Library/OpensslLib/openssl/crypto/ec/ec_lib.c
+index b1696d93bd6dd..1f0bf1ec795fa 100644
+--- a/CryptoPkg/Library/OpensslLib/openssl/crypto/ec/ec_lib.c
++++ b/CryptoPkg/Library/OpensslLib/openssl/crypto/ec/ec_lib.c
+@@ -20,6 +20,7 @@
+ #include <openssl/err.h>
+ #include <openssl/opensslv.h>
+ #include "crypto/ec.h"
++#include "crypto/bn.h"
+ #include "internal/nelem.h"
+ #include "ec_local.h"
+ 
+@@ -1262,10 +1263,10 @@ static int ec_field_inverse_mod_ord(const EC_GROUP *group, BIGNUM *r,
+     if (!BN_sub(e, group->order, e))
+         goto err;
+     /*-
+-     * Exponent e is public.
+-     * No need for scatter-gather or BN_FLG_CONSTTIME.
++     * Although the exponent is public we want the result to be
++     * fixed top.
+      */
+-    if (!BN_mod_exp_mont(r, x, e, group->order, ctx, group->mont_data))
++    if (!bn_mod_exp_mont_fixed_top(r, x, e, group->order, ctx, group->mont_data))
+         goto err;
+ 
+     ret = 1;
+diff --git a/CryptoPkg/Library/OpensslLib/openssl/include/crypto/bn.h b/include/CryptoPkg/Library/OpensslLib/openssl/crypto/bn.h
+index c5f328156d3a9..59a629b9f6288 100644
+--- a/CryptoPkg/Library/OpensslLib/openssl/include/crypto/bn.h
++++ b/CryptoPkg/Library/OpensslLib/openssl/include/crypto/bn.h
+@@ -73,6 +73,9 @@ int bn_set_words(BIGNUM *a, const BN_ULONG *words, int num_words);
+  */
+ int bn_mul_mont_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
+                           BN_MONT_CTX *mont, BN_CTX *ctx);
++int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
++                              const BIGNUM *m, BN_CTX *ctx,
++                              BN_MONT_CTX *in_mont);
+ int bn_to_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,
+                          BN_CTX *ctx);
+ int bn_from_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,

--- a/SPECS/edk2/CVE-2024-4741.patch
+++ b/SPECS/edk2/CVE-2024-4741.patch
@@ -1,4 +1,4 @@
-From f7a045f3143fc6da2ee66bf52d8df04829590dd4 Mon Sep 17 00:00:00 2001
+From b3f0eb0a295f58f16ba43ba99dad70d4ee5c437d Mon Sep 17 00:00:00 2001
 From: Watson Ladd <watsonbladd@gmail.com>
 Date: Wed, 24 Apr 2024 11:26:56 +0100
 Subject: [PATCH] Only free the read buffers if we're not using them
@@ -7,9 +7,14 @@ If we're part way through processing a record, or the application has
 not released all the records then we should not free our buffer because
 they are still needed.
 
+CVE-2024-4741
+
 Reviewed-by: Tomas Mraz <tomas@openssl.org>
 Reviewed-by: Neil Horman <nhorman@openssl.org>
 Reviewed-by: Matt Caswell <matt@openssl.org>
+(Merged from https://github.com/openCryptoPkg/Library/OpensslLib/openssl/ssl/openCryptoPkg/Library/OpensslLib/openssl/ssl/pull/24395)
+
+(cherry picked from commit 704f725b96aa373ee45ecfb23f6abfe8be8d9177)
 ---
  CryptoPkg/Library/OpensslLib/openssl/ssl/record/rec_layer_s3.c | 9 +++++++++
  CryptoPkg/Library/OpensslLib/openssl/ssl/record/record.h       | 1 +
@@ -17,7 +22,7 @@ Reviewed-by: Matt Caswell <matt@openssl.org>
  3 files changed, 13 insertions(+)
 
 diff --git a/CryptoPkg/Library/OpensslLib/openssl/ssl/record/rec_layer_s3.c b/CryptoPkg/Library/OpensslLib/openssl/ssl/record/rec_layer_s3.c
-index 1db1712a0..525c3abf4 100644
+index 4bcffcc41e364..1569997bea2d3 100644
 --- a/CryptoPkg/Library/OpensslLib/openssl/ssl/record/rec_layer_s3.c
 +++ b/CryptoPkg/Library/OpensslLib/openssl/ssl/record/rec_layer_s3.c
 @@ -81,6 +81,15 @@ int RECORD_LAYER_read_pending(const RECORD_LAYER *rl)
@@ -37,10 +42,10 @@ index 1db1712a0..525c3abf4 100644
  int RECORD_LAYER_processed_read_pending(const RECORD_LAYER *rl)
  {
 diff --git a/CryptoPkg/Library/OpensslLib/openssl/ssl/record/record.h b/CryptoPkg/Library/OpensslLib/openssl/ssl/record/record.h
-index af56206e0..513ab3988 100644
+index 234656bf93942..b60f71c8cb23b 100644
 --- a/CryptoPkg/Library/OpensslLib/openssl/ssl/record/record.h
 +++ b/CryptoPkg/Library/OpensslLib/openssl/ssl/record/record.h
-@@ -197,6 +197,7 @@ void RECORD_LAYER_release(RECORD_LAYER *rl);
+@@ -205,6 +205,7 @@ void RECORD_LAYER_release(RECORD_LAYER *rl);
  int RECORD_LAYER_read_pending(const RECORD_LAYER *rl);
  int RECORD_LAYER_processed_read_pending(const RECORD_LAYER *rl);
  int RECORD_LAYER_write_pending(const RECORD_LAYER *rl);
@@ -49,10 +54,10 @@ index af56206e0..513ab3988 100644
  void RECORD_LAYER_reset_write_sequence(RECORD_LAYER *rl);
  int RECORD_LAYER_is_sslv2_record(RECORD_LAYER *rl);
 diff --git a/CryptoPkg/Library/OpensslLib/openssl/ssl/ssl_lib.c b/CryptoPkg/Library/OpensslLib/openssl/ssl/ssl_lib.c
-index c01ad8291..356d65cb6 100644
+index eed649c6fdee9..d14c55ae557bc 100644
 --- a/CryptoPkg/Library/OpensslLib/openssl/ssl/ssl_lib.c
 +++ b/CryptoPkg/Library/OpensslLib/openssl/ssl/ssl_lib.c
-@@ -5248,6 +5248,9 @@ int SSL_free_buffers(SSL *ssl)
+@@ -5492,6 +5492,9 @@ int SSL_free_buffers(SSL *ssl)
      if (RECORD_LAYER_read_pending(rl) || RECORD_LAYER_write_pending(rl))
          return 0;
  
@@ -62,6 +67,3 @@ index c01ad8291..356d65cb6 100644
      RECORD_LAYER_release(rl);
      return 1;
  }
--- 
-2.33.8
-

--- a/SPECS/edk2/edk2.spec
+++ b/SPECS/edk2/edk2.spec
@@ -55,7 +55,7 @@ ExclusiveArch: x86_64
 
 Name:       edk2
 Version:    %{GITDATE}git%{GITCOMMIT}
-Release:    5%{?dist}
+Release:    6%{?dist}
 Summary:    UEFI firmware for 64-bit virtual machines
 License:    Apache-2.0 AND (BSD-2-Clause OR GPL-2.0-or-later) AND BSD-2-Clause-Patent AND BSD-3-Clause AND BSD-4-Clause AND ISC AND MIT AND LicenseRef-Fedora-Public-Domain
 URL:        http://www.tianocore.org
@@ -796,6 +796,10 @@ done
 /boot/efi/HvLoader.efi
 
 %changelog
+* Mon Apr 14 2025 Tobias Brick <tobiasb@microsoft.com> - 20240524git3e722403cd16-6
+- Patch CVE-2024-13176.
+- Rename patch for CVE-2024-4741 to standard name format.
+
 * Tue Mar 25 2025 Tobias Brick <tobiasb@microsoft.com> - 20240524git3e722403cd16-5
 - Patch vendored openssl to only free read buffers if not in use.
 

--- a/SPECS/edk2/edk2.spec
+++ b/SPECS/edk2/edk2.spec
@@ -134,6 +134,7 @@ Patch0019: 0019-NetworkPkg-DxeNetLib-adjust-PseudoRandom-error-loggi.patch
 Patch1000: CVE-2022-3996.patch
 Patch1001: CVE-2024-6119.patch
 Patch1002: CVE-2024-4741.patch
+Patch1003: CVE-2024-13176.patch
 
 # python3-devel and libuuid-devel are required for building tools.
 # python3-devel is also needed for varstore template generation and

--- a/SPECS/edk2/edk2.spec
+++ b/SPECS/edk2/edk2.spec
@@ -133,7 +133,7 @@ Patch0019: 0019-NetworkPkg-DxeNetLib-adjust-PseudoRandom-error-loggi.patch
 # Patches for the vendored OpenSSL are in the range from 1000 to 1999 (inclusive).
 Patch1000: CVE-2022-3996.patch
 Patch1001: CVE-2024-6119.patch
-Patch1002: vendored-openssl-1.1.1-Only-free-the-read-buffers-if-we-re-not-using-them.patch
+Patch1002: CVE-2024-4741.patch
 
 # python3-devel and libuuid-devel are required for building tools.
 # python3-devel is also needed for varstore template generation and


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes CVE-2024-13176 in the edk2 package's vendored openssl code.
Updated patch for CVE-2024-4741. Note that the previous patch applied correctly and fixed the vulnerability -- this is really a name change.

###### Change Log  <!-- REQUIRED -->
- Apply patch for CVE-2024-13176 in openssl vendored code in edk2
- Changed name of patch file for CVE-2024-4741 to standard name, replacing it with the patch for the correct version of openssl.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- ADO: https://microsoft.visualstudio.com/OS/_workitems/edit/57166398

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-13176

###### Test Methodology
- Manually verified that the patches applied properly and code was changed.
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=787262&view=results
