### PR TITLE
systemd: make systemd-udev provide predefined pcrlock files

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -14,7 +14,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        21%{?dist}
+Release:        22%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -93,6 +93,9 @@ popd
 /boot/efi/EFI/BOOT/grubx64.efi
 
 %changelog
+* Fri May 16 2025 Thien Trung Vuong <tvuong@microsoft.com> - 255-22
+- Bump release to match systemd spec
+
 * Mon Apr 14 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 255-21
 - Updating SRPM name to systemd-boot-signed-%%{buildarch}.
 
@@ -102,7 +105,7 @@ popd
 
 * Thu Dec 12 2024 Daniel McIlvaney <damcilva@microsoft.com> - 255-19
 - Version bump to force signing with new Azure Linux secure boot key
-- Add confilcts/recommends on shim to ensure the keys match
+- Add conflicts/recommends on shim to ensure the keys match
 
 * Fri Sep 13 2024 Thien Trung Vuong <tvuong@microsoft.com> - 255-18
 - Update sd-boot install location

--- a/SPECS/systemd/split-files.py
+++ b/SPECS/systemd/split-files.py
@@ -122,7 +122,11 @@ for file in files(buildroot):
         o = outputs['main']
     elif re.search(r'/libcryptsetup-token-systemd-.*\.so$', n):
         o = outputs['udev']
-    elif re.search(r'/lib.*\.pc|/man3/|/usr/include|\.so$', n):
+    elif re.search(r'''/lib.*\.pc$|
+                       /man3/|
+                       /usr/include|
+                       \.so$
+    ''', n):
         o = outputs['devel']
     elif re.search(r'''journal-(remote|gateway|upload)|
                        systemd-remote\.conf|
@@ -201,7 +205,8 @@ for file in files(buildroot):
                        integritytab|
                        remount-fs|
                        /initrd|
-                       systemd-pcr|
+                       systemd[.-]pcr|
+                       /pcrlock\.d|
                        systemd-measure|
                        /boot$|
                        /kernel/|

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -8,7 +8,7 @@
   "20-yama-ptrace.conf": "f7881466bff200865ec2c6b5f989ed35855ac45420a55ae5ace805f9e5111828",
   "98-default-mac-none.link": "11efa1aee1d52e74b3ca5d1db903e9e1f3ca5e07498c25ea13e40452e2430e1a",
   "macros.sysusers": "b7c3941912208657b68a5890b8e320d626a6bc17290a223b46071e251b240160",
-  "split-files.py": "ff2ace09f116028299f75ab1f81ca467a6dc4e7ad38c27c22d2e8dd1229ad0dd",
+  "split-files.py": "e07808dbb079e56ea32d7875050f665b8db43103a789cefcf69fece6aaf4f45d",
   "sysctl.conf.README": "51d16ee2e7eef12dd42e924af6b835861e8b79d11921ba0418d7d0aec7a2a93b",
   "systemd-255.tar.gz": "a3eb766ee96eb9f4cc25c2a6c933f3299e1b7ae22e72507dade0a5c86d92534f",
   "systemd-journal-gatewayd.xml": "c2559b1244fb04f7fe214628daf09e12d431560b069b5ef346ace1ceddbe1bc9",

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        21%{?dist}
+Release:        22%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -1217,6 +1217,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Fri May 16 2025 Thien Trung Vuong <tvuong@microsoft.com> - 255.22
+- Move .pcrlock files to systemd-udev
+
 * Mon Apr 14 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 255-21
 - Bumping 'Release' tag to match the 'signed' version of the spec.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Pre-defined pcrlock files, which is a part of systemd v255 (https://github.com/systemd/systemd/commit/8e35338d098e9fd78fd4611b36690ea4110ce526), is currently provided by systemd-devel likely due to [this pattern match](https://github.com/microsoft/azurelinux/blob/3.0/SPECS/systemd/split-files.py#L125) during packaging. This change updates the pattern so that the pcrlock files are explicitly provided by systemd-udev, which is the same package that provides the systemd-pcrlock binary.

Fedora's fix: https://src.fedoraproject.org/rpms/systemd/pull-request/207

Thank you @ndubchak for reporting this issue.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update patterns in split-files.py to explicitly include pcrlock files in systemd-udev

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=2366948
- https://microsoft.visualstudio.com/OS/_workitems/edit/57622649

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=811339&view=results (test failures are irrelevant to this change)
