### PR TITLE
[Medium] Patch cert-manager for CVE-2025-32386, CVE-2025-32387, CVE-2025-22872

### DIFF
--- a/SPECS/cert-manager/CVE-2025-22872.patch
+++ b/SPECS/cert-manager/CVE-2025-22872.patch
@@ -1,0 +1,59 @@
+From bbe4000b0322fd46086cf73856cbafff9823b421 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Mon, 24 Feb 2025 11:18:31 -0800
+Subject: [PATCH] html: properly handle trailing solidus in unquoted attribute
+ value in foreign content
+
+The parser properly treats tags like <p a=/> as <p a="/">, but the
+tokenizer emits the SelfClosingTagToken token incorrectly. When the
+parser is used to parse foreign content, this results in an incorrect
+DOM.
+
+Thanks to Sean Ng (https://ensy.zip) for reporting this issue.
+
+Fixes golang/go#73070
+Fixes CVE-2025-22872
+
+Change-Id: I65c18df6d6244bf943b61e6c7a87895929e78f4f
+Reviewed-on: https://go-review.googlesource.com/c/net/+/661256
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Link: https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
+---
+ cmd/ctl/vendor/golang.org/x/net/html/token.go | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/cmd/ctl/vendor/golang.org/x/net/html/token.go b/cmd/ctl/vendor/golang.org/x/net/html/token.go
+index 3c57880..6598c1f 100644
+--- a/cmd/ctl/vendor/golang.org/x/net/html/token.go
++++ b/cmd/ctl/vendor/golang.org/x/net/html/token.go
+@@ -839,8 +839,22 @@ func (z *Tokenizer) readStartTag() TokenType {
+ 	if raw {
+ 		z.rawTag = strings.ToLower(string(z.buf[z.data.start:z.data.end]))
+ 	}
+-	// Look for a self-closing token like "<br/>".
+-	if z.err == nil && z.buf[z.raw.end-2] == '/' {
++	// Look for a self-closing token (e.g. <br/>).
++	//
++	// Originally, we did this by just checking that the last character of the
++	// tag (ignoring the closing bracket) was a solidus (/) character, but this
++	// is not always accurate.
++	//
++	// We need to be careful that we don't misinterpret a non-self-closing tag
++	// as self-closing, as can happen if the tag contains unquoted attribute
++	// values (i.e. <p a=/>).
++	//
++	// To avoid this, we check that the last non-bracket character of the tag
++	// (z.raw.end-2) isn't the same character as the last non-quote character of
++	// the last attribute of the tag (z.pendingAttr[1].end-1), if the tag has
++	// attributes.
++	nAttrs := len(z.attr)
++	if z.err == nil && z.buf[z.raw.end-2] == '/' && (nAttrs == 0 || z.raw.end-2 != z.attr[nAttrs-1][1].end-1) {
+ 		return SelfClosingTagToken
+ 	}
+ 	return StartTagToken
+-- 
+2.34.1
+

--- a/SPECS/cert-manager/CVE-2025-22872.patch
+++ b/SPECS/cert-manager/CVE-2025-22872.patch
@@ -1,26 +1,9 @@
-From bbe4000b0322fd46086cf73856cbafff9823b421 Mon Sep 17 00:00:00 2001
-From: Roland Shoemaker <roland@golang.org>
-Date: Mon, 24 Feb 2025 11:18:31 -0800
-Subject: [PATCH] html: properly handle trailing solidus in unquoted attribute
- value in foreign content
+From 160cea2aabe42233d5840bcdd246e0232bee0035 Mon Sep 17 00:00:00 2001
+From: Kevin Lockwood <v-klockwood@microsoft.com>
+Date: Thu, 8 May 2025 12:53:56 -0700
+Subject: [PATCH] Patch CVE-2025-22872
 
-The parser properly treats tags like <p a=/> as <p a="/">, but the
-tokenizer emits the SelfClosingTagToken token incorrectly. When the
-parser is used to parse foreign content, this results in an incorrect
-DOM.
-
-Thanks to Sean Ng (https://ensy.zip) for reporting this issue.
-
-Fixes golang/go#73070
-Fixes CVE-2025-22872
-
-Change-Id: I65c18df6d6244bf943b61e6c7a87895929e78f4f
-Reviewed-on: https://go-review.googlesource.com/c/net/+/661256
-Reviewed-by: Neal Patel <nealpatel@google.com>
-Reviewed-by: Roland Shoemaker <roland@golang.org>
-LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
-Auto-Submit: Gopher Robot <gobot@golang.org>
-Link: https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
+Upstream Patch Reference: https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9.patch
 ---
  cmd/ctl/vendor/golang.org/x/net/html/token.go | 18 ++++++++++++++++--
  1 file changed, 16 insertions(+), 2 deletions(-)

--- a/SPECS/cert-manager/CVE-2025-32386.patch
+++ b/SPECS/cert-manager/CVE-2025-32386.patch
@@ -1,9 +1,9 @@
-From 2c1636b9000e73d053b7a9fd38f2009ca349fa8b Mon Sep 17 00:00:00 2001
-From: Matt Farina <matt@mattfarina.com>
-Date: Mon, 7 Apr 2025 13:40:29 -0400
-Subject: [PATCH] Unarchiving fix
+From 8374e59e76c401229470d6f3840cdbbdfa1512a8 Mon Sep 17 00:00:00 2001
+From: Kevin Lockwood <v-klockwood@microsoft.com>
+Date: Wed, 21 May 2025 13:29:45 -0700
+Subject: [PATCH] Fix CVE-2025-32387
 
-Signed-off-by: Matt Farina <matt@mattfarina.com>
+Upstream Link: https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7.patch
 ---
  .../helm/v3/pkg/chart/loader/archive.go       | 32 ++++++++++++++++++-
  .../helm/v3/pkg/chart/loader/directory.go     |  4 +++

--- a/SPECS/cert-manager/CVE-2025-32386.patch
+++ b/SPECS/cert-manager/CVE-2025-32386.patch
@@ -1,0 +1,89 @@
+From 2c1636b9000e73d053b7a9fd38f2009ca349fa8b Mon Sep 17 00:00:00 2001
+From: Matt Farina <matt@mattfarina.com>
+Date: Mon, 7 Apr 2025 13:40:29 -0400
+Subject: [PATCH] Unarchiving fix
+
+Signed-off-by: Matt Farina <matt@mattfarina.com>
+---
+ .../helm/v3/pkg/chart/loader/archive.go       | 32 ++++++++++++++++++-
+ .../helm/v3/pkg/chart/loader/directory.go     |  4 +++
+ 2 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go b/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go
+index 196e5f8..4cb994c 100644
+--- a/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go
++++ b/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/archive.go
+@@ -33,6 +33,15 @@ import (
+ 	"helm.sh/helm/v3/pkg/chart"
+ )
+ 
++// MaxDecompressedChartSize is the maximum size of a chart archive that will be
++// decompressed. This is the decompressed size of all the files.
++// The default value is 100 MiB.
++var MaxDecompressedChartSize int64 = 100 * 1024 * 1024 // Default 100 MiB
++
++// MaxDecompressedFileSize is the size of the largest file that Helm will attempt to load.
++// The size of the file is the decompressed version of it when it is stored in an archive.
++var MaxDecompressedFileSize int64 = 5 * 1024 * 1024 // Default 5 MiB
++
+ var drivePathPattern = regexp.MustCompile(`^[a-zA-Z]:/`)
+ 
+ // FileLoader loads a chart from a file
+@@ -119,6 +128,7 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
+ 
+ 	files := []*BufferedFile{}
+ 	tr := tar.NewReader(unzipped)
++	remainingSize := MaxDecompressedChartSize
+ 	for {
+ 		b := bytes.NewBuffer(nil)
+ 		hd, err := tr.Next()
+@@ -178,10 +188,30 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
+ 			return nil, errors.New("chart yaml not in base directory")
+ 		}
+ 
+-		if _, err := io.Copy(b, tr); err != nil {
++		if hd.Size > remainingSize {
++			return nil, fmt.Errorf("decompressed chart is larger than the maximum size %d", MaxDecompressedChartSize)
++		}
++
++		if hd.Size > MaxDecompressedFileSize {
++			return nil, fmt.Errorf("decompressed chart file %q is larger than the maximum file size %d", hd.Name, MaxDecompressedFileSize)
++		}
++
++		limitedReader := io.LimitReader(tr, remainingSize)
++
++		bytesWritten, err := io.Copy(b, limitedReader)
++		if err != nil {
+ 			return nil, err
+ 		}
+ 
++		remainingSize -= bytesWritten
++		// When the bytesWritten are less than the file size it means the limit reader ended
++		// copying early. Here we report that error. This is important if the last file extracted
++		// is the one that goes over the limit. It assumes the Size stored in the tar header
++		// is correct, something many applications do.
++		if bytesWritten < hd.Size || remainingSize <= 0 {
++			return nil, fmt.Errorf("decompressed chart is larger than the maximum size %d", MaxDecompressedChartSize)
++		}
++
+ 		data := bytes.TrimPrefix(b.Bytes(), utf8bom)
+ 
+ 		files = append(files, &BufferedFile{Name: n, Data: data})
+diff --git a/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go b/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go
+index 9bcbee6..fd8e02e 100644
+--- a/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go
++++ b/cmd/ctl/vendor/helm.sh/helm/v3/pkg/chart/loader/directory.go
+@@ -101,6 +101,10 @@ func LoadDir(dir string) (*chart.Chart, error) {
+ 			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
+ 		}
+ 
++		if fi.Size() > MaxDecompressedFileSize {
++			return fmt.Errorf("chart file %q is larger than the maximum file size %d", fi.Name(), MaxDecompressedFileSize)
++		}
++
+ 		data, err := os.ReadFile(name)
+ 		if err != nil {
+ 			return errors.Wrapf(err, "error reading %s", n)
+-- 
+2.34.1
+

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -18,6 +18,9 @@ Patch1:         CVE-2025-27144.patch
 Patch2:         CVE-2025-22868.patch
 Patch3:         CVE-2025-22869.patch
 Patch4:         CVE-2025-30204.patch
+# CVE-2025-32386 and CVE-2025-32387 are fixed in 3.17.3 by https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7
+Patch5:         CVE-2025-32386.patch
+
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
 Requires:       %{name}-cainjector
@@ -108,6 +111,10 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %{_bindir}/webhook
 
 %changelog
+* Wed Apr 16 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 1.12.15-4
+- Patch CVE-2025-32386
+- Patch CVE-2025-32387
+
 * Fri Mar 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.12.15-3
 - Patch CVE-2025-30204
 

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -18,9 +18,7 @@ Patch1:         CVE-2025-27144.patch
 Patch2:         CVE-2025-22868.patch
 Patch3:         CVE-2025-22869.patch
 Patch4:         CVE-2025-30204.patch
-# CVE-2025-32386 and CVE-2025-32387 are fixed in 3.17.3 by https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7
 Patch5:         CVE-2025-32386.patch
-# CVE-2025-22872 is fixed in go net v0.38 by https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
 Patch6:         CVE-2025-22872.patch
 
 BuildRequires:  golang

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -112,8 +112,7 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 
 %changelog
 * Wed Apr 16 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 1.12.15-4
-- Patch CVE-2025-32386
-- Patch CVE-2025-32387
+- Patch CVE-2025-32386 (also fixes CVE-2025-32387)
 
 * Fri Mar 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.12.15-3
 - Patch CVE-2025-30204

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -1,7 +1,7 @@
 Summary:        Automatically provision and manage TLS certificates in Kubernetes
 Name:           cert-manager
 Version:        1.12.15
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -20,6 +20,8 @@ Patch3:         CVE-2025-22869.patch
 Patch4:         CVE-2025-30204.patch
 # CVE-2025-32386 and CVE-2025-32387 are fixed in 3.17.3 by https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7
 Patch5:         CVE-2025-32386.patch
+# CVE-2025-22872 is fixed in go net v0.38 by https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
+Patch6:         CVE-2025-22872.patch
 
 BuildRequires:  golang
 Requires:       %{name}-acmesolver
@@ -113,6 +115,7 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %changelog
 * Wed Apr 16 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 1.12.15-4
 - Patch CVE-2025-32386 (also fixes CVE-2025-32387)
+- Patch CVE-2025-22872
 
 * Fri Mar 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.12.15-3
 - Patch CVE-2025-30204


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch `cert-manager` for CVE-2025-32386, CVE-2025-32387, and CVE-2025-22872

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for CVE-2025-32386 and CVE-2025-32387
- Add patch for CVE-2025-22872

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-32386
- https://nvd.nist.gov/vuln/detail/CVE-2025-32387
- https://nvd.nist.gov/vuln/detail/CVE-2025-22872

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
