### PR TITLE
[Medium] Patch libxml2 for CVE-2025-32414 and CVE-2025-32415

### DIFF
--- a/SPECS/libxml2/CVE-2025-32414.patch
+++ b/SPECS/libxml2/CVE-2025-32414.patch
@@ -1,0 +1,73 @@
+From df738c6288e9f48f299569016cf4e2716543ecea Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Fri, 18 Apr 2025 17:44:25 -0500
+Subject: [PATCH] Address CVE-2025-32414
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/issues/889
+
+---
+ python/libxml.c | 28 ++++++++++++++++++----------
+ 1 file changed, 18 insertions(+), 10 deletions(-)
+
+diff --git a/python/libxml.c b/python/libxml.c
+index fb14c7a..ebd51ef 100644
+--- a/python/libxml.c
++++ b/python/libxml.c
+@@ -266,7 +266,9 @@ xmlPythonFileReadRaw (void * context, char * buffer, int len) {
+ #endif
+     file = (PyObject *) context;
+     if (file == NULL) return(-1);
+-    ret = PyObject_CallMethod(file, (char *) "read", (char *) "(i)", len);
++    /* When read() returns a string, the length is in characters not bytes, so
++       request at most len / 4 characters to leave space for UTF-8 encoding. */
++    ret = PyObject_CallMethod(file, (char *) "read", (char *) "(i)", len / 4);
+     if (ret == NULL) {
+ 	printf("xmlPythonFileReadRaw: result is NULL\n");
+ 	return(-1);
+@@ -301,10 +303,12 @@ xmlPythonFileReadRaw (void * context, char * buffer, int len) {
+ 	Py_DECREF(ret);
+ 	return(-1);
+     }
+-    if (lenread > len)
+-	memcpy(buffer, data, len);
+-    else
+-	memcpy(buffer, data, lenread);
++    if (lenread < 0 || lenread > len) {
++	printf("xmlPythonFileReadRaw: invalid lenread\n");
++	Py_DECREF(ret);
++	return(-1);
++    }
++    memcpy(buffer, data, lenread);
+     Py_DECREF(ret);
+     return(lenread);
+ }
+@@ -331,7 +335,9 @@ xmlPythonFileRead (void * context, char * buffer, int len) {
+ #endif
+     file = (PyObject *) context;
+     if (file == NULL) return(-1);
+-    ret = PyObject_CallMethod(file, (char *) "io_read", (char *) "(i)", len);
++    /* When read() returns a string, the length is in characters not bytes, so
++       request at most len / 4 characters to leave space for UTF-8 encoding. */
++    ret = PyObject_CallMethod(file, (char *) "io_read", (char *) "(i)", len / 4);
+     if (ret == NULL) {
+ 	printf("xmlPythonFileRead: result is NULL\n");
+ 	return(-1);
+@@ -366,10 +372,12 @@ xmlPythonFileRead (void * context, char * buffer, int len) {
+ 	Py_DECREF(ret);
+ 	return(-1);
+     }
+-    if (lenread > len)
+-	memcpy(buffer, data, len);
+-    else
+-	memcpy(buffer, data, lenread);
++    if (lenread < 0 || lenread > len) {
++	printf("xmlPythonFileRead: invalid lenread\n");
++	Py_DECREF(ret);
++	return(-1);
++    }
++    memcpy(buffer, data, lenread);
+     Py_DECREF(ret);
+     return(lenread);
+ }
+-- 
+2.45.2
+

--- a/SPECS/libxml2/CVE-2025-32414.patch
+++ b/SPECS/libxml2/CVE-2025-32414.patch
@@ -2,7 +2,7 @@ From df738c6288e9f48f299569016cf4e2716543ecea Mon Sep 17 00:00:00 2001
 From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
 Date: Fri, 18 Apr 2025 17:44:25 -0500
 Subject: [PATCH] Address CVE-2025-32414
-Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/issues/889
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/8d415b8911be26b12b85497f7cc57143b5321787.patch
 
 ---
  python/libxml.c | 28 ++++++++++++++++++----------

--- a/SPECS/libxml2/CVE-2025-32415.patch
+++ b/SPECS/libxml2/CVE-2025-32415.patch
@@ -1,0 +1,35 @@
+From 1237c9a36a0037553574b80641e653e46022b737 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 5 May 2025 11:35:22 -0500
+Subject: [PATCH] Address CVE-2025-32415
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/487ee1d8711c6415218b373ef455fcd969d12399
+
+---
+ xmlschemas.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xmlschemas.c b/xmlschemas.c
+index 8a89e2a..40536bc 100644
+--- a/xmlschemas.c
++++ b/xmlschemas.c
+@@ -23632,7 +23632,7 @@ xmlSchemaIDCFillNodeTables(xmlSchemaValidCtxtPtr vctxt,
+ 			j++;
+ 		    } while (j < nbDupls);
+ 		}
+-		if (nbNodeTable) {
++		if (bind->nbNodes) {
+ 		    j = 0;
+ 		    do {
+ 			if (nbFields == 1) {
+@@ -23683,7 +23683,7 @@ xmlSchemaIDCFillNodeTables(xmlSchemaValidCtxtPtr vctxt,
+ 
+ next_node_table_entry:
+ 			j++;
+-		    } while (j < nbNodeTable);
++		    } while (j < bind->nbNodes);
+ 		}
+ 		/*
+ 		* If everything is fine, then add the IDC target-node to
+-- 
+2.45.2
+

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -16,6 +16,7 @@ Patch4:         CVE-2025-24928.patch
 Patch5:         CVE-2024-25062.patch
 Patch6:         CVE-2025-27113.patch
 Patch7:         CVE-2025-32414.patch
+Patch8:         CVE-2025-32415.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -86,8 +87,8 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
-* Fri Apr 18 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.11.5-5
-- Patch CVE-2025-32414
+* Mon May 05 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.11.5-5
+- Patch CVE-2025-32414 and CVE-2025-32415
 
 * Sat Feb 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.11.5-4
 - Patch CVE-2025-24928, CVE-2024-56171, CVE-2024-25062, CVE-2025-27113

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.11.5
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -15,6 +15,7 @@ Patch3:         CVE-2024-56171.patch
 Patch4:         CVE-2025-24928.patch
 Patch5:         CVE-2024-25062.patch
 Patch6:         CVE-2025-27113.patch
+Patch7:         CVE-2025-32414.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -85,6 +86,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Fri Apr 18 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.11.5-5
+- Patch CVE-2025-32414
+
 * Sat Feb 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.11.5-4
 - Patch CVE-2025-24928, CVE-2024-56171, CVE-2024-25062, CVE-2025-27113
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -203,8 +203,8 @@ curl-8.11.1-3.azl3.aarch64.rpm
 curl-devel-8.11.1-3.azl3.aarch64.rpm
 curl-libs-8.11.1-3.azl3.aarch64.rpm
 createrepo_c-1.0.3-1.azl3.aarch64.rpm
-libxml2-2.11.5-4.azl3.aarch64.rpm
-libxml2-devel-2.11.5-4.azl3.aarch64.rpm
+libxml2-2.11.5-5.azl3.aarch64.rpm
+libxml2-devel-2.11.5-5.azl3.aarch64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 libsepol-3.6-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -203,8 +203,8 @@ curl-8.11.1-3.azl3.x86_64.rpm
 curl-devel-8.11.1-3.azl3.x86_64.rpm
 curl-libs-8.11.1-3.azl3.x86_64.rpm
 createrepo_c-1.0.3-1.azl3.x86_64.rpm
-libxml2-2.11.5-4.azl3.x86_64.rpm
-libxml2-devel-2.11.5-4.azl3.x86_64.rpm
+libxml2-2.11.5-5.azl3.x86_64.rpm
+libxml2-devel-2.11.5-5.azl3.x86_64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 libsepol-3.6-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -242,9 +242,9 @@ libtool-debuginfo-2.4.7-1.azl3.aarch64.rpm
 libxcrypt-4.4.36-2.azl3.aarch64.rpm
 libxcrypt-debuginfo-4.4.36-2.azl3.aarch64.rpm
 libxcrypt-devel-4.4.36-2.azl3.aarch64.rpm
-libxml2-2.11.5-4.azl3.aarch64.rpm
-libxml2-debuginfo-2.11.5-4.azl3.aarch64.rpm
-libxml2-devel-2.11.5-4.azl3.aarch64.rpm
+libxml2-2.11.5-5.azl3.aarch64.rpm
+libxml2-debuginfo-2.11.5-5.azl3.aarch64.rpm
+libxml2-devel-2.11.5-5.azl3.aarch64.rpm
 libxslt-1.1.43-1.azl3.aarch64.rpm
 libxslt-debuginfo-1.1.43-1.azl3.aarch64.rpm
 libxslt-devel-1.1.43-1.azl3.aarch64.rpm
@@ -543,7 +543,7 @@ python3-gpg-1.23.2-2.azl3.aarch64.rpm
 python3-jinja2-3.1.2-3.azl3.noarch.rpm
 python3-libcap-ng-0.8.4-1.azl3.aarch64.rpm
 python3-libs-3.12.9-1.azl3.aarch64.rpm
-python3-libxml2-2.11.5-4.azl3.aarch64.rpm
+python3-libxml2-2.11.5-5.azl3.aarch64.rpm
 python3-lxml-4.9.3-1.azl3.aarch64.rpm
 python3-magic-5.45-1.azl3.noarch.rpm
 python3-markupsafe-2.1.3-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -247,9 +247,9 @@ libtasn1-debuginfo-4.19.0-2.azl3.x86_64.rpm
 libtasn1-devel-4.19.0-2.azl3.x86_64.rpm
 libtool-2.4.7-1.azl3.x86_64.rpm
 libtool-debuginfo-2.4.7-1.azl3.x86_64.rpm
-libxml2-2.11.5-4.azl3.x86_64.rpm
-libxml2-debuginfo-2.11.5-4.azl3.x86_64.rpm
-libxml2-devel-2.11.5-4.azl3.x86_64.rpm
+libxml2-2.11.5-5.azl3.x86_64.rpm
+libxml2-debuginfo-2.11.5-5.azl3.x86_64.rpm
+libxml2-devel-2.11.5-5.azl3.x86_64.rpm
 libxcrypt-4.4.36-2.azl3.x86_64.rpm
 libxcrypt-debuginfo-4.4.36-2.azl3.x86_64.rpm
 libxcrypt-devel-4.4.36-2.azl3.x86_64.rpm
@@ -551,7 +551,7 @@ python3-gpg-1.23.2-2.azl3.x86_64.rpm
 python3-jinja2-3.1.2-3.azl3.noarch.rpm
 python3-libcap-ng-0.8.4-1.azl3.x86_64.rpm
 python3-libs-3.12.9-1.azl3.x86_64.rpm
-python3-libxml2-2.11.5-4.azl3.x86_64.rpm
+python3-libxml2-2.11.5-5.azl3.x86_64.rpm
 python3-lxml-4.9.3-1.azl3.x86_64.rpm
 python3-magic-5.45-1.azl3.noarch.rpm
 python3-markupsafe-2.1.3-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
libxml2: Patch for CVE-2025-32414 and CVE-2025-32415

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: **SPECS/libxml2/CVE-2025-32414.patch**
- new file: **SPECS/libxml2/CVE-2025-32415.patch**
- modified: **SPECS/libxml2/libxml2.spec**
- modified: **toolkit/resources/manifests/package/pkggen_core_aarch64.txt**
- modified: **toolkit/resources/manifests/package/pkggen_core_x86_64.txt**
- modified: **toolkit/resources/manifests/package/toolchain_aarch64.txt**
- modified: **toolkit/resources/manifests/package/toolchain_x86_64.txt**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-32414

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
