### PR TITLE
SymCrypt-OpenSSL -- Update mechanism for creating keysinuse logging directory.

### DIFF
--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
@@ -1,7 +1,7 @@
 Summary:        The SymCrypt engine for OpenSSL (SCOSSL) allows the use of OpenSSL with SymCrypt as the provider for core cryptographic operations
 Name:           SymCrypt-OpenSSL
 Version:        1.8.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -80,6 +80,9 @@ install SymCryptProvider/symcrypt_prov.cnf %{buildroot}%{_sysconfdir}/pki/tls/sy
 %dir %attr(1733, root, root) %{_localstatedir}/log/keysinuse/
 
 %changelog
+* Thu May 08 2025 Tobias Brick <tobiasb@microsoft.com> - 1.8.0-2
+- Update mechanism for creating keysinuse logging directory.
+
 * Thu Mar 27 2025 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.8.0-1
 - Upgrade to SymCrypt-OpenSSL 1.8.0 with PBKDF2 and minor bugfixes
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Change the management of the `/var/log/keysinuse` directory in the `SymCrypt-OpenSSL` spec from shell commands in the `%post` and `%postun` scriptlets to a `%dir` directive in the `%files` section. This has a few advantages:
1. It removes the implicit dependency on `/bin/sh` that the scriptlets pull in to run the shell commands. This dependency is undesirable on distroless containers and this package is installed by default everywhere, including distroless.
2. We no longer delete the log files on uninstall. According [Fedora's draft guidance](https://fedoraproject.org/wiki/PackagingDrafts/Logfiles), it is more correct to leave them.
3. It informs `rpm` that this package owns `/var/log/keysinuse`. For example, `rpm -q --whatprovides /var/log/keysinuse` will return this package rather than nothing.

###### Change Log
- Changed mechanism for creating `/var/log/keysinuse`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues
- ADO: https://microsoft.visualstudio.com/OS/_queries/edit/57424422

###### Test Methodology
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=805730&view=results

On both an amd64 and arm64 vm:
1. Validated that with the new version, `openssl speed`, which does a bunch of crypto operations, worked properly
2. Confirmed that with a clean install and an upgrade, `/var/log/keysinuse` has the same permissions as before.
3. Enabled the `keysinuse` logging and confirmed the log files are created in the same way as before.

For both the amd64 and arm64 rpms:
1. Confirmed that `rpm -qp --requires --recommends /path/to/rpm` was exactly the same as the `1.7.0-1` rpm (and specifically does not contain `/bin/sh`).
2. Confirmed that `tdnf install -y --releasever=3.0 --installroot /path/to/temporary/installroot /path/to/rpm` does not install `/bin/sh` and that the tree structure is identical to the `1.7.0-1` version.
