### PR TITLE
[MEDIUM] Patch glib for CVE-2025-4373

### DIFF
--- a/SPECS/glib/CVE-2025-4373.patch
+++ b/SPECS/glib/CVE-2025-4373.patch
@@ -1,0 +1,104 @@
+From e52fbaf44f038b60f793e1933688e613e7e1974c Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Mon, 9 Jun 2025 14:19:42 -0400
+Subject: [PATCH] Address CVE-2025-4373
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588.patch
+---
+ glib/gstring.c | 36 +++++++++++++++++++++++-------------
+ 1 file changed, 23 insertions(+), 13 deletions(-)
+
+diff --git a/glib/gstring.c b/glib/gstring.c
+index 0a509e5..d6f8735 100644
+--- a/glib/gstring.c
++++ b/glib/gstring.c
+@@ -424,8 +424,9 @@ g_string_insert_len (GString     *string,
+     return string;
+ 
+   if (len < 0)
+-    len = strlen (val);
+-  len_unsigned = len;
++    len_unsigned = strlen (val);
++  else
++    len_unsigned = len;
+ 
+   if (pos < 0)
+     pos_unsigned = string->len;
+@@ -723,10 +724,12 @@ g_string_insert_c (GString *string,
+   g_string_maybe_expand (string, 1);
+ 
+   if (pos < 0)
+-    pos = string->len;
++    pos_unsigned = string->len;
+   else
+-    g_return_val_if_fail ((gsize) pos <= string->len, string);
+-  pos_unsigned = pos;
++    {
++      pos_unsigned = pos;
++      g_return_val_if_fail (pos_unsigned <= string->len, string);
++    }
+ 
+   /* If not just an append, move the old stuff */
+   if (pos_unsigned < string->len)
+@@ -759,6 +762,7 @@ g_string_insert_unichar (GString  *string,
+                          gssize    pos,
+                          gunichar  wc)
+ {
++  gsize pos_unsigned;
+   gint charlen, first, i;
+   gchar *dest;
+ 
+@@ -800,15 +804,18 @@ g_string_insert_unichar (GString  *string,
+   g_string_maybe_expand (string, charlen);
+ 
+   if (pos < 0)
+-    pos = string->len;
++    pos_unsigned = string->len;
+   else
+-    g_return_val_if_fail ((gsize) pos <= string->len, string);
++    {
++      pos_unsigned = pos;
++      g_return_val_if_fail (pos_unsigned <= string->len, string);
++    }
+ 
+   /* If not just an append, move the old stuff */
+-  if ((gsize) pos < string->len)
+-    memmove (string->str + pos + charlen, string->str + pos, string->len - pos);
++  if (pos_unsigned < string->len)
++    memmove (string->str + pos_unsigned + charlen, string->str + pos_unsigned, string->len - pos_unsigned);
+ 
+-  dest = string->str + pos;
++  dest = string->str + pos_unsigned;
+   /* Code copied from g_unichar_to_utf() */
+   for (i = charlen - 1; i > 0; --i)
+     {
+@@ -866,6 +873,7 @@ g_string_overwrite_len (GString     *string,
+                         const gchar *val,
+                         gssize       len)
+ {
++  gssize len_unsigned;
+   gsize end;
+ 
+   g_return_val_if_fail (string != NULL, NULL);
+@@ -877,14 +885,16 @@ g_string_overwrite_len (GString     *string,
+   g_return_val_if_fail (pos <= string->len, string);
+ 
+   if (len < 0)
+-    len = strlen (val);
++    len_unsigned = strlen (val);
++  else
++    len_unsigned = len;
+ 
+-  end = pos + len;
++  end = pos + len_unsigned;
+ 
+   if (end > string->len)
+     g_string_maybe_expand (string, end - string->len);
+ 
+-  memcpy (string->str + pos, val, len);
++  memcpy (string->str + pos, val, len_unsigned);
+ 
+   if (end > string->len)
+     {
+-- 
+2.34.1
+

--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -2,7 +2,7 @@
 Summary:        Low-level libraries useful for providing data structure handling for C.
 Name:           glib
 Version:        2.71.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -14,6 +14,7 @@ Patch1:         CVE-2023-29499.patch
 # This patch fixes 2 CVEs - CVE-2023-32643 and CVE-2023-32636 
 Patch2:         CVE-2023-32643-CVE-2023-32636.patch
 Patch3:         CVE-2025-3360.patch
+Patch4:         CVE-2025-4373.patch
 BuildRequires:  cmake
 BuildRequires:  gtk-doc
 BuildRequires:  libffi-devel
@@ -127,6 +128,9 @@ touch %{buildroot}%{_libdir}/gio/modules/giomodule.cache
 %doc %{_datadir}/gtk-doc/html/*
 
 %changelog
+* Mon Jun 09 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 2.71.0-6
+- Patch CVE-2025-4373
+
 * Wed Apr 16 2025 Archana Shettigar <v-shettigara@microsoft.com> - 2.71.0-5
 - Patch CVE-2025-3360
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -199,7 +199,7 @@ libxml2-devel-2.10.4-6.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm
-glib-2.71.0-5.cm2.aarch64.rpm
+glib-2.71.0-6.cm2.aarch64.rpm
 libltdl-2.4.6-8.cm2.aarch64.rpm
 libltdl-devel-2.4.6-8.cm2.aarch64.rpm
 pcre-8.45-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -199,7 +199,7 @@ libxml2-devel-2.10.4-6.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm
-glib-2.71.0-5.cm2.x86_64.rpm
+glib-2.71.0-6.cm2.x86_64.rpm
 libltdl-2.4.6-8.cm2.x86_64.rpm
 libltdl-devel-2.4.6-8.cm2.x86_64.rpm
 pcre-8.45-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -101,11 +101,11 @@ gdbm-lang-1.21-1.cm2.aarch64.rpm
 gettext-0.21-3.cm2.aarch64.rpm
 gettext-debuginfo-0.21-3.cm2.aarch64.rpm
 gfortran-11.2.0-8.cm2.aarch64.rpm
-glib-2.71.0-5.cm2.aarch64.rpm
-glib-debuginfo-2.71.0-5.cm2.aarch64.rpm
-glib-devel-2.71.0-5.cm2.aarch64.rpm
-glib-doc-2.71.0-5.cm2.noarch.rpm
-glib-schemas-2.71.0-5.cm2.aarch64.rpm
+glib-2.71.0-6.cm2.aarch64.rpm
+glib-debuginfo-2.71.0-6.cm2.aarch64.rpm
+glib-devel-2.71.0-6.cm2.aarch64.rpm
+glib-doc-2.71.0-6.cm2.noarch.rpm
+glib-schemas-2.71.0-6.cm2.aarch64.rpm
 glibc-2.35-7.cm2.aarch64.rpm
 glibc-debuginfo-2.35-7.cm2.aarch64.rpm
 glibc-devel-2.35-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -106,11 +106,11 @@ gdbm-lang-1.21-1.cm2.x86_64.rpm
 gettext-0.21-3.cm2.x86_64.rpm
 gettext-debuginfo-0.21-3.cm2.x86_64.rpm
 gfortran-11.2.0-8.cm2.x86_64.rpm
-glib-2.71.0-5.cm2.x86_64.rpm
-glib-debuginfo-2.71.0-5.cm2.x86_64.rpm
-glib-devel-2.71.0-5.cm2.x86_64.rpm
-glib-doc-2.71.0-5.cm2.noarch.rpm
-glib-schemas-2.71.0-5.cm2.x86_64.rpm
+glib-2.71.0-6.cm2.x86_64.rpm
+glib-debuginfo-2.71.0-6.cm2.x86_64.rpm
+glib-devel-2.71.0-6.cm2.x86_64.rpm
+glib-doc-2.71.0-6.cm2.noarch.rpm
+glib-schemas-2.71.0-6.cm2.x86_64.rpm
 glibc-2.35-7.cm2.x86_64.rpm
 glibc-debuginfo-2.35-7.cm2.x86_64.rpm
 glibc-devel-2.35-7.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2025-4373

Upstream Patch Applies Cleanly: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588.patch
Patch commit in astrolabe: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588/diffs?commit_id=cc647f9e46d55509a93498af19659baf9c80f2e3

Also checked local build log file to ensure patch applied cleanly.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified:   ../SPECS/glib/glib.spec
- modified:   resources/manifests/package/pkggen_core_aarch64.txt
- modified:   resources/manifests/package/pkggen_core_x86_64.txt
- modified:   resources/manifests/package/toolchain_aarch64.txt
- modified:   resources/manifests/package/toolchain_x86_64.txt
- added:   ../SPECS/glib/CVE-2025-4373.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4373

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
- Needs toolchain rebuild as glib is part of toolchain