### PR TITLE
[Medium] Patch cert-manager for CVE-2025-32386, CVE-2025-32387, CVE-2025-22872

### DIFF
--- a/SPECS/cert-manager/CVE-2025-22872.patch
+++ b/SPECS/cert-manager/CVE-2025-22872.patch
@@ -1,0 +1,59 @@
+From bbe4000b0322fd46086cf73856cbafff9823b421 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Mon, 24 Feb 2025 11:18:31 -0800
+Subject: [PATCH] html: properly handle trailing solidus in unquoted attribute
+ value in foreign content
+
+The parser properly treats tags like <p a=/> as <p a="/">, but the
+tokenizer emits the SelfClosingTagToken token incorrectly. When the
+parser is used to parse foreign content, this results in an incorrect
+DOM.
+
+Thanks to Sean Ng (https://ensy.zip) for reporting this issue.
+
+Fixes golang/go#73070
+Fixes CVE-2025-22872
+
+Change-Id: I65c18df6d6244bf943b61e6c7a87895929e78f4f
+Reviewed-on: https://go-review.googlesource.com/c/net/+/661256
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Link: https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
+---
+ vendor/golang.org/x/net/html/token.go | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index 3c57880..6598c1f 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -839,8 +839,22 @@ func (z *Tokenizer) readStartTag() TokenType {
+ 	if raw {
+ 		z.rawTag = strings.ToLower(string(z.buf[z.data.start:z.data.end]))
+ 	}
+-	// Look for a self-closing token like "<br/>".
+-	if z.err == nil && z.buf[z.raw.end-2] == '/' {
++	// Look for a self-closing token (e.g. <br/>).
++	//
++	// Originally, we did this by just checking that the last character of the
++	// tag (ignoring the closing bracket) was a solidus (/) character, but this
++	// is not always accurate.
++	//
++	// We need to be careful that we don't misinterpret a non-self-closing tag
++	// as self-closing, as can happen if the tag contains unquoted attribute
++	// values (i.e. <p a=/>).
++	//
++	// To avoid this, we check that the last non-bracket character of the tag
++	// (z.raw.end-2) isn't the same character as the last non-quote character of
++	// the last attribute of the tag (z.pendingAttr[1].end-1), if the tag has
++	// attributes.
++	nAttrs := len(z.attr)
++	if z.err == nil && z.buf[z.raw.end-2] == '/' && (nAttrs == 0 || z.raw.end-2 != z.attr[nAttrs-1][1].end-1) {
+ 		return SelfClosingTagToken
+ 	}
+ 	return StartTagToken
+-- 
+2.34.1
+

--- a/SPECS/cert-manager/CVE-2025-22872.patch
+++ b/SPECS/cert-manager/CVE-2025-22872.patch
@@ -1,32 +1,15 @@
-From bbe4000b0322fd46086cf73856cbafff9823b421 Mon Sep 17 00:00:00 2001
-From: Roland Shoemaker <roland@golang.org>
-Date: Mon, 24 Feb 2025 11:18:31 -0800
-Subject: [PATCH] html: properly handle trailing solidus in unquoted attribute
- value in foreign content
+From 0e7a1fa0b7d23464ad2102424d1c9af0f1b576d7 Mon Sep 17 00:00:00 2001
+From: Kevin Lockwood <v-klockwood@microsoft.com>
+Date: Wed, 21 May 2025 13:55:14 -0700
+Subject: [PATCH] Patch CVE-2025-22872
 
-The parser properly treats tags like <p a=/> as <p a="/">, but the
-tokenizer emits the SelfClosingTagToken token incorrectly. When the
-parser is used to parse foreign content, this results in an incorrect
-DOM.
-
-Thanks to Sean Ng (https://ensy.zip) for reporting this issue.
-
-Fixes golang/go#73070
-Fixes CVE-2025-22872
-
-Change-Id: I65c18df6d6244bf943b61e6c7a87895929e78f4f
-Reviewed-on: https://go-review.googlesource.com/c/net/+/661256
-Reviewed-by: Neal Patel <nealpatel@google.com>
-Reviewed-by: Roland Shoemaker <roland@golang.org>
-LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
-Auto-Submit: Gopher Robot <gobot@golang.org>
-Link: https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
+Upstream reference: https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9.patch
 ---
  vendor/golang.org/x/net/html/token.go | 18 ++++++++++++++++--
  1 file changed, 16 insertions(+), 2 deletions(-)
 
 diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
-index 3c57880..6598c1f 100644
+index 50f7c6a..cf52f26 100644
 --- a/vendor/golang.org/x/net/html/token.go
 +++ b/vendor/golang.org/x/net/html/token.go
 @@ -839,8 +839,22 @@ func (z *Tokenizer) readStartTag() TokenType {

--- a/SPECS/cert-manager/CVE-2025-32386.patch
+++ b/SPECS/cert-manager/CVE-2025-32386.patch
@@ -1,0 +1,89 @@
+From cd21b448e8cdd4a4be1bae172d3dad8dbeafa59b Mon Sep 17 00:00:00 2001
+From: Kevin Lockwood <v-klockwood@microsoft.com>
+Date: Wed, 16 Apr 2025 12:57:19 -0700
+Subject: [PATCH] [Medium] Patch cert-manager for CVE-2025-32386
+
+Link: https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7
+---
+ .../helm/v3/pkg/chart/loader/archive.go       | 32 ++++++++++++++++++-
+ .../helm/v3/pkg/chart/loader/directory.go     |  4 +++
+ 2 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go b/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go
+index 8b38cb8..c42ff31 100644
+--- a/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go
++++ b/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go
+@@ -33,6 +33,15 @@ import (
+ 	"helm.sh/helm/v3/pkg/chart"
+ )
+ 
++// MaxDecompressedChartSize is the maximum size of a chart archive that will be
++// decompressed. This is the decompressed size of all the files.
++// The default value is 100 MiB.
++var MaxDecompressedChartSize int64 = 100 * 1024 * 1024 // Default 100 MiB
++
++// MaxDecompressedFileSize is the size of the largest file that Helm will attempt to load.
++// The size of the file is the decompressed version of it when it is stored in an archive.
++var MaxDecompressedFileSize int64 = 5 * 1024 * 1024 // Default 5 MiB
++
+ var drivePathPattern = regexp.MustCompile(`^[a-zA-Z]:/`)
+ 
+ // FileLoader loads a chart from a file
+@@ -110,6 +119,7 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
+ 
+ 	files := []*BufferedFile{}
+ 	tr := tar.NewReader(unzipped)
++	remainingSize := MaxDecompressedChartSize
+ 	for {
+ 		b := bytes.NewBuffer(nil)
+ 		hd, err := tr.Next()
+@@ -169,10 +179,30 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
+ 			return nil, errors.New("chart yaml not in base directory")
+ 		}
+ 
+-		if _, err := io.Copy(b, tr); err != nil {
++		if hd.Size > remainingSize {
++			return nil, fmt.Errorf("decompressed chart is larger than the maximum size %d", MaxDecompressedChartSize)
++		}
++
++		if hd.Size > MaxDecompressedFileSize {
++			return nil, fmt.Errorf("decompressed chart file %q is larger than the maximum file size %d", hd.Name, MaxDecompressedFileSize)
++		}
++
++		limitedReader := io.LimitReader(tr, remainingSize)
++
++		bytesWritten, err := io.Copy(b, limitedReader)
++		if err != nil {
+ 			return nil, err
+ 		}
+ 
++		remainingSize -= bytesWritten
++		// When the bytesWritten are less than the file size it means the limit reader ended
++		// copying early. Here we report that error. This is important if the last file extracted
++		// is the one that goes over the limit. It assumes the Size stored in the tar header
++		// is correct, something many applications do.
++		if bytesWritten < hd.Size || remainingSize <= 0 {
++			return nil, fmt.Errorf("decompressed chart is larger than the maximum size %d", MaxDecompressedChartSize)
++		}
++
+ 		data := bytes.TrimPrefix(b.Bytes(), utf8bom)
+ 
+ 		files = append(files, &BufferedFile{Name: n, Data: data})
+diff --git a/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go b/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go
+index bbe5438..fe3e67a 100644
+--- a/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go
++++ b/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go
+@@ -102,6 +102,10 @@ func LoadDir(dir string) (*chart.Chart, error) {
+ 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
+ 		}
+ 
++		if fi.Size() > MaxDecompressedFileSize {
++			return fmt.Errorf("chart file %q is larger than the maximum file size %d", fi.Name(), MaxDecompressedFileSize)
++		}
++
+ 		data, err := ioutil.ReadFile(name)
+ 		if err != nil {
+ 			return errors.Wrapf(err, "error reading %s", n)
+-- 
+2.34.1
+

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -36,9 +36,7 @@ Patch13:        CVE-2025-22868.patch
 Patch14:        CVE-2025-22869.patch
 Patch15:        CVE-2025-30204.patch
 Patch16:        CVE-2024-51744.patch
-# CVE-2025-32386 and CVE-2025-32387 are fixed in 3.17.3 by https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7
 Patch17:        CVE-2025-32386.patch
-# CVE-2025-22872 is fixed in go net v0.38 by https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
 Patch18:        CVE-2025-22872.patch
 
 BuildRequires:  golang

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -38,6 +38,8 @@ Patch15:        CVE-2025-30204.patch
 Patch16:        CVE-2024-51744.patch
 # CVE-2025-32386 and CVE-2025-32387 are fixed in 3.17.3 by https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7
 Patch17:        CVE-2025-32386.patch
+# CVE-2025-22872 is fixed in go net v0.38 by https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
+Patch18:        CVE-2025-22872.patch
 
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
@@ -132,8 +134,8 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 
 %changelog
 * Tue Apr 15 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 1.11.2-23
-- Fix CVE-2025-32386
-- Fix CVE-2025-32387
+- Fix CVE-2025-32386 and Fix CVE-2025-32387
+- Fix CVE-2025-22872
 
 * Mon Mar 31 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 1.11.2-22
 - Fix CVE-2024-51744

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -1,7 +1,7 @@
 Summary:        Automatically provision and manage TLS certificates in Kubernetes
 Name:           cert-manager
 Version:        1.11.2
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,8 @@ Patch13:        CVE-2025-22868.patch
 Patch14:        CVE-2025-22869.patch
 Patch15:        CVE-2025-30204.patch
 Patch16:        CVE-2024-51744.patch
+# CVE-2025-32386 and CVE-2025-32387 are fixed in 3.17.3 by https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7
+Patch17:        CVE-2025-32386.patch
 
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
@@ -129,6 +131,10 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %{_bindir}/webhook
 
 %changelog
+* Tue Apr 15 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 1.11.2-23
+- Fix CVE-2025-32386
+- Fix CVE-2025-32387
+
 * Mon Mar 31 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 1.11.2-22
 - Fix CVE-2024-51744
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch `cert-manager` for CVE-2025-32386, CVE-2025-32387, and CVE-2025-22872

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for CVE-2025-32386 and CVE-2025-32387
- Add patch for CVE-2025-22872

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-32386
- https://nvd.nist.gov/vuln/detail/CVE-2025-32387
- https://nvd.nist.gov/vuln/detail/CVE-2025-22872

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
