### PR TITLE
[Medium] Patch rubygem-rexml for CVE-2024-43398 & Upgrade rubygem-rexml to 3.2.9

### DIFF
--- a/SPECS/rubygem-rexml/CVE-2024-39908.patch
+++ b/SPECS/rubygem-rexml/CVE-2024-39908.patch
@@ -1,36 +1,19 @@
-From 66d3d405337c1dea5b4522bf87e06a8cfe815298 Mon Sep 17 00:00:00 2001
-From: Kevin Lockwood <v-klockwood@microsoft.com>
-Date: Tue, 18 Feb 2025 12:13:44 -0800
-Subject: [PATCH] [Medium] rubygem-rexml: Patch CVE-2024-39908
+From 76163d54d61fc9571ad4ce4312eac75baa41680b Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Mon, 9 Jun 2025 13:26:17 +0000
+Subject: [PATCH] Address CVE-2024-39908
 
-Link: https://github.com/ruby/rexml/raw/refs/tags/v3.3.2/lib/rexml/parsers/baseparser.rb
+Patch Reference: https://raw.githubusercontent.com/ruby/rexml/refs/tags/v3.3.2/lib/rexml/parsers/baseparser.rb
+
 ---
- lib/rexml/parsers/baseparser.rb | 126 ++++++++++++++++++++++++--------
- 1 file changed, 97 insertions(+), 29 deletions(-)
+ lib/rexml/parsers/baseparser.rb | 101 ++++++++++++++++++++++++--------
+ 1 file changed, 75 insertions(+), 26 deletions(-)
 
 diff --git a/lib/rexml/parsers/baseparser.rb b/lib/rexml/parsers/baseparser.rb
-index 25bc371..a2818ae 100644
+index 7739f9d..71f609c 100644
 --- a/lib/rexml/parsers/baseparser.rb
 +++ b/lib/rexml/parsers/baseparser.rb
-@@ -7,6 +7,17 @@ require "strscan"
- 
- module REXML
-   module Parsers
-+    if StringScanner::Version < "3.0.8"
-+      module StringScannerCaptures
-+        refine StringScanner do
-+          def captures
-+            values_at(*(1...size))
-+          end
-+        end
-+      end
-+      using StringScannerCaptures
-+    end
-+
-     # = Using the Pull Parser
-     # <em>This API is experimental, and subject to change.</em>
-     #  parser = PullParser.new( "<a>text<b att='val'/>txet</a>" )
-@@ -113,6 +124,14 @@ module REXML
+@@ -124,6 +124,14 @@ module REXML
        }
  
        module Private
