### PR TITLE
containerd2: add back updated tardev-snapshotter patch

### DIFF
--- a/SPECS/containerd2/add-tardev-support.patch
+++ b/SPECS/containerd2/add-tardev-support.patch
@@ -1,0 +1,302 @@
+From b4c672fcfc8faad7d0534d887d72e2a68c112d20 Mon Sep 17 00:00:00 2001
+From: Mitch Zhu <mitchzhu@microsoft.com>
+Date: Mon, 3 Feb 2025 22:42:14 +0000
+Subject: [PATCH] Enhance snapshot handling and CRI runtime compatibility for
+ tardev-snapshotter
+
+---
+ client/image.go                               |  4 +-
+ internal/cri/server/container_status_test.go  |  2 +-
+ internal/cri/server/images/image_pull.go      | 37 +++++++++++--------
+ internal/cri/server/images/image_pull_test.go |  2 +-
+ internal/cri/server/podsandbox/controller.go  |  2 +-
+ internal/cri/server/podsandbox/sandbox_run.go | 30 ++++++++-------
+ internal/cri/server/service.go                |  2 +-
+ internal/cri/store/image/image.go             | 29 ++++++++++++---
+ 8 files changed, 69 insertions(+), 39 deletions(-)
+
+diff --git a/client/image.go b/client/image.go
+index 355bcba..791db88 100644
+--- a/client/image.go
++++ b/client/image.go
+@@ -31,6 +31,7 @@ import (
+ 	"github.com/containerd/containerd/v2/internal/kmutex"
+ 	"github.com/containerd/containerd/v2/pkg/labels"
+ 	"github.com/containerd/containerd/v2/pkg/rootfs"
++	"github.com/containerd/containerd/v2/pkg/snapshotters"
+ 	"github.com/containerd/errdefs"
+ 	"github.com/containerd/platforms"
+ 	"github.com/opencontainers/go-digest"
+@@ -333,7 +334,8 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
+ 	}
+ 
+ 	for _, layer := range layers {
+-		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
++		snOpts := append(config.SnapshotOpts, snapshots.WithLabels(map[string]string{snapshotters.TargetLayerDigestLabel: layer.Blob.Digest.String()}))
++		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, snOpts, config.ApplyOpts)
+ 		if err != nil {
+ 			return fmt.Errorf("apply layer error for %q: %w", i.Name(), err)
+ 		}
+diff --git a/internal/cri/server/container_status_test.go b/internal/cri/server/container_status_test.go
+index 05b1650..71dcc10 100644
+--- a/internal/cri/server/container_status_test.go
++++ b/internal/cri/server/container_status_test.go
+@@ -302,7 +302,7 @@ func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error
+ 
+ func (s *fakeImageService) ImageFSPaths() map[string]string { return make(map[string]string) }
+ 
+-func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), *runtime.PodSandboxConfig, string) (string, error) {
++func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), *runtime.PodSandboxConfig, string, string) (string, error) {
+ 	return "", errors.New("not implemented")
+ }
+ 
+diff --git a/internal/cri/server/images/image_pull.go b/internal/cri/server/images/image_pull.go
+index e59b88b..f9c90b7 100644
+--- a/internal/cri/server/images/image_pull.go
++++ b/internal/cri/server/images/image_pull.go
+@@ -96,6 +96,15 @@ import (
+ 
+ // PullImage pulls an image with authentication config.
+ func (c *GRPCCRIImageService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (_ *runtime.PullImageResponse, err error) {
++	imageRef := r.GetImage().GetImage()
++	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, imageRef, r.SandboxConfig, r.GetImage().GetRuntimeHandler())
++	if err != nil {
++		return nil, err
++	}
++	return c.pullImage(ctx, r, snapshotter)
++}
++
++func (c *GRPCCRIImageService) pullImage(ctx context.Context, r *runtime.PullImageRequest, snapshotter string) (_ *runtime.PullImageResponse, err error) {
+ 
+ 	imageRef := r.GetImage().GetImage()
+ 
+@@ -110,14 +119,14 @@ func (c *GRPCCRIImageService) PullImage(ctx context.Context, r *runtime.PullImag
+ 		return ParseAuth(hostauth, host)
+ 	}
+ 
+-	ref, err := c.CRIImageService.PullImage(ctx, imageRef, credentials, r.SandboxConfig, r.GetImage().GetRuntimeHandler())
++	ref, err := c.CRIImageService.PullImage(ctx, imageRef, credentials, r.SandboxConfig, r.GetImage().GetRuntimeHandler(), snapshotter)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	return &runtime.PullImageResponse{ImageRef: ref}, nil
+ }
+ 
+-func (c *CRIImageService) PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (_ string, err error) {
++func (c *CRIImageService) PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string, snapshotter string) (_ string, err error) {
+ 	span := tracing.SpanFromContext(ctx)
+ 	defer func() {
+ 		// TODO: add domain label for imagePulls metrics, and we may need to provide a mechanism
+@@ -167,10 +176,6 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
+ 	)
+ 
+ 	defer pcancel()
+-	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, ref, sandboxConfig)
+-	if err != nil {
+-		return "", err
+-	}
+ 	log.G(ctx).Debugf("PullImage %q with snapshotter %s", ref, snapshotter)
+ 	span.SetAttributes(
+ 		tracing.Attribute("image.ref", ref),
+@@ -761,17 +766,19 @@ func (rt *pullRequestReporterRoundTripper) RoundTrip(req *http.Request) (*http.R
+ // Once we know the runtime, try to override default snapshotter if it is set for this runtime.
+ // See https://github.com/containerd/containerd/issues/6657
+ func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, imageRef string,
+-	s *runtime.PodSandboxConfig) (string, error) {
++	s *runtime.PodSandboxConfig, runtimeHandler string) (string, error) {
+ 	snapshotter := c.config.Snapshotter
+-	if s == nil || s.Annotations == nil {
+-		return snapshotter, nil
+-	}
+ 
+-	// TODO(kiashok): honor the new CRI runtime handler field added to v0.29.0
+-	// for image pull per runtime class support.
+-	runtimeHandler, ok := s.Annotations[annotations.RuntimeHandler]
+-	if !ok {
+-		return snapshotter, nil
++	if runtimeHandler == "" {
++		if s == nil || s.Annotations == nil {
++			return snapshotter, nil
++		} else {
++			ok := false
++			runtimeHandler, ok = s.Annotations[annotations.RuntimeHandler]
++			if !ok {
++				return snapshotter, nil
++			}
++		}
+ 	}
+ 
+ 	// TODO: Ensure error is returned if runtime not found?
+diff --git a/internal/cri/server/images/image_pull_test.go b/internal/cri/server/images/image_pull_test.go
+index bc79e35..af6a451 100644
+--- a/internal/cri/server/images/image_pull_test.go
++++ b/internal/cri/server/images/image_pull_test.go
+@@ -429,7 +429,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
+ 				Platform:    platforms.DefaultSpec(),
+ 				Snapshotter: runtimeSnapshotter,
+ 			}
+-			snapshotter, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig)
++			snapshotter, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig, "")
+ 			assert.Equal(t, tt.expectedSnapshotter, snapshotter)
+ 			if tt.expectedErr {
+ 				assert.Error(t, err)
+diff --git a/internal/cri/server/podsandbox/controller.go b/internal/cri/server/podsandbox/controller.go
+index a185a4c..8fd032b 100644
+--- a/internal/cri/server/podsandbox/controller.go
++++ b/internal/cri/server/podsandbox/controller.go
+@@ -110,7 +110,7 @@ type RuntimeService interface {
+ type ImageService interface {
+ 	LocalResolve(refOrID string) (imagestore.Image, error)
+ 	GetImage(id string) (imagestore.Image, error)
+-	PullImage(ctx context.Context, name string, creds func(string) (string, string, error), sc *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
++	PullImage(ctx context.Context, name string, creds func(string) (string, string, error), sc *runtime.PodSandboxConfig, runtimeHandler string, snapshotter string) (string, error)
+ 	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
+ 	PinnedImage(string) string
+ }
+diff --git a/internal/cri/server/podsandbox/sandbox_run.go b/internal/cri/server/podsandbox/sandbox_run.go
+index 53d949f..35e0075 100644
+--- a/internal/cri/server/podsandbox/sandbox_run.go
++++ b/internal/cri/server/podsandbox/sandbox_run.go
+@@ -77,23 +77,25 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
+ 
+ 	sandboxImage := c.getSandboxImageName()
+ 	// Ensure sandbox container image snapshot.
+-	image, err := c.ensureImageExists(ctx, sandboxImage, config, metadata.RuntimeHandler)
++	ociRuntime, err := c.config.GetSandboxRuntime(config, metadata.RuntimeHandler)
+ 	if err != nil {
+-		return cin, fmt.Errorf("failed to get sandbox image %q: %w", sandboxImage, err)
++		return cin, fmt.Errorf("failed to get sandbox runtime: %w", err)
+ 	}
++	log.G(ctx).WithField("podsandboxid", id).Debugf("use OCI runtime %+v", ociRuntime)
+ 
+-	containerdImage, err := c.toContainerdImage(ctx, *image)
++	labels["oci_runtime_type"] = ociRuntime.Type
++
++	snapshotter := c.imageService.RuntimeSnapshotter(ctx, ociRuntime)
++
++	image, err := c.ensureImageExists(ctx, sandboxImage, config, metadata.RuntimeHandler, snapshotter)
+ 	if err != nil {
+-		return cin, fmt.Errorf("failed to get image from containerd %q: %w", image.ID, err)
++		return cin, fmt.Errorf("failed to get sandbox image %q: %w", sandboxImage, err)
+ 	}
+ 
+-	ociRuntime, err := c.config.GetSandboxRuntime(config, metadata.RuntimeHandler)
++	containerdImage, err := c.toContainerdImage(ctx, *image)
+ 	if err != nil {
+-		return cin, fmt.Errorf("failed to get sandbox runtime: %w", err)
++		return cin, fmt.Errorf("failed to get image from containerd %q: %w", image.ID, err)
+ 	}
+-	log.G(ctx).WithField("podsandboxid", id).Debugf("use OCI runtime %+v", ociRuntime)
+-
+-	labels["oci_runtime_type"] = ociRuntime.Type
+ 
+ 	// Create sandbox container root directories.
+ 	sandboxRootDir := c.getSandboxRootDir(id)
+@@ -173,7 +175,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
+ 	snapshotterOpt = append(snapshotterOpt, extraSOpts...)
+ 
+ 	opts := []containerd.NewContainerOpts{
+-		containerd.WithSnapshotter(c.imageService.RuntimeSnapshotter(ctx, ociRuntime)),
++		containerd.WithSnapshotter(snapshotter),
+ 		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt...),
+ 		containerd.WithSpec(spec, specOpts...),
+ 		containerd.WithContainerLabels(sandboxLabels),
+@@ -299,17 +301,19 @@ func (c *Controller) Create(_ctx context.Context, info sandbox.Sandbox, opts ...
+ 	return c.store.Save(podSandbox)
+ }
+ 
+-func (c *Controller) ensureImageExists(ctx context.Context, ref string, config *runtime.PodSandboxConfig, runtimeHandler string) (*imagestore.Image, error) {
++func (c *Controller) ensureImageExists(ctx context.Context, ref string, config *runtime.PodSandboxConfig, runtimeHandler string, snapshotter string) (*imagestore.Image, error) {
+ 	image, err := c.imageService.LocalResolve(ref)
+ 	if err != nil && !errdefs.IsNotFound(err) {
+ 		return nil, fmt.Errorf("failed to get image %q: %w", ref, err)
+ 	}
+ 	if err == nil {
+-		return &image, nil
++		if _, ok := image.Snapshotters[snapshotter]; ok || len(image.Snapshotters) == 0 {
++			return &image, nil
++		}
+ 	}
+ 	// Pull image to ensure the image exists
+ 	// TODO: Cleaner interface
+-	imageID, err := c.imageService.PullImage(ctx, ref, nil, config, runtimeHandler)
++	imageID, err := c.imageService.PullImage(ctx, ref, nil, config, runtimeHandler, snapshotter)
+ 	if err != nil {
+ 		return nil, fmt.Errorf("failed to pull image %q: %w", ref, err)
+ 	}
+diff --git a/internal/cri/server/service.go b/internal/cri/server/service.go
+index 37d66f0..5d1546e 100644
+--- a/internal/cri/server/service.go
++++ b/internal/cri/server/service.go
+@@ -97,7 +97,7 @@ type RuntimeService interface {
+ type ImageService interface {
+ 	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
+ 
+-	PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
++	PullImage(ctx context.Context, name string, credentials func(string) (string, string, error), sandboxConfig *runtime.PodSandboxConfig, runtimeHandler string, snapshotter string) (string, error)
+ 	UpdateImage(ctx context.Context, r string) error
+ 
+ 	CheckImages(ctx context.Context) error
+diff --git a/internal/cri/store/image/image.go b/internal/cri/store/image/image.go
+index 5887e75..43ecf0d 100644
+--- a/internal/cri/store/image/image.go
++++ b/internal/cri/store/image/image.go
+@@ -20,6 +20,7 @@ import (
+ 	"context"
+ 	"encoding/json"
+ 	"fmt"
++	"strings"
+ 	"sync"
+ 
+ 	"github.com/containerd/containerd/v2/core/content"
+@@ -53,6 +54,8 @@ type Image struct {
+ 	ImageSpec imagespec.Image
+ 	// Pinned image to prevent it from garbage collection
+ 	Pinned bool
++	// Snapshotters is a map whose keys are snapshotters for which this image has a snapshot.
++	Snapshotters map[string]struct{}
+ }
+ 
+ // Getter is used to get images but does not make changes
+@@ -170,6 +173,19 @@ func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
+ 		return nil, fmt.Errorf("read image config from content store: %w", err)
+ 	}
+ 
++	info, err := s.provider.Info(ctx, desc.Digest)
++	if err != nil {
++		return nil, fmt.Errorf("get content store config info: %w", err)
++	}
++
++	snapshotters := make(map[string]struct{})
++	for label := range info.Labels {
++		const Prefix = "containerd.io/gc.ref.snapshot."
++		if strings.HasPrefix(label, Prefix) {
++			snapshotters[label[len(Prefix):]] = struct{}{}
++		}
++	}
++
+ 	var spec imagespec.Image
+ 	if err := json.Unmarshal(blob, &spec); err != nil {
+ 		return nil, fmt.Errorf("unmarshal image config %s: %w", blob, err)
+@@ -178,12 +194,13 @@ func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
+ 	pinned := i.Labels[labels.PinnedImageLabelKey] == labels.PinnedImageLabelValue
+ 
+ 	return &Image{
+-		ID:         id,
+-		References: []string{i.Name},
+-		ChainID:    chainID.String(),
+-		Size:       size,
+-		ImageSpec:  spec,
+-		Pinned:     pinned,
++		ID:           id,
++		References:   []string{i.Name},
++		ChainID:      chainID.String(),
++		Size:         size,
++		ImageSpec:    spec,
++		Pinned:       pinned,
++		Snapshotters: snapshotters,
+ 	}, nil
+ 
+ }
+-- 
+2.34.1

--- a/SPECS/containerd2/containerd2.spec
+++ b/SPECS/containerd2/containerd2.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: %{upstream_name}2
 Version: 2.0.0
-Release: 8%{?dist}
+Release: 9%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -19,6 +19,7 @@ Source2: containerd.toml
 Patch0:	CVE-2024-45338.patch
 Patch1:	CVE-2025-27144.patch
 Patch2:	CVE-2024-40635.patch
+Patch3: add-tardev-support.patch
 %{?systemd_requires}
 
 BuildRequires: golang
@@ -90,6 +91,9 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Fri May 02 2025 Mitch Zhu <mitchzhu@microsoft.com> - 2.0.0-9
+- Added updated patch to support tardev-snapshotter for Kata CC.
+
 * Wed Apr 09 2025 Aadhar Agarwal <aadagarwal@microsoft.com> - 2.0.0-8
 - Fix CVE-2024-40635
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update tardev-snapshotter support patch so that containerd2 passes NetworkIsolatedCluster test scenario in AKS E2Ev3.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added an additional check in ensureImageExists to check if there is any snapshot in record after c.imageService.LocaResolve returns true. If not then we can confirm that there is a local copy of the image in blob store and we can skip re-pulling the image.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- buddybuild with ptest: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=802020&view=results
- imagebuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=803735&view=results
- AKS Tests:
  - conformance test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=805458&view=results
  - performance test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=805459&view=results
  - pre-release test (critest): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=805460&view=results
  - AKS E2Ev3 test passing with network isolated cluster:
