### PR TITLE
[High] Patch opa for CVE-2025-46569

### DIFF
--- a/SPECS/opa/CVE-2025-46569.patch
+++ b/SPECS/opa/CVE-2025-46569.patch
@@ -1,0 +1,373 @@
+From 7884928e4539de0a800414e2c68a2912a386344d Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Tue, 10 Jun 2025 07:21:09 +0000
+Subject: [PATCH] Address CVE-2025-46569
+
+Upstream Patch Reference: https://github.com/open-policy-agent/opa/commit/ad2063247a14711882f18c387a511fc8094aa79c
+
+---
+ server/server.go                 |  92 +++++++++++++++----
+ server/server_test.go            | 150 ++++++++++++++++++++++++++++++-
+ test/e2e/metrics/metrics_test.go |   1 -
+ 3 files changed, 226 insertions(+), 17 deletions(-)
+
+diff --git a/server/server.go b/server/server.go
+index 64eeaa6..e5ab876 100644
+--- a/server/server.go
++++ b/server/server.go
+@@ -1135,19 +1135,23 @@ func (s *Server) v0QueryPath(w http.ResponseWriter, r *http.Request, urlPath str
+ 	}
+ 
+ 	if len(rs) == 0 {
+-		ref := stringPathToDataRef(urlPath)
++		ref, err := stringPathToDataRef(urlPath)
++		if err != nil {
++			writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, "invalid path: %v", err))
++			return
++		}
+ 
+ 		var messageType = types.MsgMissingError
+ 		if len(s.getCompiler().GetRulesForVirtualDocument(ref)) > 0 {
+ 			messageType = types.MsgFoundUndefinedError
+ 		}
+-		err := types.NewErrorV1(types.CodeUndefinedDocument, fmt.Sprintf("%v: %v", messageType, ref))
+-		if err := logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, err, m); err != nil {
++		errV1 := types.NewErrorV1(types.CodeUndefinedDocument, "%v: %v", messageType, ref)
++		if err := logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, errV1, m); err != nil {
+ 			writer.ErrorAuto(w, err)
+ 			return
+ 		}
+ 
+-		writer.Error(w, http.StatusNotFound, err)
++		writer.Error(w, http.StatusNotFound, errV1)
+ 		return
+ 	}
+ 	err = logger.Log(ctx, txn, urlPath, "", goInput, input, &rs[0].Expressions[0].Value, ndbCache, nil, m)
+@@ -1306,10 +1310,15 @@ func (s *Server) unversionedGetHealthWithPolicy(w http.ResponseWriter, r *http.R
+ 	vars := mux.Vars(r)
+ 	urlPath := vars["path"]
+ 	healthDataPath := fmt.Sprintf("/system/health/%s", urlPath)
+-	healthDataPath = stringPathToDataRef(healthDataPath).String()
++
++	healthDataPathQuery, err := stringPathToQuery(healthDataPath)
++	if err != nil {
++		writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, "invalid path: %v", err))
++		return
++	}
+ 
+ 	rego := rego.New(
+-		rego.Query(healthDataPath),
++		rego.ParsedQuery(healthDataPathQuery),
+ 		rego.Compiler(s.getCompiler()),
+ 		rego.Store(s.store),
+ 		rego.Input(input),
+@@ -1324,7 +1333,7 @@ func (s *Server) unversionedGetHealthWithPolicy(w http.ResponseWriter, r *http.R
+ 	}
+ 
+ 	if len(rs) == 0 {
+-		writeHealthResponse(w, fmt.Errorf("health check (%v) was undefined", healthDataPath))
++		writeHealthResponse(w, fmt.Errorf("health check (%v) was undefined", healthDataPathQuery))
+ 		return
+ 	}
+ 
+@@ -1334,7 +1343,7 @@ func (s *Server) unversionedGetHealthWithPolicy(w http.ResponseWriter, r *http.R
+ 		return
+ 	}
+ 
+-	writeHealthResponse(w, fmt.Errorf("health check (%v) returned unexpected value", healthDataPath))
++	writeHealthResponse(w, fmt.Errorf("health check (%v) returned unexpected value", healthDataPathQuery))
+ }
+ 
+ func writeHealthResponse(w http.ResponseWriter, err error) {
+@@ -2551,12 +2560,15 @@ func (s *Server) makeRego(ctx context.Context,
+ 	tracer topdown.QueryTracer,
+ 	opts []func(*rego.Rego),
+ ) (*rego.Rego, error) {
+-	queryPath := stringPathToDataRef(urlPath).String()
++	query, err := stringPathToQuery(urlPath)
++	if err != nil {
++		return nil, types.NewErrorV1(types.CodeInvalidParameter, "invalid path: %v", err)
++	}
+ 
+ 	opts = append(
+ 		opts,
+ 		rego.Transaction(txn),
+-		rego.Query(queryPath),
++		rego.ParsedQuery(query),
+ 		rego.ParsedInput(input),
+ 		rego.Metrics(m),
+ 		rego.QueryTracer(tracer),
+@@ -2571,6 +2583,43 @@ func (s *Server) makeRego(ctx context.Context,
+ 	return rego.New(opts...), nil
+ }
+ 
++func stringPathToQuery(urlPath string) (ast.Body, error) {
++	ref, err := stringPathToDataRef(urlPath)
++	if err != nil {
++		return nil, err
++	}
++
++	return parseRefQuery(ref.String())
++}
++
++// parseRefQuery parses a string into a query ast.Body.
++// The resulting query must be comprised of a single ref, or an error will be returned.
++func parseRefQuery(str string) (ast.Body, error) {
++	query, err := ast.ParseBody(str)
++	if err != nil {
++		return nil, errors.New("failed to parse query")
++	}
++
++	// assert the query is exactly one statement
++	if l := len(query); l == 0 {
++		return nil, errors.New("no ref")
++	} else if l > 1 {
++		return nil, errors.New("complex query")
++	}
++
++	// assert the single statement is a lone ref
++	expr := query[0]
++	switch t := expr.Terms.(type) {
++	case *ast.Term:
++		switch t.Value.(type) {
++		case ast.Ref:
++			return query, nil
++		}
++	}
++
++	return nil, errors.New("complex query")
++}
++
+ func (s *Server) prepareV1PatchSlice(root string, ops []types.PatchV1) (result []patchImpl, err error) {
+ 
+ 	root = "/" + strings.Trim(root, "/")
+@@ -2678,23 +2727,36 @@ func (s *Server) updateNDCache(enabled bool) {
+ 	s.ndbCacheEnabled = enabled
+ }
+ 
+-func stringPathToDataRef(s string) (r ast.Ref) {
++func stringPathToDataRef(s string) (ast.Ref, error) {
+ 	result := ast.Ref{ast.DefaultRootDocument}
+-	return append(result, stringPathToRef(s)...)
++	r, err := stringPathToRef(s)
++	if err != nil {
++		return nil, err
++	}
++	return append(result, r...), nil
+ }
+ 
+-func stringPathToRef(s string) (r ast.Ref) {
++func stringPathToRef(s string) (ast.Ref, error) {
++	r := ast.Ref{}
++
+ 	if len(s) == 0 {
+-		return r
++		return r, nil
+ 	}
++
+ 	p := strings.Split(s, "/")
+ 	for _, x := range p {
+ 		if x == "" {
+ 			continue
+ 		}
++
+ 		if y, err := url.PathUnescape(x); err == nil {
+ 			x = y
+ 		}
++
++		if strings.Contains(x, "\"") {
++			return nil, fmt.Errorf("invalid ref term '%s'", x)
++		}
++
+ 		i, err := strconv.Atoi(x)
+ 		if err != nil {
+ 			r = append(r, ast.StringTerm(x))
+@@ -2702,7 +2764,7 @@ func stringPathToRef(s string) (r ast.Ref) {
+ 			r = append(r, ast.IntNumberTerm(i))
+ 		}
+ 	}
+-	return r
++	return r, nil
+ }
+ 
+ func validateQuery(query string) (ast.Body, error) {
+diff --git a/server/server_test.go b/server/server_test.go
+index 9a827af..8de136e 100644
+--- a/server/server_test.go
++++ b/server/server_test.go
+@@ -2736,7 +2736,6 @@ func TestDataMetricsEval(t *testing.T) {
+ 			"counter_disk_read_keys",
+ 			"counter_disk_read_bytes",
+ 			"timer_rego_input_parse_ns",
+-			"timer_rego_query_parse_ns",
+ 			"timer_rego_query_compile_ns",
+ 			"timer_rego_query_eval_ns",
+ 			"timer_server_handler_ns",
+@@ -5739,3 +5738,152 @@ func zipString(input string) []byte {
+ 	}
+ 	return b.Bytes()
+ }
++
++func TestStringPathToDataRef(t *testing.T) {
++	t.Parallel()
++
++	cases := []struct {
++		note   string
++		path   string
++		expRef string
++		expErr string
++	}{
++		{path: "foo", expRef: `data.foo`},
++		{path: "foo/", expRef: `data.foo`},
++		{path: "foo/bar", expRef: `data.foo.bar`},
++		{path: "foo/bar/", expRef: `data.foo.bar`},
++		{path: "foo/../bar", expRef: `data.foo[".."].bar`},
++
++		// Path injection attack
++		// url path: `foo%22%5D%3Bmalicious_call%28%29%3Bx%3D%5B%22`
++		// url decoded: `foo"];malicious_call();x=["`
++		// data ref .String(): `data.foo["\"];malicious_call();x=[\""]`
++		// Above attack is mitigated by rejecting any ref component containing string terminators (`"`).
++		{
++			note:   "string terminals inside ref term",
++			path:   "foo%22%5D%3Bmalicious_call%28%29%3Bx%3D%5B%22", // foo"];malicious_call();x=["
++			expErr: `invalid ref term 'foo"];malicious_call();x=["'`,
++		},
++	}
++
++	for _, tc := range cases {
++		note := tc.note
++		if note == "" {
++			note = strings.ReplaceAll(tc.path, "/", "_")
++		}
++
++		t.Run(note, func(t *testing.T) {
++			ref, err := stringPathToDataRef(tc.path)
++
++			if tc.expRef != "" {
++				if err != nil {
++					t.Fatalf("Expected ref:\n\n%s\n\nbut got error:\n\n%s", tc.expRef, err)
++				}
++				if refStr := ref.String(); refStr != tc.expRef {
++					t.Fatalf("Expected ref:\n\n%s\n\nbut got:\n\n%s", tc.expRef, refStr)
++				}
++			}
++
++			if tc.expErr != "" {
++				if ref != nil {
++					t.Fatalf("Expected error:\n\n%s\n\nbut got ref:\n\n%s", tc.expErr, ref.String())
++				}
++				if errStr := err.Error(); errStr != tc.expErr {
++					t.Fatalf("Expected error:\n\n%s\n\nbut got ref:\n\n%s", tc.expErr, errStr)
++				}
++			}
++		})
++	}
++}
++
++func TestParseRefQuery(t *testing.T) {
++	t.Parallel()
++
++	cases := []struct {
++		note    string
++		raw     string
++		expBody ast.Body
++		expErr  string
++	}{
++		{
++			note:   "unparseable",
++			raw:    `}abc{`,
++			expErr: "failed to parse query",
++		},
++		{
++			note:   "empty",
++			raw:    ``,
++			expErr: "no ref",
++		},
++		{
++			note:    "single ref",
++			raw:     `data.foo.bar`,
++			expBody: ast.MustParseBody(`data.foo.bar`),
++		},
++		{
++			note:   "multiple refs,';' separated",
++			raw:    `data.foo.bar;data.baz.qux`,
++			expErr: "complex query",
++		},
++		{
++			note: "multiple refs,newline separated",
++			raw: `data.foo.bar
++data.baz.qux`,
++			expErr: "complex query",
++		},
++		{
++			note:   "single ref + call",
++			raw:    `data.foo.bar;data.baz.qux()`,
++			expErr: "complex query",
++		},
++		{
++			note:   "single ref + assignment",
++			raw:    `data.foo.bar;x := 42`,
++			expErr: "complex query",
++		},
++		{
++			note:   "single call",
++			raw:    `data.foo.bar()`,
++			expErr: "complex query",
++		},
++		{
++			note:   "single assignment",
++			raw:    `x := 42`,
++			expErr: "complex query",
++		},
++		{
++			note:   "single unification",
++			raw:    `x = 42`,
++			expErr: "complex query",
++		},
++		{
++			note:   "single equality",
++			raw:    `x == 42`,
++			expErr: "complex query",
++		},
++	}
++
++	for _, tc := range cases {
++		t.Run(tc.note, func(t *testing.T) {
++			body, err := parseRefQuery(tc.raw)
++
++			if tc.expBody != nil {
++				if err != nil {
++					t.Fatalf("Expected body:\n\n%s\n\nbut got error:\n\n%s", tc.expBody, err)
++				}
++				if body.String() != tc.expBody.String() {
++					t.Fatalf("Expected body:\n\n%s\n\nbut got:\n\n%s", tc.expBody, body.String())
++				}
++			}
++
++			if tc.expErr != "" {
++				if body != nil {
++					t.Fatalf("Expected error:\n\n%s\n\nbut got body:\n\n%s", tc.expErr, body.String())
++				}
++				if errStr := err.Error(); errStr != tc.expErr {
++					t.Fatalf("Expected error:\n\n%s\n\nbut got body:\n\n%s", tc.expErr, errStr)
++				}
++			}
++		})
++	}
++}
+diff --git a/test/e2e/metrics/metrics_test.go b/test/e2e/metrics/metrics_test.go
+index e067909..e90d8fb 100644
+--- a/test/e2e/metrics/metrics_test.go
++++ b/test/e2e/metrics/metrics_test.go
+@@ -211,7 +211,6 @@ func assertDataInstrumentationMetricsInMap(t *testing.T, includeCompile bool, me
+ 		"timer_server_handler_ns",
+ 	}
+ 	compileStageKeys := []string{
+-		"timer_rego_query_parse_ns",
+ 		"timer_rego_query_compile_ns",
+ 		"timer_query_compile_stage_build_comprehension_index_ns",
+ 		"timer_query_compile_stage_check_safety_ns",
+-- 
+2.45.2
+

--- a/SPECS/opa/opa.spec
+++ b/SPECS/opa/opa.spec
@@ -5,7 +5,7 @@
 Summary:        Open source, general-purpose policy engine
 Name:           opa
 Version:        0.63.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 # Upstream license specification: MIT and Apache-2.0
 # Main package:    ASL 2.0
 # internal/jwx:    MIT
@@ -21,6 +21,7 @@ Patch0:         0001-Make-telemetry-opt-out.patch
 # Skip tests requiring network
 Patch1:         0001-Skip-tests-requiring-network.patch
 Patch2:         CVE-2023-45288.patch
+Patch3:         CVE-2025-46569.patch
 # Warn users about WebAssembly missing
 BuildRequires:  golang
 BuildRequires:  make
@@ -54,6 +55,9 @@ install -D -p -m 0644 man/*             %{buildroot}%{_mandir}/man1/
 %{_bindir}/*
 
 %changelog
+* Tue Jun 10 2025 Akhila Guruju <v-guakhila@microsoft.com> - 0.63.0-2
+- Patch CVE-2025-46569
+
 * Fri Jun 28 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.63.0-1
 - Auto-upgrade to 0.63.0 - CVE-2023-45142
 - Adding a patch for CVE-2023-45288.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
 Patch opa for CVE-2025-46569
- [x] No modifications for upstream patch
Upstream patch applies cleanly
- Taken patch https://github.com/open-policy-agent/opa/commit/ad2063247a14711882f18c387a511fc8094aa79c from upstream. NIST mentions here https://nvd.nist.gov/vuln/detail/CVE-2025-46569 that it fixes this CVE.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/opa/CVE-2025-46569.patch
- modified:   SPECS/opa/opa.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-46569

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Patch applies cleanly
<img width="685" alt="image" src="https://github.com/user-attachments/assets/28c78642-7c4f-4dd2-8824-0411cbc4a11e" />

