### PR TITLE
Fix 5 more ptests (perl-Net-SSLeay perl-Module-Implementation perl-URI rubygem-introspection rubygem-metaclass)

### DIFF
--- a/SPECS/perl-Module-Implementation/perl-Module-Implementation.spec
+++ b/SPECS/perl-Module-Implementation/perl-Module-Implementation.spec
@@ -10,7 +10,7 @@
 
 Name:		perl-Module-Implementation
 Version:	0.09
-Release:	25%{?dist}
+Release:	26%{?dist}
 Summary:	Loads one of several alternate underlying implementations for a module
 License:	Artistic 2.0
 Vendor:         Microsoft Corporation
@@ -45,6 +45,7 @@ BuildRequires:	perl(lib)
 BuildRequires:	perl(Test::Fatal) >= 0.006
 BuildRequires:	perl(Test::More) >= 0.96
 BuildRequires:	perl(Test::Requires)
+BuildRequires:  perl(blib)
 %if %{with perl_Module_Implementation_enables_optional_test}
 # ===================================================================
 # Optional test requirements
@@ -131,6 +132,9 @@ make test
 %{_mandir}/man3/Module::Implementation.3*
 
 %changelog
+* Wed May 21 2025 Riken Maharjan <rmaharjan@microsoft.com> - 0.09-26
+- Fix ptest byadding missing test dep.
+
 * Wed Aug 28 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 0.09-25
 - Promote package to Core repository.
 - License verified.

--- a/SPECS/perl-Net-SSLeay/compatible-openssl.patch
+++ b/SPECS/perl-Net-SSLeay/compatible-openssl.patch
@@ -1,0 +1,51 @@
+diff -urN Net-SSLeay-1.92/t/local/33_x509_create_cert.t Net-SSLeay-1.92/t/local/33_x509_create_cert.t
+--- Net-SSLeay-1.92/t/local/33_x509_create_cert.t	2021-09-28 22:15:32.000000000 +0000
++++ Net-SSLeay-1.92/t/local/33_x509_create_cert.t	2025-05-21 19:23:50.928133272 +0000
+@@ -53,7 +53,8 @@
+   #set organizationName via add_entry_by_txt
+   ok(Net::SSLeay::X509_NAME_add_entry_by_txt($name, "organizationName", MBSTRING_UTF8, "Company Name"), "X509_NAME_add_entry_by_txt");
+   
+-  ok(Net::SSLeay::X509_set_version($x509, 3), "X509_set_version");
++  my $x509_version_3 = (defined &Net::SSLeay::X509_VERSION_3) ? Net::SSLeay::X509_VERSION_3() : 2; # Note: X509_VERSION_3 is 2
++  ok(Net::SSLeay::X509_set_version($x509, $x509_version_3), "X509_set_version");
+   ok(my $sn = Net::SSLeay::X509_get_serialNumber($x509), "X509_get_serialNumber");
+   
+   my $pubkey = Net::SSLeay::X509_get_X509_PUBKEY($x509);
+@@ -96,7 +97,7 @@
+   ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
+   ok(Net::SSLeay::X509_sign($x509, $ca_pk, $sha1_digest), "X509_sign");
+   
+-  is(Net::SSLeay::X509_get_version($x509), 3, "X509_get_version");  
++  is(Net::SSLeay::X509_get_version($x509), $x509_version_3, "X509_get_version");
+   is(Net::SSLeay::X509_verify($x509, Net::SSLeay::X509_get_pubkey($ca_cert)), 1, "X509_verify");
+   
+   like(my $crt_pem = Net::SSLeay::PEM_get_string_X509($x509), qr/-----BEGIN CERTIFICATE-----/, "PEM_get_string_X509");
+@@ -184,7 +185,8 @@
+   #49 = NID_pkcs9_unstructuredName - XXX-TODO add new constant
+   ok(Net::SSLeay::X509_REQ_add1_attr_by_NID($req, 49, MBSTRING_ASC, 'Any Uns.name'), "X509_REQ_add1_attr_by_NID");
+    
+-  ok(Net::SSLeay::X509_REQ_set_version($req, 2), "X509_REQ_set_version");
++  my $x509_req_version_1 = (defined &Net::SSLeay::X509_REQ_VERSION_1) ? Net::SSLeay::X509_REQ_VERSION_1() : 0; # Note: X509_REQ_VERSION_1 is 0
++  ok(Net::SSLeay::X509_REQ_set_version($req, $x509_req_version_1), "X509_REQ_set_version");
+ 
+   ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
+   ok(Net::SSLeay::X509_REQ_sign($req, $pk, $sha1_digest), "X509_REQ_sign");
+@@ -192,7 +194,7 @@
+   ok(my $req_pubkey = Net::SSLeay::X509_REQ_get_pubkey($req), "X509_REQ_get_pubkey");
+   is(Net::SSLeay::X509_REQ_verify($req, $req_pubkey), 1, "X509_REQ_verify");
+   
+-  is(Net::SSLeay::X509_REQ_get_version($req), 2, "X509_REQ_get_version");
++  is(Net::SSLeay::X509_REQ_get_version($req), $x509_req_version_1, "X509_REQ_get_version");
+   ok(my $obj_challengePassword = Net::SSLeay::OBJ_txt2obj('1.2.840.113549.1.9.7'), "OBJ_txt2obj");
+   ok(my $nid_challengePassword = Net::SSLeay::OBJ_obj2nid($obj_challengePassword), "OBJ_obj2nid");  
+   is(Net::SSLeay::X509_REQ_get_attr_count($req), 3, "X509_REQ_get_attr_count");
+@@ -214,7 +216,8 @@
+   
+   ## PHASE2 - turn X509_REQ into X509 cert + sign with CA key
+   ok(my $x509ss = Net::SSLeay::X509_new(), "X509_new");
+-  ok(Net::SSLeay::X509_set_version($x509ss, 2), "X509_set_version");
++  my $x509_version_3 = (defined &Net::SSLeay::X509_VERSION_3) ? Net::SSLeay::X509_VERSION_3() : 2; # Note: X509_VERSION_3 is 2
++  ok(Net::SSLeay::X509_set_version($x509ss, $x509_version_3), "X509_set_version");
+   ok(my $sn = Net::SSLeay::X509_get_serialNumber($x509ss), "X509_get_serialNumber");
+   Net::SSLeay::P_ASN1_INTEGER_set_hex($sn, 'ABCDEF');
+   Net::SSLeay::X509_set_issuer_name($x509ss, Net::SSLeay::X509_get_subject_name($ca_cert));

