### PR TITLE
[Medium] Patch systemd for CVE-2025-4598

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        23%{?dist}
+Release:        24%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Tue Sep 16 2025 Akhila Guruju <v-guakhila@microsoft.com> - 255-24
+- Bump release to match systemd spec
+
 * Mon Aug 18 2025 Sean Dougherty <sdougherty@microsoft.com> - 255-23
 - Add aarch64 package
 

--- a/SPECS/systemd/CVE-2025-4598.patch
+++ b/SPECS/systemd/CVE-2025-4598.patch
@@ -1,0 +1,175 @@
+From 254ab8d2a7866679cee006d844d078774cbac3c9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Tue, 29 Apr 2025 14:47:59 +0200
+Subject: [PATCH] coredump: use %d in kernel core pattern
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The kernel provides %d which is documented as
+"dump mode—same as value returned by prctl(2) PR_GET_DUMPABLE".
+
+We already query /proc/pid/auxv for this information, but unfortunately this
+check is subject to a race, because the crashed process may be replaced by an
+attacker before we read this data, for example replacing a SUID process that
+was killed by a signal with another process that is not SUID, tricking us into
+making the coredump of the original process readable by the attacker.
+
+With this patch, we effectively add one more check to the list of conditions
+that need be satisfied if we are to make the coredump accessible to the user.
+
+Reportedy-by: Qualys Security Advisory <qsa@qualys.com>
+
+(cherry-picked from commit 0c49e0049b7665bb7769a13ef346fef92e1ad4d6)
+(cherry-picked from commit c58a8a6ec9817275bb4babaa2c08e0e35090d4e3)
+(cherry picked from commit 19d439189ab85dd7222bdd59fd442bbcc8ea99a7)
+
+Modified to apply to Azure Linux
+Modified by: akhila-guruju <v-guakhila@microsoft.com>
+Date: Fri, 13 Jun 2025 06:54:43 +0000
+
+Upstream Patch Reference: https://github.com/systemd/systemd-stable/commit/254ab8d2a7866679cee006d844d078774cbac3c9.patch
+
+---
+ man/systemd-coredump.xml            | 12 ++++++++++++
+ man/version-info.xml                |  2 ++
+ src/coredump/coredump.c             | 21 ++++++++++++++++++---
+ sysctl.d/50-coredump.conf.in        |  2 +-
+ test/units/testsuite-74.coredump.sh |  5 +++++
+ 5 files changed, 38 insertions(+), 4 deletions(-)
+
+diff --git a/man/systemd-coredump.xml b/man/systemd-coredump.xml
+index 762873a..70bfb86 100644
+--- a/man/systemd-coredump.xml
++++ b/man/systemd-coredump.xml
+@@ -292,6 +292,18 @@ COREDUMP_FILENAME=/var/lib/systemd/coredump/core.Web….552351.….zst
+         </listitem>
+       </varlistentry>
+ 
++      <varlistentry>
++        <term><varname>COREDUMP_DUMPABLE=</varname></term>
++
++        <listitem><para>The <constant>PR_GET_DUMPABLE</constant> field as reported by the kernel, see
++        <citerefentry
++        project='man-pages'><refentrytitle>prctl</refentrytitle><manvolnum>2</manvolnum></citerefentry>.
++        </para>
++
++        <xi:include href="version-info.xml" xpointer="v258"/>
++        </listitem>
++      </varlistentry>
++
+       <varlistentry>
+         <term><varname>COREDUMP_OPEN_FDS=</varname></term>
+ 
+diff --git a/man/version-info.xml b/man/version-info.xml
+index 5dabf9d..9311c0c 100644
+--- a/man/version-info.xml
++++ b/man/version-info.xml
+@@ -78,4 +78,6 @@
+   <para id="v254">Added in version 254.</para>
+   <para id="v255">Added in version 255.</para>
+   <para id="v256">Added in version 256.</para>
++  <para id="v257">Added in version 257.</para>
++  <para id="v258">Added in version 258.</para>
+ </refsect1>
+diff --git a/src/coredump/coredump.c b/src/coredump/coredump.c
+index 32c1766..64d68ab 100644
+--- a/src/coredump/coredump.c
++++ b/src/coredump/coredump.c
+@@ -96,6 +96,7 @@ enum {
+         META_ARGV_TIMESTAMP,    /* %t: time of dump, expressed as seconds since the Epoch (we expand this to μs granularity) */
+         META_ARGV_RLIMIT,       /* %c: core file size soft resource limit */
+         META_ARGV_HOSTNAME,     /* %h: hostname */
++        META_ARGV_DUMPABLE,     /* %d: as set by the kernel */
+         _META_ARGV_MAX,
+ 
+         /* The following indexes are cached for a couple of special fields we use (and
+@@ -123,6 +124,7 @@ static const char * const meta_field_names[_META_MAX] = {
+         [META_ARGV_TIMESTAMP] = "COREDUMP_TIMESTAMP=",
+         [META_ARGV_RLIMIT]    = "COREDUMP_RLIMIT=",
+         [META_ARGV_HOSTNAME]  = "COREDUMP_HOSTNAME=",
++        [META_ARGV_DUMPABLE]  = "COREDUMP_DUMPABLE=",
+         [META_COMM]           = "COREDUMP_COMM=",
+         [META_EXE]            = "COREDUMP_EXE=",
+         [META_UNIT]           = "COREDUMP_UNIT=",
+@@ -135,6 +137,7 @@ typedef struct Context {
+         pid_t pid;
+         uid_t uid;
+         gid_t gid;
++        unsigned dumpable;
+         bool is_pid1;
+         bool is_journald;
+ } Context;
+@@ -393,14 +396,16 @@ static int grant_user_access(int core_fd, const Context *context) {
+         if (r < 0)
+                 return r;
+ 
+-        /* We allow access if we got all the data and at_secure is not set and
+-         * the uid/gid matches euid/egid. */
++        /* We allow access if dumpable on the command line was exactly 1, we got all the data,
++         * at_secure is not set, and the uid/gid match euid/egid. */
+         bool ret =
++                context->dumpable == 1 &&
+                 at_secure == 0 &&
+                 uid != UID_INVALID && euid != UID_INVALID && uid == euid &&
+                 gid != GID_INVALID && egid != GID_INVALID && gid == egid;
+-        log_debug("Will %s access (uid="UID_FMT " euid="UID_FMT " gid="GID_FMT " egid="GID_FMT " at_secure=%s)",
++        log_debug("Will %s access (dumpable=%u uid="UID_FMT " euid="UID_FMT " gid="GID_FMT " egid="GID_FMT " at_secure=%s)",
+                   ret ? "permit" : "restrict",
++                  context->dumpable,
+                   uid, euid, gid, egid, yes_no(at_secure));
+         return ret;
+ }
+@@ -987,6 +992,16 @@ static int save_context(Context *context, const struct iovec_wrapper *iovw) {
+         if (r < 0)
+                 return log_error_errno(r, "Failed to parse GID \"%s\": %m", context->meta[META_ARGV_GID]);
+ 
++        /* The value is set to contents of /proc/sys/fs/suid_dumpable, which we set to 2,
++         * if the process is marked as not dumpable, see PR_SET_DUMPABLE(2const). */
++        if (context->meta[META_ARGV_DUMPABLE]) {
++                r = safe_atou(context->meta[META_ARGV_DUMPABLE], &context->dumpable);
++                if (r < 0)
++                        return log_error_errno(r, "Failed to parse dumpable field \"%s\": %m", context->meta[META_ARGV_DUMPABLE]);
++                if (context->dumpable > 2)
++                        log_notice("Got unexpected %%d/dumpable value %u.", context->dumpable);
++        }
++
+         unit = context->meta[META_UNIT];
+         context->is_pid1 = streq(context->meta[META_ARGV_PID], "1") || streq_ptr(unit, SPECIAL_INIT_SCOPE);
+         context->is_journald = streq_ptr(unit, SPECIAL_JOURNALD_SERVICE);
+diff --git a/sysctl.d/50-coredump.conf.in b/sysctl.d/50-coredump.conf.in
+index 90c080b..a550c87 100644
+--- a/sysctl.d/50-coredump.conf.in
++++ b/sysctl.d/50-coredump.conf.in
+@@ -13,7 +13,7 @@
+ # the core dump.
+ #
+ # See systemd-coredump(8) and core(5).
+-kernel.core_pattern=|{{LIBEXECDIR}}/systemd-coredump %P %u %g %s %t %c %h
++kernel.core_pattern=|{{LIBEXECDIR}}/systemd-coredump %P %u %g %s %t %c %h %d
+ 
+ # Allow 16 coredumps to be dispatched in parallel by the kernel.
+ # We collect metadata from /proc/%P/, and thus need to make sure the crashed
+diff --git a/test/units/testsuite-74.coredump.sh b/test/units/testsuite-74.coredump.sh
+index 6552643..f9b56ac 100755
+--- a/test/units/testsuite-74.coredump.sh
++++ b/test/units/testsuite-74.coredump.sh
+@@ -191,10 +191,15 @@ rm -f /tmp/core.{output,redirected}
+ # systemd-coredump args: PID UID GID SIGNUM TIMESTAMP CORE_SOFT_RLIMIT HOSTNAME
+ journalctl -b -n 1 --output=export --output-fields=MESSAGE,COREDUMP COREDUMP_EXE="/usr/bin/test-dump" |
+     /usr/lib/systemd/systemd-coredump --backtrace $$ 0 0 6 1679509994 12345 mymachine
++journalctl -b -n 1 --output=export --output-fields=MESSAGE,COREDUMP COREDUMP_EXE="/usr/bin/test-dump" |
++    /usr/lib/systemd/systemd-coredump --backtrace $$ 0 0 6 1679509902 12345 youmachine 1
+ # Wait a bit for the coredump to get processed
+ timeout 30 bash -c "while [[ \$(coredumpctl list -q --no-legend $$ | wc -l) -eq 0 ]]; do sleep 1; done"
+ coredumpctl info "$$"
+ coredumpctl info COREDUMP_HOSTNAME="mymachine"
++coredumpctl info COREDUMP_TIMESTAMP=1679509902000000
++coredumpctl info COREDUMP_HOSTNAME="youmachine"
++coredumpctl info COREDUMP_DUMPABLE="1"
+ 
+ # This used to cause a stack overflow
+ systemd-run -t --property CoredumpFilter=all ls /tmp
+-- 
+2.45.2
+

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        23%{?dist}
+Release:        24%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -143,6 +143,7 @@ Patch0491:      azurelinux-use-system-auth-in-pam-systemd-user.patch
 Patch0900:      do-not-test-openssl-sm3.patch
 Patch0901:      networkd-default-use-domains.patch
 Patch0902:      CVE-2023-7008.patch
+Patch0903:      CVE-2025-4598.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1228,6 +1229,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Tue Sep 16 2025 Akhila Guruju <v-guakhila@microsoft.com> - 255-24
+- Patch CVE-2025-4598
+
 * Mon Aug 18 2025 Sean Dougherty <sdougherty@microsoft.com> - 255-23
 - Bump release to match systemd-boot-signed spec
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch systemd for CVE-2025-4598
**For CVE-2025-4598:**
Patch Modified: Yes
- Modified the file `man/version-info.xml` by adding XML id (from upstream), because the file `systemd-coredump.xml` introduced new id in upstream patch. Without this modification the build fails. Except this, every file change matches with upstream patch.

Taken patch https://github.com/systemd/systemd-stable/commit/254ab8d2a7866679cee006d844d078774cbac3c9 from upstream. Debian mentions here https://security-tracker.debian.org/tracker/CVE-2025-4598 , https://www.qualys.com/2025/05/29/apport-coredump/apport-coredump.txt that it fixes this CVE

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/systemd/CVE-2025-4598.patch
- modified:   SPECS/systemd/systemd.spec
- modified: SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec (Bump release to match systemd spec and to pass PR check)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4598

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- same ptests are failing before applying patch
- Patch applies cleanly
![Screenshot 2025-06-18 182934](https://github.com/user-attachments/assets/219c5ddd-6d6b-4a6e-86ee-012020eba71c)
