### PR TITLE
[Medium] Patch binutils for CVE-2025-5245 and CVE-2025-5244

### DIFF
--- a/SPECS/binutils/CVE-2025-5244.patch
+++ b/SPECS/binutils/CVE-2025-5244.patch
@@ -1,0 +1,28 @@
+From 186b3fef5b6938267c1b997ac63108a2938316f7 Mon Sep 17 00:00:00 2001
+From: AkarshHCL <v-akarshc@microsoft.com>
+Date: Thu, 29 May 2025 05:52:21 +0000
+Subject: [PATCH] Address CVE-2025-5244
+
+Upstream Patch reference: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=d1458933830456e54223d9fc61f0d9b3a19256f5
+
+---
+ bfd/elflink.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 30b32bf9..be2a2f53 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -14120,7 +14120,8 @@ elf_gc_sweep (bfd *abfd, struct bfd_link_info *info)
+ 	  if (o->flags & SEC_GROUP)
+ 	    {
+ 	      asection *first = elf_next_in_group (o);
+-	      o->gc_mark = first->gc_mark;
++	      if (first != NULL)
++		o->gc_mark = first->gc_mark;
+ 	    }
+ 
+ 	  if (o->gc_mark)
+-- 
+2.45.2
+

--- a/SPECS/binutils/CVE-2025-5245.patch
+++ b/SPECS/binutils/CVE-2025-5245.patch
@@ -1,0 +1,41 @@
+From 0337a44778cd8c29da76653f438b39f7ce674fd1 Mon Sep 17 00:00:00 2001
+From: AkarshHCL <v-akarshc@microsoft.com>
+Date: Wed, 28 May 2025 12:10:43 +0000
+Subject: [PATCH] Address CVE-2025-5245
+
+Upstream Patch Reference: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=6c3458a8b7ee7d39f070c7b2350851cb2110c65a
+
+---
+ binutils/debug.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/binutils/debug.c b/binutils/debug.c
+index bb26d914..59ba206e 100644
+--- a/binutils/debug.c
++++ b/binutils/debug.c
+@@ -2554,9 +2554,6 @@ debug_write_type (struct debug_handle *info,
+     case DEBUG_KIND_UNION_CLASS:
+       return debug_write_class_type (info, fns, fhandle, type, tag);
+     case DEBUG_KIND_ENUM:
+-      if (type->u.kenum == NULL)
+-	return (*fns->enum_type) (fhandle, tag, (const char **) NULL,
+-				  (bfd_signed_vma *) NULL);
+       return (*fns->enum_type) (fhandle, tag, type->u.kenum->names,
+ 				type->u.kenum->values);
+     case DEBUG_KIND_POINTER:
+@@ -3097,9 +3094,9 @@ debug_type_samep (struct debug_handle *info, struct debug_type_s *t1,
+       break;
+ 
+     case DEBUG_KIND_ENUM:
+-      if (t1->u.kenum == NULL)
+-	ret = t2->u.kenum == NULL;
+-      else if (t2->u.kenum == NULL)
++      if (t1->u.kenum->names == NULL)
++	ret = t2->u.kenum->names == NULL;
++      else if (t2->u.kenum->names == NULL)
+ 	ret = false;
+       else
+ 	{
+-- 
+2.45.2
+

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -21,7 +21,7 @@
 Summary:        Contains a linker, an assembler, and other tools
 Name:           binutils
 Version:        2.41
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -38,6 +38,7 @@ Patch4:         CVE-2025-1181.patch
 Patch5:         CVE-2025-1182.patch
 Patch6:         CVE-2025-0840.patch
 Patch7:		CVE-2025-1744.patch
+Patch8:         CVE-2025-5245.patch
 Provides:       bundled(libiberty)
 
 # Moving macro before the "SourceX" tags breaks PR checks parsing the specs.
@@ -327,6 +328,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %do_files aarch64-linux-gnu %{build_aarch64}
 
 %changelog
+* Wed May 28 2025 Akarsh Chaudhary <v-akarshc@microsoft.com> - 2.41-6
+- Patch CVE-2025-5245
+
 * Tue Mar 11 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 2.41-5
 - Fix CVE-2025-1744
 

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -39,6 +39,7 @@ Patch5:         CVE-2025-1182.patch
 Patch6:         CVE-2025-0840.patch
 Patch7:		CVE-2025-1744.patch
 Patch8:         CVE-2025-5245.patch
+Patch9:         CVE-2025-5244.patch
 Provides:       bundled(libiberty)
 
 # Moving macro before the "SourceX" tags breaks PR checks parsing the specs.
@@ -329,7 +330,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 
 %changelog
 * Wed May 28 2025 Akarsh Chaudhary <v-akarshc@microsoft.com> - 2.41-6
-- Patch CVE-2025-5245
+- Patch CVE-2025-5245 , CVE-2025-5244
 
 * Tue Mar 11 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 2.41-5
 - Fix CVE-2025-1744

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -13,8 +13,8 @@ zlib-devel-1.3.1-1.azl3.aarch64.rpm
 file-5.45-1.azl3.aarch64.rpm
 file-devel-5.45-1.azl3.aarch64.rpm
 file-libs-5.45-1.azl3.aarch64.rpm
-binutils-2.41-5.azl3.aarch64.rpm
-binutils-devel-2.41-5.azl3.aarch64.rpm
+binutils-2.41-6.azl3.aarch64.rpm
+binutils-devel-2.41-6.azl3.aarch64.rpm
 gmp-6.3.0-1.azl3.aarch64.rpm
 gmp-devel-6.3.0-1.azl3.aarch64.rpm
 mpfr-4.2.1-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -13,8 +13,8 @@ zlib-devel-1.3.1-1.azl3.x86_64.rpm
 file-5.45-1.azl3.x86_64.rpm
 file-devel-5.45-1.azl3.x86_64.rpm
 file-libs-5.45-1.azl3.x86_64.rpm
-binutils-2.41-5.azl3.x86_64.rpm
-binutils-devel-2.41-5.azl3.x86_64.rpm
+binutils-2.41-6.azl3.x86_64.rpm
+binutils-devel-2.41-6.azl3.x86_64.rpm
 gmp-6.3.0-1.azl3.x86_64.rpm
 gmp-devel-6.3.0-1.azl3.x86_64.rpm
 mpfr-4.2.1-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -30,9 +30,9 @@ bash-5.2.15-3.azl3.aarch64.rpm
 bash-debuginfo-5.2.15-3.azl3.aarch64.rpm
 bash-devel-5.2.15-3.azl3.aarch64.rpm
 bash-lang-5.2.15-3.azl3.aarch64.rpm
-binutils-2.41-5.azl3.aarch64.rpm
-binutils-debuginfo-2.41-5.azl3.aarch64.rpm
-binutils-devel-2.41-5.azl3.aarch64.rpm
+binutils-2.41-6.azl3.aarch64.rpm
+binutils-debuginfo-2.41-6.azl3.aarch64.rpm
+binutils-devel-2.41-6.azl3.aarch64.rpm
 bison-3.8.2-1.azl3.aarch64.rpm
 bison-debuginfo-3.8.2-1.azl3.aarch64.rpm
 bzip2-1.0.8-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -70,7 +70,7 @@ cracklib-lang-2.9.11-1.azl3.x86_64.rpm
 createrepo_c-1.0.3-1.azl3.x86_64.rpm
 createrepo_c-debuginfo-1.0.3-1.azl3.x86_64.rpm
 createrepo_c-devel-1.0.3-1.azl3.x86_64.rpm
-cross-binutils-common-2.41-5.azl3.noarch.rpm
+cross-binutils-common-2.41-6.azl3.noarch.rpm
 cross-gcc-common-13.2.0-7.azl3.noarch.rpm
 curl-8.11.1-3.azl3.x86_64.rpm
 curl-debuginfo-8.11.1-3.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -32,10 +32,10 @@ bash-5.2.15-3.azl3.x86_64.rpm
 bash-debuginfo-5.2.15-3.azl3.x86_64.rpm
 bash-devel-5.2.15-3.azl3.x86_64.rpm
 bash-lang-5.2.15-3.azl3.x86_64.rpm
-binutils-2.41-5.azl3.x86_64.rpm
-binutils-aarch64-linux-gnu-2.41-5.azl3.x86_64.rpm
-binutils-debuginfo-2.41-5.azl3.x86_64.rpm
-binutils-devel-2.41-5.azl3.x86_64.rpm
+binutils-2.41-6.azl3.x86_64.rpm
+binutils-aarch64-linux-gnu-2.41-6.azl3.x86_64.rpm
+binutils-debuginfo-2.41-6.azl3.x86_64.rpm
+binutils-devel-2.41-6.azl3.x86_64.rpm
 bison-3.8.2-1.azl3.x86_64.rpm
 bison-debuginfo-3.8.2-1.azl3.x86_64.rpm
 bzip2-1.0.8-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2025-5245  CVE-2025-5244

CVE-2025-5245 Upstream Patch Reference: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=6c3458a8b7ee7d39f070c7b2350851cb2110c65a
CVE-2025-5244  Upstream Patch Reference: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=d1458933830456e54223d9fc61f0d9b3a19256f5


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/binutils/CVE-2025-5244.patch
- SPECS/binutils/CVE-2025-5244.patch
- SPECS/binutils/binutils.spec
- toolkit/resources/manifests/package/pkggen_core_aarch64.txt
- toolkit/resources/manifests/package/pkggen_core_x86_64.txt
- toolkit/resources/manifests/package/toolchain_x86_64.txt


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-5245

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
