### PR TITLE
[High] Patch libsoup for CVE-2025-32913, CVE-2025-32906

### DIFF
--- a/SPECS/libsoup/CVE-2025-32906.patch
+++ b/SPECS/libsoup/CVE-2025-32906.patch
@@ -1,0 +1,38 @@
+From e0831346d685ee907065fa5e489e133f8ca12013 Mon Sep 17 00:00:00 2001
+From: Patrick Griffis <pgriffis@igalia.com>
+Date: Wed, 12 Feb 2025 11:30:02 -0600
+Subject: [PATCH] headers: Handle parsing only newlines
+
+Closes #404
+Closes #407
+
+Link: https://gitlab.gnome.org/GNOME/libsoup/-/commit/af5b9a4a3945c52b940d5ac181ef51bb12011f1f.patch
+---
+ libsoup/soup-headers.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libsoup/soup-headers.c b/libsoup/soup-headers.c
+index a0cf351..88aafc9 100644
+--- a/libsoup/soup-headers.c
++++ b/libsoup/soup-headers.c
+@@ -193,7 +193,7 @@ soup_headers_parse_request (const char          *str,
+ 	/* RFC 2616 4.1 "servers SHOULD ignore any empty line(s)
+ 	 * received where a Request-Line is expected."
+ 	 */
+-	while ((*str == '\r' || *str == '\n') && len > 0) {
++	while (len > 0 && (*str == '\r' || *str == '\n')) {
+ 		str++;
+ 		len--;
+ 	}
+@@ -378,7 +378,7 @@ soup_headers_parse_response (const char          *str,
+ 	 * after a response, which we then see prepended to the next
+ 	 * response on that connection.
+ 	 */
+-	while ((*str == '\r' || *str == '\n') && len > 0) {
++	while (len > 0 && (*str == '\r' || *str == '\n')) {
+ 		str++;
+ 		len--;
+ 	}
+-- 
+2.34.1
+

--- a/SPECS/libsoup/CVE-2025-32913.patch
+++ b/SPECS/libsoup/CVE-2025-32913.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] soup_message_headers_get_content_disposition: strdup
  truncated filenames
 
 This table frees the strings it contains.
+Link: https://gitlab.gnome.org/GNOME/libsoup/-/commit/f4a761fb66512fff59798765e8ac5b9e57dceef0.patch
 ---
  libsoup/soup-message-headers.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/SPECS/libsoup/CVE-2025-32913.patch
+++ b/SPECS/libsoup/CVE-2025-32913.patch
@@ -1,0 +1,27 @@
+From 260ce178f526f4b8baaa1cafc6e1e81fab225f53 Mon Sep 17 00:00:00 2001
+From: Patrick Griffis <pgriffis@igalia.com>
+Date: Fri, 27 Dec 2024 18:00:39 -0600
+Subject: [PATCH] soup_message_headers_get_content_disposition: strdup
+ truncated filenames
+
+This table frees the strings it contains.
+---
+ libsoup/soup-message-headers.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libsoup/soup-message-headers.c b/libsoup/soup-message-headers.c
+index bcee5b9..18cbf98 100644
+--- a/libsoup/soup-message-headers.c
++++ b/libsoup/soup-message-headers.c
+@@ -1611,7 +1611,7 @@ soup_message_headers_get_content_disposition (SoupMessageHeaders  *hdrs,
+ 		char *filename = strrchr (orig_value, '/');
+ 
+ 		if (filename)
+-			g_hash_table_insert (*params, g_strdup (orig_key), filename + 1);
++			g_hash_table_insert (*params, g_strdup (orig_key), g_strdup (filename + 1));
+ 	}
+ 	return TRUE;
+ }
+-- 
+2.34.1
+

--- a/SPECS/libsoup/libsoup.spec
+++ b/SPECS/libsoup/libsoup.spec
@@ -15,6 +15,8 @@ Patch:          CVE-2024-52531.patch
 Patch:          CVE-2024-52532.patch
 # CVE-2025-32913 will be fixed in 3.6.2 by https://gitlab.gnome.org/GNOME/libsoup/-/commit/f4a761fb66512fff59798765e8ac5b9e57dceef0
 Patch:          CVE-2025-32913.patch
+# CVE-2025-32906 will be fixed in 3.6.5 by https://gitlab.gnome.org/GNOME/libsoup/-/commit/af5b9a4a3945c52b940d5ac181ef51bb12011f1f
+Patch:          CVE-2025-32906.patch
 
 BuildRequires:  meson
 BuildRequires:  autogen
@@ -128,6 +130,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %changelog
 * Wed Apr 16 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 3.0.4-3
 - Add patch for CVE-2025-32913
+- Add patch for CVE-2025-32906
 
 * Fri Nov 15 2024 Thien Trung Vuong <tvuong@microsoft.com> - 3.0.4-2
 - Add patches for CVE-2024-52530, CVE-2024-52531, CVE-2024-52532

--- a/SPECS/libsoup/libsoup.spec
+++ b/SPECS/libsoup/libsoup.spec
@@ -2,7 +2,7 @@
 Summary:        libsoup HTTP client/server library
 Name:           libsoup
 Version:        %{BaseVersion}.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,8 @@ Source0:        https://ftp.gnome.org/pub/GNOME/sources/libsoup/%{BaseVersion}/%
 Patch:          CVE-2024-52530.patch
 Patch:          CVE-2024-52531.patch
 Patch:          CVE-2024-52532.patch
+# CVE-2025-32913 will be fixed in 3.6.2 by https://gitlab.gnome.org/GNOME/libsoup/-/commit/f4a761fb66512fff59798765e8ac5b9e57dceef0
+Patch:          CVE-2025-32913.patch
 
 BuildRequires:  meson
 BuildRequires:  autogen
@@ -124,6 +126,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %defattr(-,root,root)
 
 %changelog
+* Wed Apr 16 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 3.0.4-3
+- Add patch for CVE-2025-32913
+
 * Fri Nov 15 2024 Thien Trung Vuong <tvuong@microsoft.com> - 3.0.4-2
 - Add patches for CVE-2024-52530, CVE-2024-52531, CVE-2024-52532
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch `libsoup` for CVE-2025-32913, CVE-2025-32906

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for CVE-2025-32913
- Add patch for CVE-2025-32906

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-32913
- https://nvd.nist.gov/vuln/detail/CVE-2025-32906

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
