### PR TITLE
mock: backport upstream change for disabling ca-trust copying

### DIFF
--- a/SPECS/mock/disable-copying-ca-trust-dirs.patch
+++ b/SPECS/mock/disable-copying-ca-trust-dirs.patch
@@ -1,0 +1,88 @@
+From f40ef246bcaa479eed39bbe1657c9952bb431211 Mon Sep 17 00:00:00 2001
+From: reuben olinsky <reubeno@users.noreply.github.com>
+Date: Mon, 28 Apr 2025 09:49:16 -0700
+Subject: [PATCH] fix: disable copying ca-trust dirs with Azure Linux 3
+
+Makes ca-trust dir copying in copy_certs() a configurable behavior
+via new config option 'ssl_copied_ca_trust_dirs'. Disables this option
+in Azure Linux 3 configurations to avoid clashes between files copied
+from the host and a symlink installed by the ca-certificates-shared
+package in that distro.
+
+Fixes #1572
+---
+ mock/docs/site-defaults.cfg                           | 11 +++++++++++
+ mock/py/mockbuild/config.py                           |  5 +++++
+ mock/py/mockbuild/package_manager.py                  | 10 ++++++----
+ releng/release-notes-next/azure-linux-ca-trust.bugfix |  5 +++++
+
+diff --git a/mock/docs/site-defaults.cfg b/mock/docs/site-defaults.cfg
+index 61d890f20..622eae3a8 100644
+--- a/mock/docs/site-defaults.cfg
++++ b/mock/docs/site-defaults.cfg
+@@ -661,6 +661,17 @@
+ # if 0 is set, then no time limit is used
+ # config_opts['opstimeout'] = 0
+ 
++# Copy host's ca-trust directories into the specified locations inside the
++# chroot. Each item in the list is a pair of (host, chroot) paths for the
++# directories to be copied, since some hosts and some destination chroots
++# may use different paths. The directories are copied recursively.
++#config_opts['ssl_copied_ca_trust_dirs'] = None
++# Example:
++#config_opts['ssl_copied_ca_trust_dirs'] = [
++#    ('/etc/pki/ca-trust', '/etc/pki/ca-trust'),
++#    ('/usr/share/pki/ca-trust-source', '/usr/share/pki/ca-trust-source')
++#]
++
+ # Copy host's SSL certificate bundle ('/etc/pki/tls/certs/ca-bundle.crt') into
+ # specified location inside chroot.  This usually isn't needed because we copy
+ # the whole /etc/pki/ca-trust/extracted directory recursively by default, and
+diff --git a/mock/py/mockbuild/config.py b/mock/py/mockbuild/config.py
+index d69a11d36..f6c11fc9c 100644
+--- a/mock/py/mockbuild/config.py
++++ b/mock/py/mockbuild/config.py
+@@ -136,6 +136,11 @@ def setup_default_config_opts():
+ 
+     config_opts['ssl_ca_bundle_path'] = None
+ 
++    config_opts['ssl_copied_ca_trust_dirs'] = [
++        ('/etc/pki/ca-trust', '/etc/pki/ca-trust'),
++        ('/usr/share/pki/ca-trust-source', '/usr/share/pki/ca-trust-source')
++    ]
++
+     config_opts['ssl_extra_certs'] = None
+ 
+     # (global) plugins and plugin configs.
+diff --git a/mock/py/mockbuild/package_manager.py b/mock/py/mockbuild/package_manager.py
+index f88b3e6a5..8a8848079 100644
+--- a/mock/py/mockbuild/package_manager.py
++++ b/mock/py/mockbuild/package_manager.py
+@@ -398,10 +398,12 @@ def copy_gpg_keys(self):
+ 
+     @traceLog()
+     def copy_certs(self):
+-        cert_paths = ["/etc/pki/ca-trust", "/usr/share/pki/ca-trust-source"]
+-        for cert_path in cert_paths:
+-            pki_dir = self.buildroot.make_chroot_path(cert_path)
+-            file_util.update_tree(pki_dir, cert_path)
++        copied_ca_cert_paths = self.config['ssl_copied_ca_trust_dirs']
++        if copied_ca_cert_paths:
++            for host_path, root_path in copied_ca_cert_paths:
++                self.buildroot.root_log.debug('copying CA trust dir into chroot: %s => %s', host_path, root_path)
++                dest_dir = self.buildroot.make_chroot_path(root_path)
++                file_util.update_tree(dest_dir, host_path)
+ 
+         bundle_path = self.config['ssl_ca_bundle_path']
+         if bundle_path:
+diff --git a/releng/release-notes-next/azure-linux-ca-trust.bugfix b/releng/release-notes-next/azure-linux-ca-trust.bugfix
+new file mode 100644
+index 000000000..3937d3ca1
+--- /dev/null
++++ b/releng/release-notes-next/azure-linux-ca-trust.bugfix
+@@ -0,0 +1,5 @@
++Disables copying /etc/pki/ca-trust and /usr/share/pki/ca-trust-source on
++Azure Linux 3.0 via a new config options ('ssl_copied_ca_trust_dirs').
++This avoids file ownership conflicts with a symlink installed by the
++ca-certificates-shared packages on that distro. Behavior should be unchanged
++for other configurations.

--- a/SPECS/mock/mock.spec
+++ b/SPECS/mock/mock.spec
@@ -10,11 +10,12 @@
 Summary:       Builds packages inside chroots
 Name:          mock
 Version:       5.6
-Release:       1%{?dist}
+Release:       2%{?dist}
 Vendor:        Microsoft Corporation
 Distribution:  Azure Linux
 License:       GPL-2.0-or-later
 Source:        https://github.com/rpm-software-management/mock/archive/refs/tags/%{name}-%{version}-1.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:        disable-copying-ca-trust-dirs.patch
 URL:           https://github.com/rpm-software-management/mock/
 BuildArch:     noarch
 Requires:      tar
@@ -152,7 +153,7 @@ Requires(pre): shadow-utils
 Filesystem layout and group for Mock.
 
 %prep
-%setup -q -n mock-%{name}-%{version}-1/%{name}
+%autosetup -p2 -n mock-%{name}-%{version}-1/%{name}
 for file in py/mock.py py/mock-parse-buildlog.py; do
   sed -i 1"s|#!/usr/bin/python3 |#!%{__python} |" $file
 done
@@ -298,6 +299,9 @@ pylint-3 py/mockbuild/ py/*.py py/mockbuild/plugins/* || :
 %dir  %{_datadir}/cheat
 
 %changelog
+* Wed May 07 2025 Reuben Olinsky <reubeno@microsoft.com> - 5.6-2
+- Backport change allowing disabling ca-trust file copying.
+
 * Wed Aug 28 2024 Reuben Olinsky <reubeno@microsoft.com> - 5.6-1
 - Sync with Fedora 41 version of spec.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
Backports to AZL3.0 an upstream `mock` change to fix runtime errors we've seen using `mock` to build Azure Linux 3.0 RPMs that have a build-time requirement on `ca-certificates`. The change allows us to disable `mock` from copying ca-trust dirs from the host system into the build root; this let us work around problems on an Azure Linux 3.0 host due to symlinks under `/etc/pki/ca-trust` causing conflicts within the build root.

More details can be found on the upstream change: https://github.com/rpm-software-management/mock/pull/1573.

###### Change Log  <!-- REQUIRED -->
Ports the linked PR to the version of `mock` in Azure Linux 3.0.

###### Does this affect the toolchain?  <!-- REQUIRED -->
No

###### Test Methodology
Local build + buddy build