### PR TITLE
Prevent stripping of BTF data from kernel modules

### DIFF
--- a/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
+++ b/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
@@ -14,6 +14,8 @@
 %undefine _unique_debug_names
 %global _missing_build_ids_terminate_build 1
 %global _no_recompute_build_ids 1
+# Prevent find_debuginfo.sh from removing the BTF section from modules
+%define _find_debuginfo_opts --keep-section '.BTF'
 
 %ifarch x86_64
 %define arch x86_64
@@ -31,7 +33,7 @@
 Summary:        Linux Kernel
 Name:           kernel-ipe
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -451,6 +453,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue May 27 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Prevent debuginfo from stripping BTF data
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
+++ b/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
@@ -453,7 +453,7 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Tue May 27 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
 - Prevent debuginfo from stripping BTF data
 
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1

--- a/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
+++ b/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
@@ -7,7 +7,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-64k-signed-%{buildarch}
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,6 +105,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Bump release to match kernel
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -145,6 +145,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Bump release to match kernel
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -376,7 +376,7 @@ echo "initrd of kernel %{uname_r} removed" >&2
 * Fri Feb 23 2024 Chris Gunn <chrisgun@microsoft.com> - 6.6.14.1-3
 - Rename initrd.img-<kver> to initramfs-<kver>.img
 
-* Tue Jan 30 2024 Cameron Baird <cameronbaird@microsoft.com> - 6.6.14.1-2
+* Tue Feb 20 2024 Cameron Baird <cameronbaird@microsoft.com> - 6.6.14.1-2
 - Remove legacy /boot/mariner.cfg
 - Introduce /etc/default/grub.d/10_kernel.cfg
 
@@ -419,7 +419,7 @@ echo "initrd of kernel %{uname_r} removed" >&2
 * Tue Sep 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.133.1-1
 - Auto-upgrade to 5.15.133.1
 
-* Tue Sep 22 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.131.1-3
+* Thu Sep 21 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.131.1-3
 - Bump release to match kernel
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 5.15.131.1-2

--- a/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
+++ b/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed Unified Kernel Image for %{buildarch} systems
 Name:           kernel-uki-signed-%{buildarch}
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -68,6 +68,9 @@ popd
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Bump release to match kernel
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/SPECS/kernel-64k/kernel-64k.spec
+++ b/SPECS/kernel-64k/kernel-64k.spec
@@ -14,6 +14,8 @@
 %undefine _unique_debug_names
 %global _missing_build_ids_terminate_build 1
 %global _no_recompute_build_ids 1
+# Prevent find_debuginfo.sh from removing the BTF section from modules
+%define _find_debuginfo_opts --keep-section '.BTF'
 
 %ifarch aarch64
 %global __provides_exclude_from %{_libdir}/debug/.build-id/
@@ -25,7 +27,7 @@
 Summary:        Linux Kernel
 Name:           kernel-64k
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -371,6 +373,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue May 27 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Prevent debuginfo from stripping BTF data
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/SPECS/kernel-64k/kernel-64k.spec
+++ b/SPECS/kernel-64k/kernel-64k.spec
@@ -373,7 +373,7 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Tue May 27 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
 - Prevent debuginfo from stripping BTF data
 
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +75,9 @@ done
 %endif
 
 %changelog
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Bump release to match kernel
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/SPECS/kernel/kernel-uki.spec
+++ b/SPECS/kernel/kernel-uki.spec
@@ -13,7 +13,7 @@
 Summary:        Unified Kernel Image
 Name:           kernel-uki
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -70,6 +70,9 @@ cp %{buildroot}/boot/vmlinuz-uki-%{kernelver}.efi %{buildroot}/boot/efi/EFI/Linu
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Bump release to match kernel
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -430,7 +430,7 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Tue May 27 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+* Mon Jun 09 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
 - Prevent debuginfo from stripping BTF data
 
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -13,6 +13,8 @@
 %undefine _unique_debug_names
 %global _missing_build_ids_terminate_build 1
 %global _no_recompute_build_ids 1
+# Prevent find_debuginfo.sh from removing the BTF section from modules
+%define _find_debuginfo_opts --keep-section '.BTF'
 
 %ifarch x86_64
 %define arch x86_64
@@ -30,7 +32,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.92.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -428,6 +430,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue May 27 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.92.2-2
+- Prevent debuginfo from stripping BTF data
+
 * Fri May 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.92.2-1
 - Auto-upgrade to 6.6.92.2
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
-kernel-headers-6.6.92.2-1.azl3.noarch.rpm
+kernel-headers-6.6.92.2-2.azl3.noarch.rpm
 glibc-2.38-10.azl3.aarch64.rpm
 glibc-devel-2.38-10.azl3.aarch64.rpm
 glibc-i18n-2.38-10.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
