### PR TITLE
Switched the fast-track PR check to run on an AZL 3.0 agent pool.

### DIFF
--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -11,12 +11,12 @@ parameters:
     type: object
     default:
       - name: "AMD64"
-        agentPool: "$(DEV_AMD64_Managed)"
+        agentPool: "$(DEV_AMD64_Managed_NoUMI_AZL3)"
         maxCPUs: "$(($(nproc) / 2))"
         rawToolchainCacheURL: "$(rawToolchainCacheURL_AMD64_3.0)"
         rawToolchainExpectedHash: "$(rawToolchainCacheHash_AMD64_3.0)"
       - name: "ARM64"
-        agentPool: "$(DEV_ARM64_Managed)"
+        agentPool: "$(DEV_ARM64_Managed_NoUMI_AZL3)"
         maxCPUs: "$(($(nproc) / 3))"
         rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64_3.0)"
         rawToolchainExpectedHash: "$(rawToolchainCacheHash_ARM64_3.0)"
@@ -63,6 +63,13 @@ extends:
                   ob_artifactBaseName: $(toolchainArtifactNameBase)_${{ configuration.name }}_$(System.JobAttempt)
                   ob_outputDirectory: $(Build.ArtifactStagingDirectory)
                 steps:
+                  # Making sure all pip installations are using the authorized feed.
+                  - task: PipAuthenticate@1
+                    displayName: Enable internal pip feed
+                    inputs:
+                      onlyAddExtraIndex: false
+                      artifactFeeds: "MarinerFeed"
+
                   - template: .pipelines/templates/RawToolchainDownload.yml@self
                     parameters:
                       rawToolchainCacheURL: ${{ configuration.rawToolchainCacheURL }}
@@ -120,6 +127,13 @@ extends:
                       patterns: "**/$(toolchainTarballName)"
                       targetPath: $(inputArtifactsLocation)
 
+                  # Making sure all pip installations are using the authorized feed.
+                  - task: PipAuthenticate@1
+                    displayName: Enable internal pip feed
+                    inputs:
+                      onlyAddExtraIndex: false
+                      artifactFeeds: "MarinerFeed"
+
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
                       checkBuildRetries: "1"
@@ -172,6 +186,13 @@ extends:
                       patterns: "**/$(toolchainTarballName)"
                       targetPath: $(inputArtifactsLocation)
 
+                  # Making sure all pip installations are using the authorized feed.
+                  - task: PipAuthenticate@1
+                    displayName: Enable internal pip feed
+                    inputs:
+                      onlyAddExtraIndex: false
+                      artifactFeeds: "MarinerFeed"
+
                   - template: .pipelines/templates/PackageBuild.yml@self
                     parameters:
                       checkBuildRetries: "1"
@@ -215,6 +236,13 @@ extends:
                       artifact: $(rpmsArtifactName)
                       patterns: "**/$(rpmsTarballName)"
                       targetPath: $(inputArtifactsLocation)
+
+                  # Making sure all pip installations are using the authorized feed.
+                  - task: PipAuthenticate@1
+                    displayName: Enable internal pip feed
+                    inputs:
+                      onlyAddExtraIndex: false
+                      artifactFeeds: "MarinerFeed"
 
                   - template: .pipelines/templatesWithCheckout/SodiffCheck.yml@self
                     parameters:

--- a/.pipelines/templates/PackageTestResultsAnalysis.yml
+++ b/.pipelines/templates/PackageTestResultsAnalysis.yml
@@ -32,7 +32,7 @@ parameters:
     default: "$(Agent.TempDirectory)"
 
 steps:
-  - bash: sudo tdnf install -y python3-junit-xml
+  - bash: pip3 install --user junit_xml==1.9
     retryCountOnTaskFailure: 3
     displayName: "Install Python dependencies"
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

#### Cherry-pick of #13660

We're migrating all workloads to agents running AZL 3.0 and that includes this fast-track PR check as well.

Had to switch from installing our `python3-junit-xml` to a `pip install junit_xml`, because 3.0 AZL doesn't have the `python3-junit-xml` package. The `python3-junitxml` is a different Python module.

2.0 counterpart: #13701.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- This PR check.