@@ -45,7 +28,7 @@ index 25bc371..a2818ae 100644
          INSTRUCTION_END = /#{NAME}(\s+.*?)?\?>/um
          TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
          CLOSE_PATTERN = /(#{QNAME_STR})\s*>/um
-@@ -121,14 +140,21 @@ module REXML
+@@ -132,14 +140,21 @@ module REXML
          GEDECL_PATTERN = "\\s+#{NAME}\\s+#{ENTITYDEF}\\s*>"
          PEDECL_PATTERN = "\\s+(%)\\s+#{NAME}\\s+#{PEDEF}\\s*>"
          ENTITYDECL_PATTERN = /(?:#{GEDECL_PATTERN})|(?:#{PEDECL_PATTERN})/um
@@ -68,7 +51,7 @@ index 25bc371..a2818ae 100644
        end
  
        def add_listener( listener )
-@@ -141,6 +167,7 @@ module REXML
+@@ -152,6 +167,7 @@ module REXML
        def stream=( source )
          @source = SourceFactory.create_from( source )
          @closed = nil
@@ -76,7 +59,7 @@ index 25bc371..a2818ae 100644
          @document_status = nil
          @tags = []
          @stack = []
-@@ -195,6 +222,8 @@ module REXML
+@@ -206,6 +222,8 @@ module REXML
  
        # Returns the next event.  This is a +PullEvent+ object.
        def pull
@@ -85,7 +68,7 @@ index 25bc371..a2818ae 100644
          pull_event.tap do |event|
            @listeners.each do |listener|
              listener.receive event
-@@ -207,7 +236,12 @@ module REXML
+@@ -218,7 +236,12 @@ module REXML
            x, @closed = @closed, nil
            return [ :end_element, x ]
          end
@@ -99,7 +82,7 @@ index 25bc371..a2818ae 100644
          return @stack.shift if @stack.size > 0
          #STDERR.puts @source.encoding
          #STDERR.puts "BUFFER = #{@source.buffer.inspect}"
-@@ -219,7 +253,14 @@ module REXML
+@@ -230,7 +253,14 @@ module REXML
              return process_instruction(start_position)
            elsif @source.match("<!", true)
              if @source.match("--", true)
@@ -115,7 +98,7 @@ index 25bc371..a2818ae 100644
              elsif @source.match("DOCTYPE", true)
                base_error_message = "Malformed DOCTYPE"
                unless @source.match(/\s+/um, true)
-@@ -231,7 +272,7 @@ module REXML
+@@ -242,7 +272,7 @@ module REXML
                  @source.position = start_position
                  raise REXML::ParseException.new(message, @source)
                end
@@ -124,7 +107,7 @@ index 25bc371..a2818ae 100644
                name = parse_name(base_error_message)
                if @source.match(/\s*\[/um, true)
                  id = [nil, nil, nil]
-@@ -279,7 +320,7 @@ module REXML
+@@ -290,7 +320,7 @@ module REXML
                raise REXML::ParseException.new( "Bad ELEMENT declaration!", @source ) if md.nil?
                return [ :elementdecl, "<!ELEMENT" + md[1] ]
              elsif @source.match("ENTITY", true)
@@ -133,7 +116,7 @@ index 25bc371..a2818ae 100644
                ref = false
                if match[1] == '%'
                  ref = true
-@@ -305,13 +346,13 @@ module REXML
+@@ -316,13 +346,13 @@ module REXML
                match << '%' if ref
                return match
              elsif @source.match("ATTLIST", true)
@@ -149,7 +132,7 @@ index 25bc371..a2818ae 100644
                values.each do |attdef|
                  unless attdef[3] == "#IMPLIED"
                    attdef.compact!
-@@ -344,19 +385,22 @@ module REXML
+@@ -355,19 +385,22 @@ module REXML
                  raise REXML::ParseException.new(message, @source)
                end
                return [:notationdecl, name, *id]
@@ -174,23 +157,7 @@ index 25bc371..a2818ae 100644
          end
          if @document_status == :after_doctype
            @source.match(/\s*/um, true)
-@@ -364,10 +408,14 @@ module REXML
-         begin
-           start_position = @source.position
-           if @source.match("<", true)
-+            # :text's read_until may remain only "<" in buffer. In the
-+            # case, buffer is empty here. So we need to fill buffer
-+            # here explicitly.
-+            @source.ensure_buffer
-             if @source.match("/", true)
-               @nsstack.shift
-               last_tag = @tags.pop
--              md = @source.match(CLOSE_PATTERN, true)
-+              md = @source.match(Private::CLOSE_PATTERN, true)
-               if md and !last_tag
-                 message = "Unexpected top-level end tag (got '#{md[1]}')"
-                 raise REXML::ParseException.new(message, @source)
-@@ -384,16 +432,15 @@ module REXML
+@@ -399,16 +432,15 @@ module REXML
                #STDERR.puts "SOURCE BUFFER = #{source.buffer}, #{source.buffer.size}"
                raise REXML::ParseException.new("Malformed node", @source) unless md
                if md[0][0] == ?-
@@ -211,7 +178,7 @@ index 25bc371..a2818ae 100644
                  return [ :cdata, md[1] ] if md
                end
                raise REXML::ParseException.new( "Declarations can only occur "+
-@@ -402,19 +449,19 @@ module REXML
+@@ -417,19 +449,19 @@ module REXML
                return process_instruction(start_position)
              else
                # Get the next tag
@@ -236,7 +203,7 @@ index 25bc371..a2818ae 100644
                  unless @nsstack.find{|k| k.member?(prefix)}
                    raise UndefinedNamespaceException.new(prefix,@source,self)
                  end
-@@ -424,13 +471,25 @@ module REXML
+@@ -439,8 +471,12 @@ module REXML
                  @closed = tag
                  @nsstack.shift
                else
@@ -249,12 +216,10 @@ index 25bc371..a2818ae 100644
                return [ :start_element, tag, attributes ]
              end
            else
--            md = @source.match(/([^<]*)/um, true)
--            text = md[1]
-+            text = @source.read_until("<")
-+            if text.chomp!("<")
-+              @source.position -= "<".bytesize
-+            end
+@@ -448,6 +484,12 @@ module REXML
+             if text.chomp!("<")
+               @source.position -= "<".bytesize
+             end
 +            if @tags.empty? and @have_root
 +              unless /\A\s*\z/.match?(text)
 +                raise ParseException.new("Malformed XML: Extra content at the end of the document (got '#{text}')", @source)
@@ -264,7 +229,7 @@ index 25bc371..a2818ae 100644
              return [ :text, text ]
            end
          rescue REXML::UndefinedNamespaceException
-@@ -475,10 +534,14 @@ module REXML
+@@ -492,10 +534,14 @@ module REXML
  
        # Unescapes all possible entities
        def unnormalize( string, entities=nil, filter=nil )
@@ -281,7 +246,7 @@ index 25bc371..a2818ae 100644
            m=$1
            if m.start_with?("x")
              code_point = Integer(m[1..-1], 16)
-@@ -494,7 +557,7 @@ module REXML
+@@ -511,7 +557,7 @@ module REXML
              unless filter and filter.include?(entity_reference)
                entity_value = entity( entity_reference, entities )
                if entity_value
@@ -290,7 +255,7 @@ index 25bc371..a2818ae 100644
                  rv.gsub!( re, entity_value )
                  sum += rv.bytesize
                  if sum > Security.entity_expansion_text_limit
-@@ -506,7 +569,7 @@ module REXML
+@@ -523,7 +569,7 @@ module REXML
                end
              end
            end
@@ -299,7 +264,7 @@ index 25bc371..a2818ae 100644
          end
          rv
        end
-@@ -527,7 +590,7 @@ module REXML
+@@ -544,7 +590,7 @@ module REXML
        end
  
        def parse_name(base_error_message)
@@ -308,7 +273,7 @@ index 25bc371..a2818ae 100644
          unless md
            if @source.match(/\s*\S/um)
              message = "#{base_error_message}: invalid name"
-@@ -606,13 +669,16 @@ module REXML
+@@ -623,13 +669,16 @@ module REXML
        end
  
        def process_instruction(start_position)
@@ -327,17 +292,6 @@ index 25bc371..a2818ae 100644
            content = match_data[2]
            version = VERSION.match(content)
            version = version[1] unless version.nil?
-@@ -654,8 +720,10 @@ module REXML
-               raise REXML::ParseException.new(message, @source)
-             end
-             quote = match[1]
-+            start_position = @source.position
-             value = @source.read_until(quote)
-             unless value.chomp!(quote)
-+              @source.position = start_position
-               message = "Missing attribute value end quote: <#{name}>: <#{quote}>"
-               raise REXML::ParseException.new(message, @source)
-             end
 -- 
-2.34.1
+2.45.2
 

--- a/SPECS/rubygem-rexml/CVE-2024-43398.patch
+++ b/SPECS/rubygem-rexml/CVE-2024-43398.patch
@@ -1,0 +1,110 @@
+From e5bcd0e09cc9dde045e850c657071974080d11e6 Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Wed, 21 May 2025 12:09:38 +0000
+Subject: [PATCH] Address CVE-2024-43398
+
+Upstream Patch reference: https://github.com/ruby/rexml/commit/7cb5eaeb221c322b9912f724183294d8ce96bae3
+
+---
+ lib/rexml/element.rb            | 11 -----------
+ lib/rexml/parsers/baseparser.rb | 15 +++++++++++++++
+ test/parse/test_element.rb      | 14 ++++++++++++++
+ test/test_core.rb               |  2 +-
+ 4 files changed, 30 insertions(+), 12 deletions(-)
+
+diff --git a/lib/rexml/element.rb b/lib/rexml/element.rb
+index bf913a8..b44f41d 100644
+--- a/lib/rexml/element.rb
++++ b/lib/rexml/element.rb
+@@ -2388,17 +2388,6 @@ module REXML
+       elsif old_attr.kind_of? Hash
+         old_attr[value.prefix] = value
+       elsif old_attr.prefix != value.prefix
+-        # Check for conflicting namespaces
+-        if value.prefix != "xmlns" and old_attr.prefix != "xmlns"
+-          old_namespace = old_attr.namespace
+-          new_namespace = value.namespace
+-          if old_namespace == new_namespace
+-            raise ParseException.new(
+-                    "Namespace conflict in adding attribute \"#{value.name}\": "+
+-                    "Prefix \"#{old_attr.prefix}\" = \"#{old_namespace}\" and "+
+-                    "prefix \"#{value.prefix}\" = \"#{new_namespace}\"")
+-          end
+-        end
+         store value.name, {old_attr.prefix => old_attr,
+                            value.prefix    => value}
+       else
+diff --git a/lib/rexml/parsers/baseparser.rb b/lib/rexml/parsers/baseparser.rb
+index a2818ae..f66e20a 100644
+--- a/lib/rexml/parsers/baseparser.rb
++++ b/lib/rexml/parsers/baseparser.rb
+@@ -699,6 +699,7 @@ module REXML
+ 
+       def parse_attributes(prefixes, curr_ns)
+         attributes = {}
++	expanded_names = {}
+         closed = false
+         while true
+           if @source.match(">", true)
+@@ -750,6 +751,20 @@ module REXML
+               raise REXML::ParseException.new(msg, @source, self)
+             end
+ 
++            unless prefix == "xmlns"
++              uri = @namespaces[prefix]
++              expanded_name = [uri, local_part]
++              existing_prefix = expanded_names[expanded_name]
++              if existing_prefix
++                message = "Namespace conflict in adding attribute " +
++                          "\"#{local_part}\": " +
++                          "Prefix \"#{existing_prefix}\" = \"#{uri}\" and " +
++                          "prefix \"#{prefix}\" = \"#{uri}\""
++                raise REXML::ParseException.new(message, @source, self)
++              end
++              expanded_names[expanded_name] = prefix
++            end
++
+             attributes[name] = value
+           else
+             message = "Invalid attribute name: <#{@source.buffer.split(%r{[/>\s]}).first}>"
+diff --git a/test/parse/test_element.rb b/test/parse/test_element.rb
+index 14d0703..f1a4629 100644
+--- a/test/parse/test_element.rb
++++ b/test/parse/test_element.rb
+@@ -85,6 +85,20 @@ Last 80 unconsumed characters:
+ </ </x>
+         DETAIL
+       end
++
++      def test_linear_performance_deep_same_name_attributes
++        seq = [100, 500, 1000, 1500, 2000]
++        assert_linear_performance(seq, rehearsal: 10) do |n|
++          xml = <<-XML
++<?xml version="1.0"?>
++<root xmlns:ns="ns-uri">
++#{"<x ns:name='ns-value' name='value'>\n" * n}
++#{"</x>\n" * n}
++</root>
++          XML
++          REXML::Document.new(xml)
++        end
++      end
+     end
+   end
+ end
+diff --git a/test/test_core.rb b/test/test_core.rb
+index 44e2e7e..788bcaa 100644
+--- a/test/test_core.rb
++++ b/test/test_core.rb
+@@ -117,7 +117,7 @@ module REXMLTests
+     def test_attribute_namespace_conflict
+       # https://www.w3.org/TR/xml-names/#uniqAttrs
+       message = <<-MESSAGE.chomp
+-Duplicate attribute "a"
++Namespace conflict in adding attribute "a": Prefix "n1" = "http://www.w3.org" and prefix "n2" = "http://www.w3.org"
+ Line: 4
+ Position: 140
+ Last 80 unconsumed characters:
+-- 
+2.45.2
+

--- a/SPECS/rubygem-rexml/rubygem-rexml.signatures.json
+++ b/SPECS/rubygem-rexml/rubygem-rexml.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "rexml-3.2.7.tar.gz": "e17b16cf079251c76226d8aa96a2e8ba9633d600cf6ef28fe28b08b664383387"
+  "rexml-3.2.9.tar.gz": "ac2a52d517adf5ef4a4e7168e1371df85094c0f85395b75034db2eda9d1a5199"
  }
 }

--- a/SPECS/rubygem-rexml/rubygem-rexml.spec
+++ b/SPECS/rubygem-rexml/rubygem-rexml.spec
@@ -2,8 +2,8 @@
 %global gem_name rexml
 Summary:        REXML is an XML toolkit for Ruby
 Name:           rubygem-%{gem_name}
-Version:        3.2.7
-Release:        5%{?dist}
+Version:        3.2.9
+Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -38,7 +38,8 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
-* Wed May 21 2025 Akhila Guruju <v-guakhila@microsoft.com> - 3.2.7-5
+* Mon Jun 09 2025 Akhila Guruju <v-guakhila@microsoft.com> - 3.2.9-1
+- Upgrade to 3.2.9 to fix installation
 - Patch CVE-2024-43398
 
 * Tue Feb 18 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 3.2.7-4

--- a/SPECS/rubygem-rexml/rubygem-rexml.spec
+++ b/SPECS/rubygem-rexml/rubygem-rexml.spec
@@ -3,7 +3,7 @@
 Summary:        REXML is an XML toolkit for Ruby
 Name:           rubygem-%{gem_name}
 Version:        3.2.7
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,7 @@ Source0:        https://github.com/ruby/rexml/archive/refs/tags/v%{version}.tar.
 Patch0:         CVE-2024-41946.patch
 Patch1:         CVE-2024-49761.patch
 Patch2:         CVE-2024-39908.patch
+Patch3:         CVE-2024-43398.patch
 BuildRequires:  git
 BuildRequires:  ruby
 Requires:       ruby(release)
@@ -37,6 +38,9 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
+* Wed May 21 2025 Akhila Guruju <v-guakhila@microsoft.com> - 3.2.7-5
+- Patch CVE-2024-43398
+
 * Tue Feb 18 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 3.2.7-4
 - Add patch for CVE-2024-39908
 

--- a/SPECS/rubygem-rexml/rubygem-rexml.spec
+++ b/SPECS/rubygem-rexml/rubygem-rexml.spec
@@ -17,6 +17,7 @@ Patch3:         CVE-2024-43398.patch
 BuildRequires:  git
 BuildRequires:  ruby
 Requires:       ruby(release)
+Requires:       rubygem(strscan)
 Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 %description

--- a/SPECS/rubygem-rexml/rubygem-rexml.spec
+++ b/SPECS/rubygem-rexml/rubygem-rexml.spec
@@ -17,7 +17,6 @@ Patch3:         CVE-2024-43398.patch
 BuildRequires:  git
 BuildRequires:  ruby
 Requires:       ruby(release)
-Requires:       rubygem(strscan)
 Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 %description

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -26885,8 +26885,8 @@
         "type": "other",
         "other": {
           "name": "rubygem-rexml",
-          "version": "3.2.7",
-          "downloadUrl": "https://github.com/ruby/rexml/archive/refs/tags/v3.2.7.tar.gz"
+          "version": "3.2.9",
+          "downloadUrl": "https://github.com/ruby/rexml/archive/refs/tags/v3.2.9.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch rubygem-rexml for CVE-2024-43398
Upgrade rubygem-rexml to 3.2.9
All existing CVEs still affect this version. I have created a new patch for CVE-2024-39908. Earlier, the patch was applied on version 3.2.7 but now it has to be applied on version 3.2.9. So I have created patch according. Some lines are deleted from **CVE-2024-39908.patch** as these lines are already present in *baseparser.rb* file of version 3.2.9.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/rubygem-rexml/CVE-2024-43398.patch
- modified:   SPECS/rubygem-rexml/rubygem-rexml.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-43398

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Patch applied cleanly
<img width="481" alt="image" src="https://github.com/user-attachments/assets/fd193878-dbfa-4568-b2a1-1f25177c46cb" />
