### PR TITLE
[MEDIUM] Patch nodejs for CVE-2025-23165 CVE-2025-23166

### DIFF
--- a/SPECS/nodejs/CVE-2025-23165.patch
+++ b/SPECS/nodejs/CVE-2025-23165.patch
@@ -1,0 +1,28 @@
+From 3badbd012233828132ec938253ed40a7854fd65c Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Sat, 24 May 2025 11:03:53 -0400
+Subject: [PATCH] Address CVE-2025-23165
+Upstream Patch Reference: https://github.com/nodejs/node/commit/9e13bf0a81e15c7b3a9f1826dccbcea991d7e63a
+
+---
+ src/node_file.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/node_file.cc b/src/node_file.cc
+index 0ec5c6f4..ba69879b 100644
+--- a/src/node_file.cc
++++ b/src/node_file.cc
+@@ -2609,9 +2609,9 @@ static void ReadFileUtf8(const FunctionCallbackInfo<Value>& args) {
+     FS_SYNC_TRACE_END(open);
+     if (req.result < 0) {
+       uv_fs_req_cleanup(&req);
+-      // req will be cleaned up by scope leave.
+       return env->ThrowUVException(req.result, "open", nullptr, path.out());
+     }
++    uv_fs_req_cleanup(&req);
+   }
+ 
+   auto defer_close = OnScopeLeave([file, is_fd, &req]() {
+-- 
+2.34.1
+

--- a/SPECS/nodejs/CVE-2025-23166.patch
+++ b/SPECS/nodejs/CVE-2025-23166.patch
@@ -1,0 +1,537 @@
+From cca703fb8440504e580a92256a8f16ca0e38a08e Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Sat, 24 May 2025 10:33:47 -0400
+Subject: [PATCH] Address CVE-2025-23166
+Upstream Patch Reference: https://github.com/nodejs/node/commit/6c57465920cf1b981a63031e71b1e4a73bf9beaa
+
+---
+ src/crypto/crypto_dh.cc                       |  8 +++---
+ src/crypto/crypto_dh.h                        |  8 +++---
+ src/crypto/crypto_ec.cc                       |  3 +-
+ src/crypto/crypto_ec.h                        |  8 +++---
+ src/crypto/crypto_hash.cc                     |  8 +++---
+ src/crypto/crypto_hash.h                      |  8 +++---
+ src/crypto/crypto_hkdf.cc                     |  8 +++---
+ src/crypto/crypto_hkdf.h                      |  8 +++---
+ src/crypto/crypto_hmac.cc                     |  8 +++---
+ src/crypto/crypto_hmac.h                      |  8 +++---
+ src/crypto/crypto_pbkdf2.cc                   |  8 +++---
+ src/crypto/crypto_pbkdf2.h                    |  8 +++---
+ src/crypto/crypto_random.cc                   | 20 ++++++-------
+ src/crypto/crypto_random.h                    | 19 +++++++------
+ src/crypto/crypto_scrypt.cc                   |  8 +++---
+ src/crypto/crypto_scrypt.h                    |  8 +++---
+ src/crypto/crypto_sig.cc                      | 28 +++++++++++--------
+ src/crypto/crypto_sig.h                       |  8 +++---
+ src/crypto/crypto_util.h                      |  3 +-
+ .../parallel/test-crypto-async-sign-verify.js | 26 +++++++++++++++++
+ 20 files changed, 122 insertions(+), 89 deletions(-)
+
+diff --git a/src/crypto/crypto_dh.cc b/src/crypto/crypto_dh.cc
+index b4447102..7c984652 100644
+--- a/src/crypto/crypto_dh.cc
++++ b/src/crypto/crypto_dh.cc
+@@ -705,10 +705,10 @@ Maybe<bool> DHBitsTraits::EncodeOutput(
+   return Just(!result->IsEmpty());
+ }
+ 
+-bool DHBitsTraits::DeriveBits(
+-    Environment* env,
+-    const DHBitsConfig& params,
+-    ByteSource* out) {
++bool DHBitsTraits::DeriveBits(Environment* env,
++                              const DHBitsConfig& params,
++                              ByteSource* out,
++                              CryptoJobMode mode) {
+   *out = StatelessDiffieHellmanThreadsafe(
+       params.private_key->GetAsymmetricKey(),
+       params.public_key->GetAsymmetricKey());
+diff --git a/src/crypto/crypto_dh.h b/src/crypto/crypto_dh.h
+index ec12548d..f7c4b675 100644
+--- a/src/crypto/crypto_dh.h
++++ b/src/crypto/crypto_dh.h
+@@ -131,10 +131,10 @@ struct DHBitsTraits final {
+       unsigned int offset,
+       DHBitsConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const DHBitsConfig& params,
+-      ByteSource* out_);
++  static bool DeriveBits(Environment* env,
++                         const DHBitsConfig& params,
++                         ByteSource* out_,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_ec.cc b/src/crypto/crypto_ec.cc
+index 860d5048..356e21f1 100644
+--- a/src/crypto/crypto_ec.cc
++++ b/src/crypto/crypto_ec.cc
+@@ -481,7 +481,8 @@ Maybe<bool> ECDHBitsTraits::AdditionalConfig(
+ 
+ bool ECDHBitsTraits::DeriveBits(Environment* env,
+                                 const ECDHBitsConfig& params,
+-                                ByteSource* out) {
++                                ByteSource* out,
++                                CryptoJobMode mode) {
+   size_t len = 0;
+   ManagedEVPPKey m_privkey = params.private_->GetAsymmetricKey();
+   ManagedEVPPKey m_pubkey = params.public_->GetAsymmetricKey();
+diff --git a/src/crypto/crypto_ec.h b/src/crypto/crypto_ec.h
+index f9570bd4..a6bd48d4 100644
+--- a/src/crypto/crypto_ec.h
++++ b/src/crypto/crypto_ec.h
+@@ -77,10 +77,10 @@ struct ECDHBitsTraits final {
+       unsigned int offset,
+       ECDHBitsConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const ECDHBitsConfig& params,
+-      ByteSource* out_);
++  static bool DeriveBits(Environment* env,
++                         const ECDHBitsConfig& params,
++                         ByteSource* out_,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_hash.cc b/src/crypto/crypto_hash.cc
+index 46086018..7d974d3d 100644
+--- a/src/crypto/crypto_hash.cc
++++ b/src/crypto/crypto_hash.cc
+@@ -501,10 +501,10 @@ Maybe<bool> HashTraits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool HashTraits::DeriveBits(
+-    Environment* env,
+-    const HashConfig& params,
+-    ByteSource* out) {
++bool HashTraits::DeriveBits(Environment* env,
++                            const HashConfig& params,
++                            ByteSource* out,
++                            CryptoJobMode mode) {
+   EVPMDCtxPointer ctx(EVP_MD_CTX_new());
+ 
+   if (UNLIKELY(!ctx ||
+diff --git a/src/crypto/crypto_hash.h b/src/crypto/crypto_hash.h
+index 07e3a2ae..0ea2114f 100644
+--- a/src/crypto/crypto_hash.h
++++ b/src/crypto/crypto_hash.h
+@@ -70,10 +70,10 @@ struct HashTraits final {
+       unsigned int offset,
+       HashConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const HashConfig& params,
+-      ByteSource* out);
++  static bool DeriveBits(Environment* env,
++                         const HashConfig& params,
++                         ByteSource* out,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_hkdf.cc b/src/crypto/crypto_hkdf.cc
+index 0dd9b424..526be1d0 100644
+--- a/src/crypto/crypto_hkdf.cc
++++ b/src/crypto/crypto_hkdf.cc
+@@ -100,10 +100,10 @@ Maybe<bool> HKDFTraits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool HKDFTraits::DeriveBits(
+-    Environment* env,
+-    const HKDFConfig& params,
+-    ByteSource* out) {
++bool HKDFTraits::DeriveBits(Environment* env,
++                            const HKDFConfig& params,
++                            ByteSource* out,
++                            CryptoJobMode mode) {
+   EVPKeyCtxPointer ctx =
+       EVPKeyCtxPointer(EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr));
+   if (!ctx || !EVP_PKEY_derive_init(ctx.get()) ||
+diff --git a/src/crypto/crypto_hkdf.h b/src/crypto/crypto_hkdf.h
+index c4a537ce..acd2b670 100644
+--- a/src/crypto/crypto_hkdf.h
++++ b/src/crypto/crypto_hkdf.h
+@@ -42,10 +42,10 @@ struct HKDFTraits final {
+       unsigned int offset,
+       HKDFConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const HKDFConfig& params,
+-      ByteSource* out);
++  static bool DeriveBits(Environment* env,
++                         const HKDFConfig& params,
++                         ByteSource* out,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_hmac.cc b/src/crypto/crypto_hmac.cc
+index b101d5c7..5d81a60a 100644
+--- a/src/crypto/crypto_hmac.cc
++++ b/src/crypto/crypto_hmac.cc
+@@ -220,10 +220,10 @@ Maybe<bool> HmacTraits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool HmacTraits::DeriveBits(
+-    Environment* env,
+-    const HmacConfig& params,
+-    ByteSource* out) {
++bool HmacTraits::DeriveBits(Environment* env,
++                            const HmacConfig& params,
++                            ByteSource* out,
++                            CryptoJobMode mode) {
+   HMACCtxPointer ctx(HMAC_CTX_new());
+ 
+   if (!ctx ||
+diff --git a/src/crypto/crypto_hmac.h b/src/crypto/crypto_hmac.h
+index c80cc36f..dd490f05 100644
+--- a/src/crypto/crypto_hmac.h
++++ b/src/crypto/crypto_hmac.h
+@@ -73,10 +73,10 @@ struct HmacTraits final {
+       unsigned int offset,
+       HmacConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const HmacConfig& params,
+-      ByteSource* out);
++  static bool DeriveBits(Environment* env,
++                         const HmacConfig& params,
++                         ByteSource* out,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_pbkdf2.cc b/src/crypto/crypto_pbkdf2.cc
+index 963d0db6..f6d37dad 100644
+--- a/src/crypto/crypto_pbkdf2.cc
++++ b/src/crypto/crypto_pbkdf2.cc
+@@ -111,10 +111,10 @@ Maybe<bool> PBKDF2Traits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool PBKDF2Traits::DeriveBits(
+-    Environment* env,
+-    const PBKDF2Config& params,
+-    ByteSource* out) {
++bool PBKDF2Traits::DeriveBits(Environment* env,
++                              const PBKDF2Config& params,
++                              ByteSource* out,
++                              CryptoJobMode mode) {
+   ByteSource::Builder buf(params.length);
+ 
+   // Both pass and salt may be zero length here.
+diff --git a/src/crypto/crypto_pbkdf2.h b/src/crypto/crypto_pbkdf2.h
+index 6fda7cd3..11ffad78 100644
+--- a/src/crypto/crypto_pbkdf2.h
++++ b/src/crypto/crypto_pbkdf2.h
+@@ -55,10 +55,10 @@ struct PBKDF2Traits final {
+       unsigned int offset,
+       PBKDF2Config* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const PBKDF2Config& params,
+-      ByteSource* out);
++  static bool DeriveBits(Environment* env,
++                         const PBKDF2Config& params,
++                         ByteSource* out,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_random.cc b/src/crypto/crypto_random.cc
+index 48154df7..03bdcd5c 100644
+--- a/src/crypto/crypto_random.cc
++++ b/src/crypto/crypto_random.cc
+@@ -56,10 +56,10 @@ Maybe<bool> RandomBytesTraits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool RandomBytesTraits::DeriveBits(
+-    Environment* env,
+-    const RandomBytesConfig& params,
+-    ByteSource* unused) {
++bool RandomBytesTraits::DeriveBits(Environment* env,
++                                   const RandomBytesConfig& params,
++                                   ByteSource* unused,
++                                   CryptoJobMode mode) {
+   return CSPRNG(params.buffer, params.size).is_ok();
+ }
+ 
+@@ -151,7 +151,8 @@ Maybe<bool> RandomPrimeTraits::AdditionalConfig(
+ 
+ bool RandomPrimeTraits::DeriveBits(Environment* env,
+                                    const RandomPrimeConfig& params,
+-                                   ByteSource* unused) {
++                                   ByteSource* unused,
++                                   CryptoJobMode mode) {
+   // BN_generate_prime_ex() calls RAND_bytes_ex() internally.
+   // Make sure the CSPRNG is properly seeded.
+   CHECK(CSPRNG(nullptr, 0).is_ok());
+@@ -194,11 +195,10 @@ Maybe<bool> CheckPrimeTraits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool CheckPrimeTraits::DeriveBits(
+-    Environment* env,
+-    const CheckPrimeConfig& params,
+-    ByteSource* out) {
+-
++bool CheckPrimeTraits::DeriveBits(Environment* env,
++                                  const CheckPrimeConfig& params,
++                                  ByteSource* out,
++                                  CryptoJobMode mode) {
+   BignumCtxPointer ctx(BN_CTX_new());
+ 
+   int ret = BN_is_prime_ex(
+diff --git a/src/crypto/crypto_random.h b/src/crypto/crypto_random.h
+index a2807ed6..b673cbbf 100644
+--- a/src/crypto/crypto_random.h
++++ b/src/crypto/crypto_random.h
+@@ -32,10 +32,10 @@ struct RandomBytesTraits final {
+       unsigned int offset,
+       RandomBytesConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const RandomBytesConfig& params,
+-      ByteSource* out_);
++  static bool DeriveBits(Environment* env,
++                         const RandomBytesConfig& params,
++                         ByteSource* out_,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+@@ -72,7 +72,8 @@ struct RandomPrimeTraits final {
+   static bool DeriveBits(
+       Environment* env,
+       const RandomPrimeConfig& params,
+-      ByteSource* out_);
++      ByteSource* out_,
++      CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+@@ -105,10 +106,10 @@ struct CheckPrimeTraits final {
+       unsigned int offset,
+       CheckPrimeConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const CheckPrimeConfig& params,
+-      ByteSource* out);
++  static bool DeriveBits(Environment* env,
++                         const CheckPrimeConfig& params,
++                         ByteSource* out,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_scrypt.cc b/src/crypto/crypto_scrypt.cc
+index 4dae07f1..99a6a0e7 100644
+--- a/src/crypto/crypto_scrypt.cc
++++ b/src/crypto/crypto_scrypt.cc
+@@ -114,10 +114,10 @@ Maybe<bool> ScryptTraits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool ScryptTraits::DeriveBits(
+-    Environment* env,
+-    const ScryptConfig& params,
+-    ByteSource* out) {
++bool ScryptTraits::DeriveBits(Environment* env,
++                              const ScryptConfig& params,
++                              ByteSource* out,
++                              CryptoJobMode mode) {
+   ByteSource::Builder buf(params.length);
+ 
+   // Both the pass and salt may be zero-length at this point
+diff --git a/src/crypto/crypto_scrypt.h b/src/crypto/crypto_scrypt.h
+index 3d185637..9ea9d75d 100644
+--- a/src/crypto/crypto_scrypt.h
++++ b/src/crypto/crypto_scrypt.h
+@@ -57,10 +57,10 @@ struct ScryptTraits final {
+       unsigned int offset,
+       ScryptConfig* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const ScryptConfig& params,
+-      ByteSource* out);
++  static bool DeriveBits(Environment* env,
++                         const ScryptConfig& params,
++                         ByteSource* out,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_sig.cc b/src/crypto/crypto_sig.cc
+index ab020efb..b84fd3b7 100644
+--- a/src/crypto/crypto_sig.cc
++++ b/src/crypto/crypto_sig.cc
+@@ -706,11 +706,11 @@ Maybe<bool> SignTraits::AdditionalConfig(
+   return Just(true);
+ }
+ 
+-bool SignTraits::DeriveBits(
+-    Environment* env,
+-    const SignConfiguration& params,
+-    ByteSource* out) {
+-  ClearErrorOnReturn clear_error_on_return;
++bool SignTraits::DeriveBits(Environment* env,
++                            const SignConfiguration& params,
++                            ByteSource* out,
++                            CryptoJobMode mode) {
++  bool can_throw = mode == CryptoJobMode::kCryptoJobSync;
+   EVPMDCtxPointer context(EVP_MD_CTX_new());
+   EVP_PKEY_CTX* ctx = nullptr;
+ 
+@@ -722,7 +722,7 @@ bool SignTraits::DeriveBits(
+               params.digest,
+               nullptr,
+               params.key.get())) {
+-        crypto::CheckThrow(env, SignBase::Error::kSignInit);
++        if (can_throw) crypto::CheckThrow(env, SignBase::Error::kSignInit);
+         return false;
+       }
+       break;
+@@ -733,7 +733,7 @@ bool SignTraits::DeriveBits(
+               params.digest,
+               nullptr,
+               params.key.get())) {
+-        crypto::CheckThrow(env, SignBase::Error::kSignInit);
++        if (can_throw) crypto::CheckThrow(env, SignBase::Error::kSignInit);
+         return false;
+       }
+       break;
+@@ -751,7 +751,7 @@ bool SignTraits::DeriveBits(
+           ctx,
+           padding,
+           salt_length)) {
+-    crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
++    if (can_throw) crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
+     return false;
+   }
+ 
+@@ -765,7 +765,8 @@ bool SignTraits::DeriveBits(
+             &len,
+             params.data.data<unsigned char>(),
+             params.data.size())) {
+-          crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
++          if (can_throw)
++            crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
+           return false;
+         }
+         ByteSource::Builder buf(len);
+@@ -774,7 +775,8 @@ bool SignTraits::DeriveBits(
+                             &len,
+                             params.data.data<unsigned char>(),
+                             params.data.size())) {
+-          crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
++          if (can_throw)
++            crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
+           return false;
+         }
+         *out = std::move(buf).release(len);
+@@ -785,13 +787,15 @@ bool SignTraits::DeriveBits(
+                 params.data.data<unsigned char>(),
+                 params.data.size()) ||
+             !EVP_DigestSignFinal(context.get(), nullptr, &len)) {
+-          crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
++          if (can_throw)
++            crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
+           return false;
+         }
+         ByteSource::Builder buf(len);
+         if (!EVP_DigestSignFinal(
+                 context.get(), buf.data<unsigned char>(), &len)) {
+-          crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
++          if (can_throw)
++            crypto::CheckThrow(env, SignBase::Error::kSignPrivateKey);
+           return false;
+         }
+ 
+diff --git a/src/crypto/crypto_sig.h b/src/crypto/crypto_sig.h
+index 63320147..3b2801fa 100644
+--- a/src/crypto/crypto_sig.h
++++ b/src/crypto/crypto_sig.h
+@@ -147,10 +147,10 @@ struct SignTraits final {
+       unsigned int offset,
+       SignConfiguration* params);
+ 
+-  static bool DeriveBits(
+-      Environment* env,
+-      const SignConfiguration& params,
+-      ByteSource* out);
++  static bool DeriveBits(Environment* env,
++                         const SignConfiguration& params,
++                         ByteSource* out,
++                         CryptoJobMode mode);
+ 
+   static v8::Maybe<bool> EncodeOutput(
+       Environment* env,
+diff --git a/src/crypto/crypto_util.h b/src/crypto/crypto_util.h
+index 0ae2946e..260df59d 100644
+--- a/src/crypto/crypto_util.h
++++ b/src/crypto/crypto_util.h
+@@ -498,9 +498,10 @@ class DeriveBitsJob final : public CryptoJob<DeriveBitsTraits> {
+             std::move(params)) {}
+ 
+   void DoThreadPoolWork() override {
++    ClearErrorOnReturn clear_error_on_return;
+     if (!DeriveBitsTraits::DeriveBits(
+             AsyncWrap::env(),
+-            *CryptoJob<DeriveBitsTraits>::params(), &out_)) {
++            *CryptoJob<DeriveBitsTraits>::params(), &out_, this->mode())) {
+       CryptoErrorStore* errors = CryptoJob<DeriveBitsTraits>::errors();
+       errors->Capture();
+       if (errors->Empty())
+diff --git a/test/parallel/test-crypto-async-sign-verify.js b/test/parallel/test-crypto-async-sign-verify.js
+index 4e3c32fd..5924d36e 100644
+--- a/test/parallel/test-crypto-async-sign-verify.js
++++ b/test/parallel/test-crypto-async-sign-verify.js
+@@ -141,3 +141,29 @@ test('dsa_public.pem', 'dsa_private.pem', 'sha256', false,
+   })
+   .catch(common.mustNotCall());
+ }
++
++{
++  const untrustedKey = `-----BEGIN PUBLIC KEY-----
++MCowBQYDK2VuAyEA6pwGRbadNQAI/tYN8+/p/0/hbsdHfOEGr1ADiLVk/Gc=
++-----END PUBLIC KEY-----`;
++  const data = crypto.randomBytes(32);
++  const signature = crypto.randomBytes(16);
++
++  const expected = common.hasOpenSSL3 ?
++    /operation not supported for this keytype/ : /no default digest/;
++
++  crypto.verify(undefined, data, untrustedKey, signature, common.mustCall((err) => {
++    assert.ok(err);
++    assert.match(err.message, expected);
++  }));
++}
++
++{
++  const { privateKey } = crypto.generateKeyPairSync('rsa', {
++    modulusLength: 512
++  });
++  crypto.sign('sha512', 'message', privateKey, common.mustCall((err) => {
++    assert.ok(err);
++    assert.match(err.message, /digest too big for rsa key/);
++  }));
++}
+-- 
+2.34.1
+

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -5,7 +5,7 @@ Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
 Version:        20.14.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        BSD AND MIT AND Public Domain AND NAIST-2003 AND Artistic-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -27,6 +27,8 @@ Patch8:         CVE-2020-28493.patch
 Patch9:         CVE-2024-34064.patch
 Patch10:        CVE-2025-27516.patch
 Patch11:        CVE-2025-47279.patch
+Patch12:        CVE-2025-23165.patch
+Patch13:        CVE-2025-23166.patch
 BuildRequires:  brotli-devel
 BuildRequires:  c-ares-devel
 BuildRequires:  coreutils >= 8.22
@@ -138,6 +140,9 @@ make cctest
 %{_prefix}/lib/node_modules/*
 
 %changelog
+* Tue May 27 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 20.14.0-9
+- Patch CVE-2025-23165, CVE-2025-23166
+
 * Wed May 21 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 20.14.0-8
 - Patch CVE-2025-47279
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2025-23165 CVE-2025-23166

CVE-2025-23166 Upstream Patch Reference: https://github.com/nodejs/node/commit/6c57465920cf1b981a63031e71b1e4a73bf9beaa
CVE-2025-23165 Upstream Patch Reference: https://github.com/nodejs/node/commit/9e13bf0a81e15c7b3a9f1826dccbcea991d7e63a

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified:   SPECS/nodejs/nodejs.spec
- added:  SPECS/nodejs/CVE-2025-23165.patch
- added:  SPECS/nodejs/CVE-2025-23166.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-23165
- https://nvd.nist.gov/vuln/detail/CVE-2025-23166

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Due to insufficient memory in vm could not get a successful build. It fails with the same error even without my changes