--- a/SPECS/perl-Net-SSLeay/perl-Net-SSLeay.spec
+++ b/SPECS/perl-Net-SSLeay/perl-Net-SSLeay.spec
@@ -1,12 +1,14 @@
 Summary:        Perl extension for using OpenSSL
 Name:           perl-Net-SSLeay
 Version:        1.92
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        Artistic 2.0
 Group:          Development/Libraries
 URL:            https://metacpan.org/pod/distribution/Net-SSLeay/lib/Net/SSLeay.pod
 Source:         https://cpan.metacpan.org/modules/by-module/Net/Net-SSLeay-%{version}.tar.gz
 Patch0:         0001-local-tests-skip-2-failing-tests.patch
+Patch1:         compatible-openssl.patch
+
 %if 0%{?with_fips:1}
 Source100:      openssl-fips-2.0.9-lin64.tar.gz
 %endif
@@ -49,7 +51,7 @@ Net::SSLeay module basically comprise of:
 
 %prep
 %setup -q -n Net-SSLeay-%{version}
-%patch 0 -p1
+%autopatch -p1
 
 %build
 %if 0%{?with_fips:1}
@@ -81,6 +83,9 @@ make test
 %{_mandir}/man?/*
 
 %changelog
+* Wed May 21 2025 Riken Maharjan <rmaharjan@microsoft.com> -  1.92-6
+- Fix ptest by adding upstream fix to the test.
+
 * Mon Aug 05 2024 Daniel McIlvaney <damcilva@microsoft.com> - 1.92-5
 - Fix bad capitalization of perl(AutoLoader)
 

--- a/SPECS/perl-URI/perl-URI.spec
+++ b/SPECS/perl-URI/perl-URI.spec
@@ -3,7 +3,7 @@
 
 Name:           perl-URI
 Version:        5.21
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Perl module implementing URI parsing and manipulation
 License:        GPL+ or Artistic
 Vendor:         Microsoft Corporation
@@ -42,6 +42,8 @@ BuildRequires:  perl(Storable)
 BuildRequires:  perl(Test)
 BuildRequires:  perl(Test::More) >= 0.96
 BuildRequires:  perl(Test::Needs)
+BuildRequires:  perl(Test::Fatal)
+BuildRequires:  perl(Test::Warnings)
 # Runtime
 Requires:       perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
 Requires:       perl(Cwd)
@@ -90,6 +92,9 @@ make test
 %{_mandir}/man3/URI::*.3*
 
 %changelog
+* Wed May 21 2025 Riken Maharjan <rmaharjan@microsoft.com> - 5.21-2
+- Fix ptest by adding missing runtime dep
+
 * Mon Dec 18 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.21-1
 - Auto-upgrade to 5.21 - Azure Linux 3.0 - package upgrades
 

--- a/SPECS/rubygem-introspection/rubygem-introspection.spec
+++ b/SPECS/rubygem-introspection/rubygem-introspection.spec
@@ -2,7 +2,7 @@
 Summary:        Dynamic inspection of the hierarchy of method definitions on a Ruby object
 Name:           rubygem-%{gem_name}
 Version:        0.0.4
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -50,12 +50,16 @@ cp Rakefile %{buildroot}%{gem_instdir}/
 cp Gemfile %{buildroot}%{gem_instdir}/
 
 %check
-pushd .%{gem_instdir}
 # Disable Bundler.
-sed -i '/bundler\/setup/ d' test/test_helper.rb
-
+# Drop BlankSlate test case. There should be no need for BlankSlate, when
+# there is BasicObject available for years.
+# https://github.com/floehopper/introspection/issues/11
+sed -i -e '/require.*blankslate/ s/^/#/' \
+  -e '/def test_should_cope_with_blankslate_object$/a\\    skip' \
+  test/snapshot_test.rb
+  
+sed -i '/require "bundler\/setup"/ d' test/test_helper.rb
 ruby -Ilib:test -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
-popd
 
 %files
 %license %{gem_instdir}/COPYING.txt
@@ -73,6 +77,9 @@ popd
 %doc %{gem_docdir}
 
 %changelog
+* Wed May 21 2025 Riken Maharjan <rmaharjan@microsoft.com> - 0.0.4-14
+- Fix ptest by not using bundler and skiping a known failing test case using Fedora 42 (License: MIT) 
+
 * Tue Mar 22 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 0.0.4-13
 - Build from .tar.gz source.
 

--- a/SPECS/rubygem-metaclass/rubygem-metaclass.spec
+++ b/SPECS/rubygem-metaclass/rubygem-metaclass.spec
@@ -3,7 +3,7 @@
 Summary:        Adds a metaclass method to all Ruby objects
 Name:           rubygem-%{gem_name}
 Version:        0.0.4
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -36,6 +36,7 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %check
 # test_helper.rb currently references bundler, so it is easier to avoid
 # its usage at all.
+sed -i '/require "bundler\/setup"/ d' test/test_helper.rb
 ruby -Ilib:test -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
 
 %files
@@ -43,6 +44,9 @@ ruby -Ilib:test -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
 %{gemdir}
 
 %changelog
+* Wed May 21 2025 Riken Maharjan <rmaharjan@microsoft.com> - 0.0.4-17
+- Fix ptest by not using bundler 
+
 * Tue Jul 19 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 0.0.4-16
 - Add provides, add missing files, remove doc package
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix 5 ptest: perl-Net-SSLeay perl-Module-Implementation perl-URI rubygem-introspection rubygem-metaclass

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change: perl-Net-SSLeay Add patch from the upstream to fix the failing test. 
- Change: perl-Module-Implementation : add missing test package
- Change: perl-URI : add missing test package
- Change: rubygem-introspection: Disable bundler while testing and disable a known failing test (imported from fedora 42).
- Change: rubygem-metaclass: disable bundler while testing 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**
NO


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [815406](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=815406&view=results)