-kernel-headers-6.6.92.2-1.azl3.noarch.rpm
+kernel-headers-6.6.92.2-2.azl3.noarch.rpm
 glibc-2.38-10.azl3.x86_64.rpm
 glibc-devel-2.38-10.azl3.x86_64.rpm
 glibc-i18n-2.38-10.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.aarch64.rpm
 kbd-debuginfo-2.2.0-2.azl3.aarch64.rpm
-kernel-headers-6.6.92.2-1.azl3.noarch.rpm
+kernel-headers-6.6.92.2-2.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -165,8 +165,8 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.x86_64.rpm
 kbd-debuginfo-2.2.0-2.azl3.x86_64.rpm
-kernel-cross-headers-6.6.92.2-1.azl3.noarch.rpm
-kernel-headers-6.6.92.2-1.azl3.noarch.rpm
+kernel-cross-headers-6.6.92.2-2.azl3.noarch.rpm
+kernel-headers-6.6.92.2-2.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR updates the kernel spec file to ensure that the BTF (BPF Type Format) section is preserved in all built kernel modules. Specifically, it introduces the following change:
```
%define _find_debuginfo_opts --keep-section '.BTF'
```
This directive prevents the `find-debuginfo.sh` script (invoked during RPM build and packaged in debugedit) from removing the `.BTF` ELF section when stripping debug information from kernel modules.

`_find_debuginfo_opts` is an RPM macro for additional options passed to `find-debuginfo.sh`. ([link](https://github.com/rpm-software-management/rpm/blob/master/macros.in#L161))
 `--keep-section` is an argument to find-debuginfo.sh as defined in [the script](https://sourceware.org/git/?p=debugedit.git;a=blob;f=scripts/find-debuginfo.in;h=8b9ce77a96718c2c0027c140f9be0cee27202772;hb=d7b6cb2a2a81e7896de7cb5e0389a34b5ad91b82#l220)

.BTF data is expected as the kernel config sets `CONFIG_DEBUG_INFO_BTF_MODULES` ([kconfig](https://github.com/microsoft/CBL-Mariner-Linux-Kernel/blob/rolling-lts/mariner-3/6.6.90.1/lib/Kconfig.debug#L406)) and thus each kernel module should contain a `.BTF` section.

Without this change, module BTF data is not exposed in /sys/kernel/btf/, preventing eBPF tools from tracing module symbols and types.
```
$ ls /sys/kernel/btf/
vmlinux
```

- [Linux Kernel Documentation: BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)
- [Brendan Gregg: BPF binaries, BTF, and the future of BPF perf tools](https://www.brendangregg.com/blog/2020-11-04/bpf-co-re-btf-libbpf.html)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Prevent stripping of BTF data from kernel modules

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/57252049

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=810883&view=results

- Built kernel modules using the updated spec were verified to contain the `.BTF` section:
  - Used `readelf -S <module.ko>` and confirmed `.BTF` is present.
- eBPF tools (bpftool and bpftrace) were able to successfully introspect and load BTF data from modules after this change.
- No regressions in module loading were observed.
AMD64
```
*** Smoke Testing Kernel 6.6.90.1-2.azl3 (est. < 1 min) ***
OS Version: NAME="Microsoft Azure Linux"
VERSION="3.0.20250521"
ID=azurelinux
PASS: Kernel version matches the running kernel version.
PASS: eth0 interface is up.
PASS: iptables service is running.
Boot times:
Startup finished in 1.810s (kernel) + 1.460s (initrd) + 6.744s (userspace) = 10.014s 
graphical.target reached after 6.372s in userspace.
Kernel size:
-rw------- 1 root root 15052800 May 27 18:21 /boot/vmlinuz-6.6.90.1-2.azl3
34704	/lib/modules/6.6.90.1-2.azl3
kernel memory:
MemTotal:       65853168 kB
MemFree:        65411380 kB
MemAvailable:   65047792 kB
Total memory:
               total        used        free      shared  buff/cache   available
Mem:           64309         786       63878           0         130       63523
Swap:              0           0           0
```
ARM64
```
*** Smoke Testing Kernel 6.6.90.1-2.azl3 (est. < 1 min) ***
OS Version: NAME="Microsoft Azure Linux"
VERSION="3.0.20250521"
ID=azurelinux
PASS: Kernel version matches the running kernel version.
PASS: eth0 interface is up.
PASS: iptables service is running.
Boot times:
Startup finished in 968ms (kernel) + 1.159s (initrd) + 5.311s (userspace) = 7.440s 
graphical.target reached after 5.043s in userspace.
Kernel size:
-rw------- 1 root root 48720384 May 27 18:53 /boot/vmlinuz-6.6.90.1-2.azl3
56704	/lib/modules/6.6.90.1-2.azl3
kernel memory:
MemTotal:       65719176 kB
MemFree:        65205076 kB
MemAvailable:   64848428 kB
Total memory:
               total        used        free      shared  buff/cache   available
Mem:           64178         850       63676           0         142       63328
Swap:              0           0           0

```