### PR TITLE
[Medium] Patch libxml2 for CVE-2025-32414 and CVE-2025-32415

### DIFF
--- a/SPECS/libxml2/CVE-2025-32414.patch
+++ b/SPECS/libxml2/CVE-2025-32414.patch
@@ -1,6 +1,6 @@
-From 706e523b90b220ae853345843032e6fa13d27db5 Mon Sep 17 00:00:00 2001
+From 9b15cc7ba07e5106027a319d39f7ed3aba8f8a1c Mon Sep 17 00:00:00 2001
 From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
-Date: Mon, 21 Apr 2025 11:45:37 -0500
+Date: Tue, 27 May 2025 18:48:21 -0500
 Subject: [PATCH] Address CVE-2025-32414
 Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/8d415b8911be26b12b85497f7cc57143b5321787.patch
 
@@ -9,7 +9,7 @@ Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/8d415b
  1 file changed, 18 insertions(+), 10 deletions(-)
 
 diff --git a/python/libxml.c b/python/libxml.c
-index e071e82..9fcedc6 100644
+index e071e82..9be43f8 100644
 --- a/python/libxml.c
 +++ b/python/libxml.c
 @@ -287,7 +287,9 @@ xmlPythonFileReadRaw (void * context, char * buffer, int len) {
@@ -19,7 +19,7 @@ index e071e82..9fcedc6 100644
 -    ret = PyEval_CallMethod(file, (char *) "read", (char *) "(i)", len);
 +    /* When read() returns a string, the length is in characters not bytes, so
 +       request at most len / 4 characters to leave space for UTF-8 encoding. */
-+    ret = PyEval_CallMethod(file, (char *) "read", (char *) "(i)", len / 4);
++    ret = PyObject_CallMethod(file, (char *) "read", (char *) "(i)", len / 4);
      if (ret == NULL) {
  	printf("xmlPythonFileReadRaw: result is NULL\n");
  	return(-1);
@@ -47,7 +47,7 @@ index e071e82..9fcedc6 100644
 -    ret = PyEval_CallMethod(file, (char *) "io_read", (char *) "(i)", len);
 +    /* When read() returns a string, the length is in characters not bytes, so
 +       request at most len / 4 characters to leave space for UTF-8 encoding. */
-+    ret = PyEval_CallMethod(file, (char *) "io_read", (char *) "(i)", len / 4);
++    ret = PyObject_CallMethod(file, (char *) "io_read", (char *) "(i)", len / 4);
      if (ret == NULL) {
  	printf("xmlPythonFileRead: result is NULL\n");
  	return(-1);

--- a/SPECS/libxml2/CVE-2025-32414.patch
+++ b/SPECS/libxml2/CVE-2025-32414.patch
@@ -2,7 +2,7 @@ From 706e523b90b220ae853345843032e6fa13d27db5 Mon Sep 17 00:00:00 2001
 From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
 Date: Mon, 21 Apr 2025 11:45:37 -0500
 Subject: [PATCH] Address CVE-2025-32414
-Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/issues/889
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/8d415b8911be26b12b85497f7cc57143b5321787.patch
 
 ---
  python/libxml.c | 28 ++++++++++++++++++----------

--- a/SPECS/libxml2/CVE-2025-32414.patch
+++ b/SPECS/libxml2/CVE-2025-32414.patch
@@ -1,0 +1,73 @@
+From 706e523b90b220ae853345843032e6fa13d27db5 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 21 Apr 2025 11:45:37 -0500
+Subject: [PATCH] Address CVE-2025-32414
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/issues/889
+
+---
+ python/libxml.c | 28 ++++++++++++++++++----------
+ 1 file changed, 18 insertions(+), 10 deletions(-)
+
+diff --git a/python/libxml.c b/python/libxml.c
+index e071e82..9fcedc6 100644
+--- a/python/libxml.c
++++ b/python/libxml.c
+@@ -287,7 +287,9 @@ xmlPythonFileReadRaw (void * context, char * buffer, int len) {
+ #endif
+     file = (PyObject *) context;
+     if (file == NULL) return(-1);
+-    ret = PyEval_CallMethod(file, (char *) "read", (char *) "(i)", len);
++    /* When read() returns a string, the length is in characters not bytes, so
++       request at most len / 4 characters to leave space for UTF-8 encoding. */
++    ret = PyEval_CallMethod(file, (char *) "read", (char *) "(i)", len / 4);
+     if (ret == NULL) {
+ 	printf("xmlPythonFileReadRaw: result is NULL\n");
+ 	return(-1);
+@@ -322,10 +324,12 @@ xmlPythonFileReadRaw (void * context, char * buffer, int len) {
+ 	Py_DECREF(ret);
+ 	return(-1);
+     }
+-    if (lenread > len)
+-	memcpy(buffer, data, len);
+-    else
+-	memcpy(buffer, data, lenread);
++    if (lenread < 0 || lenread > len) {
++	printf("xmlPythonFileReadRaw: invalid lenread\n");
++	Py_DECREF(ret);
++	return(-1);
++    }
++    memcpy(buffer, data, lenread);
+     Py_DECREF(ret);
+     return(lenread);
+ }
+@@ -352,7 +356,9 @@ xmlPythonFileRead (void * context, char * buffer, int len) {
+ #endif
+     file = (PyObject *) context;
+     if (file == NULL) return(-1);
+-    ret = PyEval_CallMethod(file, (char *) "io_read", (char *) "(i)", len);
++    /* When read() returns a string, the length is in characters not bytes, so
++       request at most len / 4 characters to leave space for UTF-8 encoding. */
++    ret = PyEval_CallMethod(file, (char *) "io_read", (char *) "(i)", len / 4);
+     if (ret == NULL) {
+ 	printf("xmlPythonFileRead: result is NULL\n");
+ 	return(-1);
+@@ -387,10 +393,12 @@ xmlPythonFileRead (void * context, char * buffer, int len) {
+ 	Py_DECREF(ret);
+ 	return(-1);
+     }
+-    if (lenread > len)
+-	memcpy(buffer, data, len);
+-    else
+-	memcpy(buffer, data, lenread);
++    if (lenread < 0 || lenread > len) {
++	printf("xmlPythonFileRead: invalid lenread\n");
++	Py_DECREF(ret);
++	return(-1);
++    }
++    memcpy(buffer, data, lenread);
+     Py_DECREF(ret);
+     return(lenread);
+ }
+-- 
+2.45.2
+

--- a/SPECS/libxml2/CVE-2025-32415.patch
+++ b/SPECS/libxml2/CVE-2025-32415.patch
@@ -1,0 +1,35 @@
+From 6fd5f6af7993ac513dab32e8a00faf3cf72f408b Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 5 May 2025 11:51:10 -0500
+Subject: [PATCH] Address CVE-2025-32415
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/487ee1d8711c6415218b373ef455fcd969d12399
+
+---
+ xmlschemas.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xmlschemas.c b/xmlschemas.c
+index 1045aab..8cae008 100644
+--- a/xmlschemas.c
++++ b/xmlschemas.c
+@@ -23618,7 +23618,7 @@ xmlSchemaIDCFillNodeTables(xmlSchemaValidCtxtPtr vctxt,
+ 			j++;
+ 		    } while (j < nbDupls);
+ 		}
+-		if (nbNodeTable) {
++		if (bind->nbNodes) {
+ 		    j = 0;
+ 		    do {
+ 			if (nbFields == 1) {
+@@ -23669,7 +23669,7 @@ xmlSchemaIDCFillNodeTables(xmlSchemaValidCtxtPtr vctxt,
+ 
+ next_node_table_entry:
+ 			j++;
+-		    } while (j < nbNodeTable);
++		    } while (j < bind->nbNodes);
+ 		}
+ 		/*
+ 		* If everything is fine, then add the IDC target-node to
+-- 
+2.45.2
+

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.10.4
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -15,6 +15,7 @@ Patch3:         CVE-2022-49043.patch
 Patch4:         CVE-2024-56171.patch
 Patch5:         CVE-2025-24928.patch
 Patch6:         CVE-2025-27113.patch
+Patch7:         CVE-2025-32414.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -85,6 +86,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Mon Apr 21 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-7
+- Patch CVE-2025-32414
+
 * Sat Feb 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.10.4-6
 - Patch CVE-2025-24928, CVE-2025-27113 & CVE-2024-56171
 

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -16,6 +16,7 @@ Patch4:         CVE-2024-56171.patch
 Patch5:         CVE-2025-24928.patch
 Patch6:         CVE-2025-27113.patch
 Patch7:         CVE-2025-32414.patch
+Patch8:         CVE-2025-32415.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -86,8 +87,8 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
-* Mon Apr 21 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-7
-- Patch CVE-2025-32414
+* Mon May 05 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-7
+- Patch CVE-2025-32414 and CVE-2025-32415
 
 * Sat Feb 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.10.4-6
 - Patch CVE-2025-24928, CVE-2025-27113 & CVE-2024-56171

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.aarch64.rpm
 curl-devel-8.8.0-6.cm2.aarch64.rpm
 curl-libs-8.8.0-6.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
-libxml2-2.10.4-6.cm2.aarch64.rpm
-libxml2-devel-2.10.4-6.cm2.aarch64.rpm
+libxml2-2.10.4-7.cm2.aarch64.rpm
+libxml2-devel-2.10.4-7.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.x86_64.rpm
 curl-devel-8.8.0-6.cm2.x86_64.rpm
 curl-libs-8.8.0-6.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
-libxml2-2.10.4-6.cm2.x86_64.rpm
-libxml2-devel-2.10.4-6.cm2.x86_64.rpm
+libxml2-2.10.4-7.cm2.x86_64.rpm
+libxml2-devel-2.10.4-7.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -209,9 +209,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.aarch64.rpm
 libtasn1-devel-4.19.0-2.cm2.aarch64.rpm
 libtool-2.4.6-8.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-8.cm2.aarch64.rpm
-libxml2-2.10.4-6.cm2.aarch64.rpm
-libxml2-debuginfo-2.10.4-6.cm2.aarch64.rpm
-libxml2-devel-2.10.4-6.cm2.aarch64.rpm
+libxml2-2.10.4-7.cm2.aarch64.rpm
+libxml2-debuginfo-2.10.4-7.cm2.aarch64.rpm
+libxml2-devel-2.10.4-7.cm2.aarch64.rpm
 libxslt-1.1.34-8.cm2.aarch64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.aarch64.rpm
 libxslt-devel-1.1.34-8.cm2.aarch64.rpm
@@ -521,7 +521,7 @@ python3-gpg-1.16.0-2.cm2.aarch64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.aarch64.rpm
 python3-libs-3.9.19-13.cm2.aarch64.rpm
-python3-libxml2-2.10.4-6.cm2.aarch64.rpm
+python3-libxml2-2.10.4-7.cm2.aarch64.rpm
 python3-lxml-4.9.1-1.cm2.aarch64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -215,9 +215,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.x86_64.rpm
 libtasn1-devel-4.19.0-2.cm2.x86_64.rpm
 libtool-2.4.6-8.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-8.cm2.x86_64.rpm
-libxml2-2.10.4-6.cm2.x86_64.rpm
-libxml2-debuginfo-2.10.4-6.cm2.x86_64.rpm
-libxml2-devel-2.10.4-6.cm2.x86_64.rpm
+libxml2-2.10.4-7.cm2.x86_64.rpm
+libxml2-debuginfo-2.10.4-7.cm2.x86_64.rpm
+libxml2-devel-2.10.4-7.cm2.x86_64.rpm
 libxslt-1.1.34-8.cm2.x86_64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.x86_64.rpm
 libxslt-devel-1.1.34-8.cm2.x86_64.rpm
@@ -527,7 +527,7 @@ python3-gpg-1.16.0-2.cm2.x86_64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.x86_64.rpm
 python3-libs-3.9.19-13.cm2.x86_64.rpm
-python3-libxml2-2.10.4-6.cm2.x86_64.rpm
+python3-libxml2-2.10.4-7.cm2.x86_64.rpm
 python3-lxml-4.9.1-1.cm2.x86_64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
libxml2: Patch for CVE-2025-32414 and CVE-2025-32415

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: **SPECS/libxml2/CVE-2025-32414.patch**
- new file: **SPECS/libxml2/CVE-2025-32415.patch**
- modified: **SPECS/libxml2/libxml2.spec**
- modified: **toolkit/resources/manifests/package/pkggen_core_aarch64.txt**
- modified: **toolkit/resources/manifests/package/pkggen_core_x86_64.txt**
- modified: **toolkit/resources/manifests/package/toolchain_aarch64.txt**
- modified: **toolkit/resources/manifests/package/toolchain_x86_64.txt**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-32414
- https://nvd.nist.gov/vuln/detail/CVE-2025-32415

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
