### PR TITLE
pciutils: Add %{_sbindir}/lspci symlink to %{_bindir}/lspci

### DIFF
--- a/SPECS/pciutils/pciutils.spec
+++ b/SPECS/pciutils/pciutils.spec
@@ -3,7 +3,7 @@
 Summary:        System utilities to list pci devices
 Name:           pciutils
 Version:        3.11.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,8 @@ Group:          System Environment/System Utilities
 URL:            https://mj.ucw.cz/sw/pciutils
 Source0:        https://www.kernel.org/pub/software/utils/%{name}/%{name}-%{version}.tar.gz
 Requires:       %{name}-libs = %{version}-%{release}
+Provides:	/sbin/lspci /sbin/setpci
+Provides:	/bin/lspci
 
 %description
 The pciutils package contains a set of programs for listing PCI devices, inspecting their status and setting their configuration registers.
@@ -45,6 +47,10 @@ make DESTDIR=%{buildroot} \
     SHARED=yes \
     install install-lib
 
+%if "%{_sbindir}" != "%{_bindir}"
+ln -sr %{buildroot}/%{_bindir}/lspci %{buildroot}/%{_sbindir}/lspci
+%endif
+
 %files
 %doc README ChangeLog pciutils.lsm
 %defattr(-,root,root)
@@ -64,6 +70,9 @@ make DESTDIR=%{buildroot} \
 %{_includedir}/*
 
 %changelog
+* Mon Jun 2 2025 TD Mackey <tdmackey@booleanhaiku.com=> - 3.11.1-2
+- add /sbin/lspci symlink to /bin/lspci for backwarsd compatibility
+
 * Wed Feb 28 2024 Cameron Baird <cameronbaird@microsoft.com> - 3.11.1-1
 - Upgrade to 3.11.1
 - Package new binary, lspci


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Between AzureLinux 2 and AzureLinux 3 the path of lspci moved to /usr/bin/lspci from /usr/sbin/lspci.

However, a lot of code hardcodes /sbin/lspci. To continue supporting backwards compatibility with this legacy code, symlink binary to its historical location.
   
Similar pattern adopted by Fedora, https://src.fedoraproject.org/rpms/pciutils/c/9f3c38a97bbdef6a633f5be8e9ac0d333a566268. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- add /sbin/lspci symlink to /bin/lspci for backwards compatibility

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Links to CVEs  <!-- optional -->
None

###### Test Methodology
```
tdmackey@azl3 [ ~ ]$ which lspci
/usr/bin/lspci
tdmackey@azl3 [ ~ ]$ /sbin/lspci
bash: /sbin/lspci: No such file or directory
tdmackey@azl3 [ ~ ]$ sudo dnf upgrade ./rpmbuild/RPMS/x86_64/pciutils-*
Last metadata expiration check: 0:01:08 ago on Tue Jun  3 00:05:17 2025.
Package pciutils-devel not installed, cannot update it.
No match for argument: rpmbuild/RPMS/x86_64/pciutils-devel-3.11.1-2.azl3.x86_64.rpm
Dependencies resolved.
============================================================================================================================================================================================================================================================================================================================================================
 Package                                                                                Architecture                                                                    Version                                                                                 Repository                                                                             Size
============================================================================================================================================================================================================================================================================================================================================================
Upgrading:
 pciutils                                                                               x86_64                                                                          3.11.1-2.azl3                                                                           @commandline                                                                          448 k
 pciutils-libs                                                                          x86_64                                                                          3.11.1-2.azl3                                                                           @commandline                                                                           57 k

Transaction Summary
============================================================================================================================================================================================================================================================================================================================================================
Upgrade  2 Packages

Total size: 505 k
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                                                                                                                                    1/1 
  Upgrading        : pciutils-libs-3.11.1-2.azl3.x86_64                                                                                                                                                                                                                                                                                                 1/4 
  Upgrading        : pciutils-3.11.1-2.azl3.x86_64                                                                                                                                                                                                                                                                                                      2/4 
  Cleanup          : pciutils-3.11.1-1.azl3.x86_64                                                                                                                                                                                                                                                                                                      3/4 
  Cleanup          : pciutils-libs-3.11.1-1.azl3.x86_64                                                                                                                                                                                                                                                                                                 4/4 
  Running scriptlet: pciutils-libs-3.11.1-1.azl3.x86_64                                                                                                                                                                                                                                                                                                 4/4 
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-6.6.78.1-3.azl3
Found initrd image: /boot/initramfs-6.6.78.1-3.azl3.img
fgrep: warning: fgrep is obsolescent; using grep -F
Found linux image: /boot/vmlinuz-6.6.78.1-3.azl3
Found initrd image: /boot/initramfs-6.6.78.1-3.azl3.img
Warning: os-prober will not be executed to detect other bootable partitions.
Systems on them will not be added to the GRUB boot configuration.
Check GRUB_DISABLE_OS_PROBER documentation entry.
Adding boot menu entry for UEFI Firmware Settings ...
done


Upgraded:
  pciutils-3.11.1-2.azl3.x86_64                                                                                                                                              pciutils-libs-3.11.1-2.azl3.x86_64                                                                                                                                             

Complete!
tdmackey@azl3 [ ~ ]$ /sbin/lspci
00:00.0 Host bridge: Intel Corporation Device 4621 (rev 02)
00:02.0 VGA compatible controller: Intel Corporation Alder Lake-P GT2 [Iris Xe Graphics] (rev 0c)
00:06.0 PCI bridge: Intel Corporation 12th Gen Core Processor PCI Express x4 Controller #0 (rev 02)
00:07.0 PCI bridge: Intel Corporation Alder Lake-P Thunderbolt 4 PCI Express Root Port #0 (rev 02)
00:07.2 PCI bridge: Intel Corporation Alder Lake-P Thunderbolt 4 PCI Express Root Port #2 (rev 02)
00:08.0 System peripheral: Intel Corporation 12th Gen Core Processor Gaussian & Neural Accelerator (rev 02)
00:0a.0 Signal processing controller: Intel Corporation Platform Monitoring Technology (rev 01)
00:0d.0 USB controller: Intel Corporation Alder Lake-P Thunderbolt 4 USB Controller (rev 02)
00:0d.2 USB controller: Intel Corporation Alder Lake-P Thunderbolt 4 NHI #0 (rev 02)
00:0d.3 USB controller: Intel Corporation Alder Lake-P Thunderbolt 4 NHI #1 (rev 02)
00:14.0 USB controller: Intel Corporation Alder Lake PCH USB 3.2 xHCI Host Controller (rev 01)
00:14.2 RAM memory: Intel Corporation Alder Lake PCH Shared SRAM (rev 01)
00:15.0 Serial bus controller: Intel Corporation Alder Lake PCH Serial IO I2C Controller #0 (rev 01)
00:15.1 Serial bus controller: Intel Corporation Alder Lake PCH Serial IO I2C Controller #1 (rev 01)
00:16.0 Communication controller: Intel Corporation Alder Lake PCH HECI Controller (rev 01)
00:17.0 SATA controller: Intel Corporation Alder Lake-P SATA AHCI Controller (rev 01)
00:1d.0 PCI bridge: Intel Corporation Alder Lake PCI Express Root Port #9 (rev 01)
00:1f.0 ISA bridge: Intel Corporation Alder Lake PCH eSPI Controller (rev 01)
00:1f.3 Multimedia audio controller: Intel Corporation Alder Lake PCH-P High Definition Audio Controller (rev 01)
00:1f.4 SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
00:1f.5 Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
01:00.0 Non-Volatile memory controller: Sandisk Corp WD Black SN770 / PC SN740 256GB / PC SN560 (DRAM-less) NVMe SSD (rev 01)
56:00.0 Ethernet controller: Intel Corporation Ethernet Controller I225-V (rev 03)
```