### PR TITLE
Patch libsoup for CVE-2025-32911 [CRITICAL]

### DIFF
--- a/SPECS/libsoup/CVE-2025-32911.patch
+++ b/SPECS/libsoup/CVE-2025-32911.patch
@@ -1,0 +1,86 @@
+From 10f59315ee35af1bcc4543a2dca9d227385ac1e5 Mon Sep 17 00:00:00 2001
+From: Patrick Griffis <pgriffis@igalia.com>
+Date: Fri, 27 Dec 2024 18:00:39 -0600
+Subject: [PATCH] soup_message_headers_get_content_disposition: strdup
+ truncated filenames
+
+This table frees the strings it contains.
+
+Signed-off-by: Kshitiz Godara <kgodara@microsoft.com>
+---
+ libsoup/soup-message-headers.c |  2 +-
+ tests/header-parsing-test.c    | 29 +++++++++++++++--------------
+ 2 files changed, 16 insertions(+), 15 deletions(-)
+
+diff --git a/libsoup/soup-message-headers.c b/libsoup/soup-message-headers.c
+index bcee5b9..18cbf98 100644
+--- a/libsoup/soup-message-headers.c
++++ b/libsoup/soup-message-headers.c
+@@ -1611,7 +1611,7 @@ soup_message_headers_get_content_disposition (SoupMessageHeaders  *hdrs,
+ 		char *filename = strrchr (orig_value, '/');
+ 
+ 		if (filename)
+-			g_hash_table_insert (*params, g_strdup (orig_key), filename + 1);
++			g_hash_table_insert (*params, g_strdup (orig_key), g_strdup (filename + 1));
+ 	}
+ 	return TRUE;
+ }
+diff --git a/tests/header-parsing-test.c b/tests/header-parsing-test.c
+index 5e423d2..8bf4821 100644
+--- a/tests/header-parsing-test.c
++++ b/tests/header-parsing-test.c
+@@ -1107,36 +1107,37 @@ do_content_disposition_tests (void)
+ 	g_assert_cmpstr (filename, ==, RFC5987_TEST_FALLBACK_FILENAME);
+ 	g_hash_table_destroy (params);
+ 
+-        /* Invalid disposition with only a filename still works */
+-        soup_message_headers_clear (hdrs);
+-        soup_message_headers_append (hdrs, "Content-Disposition",
+-				     RFC5987_TEST_HEADER_NO_TYPE);
++	/* Invalid disposition with only a filename still works */
++	soup_message_headers_clear (hdrs);
++	soup_message_headers_append (hdrs, "Content-Disposition",
++			RFC5987_TEST_HEADER_NO_TYPE);
+ 	if (!soup_message_headers_get_content_disposition (hdrs,
+ 							   &disposition,
+ 							   &params)) {
+ 		soup_test_assert (FALSE, "filename-only decoding FAILED");
+ 		return;
+ 	}
+-        g_assert_null (disposition);
+-        filename = g_hash_table_lookup (params, "filename");
++	g_assert_null (disposition);
++	filename = g_hash_table_lookup (params, "filename");
+ 	g_assert_cmpstr (filename, ==, RFC5987_TEST_FALLBACK_FILENAME);
+ 	g_hash_table_destroy (params);
+ 
+-        /* Invalid disposition with only two parameters still works */
+-        soup_message_headers_clear (hdrs);
+-        soup_message_headers_append (hdrs, "Content-Disposition",
+-				     RFC5987_TEST_HEADER_NO_TYPE_2);
++	/* Invalid disposition with only two parameters still works */
++	soup_message_headers_clear (hdrs);
++	soup_message_headers_append (hdrs, "Content-Disposition",
++			RFC5987_TEST_HEADER_NO_TYPE_2);
+ 	if (!soup_message_headers_get_content_disposition (hdrs,
+ 							   &disposition,
+ 							   &params)) {
+ 		soup_test_assert (FALSE, "only two parameters decoding FAILED");
+ 		return;
+ 	}
+-        g_assert_null (disposition);
+-        filename = g_hash_table_lookup (params, "filename");
++	g_assert_null (disposition);
++	g_free (disposition);
++	filename = g_hash_table_lookup (params, "filename");
+ 	g_assert_cmpstr (filename, ==, RFC5987_TEST_FALLBACK_FILENAME);
+-        parameter2 = g_hash_table_lookup (params, "foo");
+-        g_assert_cmpstr (parameter2, ==, "bar");
++	parameter2 = g_hash_table_lookup (params, "foo");
++	g_assert_cmpstr (parameter2, ==, "bar");
+ 	g_hash_table_destroy (params);
+ 
+ 	soup_message_headers_unref (hdrs);
+-- 
+2.45.3
+

--- a/SPECS/libsoup/libsoup.spec
+++ b/SPECS/libsoup/libsoup.spec
@@ -4,7 +4,7 @@
 Summary:        libsoup HTTP client/server library
 Name:           libsoup
 Version:        3.4.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -41,9 +41,10 @@ Requires:       glib-networking
 Requires:       libpsl
 Requires:       libxml2
 
-Patch:          CVE-2024-52530.patch
-Patch:          CVE-2024-52531.patch
-Patch:          CVE-2024-52532.patch
+Patch0:          CVE-2024-52530.patch
+Patch1:          CVE-2024-52531.patch
+Patch2:          CVE-2024-52532.patch
+Patch3:          CVE-2025-32911.patch
 
 %description
 libsoup is HTTP client/server library for GNOME
@@ -111,6 +112,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %defattr(-,root,root)
 
 %changelog
+* Mon Apr 21 2025 Kshitiz Godara <kgodara@microsoft.com> - 3.4.4-3
+- Add patch for CVE-2025-32911
+
 * Fri Nov 15 2024 Thien Trung Vuong <tvuong@microsoft.com> - 3.4.4-2
 - Add patches for CVE-2024-52530, CVE-2024-52531, CVE-2024-52532
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Added patch for libsoup to fix CVE-2025-32911 [CRITICAL]

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2025-32911

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-32911

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [791934](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=791934&view=results)
