### PR TITLE
[2.0] javapackages-bootstrap build reliability

### DIFF
--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -345,7 +345,7 @@ sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/common
 %build
 export LC_ALL=en_US.UTF-8 
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
-# The build tends to randomly fail and we couldn't understand why. Re-trying the build as a workaround.
+# Since the build is known to randomly fail with a dependency cycle error, detect failure and retry the build.
 if ! ./mbi.sh build -incremental; then
     echo "First build attempt failed. Re-trying."
     ./mbi.sh build -incremental

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -13,7 +13,7 @@
 
 Name:           javapackages-bootstrap
 Version:        1.5.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        A means of bootstrapping Java Packages Tools
 # For detailed info see the file javapackages-bootstrap-PACKAGE-LICENSING
 License:        ASL 2.0 and ASL 1.1 and (ASL 2.0 or EPL-2.0) and (EPL-2.0 or GPLv2 with exceptions) and MIT and (BSD with advertising) and BSD-3-Clause and EPL-1.0 and EPL-2.0 and CDDL-1.0 and xpp and CC0 and Public Domain
@@ -345,7 +345,7 @@ sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/common
 %build
 export LC_ALL=en_US.UTF-8 
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
-./mbi.sh build -parallel
+./mbi.sh build
 
 %install
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
@@ -389,6 +389,9 @@ sed -i 's|/usr/lib/jvm/java-11-openjdk|%{java_home}|' %{buildroot}%{launchersPat
 %doc AUTHORS
 
 %changelog
+* Thu May 15 2025 Andrew Phelps <anphel@microsoft.com> - 1.5.0-7
+- Remove parallel build flag to avoid random dependency cycle errors.
+
 * Wed Feb 26 2025 Kshitiz Godara <kgodara@microsoft.com> - 1.5.0-6
 - Patch CVE-2021-36373 and CVE-2021-36374.
 

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -345,8 +345,11 @@ sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/common
 %build
 export LC_ALL=en_US.UTF-8 
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
-./mbi.sh build -incremental ||:
-./mbi.sh build -incremental
+# The build tends to randomly fail and we couldn't understand why. Re-trying the build as a workaround.
+if ! ./mbi.sh build -incremental; then
+    echo "First build attempt failed. Re-trying."
+    ./mbi.sh build -incremental
+fi
 
 %install
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -345,7 +345,8 @@ sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/common
 %build
 export LC_ALL=en_US.UTF-8 
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
-./mbi.sh build
+./mbi.sh build -incremental ||:
+./mbi.sh build -incremental
 
 %install
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
@@ -390,7 +391,7 @@ sed -i 's|/usr/lib/jvm/java-11-openjdk|%{java_home}|' %{buildroot}%{launchersPat
 
 %changelog
 * Thu May 15 2025 Andrew Phelps <anphel@microsoft.com> - 1.5.0-7
-- Remove parallel build flag to avoid random dependency cycle errors.
+- Attempt incremental build twice to avoid random Dependency cycle errors
 
 * Wed Feb 26 2025 Kshitiz Godara <kgodara@microsoft.com> - 1.5.0-6
 - Patch CVE-2021-36373 and CVE-2021-36374.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Avoid the following build failure regularly seen in nightly builds by not building in parallel and attempting the build twice. Add the incremental flag to avoid rebuilding if the first attempt fails. This same error has been reported [upstream](https://github.com/fedora-java/javapackages-bootstrap/issues/84). Note that this error has been seen regularly on nightly builds in 2.0 (with version 1.5.0), but the newer version of javapackages-bootstrap (1.14.0) on AZL 3.0 does not hit the same error.

```
"+ ./mbi.sh build -parallel"
"Exception in thread \"main\" java.lang.IllegalStateException: Dependency cycle: mbi-pdc -> maven-plugin-tools -> mbi-pdc"
"\tat org.fedoraproject.mbi.plan.BuildPlan.generateBuildSteps(BuildPlan.java:86)"
"\tat org.fedoraproject.mbi.plan.BuildPlan.generateBuildSteps(BuildPlan.java:103)"
"\tat org.fedoraproject.mbi.plan.BuildPlan.generateBuildSteps(BuildPlan.java:92)"
"\tat org.fedoraproject.mbi.plan.BuildPlan.generateBuildSteps(BuildPlan.java:103)"
"\tat org.fedoraproject.mbi.plan.BuildPlan.computeBuildPlan(BuildPlan.java:62)"
"\tat org.fedoraproject.mbi.build.BuildCommand.run(BuildCommand.java:41)"
"\tat org.fedoraproject.mbi.Main.main(Main.java:52)"
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change `javapackages-bootstrap` to not build in parallel and attempt an incremental build if the first build attempt fails

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/56257042

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=811293&view=results
