### PR TITLE
[MEDIUM] Patch prometheus-adapter for CVE-2025-22872

### DIFF
--- a/SPECS/prometheus-adapter/CVE-2025-22872.patch
+++ b/SPECS/prometheus-adapter/CVE-2025-22872.patch
@@ -1,0 +1,42 @@
+From c87c77a12e5554d376945bd488e56d4fc5b9e5ac Mon Sep 17 00:00:00 2001
+From: archana25-ms <v-shettigara@microsoft.com>
+Date: Tue, 22 Apr 2025 06:32:35 +0000
+Subject: [PATCH] Address CVE-2025-22872
+Upstream Patch Reference: https://github.com/golang/net/commit/e1fcd82abba34df74614020343be8eb1fe85f0d9
+
+---
+ vendor/golang.org/x/net/html/token.go | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index 3c57880..6598c1f 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -839,8 +839,22 @@ func (z *Tokenizer) readStartTag() TokenType {
+ 	if raw {
+ 		z.rawTag = strings.ToLower(string(z.buf[z.data.start:z.data.end]))
+ 	}
+-	// Look for a self-closing token like "<br/>".
+-	if z.err == nil && z.buf[z.raw.end-2] == '/' {
++	// Look for a self-closing token (e.g. <br/>).
++	//
++	// Originally, we did this by just checking that the last character of the
++	// tag (ignoring the closing bracket) was a solidus (/) character, but this
++	// is not always accurate.
++	//
++	// We need to be careful that we don't misinterpret a non-self-closing tag
++	// as self-closing, as can happen if the tag contains unquoted attribute
++	// values (i.e. <p a=/>).
++	//
++	// To avoid this, we check that the last non-bracket character of the tag
++	// (z.raw.end-2) isn't the same character as the last non-quote character of
++	// the last attribute of the tag (z.pendingAttr[1].end-1), if the tag has
++	// attributes.
++	nAttrs := len(z.attr)
++	if z.err == nil && z.buf[z.raw.end-2] == '/' && (nAttrs == 0 || z.raw.end-2 != z.attr[nAttrs-1][1].end-1) {
+ 		return SelfClosingTagToken
+ 	}
+ 	return StartTagToken
+-- 
+2.45.3
+

--- a/SPECS/prometheus-adapter/prometheus-adapter.spec
+++ b/SPECS/prometheus-adapter/prometheus-adapter.spec
@@ -1,13 +1,14 @@
 Summary:        Kubernetes Custom, Resource, and External Metric APIs implemented to work with Prometheus.
 Name:           prometheus-adapter
 Version:        0.12.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://github.com/kubernetes-sigs/prometheus-adapter
 Source0:        https://github.com/kubernetes-sigs/%{name}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Patch0:         CVE-2024-45338.patch
+Patch1:         CVE-2025-22872.patch
 BuildRequires:  golang
 
 %description
@@ -42,6 +43,9 @@ make test
 %doc README.md RELEASE.md
 
 %changelog
+* Tue Apr 22 2025 Archana Shettigar <v-shettigara@microsoft.com> - 0.12.0-3
+- Patch CVE-2025-22872
+
 * Tue Dec 31 2024 Rohit Rawat <rohitrawat@microsoft.com> - 0.12.0-2
 - Patch CVE-2024-45338
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch prometheus-adapter for CVE-2025-22872

###### Change Log  <!-- REQUIRED -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/prometheus-adapter/CVE-2025-22872.patch
- SPECS/prometheus-adapter/prometheus-adapter.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
