### PR TITLE
[MEDIUM] Patch moby-buildx for CVE-2025-0495

### DIFF
--- a/SPECS/moby-buildx/CVE-2025-0495.patch
+++ b/SPECS/moby-buildx/CVE-2025-0495.patch
@@ -1,0 +1,105 @@
+From 4745215cea5eb7927e2ff37a57124c91355f1bd7 Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Tue, 13 May 2025 08:36:18 -0400
+Subject: [PATCH] Address CVE-2025-0495
+
+---
+ commands/bake.go      | 12 +++++++++++-
+ commands/build.go     |  7 ++++++-
+ util/tracing/trace.go |  7 +++----
+ 3 files changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/commands/bake.go b/commands/bake.go
+index 129b635..a3fa1ac 100644
+--- a/commands/bake.go
++++ b/commands/bake.go
+@@ -5,6 +5,7 @@ import (
+ 	"encoding/json"
+ 	"fmt"
+ 	"os"
++	"strings"
+ 
+ 	"github.com/containerd/containerd/platforms"
+ 	"github.com/docker/buildx/bake"
+@@ -17,6 +18,7 @@ import (
+ 	"github.com/moby/buildkit/util/appcontext"
+ 	"github.com/pkg/errors"
+ 	"github.com/spf13/cobra"
++	"go.opentelemetry.io/otel/attribute"
+ )
+ 
+ type bakeOptions struct {
+@@ -29,7 +31,15 @@ type bakeOptions struct {
+ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error) {
+ 	ctx := appcontext.Context()
+ 
+-	ctx, end, err := tracing.TraceCurrentCommand(ctx, "bake")
++	// Convert slices to strings
++	targetsStr := strings.Join(targets, ",")
++	filesStr := strings.Join(in.files, ",")
++
++	ctx, end, err := tracing.TraceCurrentCommand(ctx, append([]string{"bake"}, targets...),
++		attribute.String("builder", in.commonOptions.builder),
++		attribute.String("targets", targetsStr),
++		attribute.String("files", filesStr),	
++	)
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/commands/build.go b/commands/build.go
+index bfefd70..be6a41e 100644
+--- a/commands/build.go
++++ b/commands/build.go
+@@ -26,6 +26,7 @@ import (
+ 	"github.com/sirupsen/logrus"
+ 	"github.com/spf13/cobra"
+ 	"github.com/spf13/pflag"
++	"go.opentelemetry.io/otel/attribute"
+ )
+ 
+ const defaultTargetName = "default"
+@@ -72,7 +73,11 @@ type commonOptions struct {
+ func runBuild(dockerCli command.Cli, in buildOptions) (err error) {
+ 	ctx := appcontext.Context()
+ 
+-	ctx, end, err := tracing.TraceCurrentCommand(ctx, "build")
++	ctx, end, err := tracing.TraceCurrentCommand(ctx, []string{"build", in.contextPath},
++		attribute.String("builder", in.builder),
++		attribute.String("context", in.contextPath),
++		attribute.String("dockerfile", in.dockerfileName),
++	)
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/util/tracing/trace.go b/util/tracing/trace.go
+index c95ad5a..13ce349 100644
+--- a/util/tracing/trace.go
++++ b/util/tracing/trace.go
+@@ -2,7 +2,6 @@ package tracing
+ 
+ import (
+ 	"context"
+-	"os"
+ 	"strings"
+ 
+ 	"github.com/moby/buildkit/util/tracing/detect"
+@@ -10,13 +9,13 @@ import (
+ 	"go.opentelemetry.io/otel/trace"
+ )
+ 
+-func TraceCurrentCommand(ctx context.Context, name string) (context.Context, func(error), error) {
++func TraceCurrentCommand(ctx context.Context, args []string, attrs ...attribute.KeyValue) (context.Context, func(error), error) {
+ 	tp, err := detect.TracerProvider()
+ 	if err != nil {
+ 		return context.Background(), nil, err
+ 	}
+-	ctx, span := tp.Tracer("").Start(ctx, name, trace.WithAttributes(
+-		attribute.String("command", strings.Join(os.Args, " ")),
++	ctx, span := tp.Tracer("").Start(ctx, strings.Join(args, " "), trace.WithAttributes(
++		attrs...,
+ 	))
+ 
+ 	return ctx, func(err error) {
+-- 
+2.34.1
+

--- a/SPECS/moby-buildx/CVE-2025-0495.patch
+++ b/SPECS/moby-buildx/CVE-2025-0495.patch
@@ -2,6 +2,7 @@ From 4745215cea5eb7927e2ff37a57124c91355f1bd7 Mon Sep 17 00:00:00 2001
 From: Aninda <v-anipradhan@microsoft.com>
 Date: Tue, 13 May 2025 08:36:18 -0400
 Subject: [PATCH] Address CVE-2025-0495
+Upstream Patch Reference: https://github.com/docker/buildx/commit/0982070af84d476b232d2d75ab551c3222592db1
 
 ---
  commands/bake.go      | 12 +++++++++++-

--- a/SPECS/moby-buildx/moby-buildx.spec
+++ b/SPECS/moby-buildx/moby-buildx.spec
@@ -5,7 +5,7 @@ Summary:        A Docker CLI plugin for extended build capabilities with BuildKi
 Name:           moby-%{upstream_name}
 # update "commit_hash" above when upgrading version
 Version:        0.7.1
-Release:        24%{?dist}
+Release:        25%{?dist}
 License:        ASL 2.0
 Group:          Tools/Container
 Vendor:         Microsoft Corporation
@@ -24,6 +24,7 @@ Patch7:         CVE-2022-41717.patch
 Patch8:         CVE-2023-45288.patch
 Patch9:         CVE-2023-48795.patch
 Patch10:        CVE-2024-24786.patch
+Patch11:        CVE-2025-0495.patch
 
 BuildRequires: bash
 BuildRequires: golang
@@ -54,6 +55,9 @@ cp -aT buildx "%{buildroot}/%{_libexecdir}/docker/cli-plugins/docker-buildx"
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Tue May 13 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 0.7.1-25
+- Fixes CVE-2025-0495, referred upstream patch from debian
+
 * Thu Dec 05 2024 sthelkar <sthelkar@microsoft.com> - 0.7.1-24
 - Patch CVE-2024-24786
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Addresses moby-buildx CVE-2025-0495 [MEDIUM]

Link to Debian patch that was referred while creating this patch:
https://github.com/docker/buildx/commit/0982070af84d476b232d2d75ab551c3222592db1

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified:   ../SPECS/moby-buildx/moby-buildx.spec
- added: ../SPECS/moby-buildx/CVE-2025-0495.patc


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- None

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-0495

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
- docker install
- 
![image](https://github.com/user-attachments/assets/2ec9dd9a-aee3-40fe-989e-5bd54743841c)
