### PR TITLE
[MEDIUM] Patch glib for CVE-2025-4373 and CVE-2025-6052

### DIFF
--- a/SPECS/glib/CVE-2025-4373.patch
+++ b/SPECS/glib/CVE-2025-4373.patch
@@ -1,0 +1,105 @@
+From f8cd5f93b2ba7fedf79fd4572ad3275bc8b52f77 Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Mon, 9 Jun 2025 07:06:12 -0400
+Subject: [PATCH] Address CVE-2025-4373
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588.patch
+
+---
+ glib/gstring.c | 36 +++++++++++++++++++++++-------------
+ 1 file changed, 23 insertions(+), 13 deletions(-)
+
+diff --git a/glib/gstring.c b/glib/gstring.c
+index 9f04144..d016b65 100644
+--- a/glib/gstring.c
++++ b/glib/gstring.c
+@@ -490,8 +490,9 @@ g_string_insert_len (GString     *string,
+     return string;
+ 
+   if (len < 0)
+-    len = strlen (val);
+-  len_unsigned = len;
++    len_unsigned = strlen (val);
++  else
++    len_unsigned = len;
+ 
+   if (pos < 0)
+     pos_unsigned = string->len;
+@@ -788,10 +789,12 @@ g_string_insert_c (GString *string,
+   g_string_maybe_expand (string, 1);
+ 
+   if (pos < 0)
+-    pos = string->len;
++    pos_unsigned = string->len;
+   else
+-    g_return_val_if_fail ((gsize) pos <= string->len, string);
+-  pos_unsigned = pos;
++    {
++      pos_unsigned = pos;
++      g_return_val_if_fail (pos_unsigned <= string->len, string);
++    }
+ 
+   /* If not just an append, move the old stuff */
+   if (pos_unsigned < string->len)
+@@ -824,6 +827,7 @@ g_string_insert_unichar (GString  *string,
+                          gssize    pos,
+                          gunichar  wc)
+ {
++  gsize pos_unsigned;
+   gint charlen, first, i;
+   gchar *dest;
+ 
+@@ -865,15 +869,18 @@ g_string_insert_unichar (GString  *string,
+   g_string_maybe_expand (string, charlen);
+ 
+   if (pos < 0)
+-    pos = string->len;
++    pos_unsigned = string->len;
+   else
+-    g_return_val_if_fail ((gsize) pos <= string->len, string);
++    {
++      pos_unsigned = pos;
++      g_return_val_if_fail (pos_unsigned <= string->len, string);
++    }
+ 
+   /* If not just an append, move the old stuff */
+-  if ((gsize) pos < string->len)
+-    memmove (string->str + pos + charlen, string->str + pos, string->len - pos);
++  if (pos_unsigned < string->len)
++    memmove (string->str + pos_unsigned + charlen, string->str + pos_unsigned, string->len - pos_unsigned);
+ 
+-  dest = string->str + pos;
++  dest = string->str + pos_unsigned;
+   /* Code copied from g_unichar_to_utf() */
+   for (i = charlen - 1; i > 0; --i)
+     {
+@@ -931,6 +938,7 @@ g_string_overwrite_len (GString     *string,
+                         const gchar *val,
+                         gssize       len)
+ {
++  gssize len_unsigned;
+   gsize end;
+ 
+   g_return_val_if_fail (string != NULL, NULL);
+@@ -942,14 +950,16 @@ g_string_overwrite_len (GString     *string,
+   g_return_val_if_fail (pos <= string->len, string);
+ 
+   if (len < 0)
+-    len = strlen (val);
++    len_unsigned = strlen (val);
++  else
++    len_unsigned = len;
+ 
+-  end = pos + len;
++  end = pos + len_unsigned;
+ 
+   if (end > string->len)
+     g_string_maybe_expand (string, end - string->len);
+ 
+-  memcpy (string->str + pos, val, len);
++  memcpy (string->str + pos, val, len_unsigned);
+ 
+   if (end > string->len)
+     {
+-- 
+2.34.1
+

--- a/SPECS/glib/CVE-2025-6052.patch
+++ b/SPECS/glib/CVE-2025-6052.patch
@@ -1,0 +1,39 @@
+From fc1479f9951f046198bb50c89b052f9c0ad09a06 Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Sun, 22 Jun 2025 08:32:39 -0400
+Subject: [PATCH] Address CVE-2025-6052
+
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/glib/-/commit/37eecaa7efc48a0df22277444ff25ff791ac0ac1
+---
+ glib/gstring.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/glib/gstring.c b/glib/gstring.c
+index d016b65..75f7853 100644
+--- a/glib/gstring.c
++++ b/glib/gstring.c
+@@ -78,10 +78,6 @@ static void
+ g_string_expand (GString *string,
+                  gsize    len)
+ {
+-  /* Detect potential overflow */
+-  if G_UNLIKELY ((G_MAXSIZE - string->len - 1) < len)
+-    g_error ("adding %" G_GSIZE_FORMAT " to string would overflow", len);
+-
+   string->allocated_len = g_nearest_pow (string->len + len + 1);
+   /* If the new size is bigger than G_MAXSIZE / 2, only allocate enough
+    * memory for this string and don't over-allocate.
+@@ -96,6 +92,10 @@ static inline void
+ g_string_maybe_expand (GString *string,
+                        gsize    len)
+ {
++  /* Detect potential overflow */
++  if G_UNLIKELY ((G_MAXSIZE - string->len - 1) < len)
++    g_error ("adding %" G_GSIZE_FORMAT " to string would overflow", len);
++
+   if (G_UNLIKELY (string->len + len >= string->allocated_len))
+     g_string_expand (string, len);
+ }
+-- 
+2.34.1
+

--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -12,6 +12,7 @@ Source0:        https://ftp.gnome.org/pub/gnome/sources/glib/%{majorver}/%{name}
 Patch0:         CVE-2024-52533.patch
 Patch1:         CVE-2025-3360.patch
 Patch2:         CVE-2025-4373.patch
+Patch3:         CVE-2025-6052.patch
 BuildRequires:  cmake
 BuildRequires:  gtk-doc
 BuildRequires:  libffi-devel
@@ -126,7 +127,7 @@ touch %{buildroot}%{_libdir}/gio/modules/giomodule.cache
 
 %changelog
 * Mon Jun 09 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 2.78.6-3
-- Patch CVE-2025-4373
+- Patch CVE-2025-4373 and CVE-2025-6052.patch
 
 * Wed Apr 16 2025 Archana Shettigar <v-shettigara@microsoft.com> - 2.78.6-2
 - Patch CVE-2025-3360

--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -92,7 +92,7 @@ touch %{buildroot}%{_libdir}/gio/modules/giomodule.cache
 
 %files
 %defattr(-,root,root)
-%license COPYING
+%license LICENSES/LGPL-2.1-or-later.txt
 %{_libdir}/libglib-*.so.*
 %{_libdir}/libgthread-*.so.*
 %{_libdir}/libgmodule-*.so.*
@@ -102,7 +102,6 @@ touch %{buildroot}%{_libdir}/gio/modules/giomodule.cache
 
 %files devel
 %defattr(-, root, root)
-%license COPYING
 %{_bindir}/*
 %exclude %{_bindir}/glib-compile-schemas
 %exclude %{_bindir}/gsettings

--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -2,7 +2,7 @@
 Summary:        Low-level libraries useful for providing data structure handling for C.
 Name:           glib
 Version:        2.78.6
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,7 @@ URL:            https://developer.gnome.org/glib/
 Source0:        https://ftp.gnome.org/pub/gnome/sources/glib/%{majorver}/%{name}-%{version}.tar.xz
 Patch0:         CVE-2024-52533.patch
 Patch1:         CVE-2025-3360.patch
+Patch2:         CVE-2025-4373.patch
 BuildRequires:  cmake
 BuildRequires:  gtk-doc
 BuildRequires:  libffi-devel
@@ -123,6 +124,9 @@ touch %{buildroot}%{_libdir}/gio/modules/giomodule.cache
 %doc %{_datadir}/gtk-doc/html/*
 
 %changelog
+* Mon Jun 09 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 2.78.6-3
+- Patch CVE-2025-4373
+
 * Wed Apr 16 2025 Archana Shettigar <v-shettigara@microsoft.com> - 2.78.6-2
 - Patch CVE-2025-3360
 

--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -101,6 +101,7 @@ touch %{buildroot}%{_libdir}/gio/modules/giomodule.cache
 
 %files devel
 %defattr(-, root, root)
+%license COPYING
 %{_bindir}/*
 %exclude %{_bindir}/glib-compile-schemas
 %exclude %{_bindir}/gsettings

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -208,7 +208,7 @@ libxml2-devel-2.11.5-5.azl3.aarch64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 libsepol-3.6-2.azl3.aarch64.rpm
-glib-2.78.6-2.azl3.aarch64.rpm
+glib-2.78.6-3.azl3.aarch64.rpm
 libltdl-2.4.7-1.azl3.aarch64.rpm
 libltdl-devel-2.4.7-1.azl3.aarch64.rpm
 lua-5.4.6-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -208,7 +208,7 @@ libxml2-devel-2.11.5-5.azl3.x86_64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 libsepol-3.6-2.azl3.x86_64.rpm
-glib-2.78.6-2.azl3.x86_64.rpm
+glib-2.78.6-3.azl3.x86_64.rpm
 libltdl-2.4.7-1.azl3.x86_64.rpm
 libltdl-devel-2.4.7-1.azl3.x86_64.rpm
 lua-5.4.6-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -122,11 +122,11 @@ gdbm-lang-1.23-1.azl3.aarch64.rpm
 gettext-0.22-1.azl3.aarch64.rpm
 gettext-debuginfo-0.22-1.azl3.aarch64.rpm
 gfortran-13.2.0-7.azl3.aarch64.rpm
-glib-2.78.6-2.azl3.aarch64.rpm
-glib-debuginfo-2.78.6-2.azl3.aarch64.rpm
-glib-devel-2.78.6-2.azl3.aarch64.rpm
-glib-doc-2.78.6-2.azl3.noarch.rpm
-glib-schemas-2.78.6-2.azl3.aarch64.rpm
+glib-2.78.6-3.azl3.aarch64.rpm
+glib-debuginfo-2.78.6-3.azl3.aarch64.rpm
+glib-devel-2.78.6-3.azl3.aarch64.rpm
+glib-doc-2.78.6-3.azl3.noarch.rpm
+glib-schemas-2.78.6-3.azl3.aarch64.rpm
 glibc-2.38-11.azl3.aarch64.rpm
 glibc-debuginfo-2.38-11.azl3.aarch64.rpm
 glibc-devel-2.38-11.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -129,11 +129,11 @@ gdbm-lang-1.23-1.azl3.x86_64.rpm
 gettext-0.22-1.azl3.x86_64.rpm
 gettext-debuginfo-0.22-1.azl3.x86_64.rpm
 gfortran-13.2.0-7.azl3.x86_64.rpm
-glib-2.78.6-2.azl3.x86_64.rpm
-glib-debuginfo-2.78.6-2.azl3.x86_64.rpm
-glib-devel-2.78.6-2.azl3.x86_64.rpm
-glib-doc-2.78.6-2.azl3.noarch.rpm
-glib-schemas-2.78.6-2.azl3.x86_64.rpm
+glib-2.78.6-3.azl3.x86_64.rpm
+glib-debuginfo-2.78.6-3.azl3.x86_64.rpm
+glib-devel-2.78.6-3.azl3.x86_64.rpm
+glib-doc-2.78.6-3.azl3.noarch.rpm
+glib-schemas-2.78.6-3.azl3.x86_64.rpm
 glibc-2.38-11.azl3.x86_64.rpm
 glibc-debuginfo-2.38-11.azl3.x86_64.rpm
 glibc-devel-2.38-11.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2025-4373 and CVE-2025-6052

CVE-2025-4373:
Patch Modified: No
Upstream Patch reference: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588.patch
Patch link found in Astrolabe

CVE-2025-6052:
Patch Modified: No
Upstream Patch Applies cleanly: https://gitlab.gnome.org/GNOME/glib/-/commit/37eecaa7efc48a0df22277444ff25ff791ac0ac1
Patch link found in Astrolabe


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified:   ../SPECS/glib/glib.spec
- modified:   resources/manifests/package/pkggen_core_aarch64.txt
- modified:   resources/manifests/package/pkggen_core_x86_64.txt
- modified:   resources/manifests/package/toolchain_aarch64.txt
- modified:   resources/manifests/package/toolchain_x86_64.txt
- added:   ../SPECS/glib/CVE-2025-4373.patch
- added:   ../SPECS/glib/CVE-2025-6052.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4373
- https://nvd.nist.gov/vuln/detail/CVE-2025-6052

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
- Needs toolchain rebuild as glib is part of toolchain
- Also checked local build log file to ensure patch applied cleanly.
![image](https://github.com/user-attachments/assets/a969f5d9-351e-4a2c-8586-2d3c44745641)
