### PR TITLE
[MEDIUM] patch cmake for CVE-2025-4947

### DIFF
--- a/SPECS/cmake/CVE-2025-4947.patch
+++ b/SPECS/cmake/CVE-2025-4947.patch
@@ -1,0 +1,40 @@
+From f0b4659205da774d835434cfbf40425c25a0c813 Mon Sep 17 00:00:00 2001
+From: dj_palli <v-dpalli@microsoft.com>
+Date: Wed, 4 Jun 2025 03:37:55 +0000
+Subject: [PATCH] Address  CVE-2025-4947.patch
+
+Upstream patch URL: https://github.com/curl/curl/commit/a85f1df4803bbd272905c9e7125
+
+---
+ Utilities/cmcurl/lib/vquic/vquic-tls.c | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/vquic/vquic-tls.c b/Utilities/cmcurl/lib/vquic/vquic-tls.c
+index aca18b45..61cb6c51 100644
+--- a/Utilities/cmcurl/lib/vquic/vquic-tls.c
++++ b/Utilities/cmcurl/lib/vquic/vquic-tls.c
+@@ -324,15 +324,13 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
+ #elif defined(USE_WOLFSSL)
+   (void)data;
+   if(conn_config->verifyhost) {
+-    if(peer->sni) {
+-      WOLFSSL_X509* cert = wolfSSL_get_peer_certificate(ctx->ssl);
+-      if(wolfSSL_X509_check_host(cert, peer->sni, strlen(peer->sni), 0, NULL)
+-            == WOLFSSL_FAILURE) {
+-        result = CURLE_PEER_FAILED_VERIFICATION;
+-      }
+-      wolfSSL_X509_free(cert);
++    char *snihost = peer->sni ? peer->sni : peer->hostname;
++    WOLFSSL_X509* cert = wolfSSL_get_peer_certificate(ctx->wssl.ssl);
++    if(wolfSSL_X509_check_host(cert, snihost, strlen(snihost), 0, NULL)
++          == WOLFSSL_FAILURE) {
++      result = CURLE_PEER_FAILED_VERIFICATION;
+     }
+-
++    wolfSSL_X509_free(cert);
+   }
+ #endif
+   return result;
+-- 
+2.45.2
+

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -27,9 +27,6 @@ Patch7:         CVE-2023-44487.patch
 Patch8:         CVE-2023-35945.patch
 Patch9:		CVE-2024-48615.patch
 Patch10:	CVE-2025-4947.patch
-
-
-
 BuildRequires:  bzip2
 BuildRequires:  bzip2-devel
 BuildRequires:  curl

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -106,7 +106,7 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_libdir}/rpm/macros.d/macros.cmake
 
 %changelog
-* Wed Jun 03 2025 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 3.30.3-7
+* Tue Jun 03 2025 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 3.30.3-7
 - Patch CVE-2025-4947
 
 * Mon Apr 07 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 3.30.3-6

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -2,7 +2,7 @@
 Summary:        Cmake
 Name:           cmake
 Version:        3.30.3
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        BSD AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -26,6 +26,10 @@ Patch7:         CVE-2023-44487.patch
 # required to determine what upstream patches are included.
 Patch8:         CVE-2023-35945.patch
 Patch9:		CVE-2024-48615.patch
+Patch10:	CVE-2025-4947.patch
+
+
+
 BuildRequires:  bzip2
 BuildRequires:  bzip2-devel
 BuildRequires:  curl
@@ -105,6 +109,9 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_libdir}/rpm/macros.d/macros.cmake
 
 %changelog
+* Wed Jun 03 2025 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 3.30.3-7
+- Patch CVE-2025-4947
+
 * Mon Apr 07 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 3.30.3-6
 - Backport patch to fix CVE-2024-48615
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -51,8 +51,8 @@ check-debuginfo-0.15.2-1.azl3.aarch64.rpm
 chkconfig-1.25-1.azl3.aarch64.rpm
 chkconfig-debuginfo-1.25-1.azl3.aarch64.rpm
 chkconfig-lang-1.25-1.azl3.aarch64.rpm
-cmake-3.30.3-6.azl3.aarch64.rpm
-cmake-debuginfo-3.30.3-6.azl3.aarch64.rpm
+cmake-3.30.3-7.azl3.aarch64.rpm
+cmake-debuginfo-3.30.3-7.azl3.aarch64.rpm
 coreutils-9.4-6.azl3.aarch64.rpm
 coreutils-debuginfo-9.4-6.azl3.aarch64.rpm
 coreutils-lang-9.4-6.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -54,8 +54,8 @@ check-debuginfo-0.15.2-1.azl3.x86_64.rpm
 chkconfig-1.25-1.azl3.x86_64.rpm
 chkconfig-debuginfo-1.25-1.azl3.x86_64.rpm
 chkconfig-lang-1.25-1.azl3.x86_64.rpm
-cmake-3.30.3-6.azl3.x86_64.rpm
-cmake-debuginfo-3.30.3-6.azl3.x86_64.rpm
+cmake-3.30.3-7.azl3.x86_64.rpm
+cmake-debuginfo-3.30.3-7.azl3.x86_64.rpm
 coreutils-9.4-6.azl3.x86_64.rpm
 coreutils-debuginfo-9.4-6.azl3.x86_64.rpm
 coreutils-lang-9.4-6.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Address CVE-2025-4947
- CVE-2025-4947  Upstream Patch Reference: https://github.com/curl/curl/commit/a85f1df4803bbd272905c9e7125
- [ ]  The upstream patch has been applied cleanly.
- [x]   The upstream patch has been modified.
   - Excluded /tests/http/ and /testenv/ sections from the upstream patch due to their absence in the package.
 
  
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump up the release number by 1
- modified: SPECS/cmake/cmake.spec
- added: SPECS/cmake/CVE-2025-4947.patch


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4947

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
