### PR TITLE
Patch cloud-hypervisor for CVE-2024-43806 [Medium]

### DIFF
--- a/SPECS/cloud-hypervisor/CVE-2024-43806.patch
+++ b/SPECS/cloud-hypervisor/CVE-2024-43806.patch
@@ -1,0 +1,344 @@
+From 37d42afd3fd8488f8b83b6a2c6f8b4708bdcbe76 Mon Sep 17 00:00:00 2001
+From: Ankita Pareek <ankitapareek@microsoft.com>
+Date: Mon, 5 May 2025 13:40:01 +0530
+Subject: [PATCH] cloud-hypervisor: Add patch for CVE-2024-43806
+
+Upstream patch: https://github.com/bytecodealliance/rustix/commit/df3c3a192cf144af0da8a57417fb4addbdc611f6
+
+Signed-off-by: Ankita Pareek <ankitapareek@microsoft.com>
+---
+ vendor/rustix/src/backend/libc/fs/dir.rs      | 86 +++++++++++++++++++----
+ vendor/rustix/src/backend/linux_raw/fs/dir.rs | 95 ++++++++++++++++++++++----
+ 2 files changed, 156 insertions(+), 25 deletions(-)
+
+diff --git a/vendor/rustix/src/backend/libc/fs/dir.rs b/vendor/rustix/src/backend/libc/fs/dir.rs
+index 6a0dcb8..8cc3609 100644
+--- a/vendor/rustix/src/backend/libc/fs/dir.rs
++++ b/vendor/rustix/src/backend/libc/fs/dir.rs
+@@ -34,8 +34,13 @@ use core::ptr::NonNull;
+ use libc_errno::{errno, set_errno, Errno};
+ 
+ /// `DIR*`
+-#[repr(transparent)]
+-pub struct Dir(NonNull<c::DIR>);
++pub struct Dir {
++    /// The `libc` `DIR` pointer.
++    libc_dir: NonNull<c::DIR>,
++
++    /// Have we seen any errors in this iteration?
++    any_errors: bool,
++}
+ 
+ impl Dir {
+     /// Construct a `Dir` that reads entries from the given directory
+@@ -47,20 +52,35 @@ impl Dir {
+ 
+     #[inline]
+     fn _read_from(fd: BorrowedFd<'_>) -> io::Result<Self> {
++        let mut any_errors = false;
++
+         // Given an arbitrary `OwnedFd`, it's impossible to know whether the
+         // user holds a `dup`'d copy which could continue to modify the
+         // file description state, which would cause Undefined Behavior after
+         // our call to `fdopendir`. To prevent this, we obtain an independent
+         // `OwnedFd`.
+         let flags = fcntl_getfl(fd)?;
+-        let fd_for_dir = openat(fd, cstr!("."), flags | OFlags::CLOEXEC, Mode::empty())?;
++        let fd_for_dir = match openat(fd, cstr!("."), flags | OFlags::CLOEXEC, Mode::empty()) {
++            Ok(fd) => fd,
++            Err(io::Errno::NOENT) => {
++                // If "." doesn't exist, it means the directory was removed.
++                // We treat that as iterating through a directory with no
++                // entries.
++                any_errors = true;
++                crate::io::dup(fd)?
++            }
++            Err(err) => return Err(err),
++        };
+ 
+         let raw = owned_fd(fd_for_dir);
+         unsafe {
+             let libc_dir = c::fdopendir(raw);
+ 
+             if let Some(libc_dir) = NonNull::new(libc_dir) {
+-                Ok(Self(libc_dir))
++                Ok(Self {
++                    libc_dir,
++                    any_errors,
++                })
+             } else {
+                 let err = io::Errno::last_os_error();
+                 let _ = c::close(raw);
+@@ -72,13 +92,19 @@ impl Dir {
+     /// `rewinddir(self)`
+     #[inline]
+     pub fn rewind(&mut self) {
+-        unsafe { c::rewinddir(self.0.as_ptr()) }
++        self.any_errors = false;
++        unsafe { c::rewinddir(self.libc_dir.as_ptr()) }
+     }
+ 
+     /// `readdir(self)`, where `None` means the end of the directory.
+     pub fn read(&mut self) -> Option<io::Result<DirEntry>> {
++        // If we've seen errors, don't continue to try to read anyting further.
++        if self.any_errors {
++            return None;
++        }
++
+         set_errno(Errno(0));
+-        let dirent_ptr = unsafe { libc_readdir(self.0.as_ptr()) };
++        let dirent_ptr = unsafe { libc_readdir(self.libc_dir.as_ptr()) };
+         if dirent_ptr.is_null() {
+             let curr_errno = errno().0;
+             if curr_errno == 0 {
+@@ -86,6 +112,7 @@ impl Dir {
+                 None
+             } else {
+                 // `errno` is unknown or non-zero, so an error occurred.
++                self.any_errors = true;
+                 Some(Err(io::Errno(curr_errno)))
+             }
+         } else {
+@@ -111,7 +138,7 @@ impl Dir {
+     /// `fstat(self)`
+     #[inline]
+     pub fn stat(&self) -> io::Result<Stat> {
+-        fstat(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })
++        fstat(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.libc_dir.as_ptr())) })
+     }
+ 
+     /// `fstatfs(self)`
+@@ -124,21 +151,21 @@ impl Dir {
+     )))]
+     #[inline]
+     pub fn statfs(&self) -> io::Result<StatFs> {
+-        fstatfs(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })
++        fstatfs(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.libc_dir.as_ptr())) })
+     }
+ 
+     /// `fstatvfs(self)`
+     #[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
+     #[inline]
+     pub fn statvfs(&self) -> io::Result<StatVfs> {
+-        fstatvfs(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })
++        fstatvfs(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.libc_dir.as_ptr())) })
+     }
+ 
+     /// `fchdir(self)`
+     #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+     #[inline]
+     pub fn chdir(&self) -> io::Result<()> {
+-        fchdir(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.0.as_ptr())) })
++        fchdir(unsafe { BorrowedFd::borrow_raw(c::dirfd(self.libc_dir.as_ptr())) })
+     }
+ }
+ 
+@@ -275,7 +302,7 @@ unsafe impl Send for Dir {}
+ impl Drop for Dir {
+     #[inline]
+     fn drop(&mut self) {
+-        unsafe { c::closedir(self.0.as_ptr()) };
++        unsafe { c::closedir(self.libc_dir.as_ptr()) };
+     }
+ }
+ 
+@@ -291,7 +318,7 @@ impl Iterator for Dir {
+ impl fmt::Debug for Dir {
+     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+         f.debug_struct("Dir")
+-            .field("fd", unsafe { &c::dirfd(self.0.as_ptr()) })
++            .field("fd", unsafe { &c::dirfd(self.libc_dir.as_ptr()) })
+             .finish()
+     }
+ }
+@@ -403,3 +430,38 @@ fn check_dirent_layout(dirent: &c::dirent) {
+         }
+     );
+ }
++
++#[test]
++fn dir_iterator_handles_io_errors() {
++    // create a dir, keep the FD, then delete the dir
++    let tmp = tempfile::tempdir().unwrap();
++    let fd = crate::fs::openat(
++        crate::fs::cwd(),
++        tmp.path(),
++        crate::fs::OFlags::RDONLY | crate::fs::OFlags::CLOEXEC,
++        crate::fs::Mode::empty(),
++    )
++    .unwrap();
++
++    let file_fd = crate::fs::openat(
++        &fd,
++        tmp.path().join("test.txt"),
++        crate::fs::OFlags::WRONLY | crate::fs::OFlags::CREATE,
++        crate::fs::Mode::RWXU,
++    )
++    .unwrap();
++
++    let mut dir = Dir::read_from(&fd).unwrap();
++
++    // Reach inside the `Dir` and replace its directory with a file, which
++    // will cause the subsequent `readdir` to fail.
++    unsafe {
++        let raw_fd = c::dirfd(dir.libc_dir.as_ptr());
++        let mut owned_fd: crate::fd::OwnedFd = crate::fd::FromRawFd::from_raw_fd(raw_fd);
++        crate::io::dup2(&file_fd, &mut owned_fd).unwrap();
++        core::mem::forget(owned_fd);
++    }
++
++    assert!(matches!(dir.next(), Some(Err(_))));
++    assert!(matches!(dir.next(), None));
++}
+diff --git a/vendor/rustix/src/backend/linux_raw/fs/dir.rs b/vendor/rustix/src/backend/linux_raw/fs/dir.rs
+index cfa347d..54157ad 100644
+--- a/vendor/rustix/src/backend/linux_raw/fs/dir.rs
++++ b/vendor/rustix/src/backend/linux_raw/fs/dir.rs
+@@ -17,9 +17,17 @@ pub struct Dir {
+     /// The `OwnedFd` that we read directory entries from.
+     fd: OwnedFd,
+ 
++    /// Have we seen any errors in this iteration?
++    any_errors: bool,
++
++    /// Should we rewind the stream on the next iteration?
++    rewind: bool,
++
++    /// The buffer for `linux_dirent64` entries.
+     buf: Vec<u8>,
++
++    /// Where we are in the buffer.
+     pos: usize,
+-    next: Option<u64>,
+ }
+ 
+ impl Dir {
+@@ -37,25 +45,39 @@ impl Dir {
+ 
+         Ok(Self {
+             fd: fd_for_dir,
++            any_errors: false,
++            rewind: false,
+             buf: Vec::new(),
+             pos: 0,
+-            next: None,
+         })
+     }
+ 
+     /// `rewinddir(self)`
+     #[inline]
+     pub fn rewind(&mut self) {
++        self.any_errors = false;
++        self.rewind = true;
+         self.pos = self.buf.len();
+-        self.next = Some(0);
+     }
+ 
+     /// `readdir(self)`, where `None` means the end of the directory.
+     pub fn read(&mut self) -> Option<io::Result<DirEntry>> {
+-        if let Some(next) = self.next.take() {
+-            match crate::backend::fs::syscalls::_seek(self.fd.as_fd(), next as i64, SEEK_SET) {
++        // If we've seen errors, don't continue to try to read anyting further.
++        if self.any_errors {
++            return None;
++        }
++
++        // If a rewind was requested, seek to the beginning.
++        if self.rewind {
++            self.rewind = false;
++            match io::retry_on_intr(|| {
++                crate::backend::fs::syscalls::_seek(self.fd.as_fd(), 0, SEEK_SET)
++            }) {
+                 Ok(_) => (),
+-                Err(err) => return Some(Err(err)),
++                Err(err) => {
++                    self.any_errors = true;
++                    return Some(Err(err));
++                }
+             }
+         }
+ 
+@@ -77,7 +99,7 @@ impl Dir {
+         if self.buf.len() - self.pos < size_of::<linux_dirent64>() {
+             match self.read_more()? {
+                 Ok(()) => (),
+-                Err(e) => return Some(Err(e)),
++                Err(err) => return Some(Err(err)),
+             }
+         }
+ 
+@@ -136,14 +158,31 @@ impl Dir {
+     }
+ 
+     fn read_more(&mut self) -> Option<io::Result<()>> {
+-        let og_len = self.buf.len();
+-        // Capacity increment currently chosen by wild guess.
+-        self.buf
+-            .resize(self.buf.capacity() + 32 * size_of::<linux_dirent64>(), 0);
+-        let nread = match crate::backend::fs::syscalls::getdents(self.fd.as_fd(), &mut self.buf) {
++        // The first few times we're called, we allocate a relatively small
++        // buffer, because many directories are small. If we're called more,
++        // use progressively larger allocations, up to a fixed maximum.
++        //
++        // The specific sizes and policy here have not been tuned in detail yet
++        // and may need to be adjusted. In doing so, we should be careful to
++        // avoid unbounded buffer growth. This buffer only exists to share the
++        // cost of a `getdents` call over many entries, so if it gets too big,
++        // cache and heap usage will outweigh the benefit. And ultimately,
++        // directories can contain more entries than we can allocate contiguous
++        // memory for, so we'll always need to cap the size at some point.
++        if self.buf.len() < 1024 * size_of::<linux_dirent64>() {
++            self.buf.reserve(32 * size_of::<linux_dirent64>());
++        }
++        self.buf.resize(self.buf.capacity(), 0);
++        let nread = match io::retry_on_intr(|| {
++            crate::backend::fs::syscalls::getdents(self.fd.as_fd(), &mut self.buf)
++        }) {
+             Ok(nread) => nread,
++            Err(io::Errno::NOENT) => {
++                self.any_errors = true;
++                return None;
++            }
+             Err(err) => {
+-                self.buf.resize(og_len, 0);
++                self.any_errors = true;
+                 return Some(Err(err));
+             }
+         };
+@@ -223,3 +262,33 @@ impl DirEntry {
+         self.d_ino
+     }
+ }
++
++#[test]
++fn dir_iterator_handles_io_errors() {
++    // create a dir, keep the FD, then delete the dir
++    let tmp = tempfile::tempdir().unwrap();
++    let fd = crate::fs::openat(
++        crate::fs::cwd(),
++        tmp.path(),
++        crate::fs::OFlags::RDONLY | crate::fs::OFlags::CLOEXEC,
++        crate::fs::Mode::empty(),
++    )
++    .unwrap();
++
++    let file_fd = crate::fs::openat(
++        &fd,
++        tmp.path().join("test.txt"),
++        crate::fs::OFlags::WRONLY | crate::fs::OFlags::CREATE,
++        crate::fs::Mode::RWXU,
++    )
++    .unwrap();
++
++    let mut dir = Dir::read_from(&fd).unwrap();
++
++    // Reach inside the `Dir` and replace its directory with a file, which
++    // will cause the subsequent `getdents64` to fail.
++    crate::io::dup2(&file_fd, &mut dir.fd).unwrap();
++
++    assert!(matches!(dir.next(), Some(Err(_))));
++    assert!(matches!(dir.next(), None));
++}
+-- 
+2.34.1
+

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -5,7 +5,7 @@
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
 Name:           cloud-hypervisor
 Version:        32.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -27,6 +27,7 @@ Patch1:         CVE-2023-50711-vmm-sys-util.patch
 Patch2:         CVE-2023-50711-vhost.patch
 Patch3:         CVE-2023-50711-versionize.patch
 Patch4:         CVE-2025-1744.patch
+Patch5:			CVE-2024-43806.patch
 %endif
 
 Conflicts: cloud-hypervisor-cvm
@@ -166,6 +167,9 @@ cargo build --release --target=%{rust_musl_target} --package vhost_user_block %{
 %license LICENSE-BSD-3-Clause
 
 %changelog
+* Mon May 05 2025 Ankita Pareek <ankitapareek@microsoft.com> - 32.0-7
+- Patch CVE-2024-43806 in vendor/rustix
+
 * Tue Mar 04 2024 Kanishk Bansal <kanbansal@microsoft.com> - 32.0-6
 - Recreated patch for CVE-2025-1744 to address a bug introduced by the previous patch. This update includes both the CVE fix and the bug fix.
 


### PR DESCRIPTION
Upstream reference: https://github.com/bytecodealliance/rustix/commit/df3c3a192cf144af0da8a57417fb4addbdc611f6

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2024-43806 in cloud-hypervisor

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
-  Add patch for CVE-2024-43806 in cloud-hypervisor
- Upstream reference: [patch](https://github.com/bytecodealliance/rustix/commit/df3c3a192cf144af0da8a57417fb4addbdc611f6)
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-43806

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=803187&view=results
