### PR TITLE
Fix `crash` for CVE-2021-20197, CVE-2022-47673, CVE-2022-47696, CVE-2022-37434 [High]

### DIFF
--- a/SPECS/crash/crash.signatures.json
+++ b/SPECS/crash/crash.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "crash-8.0.1.tar.gz": "233208b1433a49e1d5a063fa88e6fc9772b99fbb7b30ae79a2115d1b8f0dfc52",
-  "gdb-10.2.tar.gz": "b33ad58d687487a821ec8d878daab0f716be60d0936f2e3ac5cf08419ce70350"
+  "gdb-10.2-3.tar.gz": "0d322f3c3ee75b364eb4f90b394c9ecc17800d2a94d2913a5ea845acead26bd2"
  }
 }

--- a/SPECS/crash/crash.spec
+++ b/SPECS/crash/crash.spec
@@ -1,6 +1,7 @@
+%global gdb_version 10.2
 Name:          crash
 Version:       8.0.1
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       kernel crash analysis utility for live systems, netdump, diskdump, kdump, LKCD or mcore dumpfiles
 Group:         Development/Tools
 Vendor:        Microsoft Corporation
@@ -8,7 +9,8 @@ Distribution:  Mariner
 URL:           https://github.com/crash-utility/crash
 Source0:       https://github.com/crash-utility/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # crash requires gdb tarball for the build. There is no option to use the host gdb. For crash 8.0.1 the newest supported gdb version is 10.2.
-Source1:       https://ftp.gnu.org/gnu/gdb/gdb-10.2.tar.gz
+# '-3' version of the tarball contains fix for CVE-2021-20197, CVE-2022-47673, CVE-2022-47696, CVE-2022-37434 which cannot be applied as a .patch because source1 is only untar'ed during crash make
+Source1:       gdb-%{gdb_version}-3.tar.gz
 # lzo patch sourced from https://src.fedoraproject.org/rpms/crash/blob/rawhide/f/lzo_snappy_zstd.patch
 Patch0:        lzo_snappy_zstd.patch
 License:       GPLv3+
@@ -36,7 +38,8 @@ This package contains libraries and header files need for development.
 
 %prep
 %autosetup -n %{name}-%{version}
-cp %{SOURCE1} .
+# make expect the gdb tarball to be named with its version only, gdb-[version].tar.gz, e.g.: gdb-10.2.tar.gz
+cp %{SOURCE1} ./gdb-%{gdb_version}.tar.gz
 
 %build
 make RPMPKG=%{version}-%{release}
@@ -55,7 +58,7 @@ cp -p defs.h %{buildroot}%{_includedir}/crash
 %license COPYING3
 %{_bindir}/crash
 %{_mandir}/man8/crash.8.gz
-%doc COPYING3 README
+%doc README
 
 %files devel
 %defattr(-,root,root)
@@ -63,6 +66,9 @@ cp -p defs.h %{buildroot}%{_includedir}/crash
 %{_includedir}/crash/*.h
 
 %changelog
+* Mon Apr 21 2025 Kanishk Bansal <kanbansal@microsoft.com> - 8.0.1-4
+- Update gdb-10.2-3.tar.gz to address CVE-2021-20197, CVE-2022-47673, CVE-2022-47696, CVE-2022-37434
+
 * Mon Oct 09 2023 Chris Co <chrco@microsoft.com> - 8.0.1-3
 - Add patch from Fedora to enable lzo, snappy, zstd compression support
 - Remove unused crash printk fix patch


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Update gdb-10.2-3.tar.gz to address CVE-2021-20197, CVE-2022-47673, CVE-2022-47696

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2021-20197
- CVE-2022-47673
- CVE-2022-47696

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-20197
- https://nvd.nist.gov/vuln/detail/CVE-2022-47673
- https://nvd.nist.gov/vuln/detail/CVE-2022-47696

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=792389&view=results)
