### PR TITLE
Patch `frr` for CVE-2024-55553 [High]

### DIFF
--- a/SPECS/frr/CVE-2024-55553.patch
+++ b/SPECS/frr/CVE-2024-55553.patch
@@ -1,0 +1,231 @@
+From ace70f308966d2a4fbb8528dab12521ecf215a2f Mon Sep 17 00:00:00 2001
+From: Kanishk Bansal <kanbansal@microsoft.com>
+Date: Fri, 13 Jun 2025 11:10:28 +0000
+Subject: [PATCH] Backport CVE-2024-55553
+
+Upstream Reference : https://github.com/opensourcerouting/frr/commit/cc1c66a7e8dd31c681f396f6635192c0d60a543c
+
+Signed-off-by: Kanishk Bansal <kanbansal@microsoft.com>
+---
+ bgpd/bgp_rpki.c | 120 +++++++++++++++++++-----------------------------
+ bgpd/bgpd.c     |   4 --
+ bgpd/bgpd.h     |   1 -
+ 3 files changed, 48 insertions(+), 77 deletions(-)
+
+diff --git a/bgpd/bgp_rpki.c b/bgpd/bgp_rpki.c
+index 73c6fe0..958867c 100644
+--- a/bgpd/bgp_rpki.c
++++ b/bgpd/bgp_rpki.c
+@@ -64,6 +64,10 @@ DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_CACHE_GROUP, "BGP RPKI Cache server group");
+ DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_RTRLIB, "BGP RPKI RTRLib");
+ DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_REVALIDATE, "BGP RPKI Revalidation");
+ 
++#define RPKI_VALID 1
++#define RPKI_NOTFOUND 2
++#define RPKI_INVALID 3
++
+ #define POLLING_PERIOD_DEFAULT 3600
+ #define EXPIRE_INTERVAL_DEFAULT 7200
+ #define RETRY_INTERVAL_DEFAULT 600
+@@ -123,7 +127,6 @@ static void print_record(const struct pfx_record *record, struct vty *vty,
+ 			 json_object *json);
+ static bool is_synchronized(void);
+ static bool is_running(void);
+-static bool is_stopping(void);
+ static void route_match_free(void *rule);
+ static enum route_map_cmd_result_t route_match(void *rule,
+ 					       const struct prefix *prefix,
+@@ -131,7 +134,6 @@ static enum route_map_cmd_result_t route_match(void *rule,
+ 					       void *object);
+ static void *route_match_compile(const char *arg);
+ static void revalidate_bgp_node(struct bgp_dest *dest, afi_t afi, safi_t safi);
+-static void revalidate_all_routes(void);
+ 
+ static struct rtr_mgr_config *rtr_config;
+ static struct list *cache_list;
+@@ -367,11 +369,6 @@ inline bool is_running(void)
+ 	return rtr_is_running;
+ }
+ 
+-inline bool is_stopping(void)
+-{
+-	return rtr_is_stopping;
+-}
+-
+ static void pfx_record_to_prefix(struct pfx_record *record,
+ 				 struct prefix *prefix)
+ {
+@@ -415,36 +412,10 @@ static void rpki_revalidate_prefix(struct thread *thread)
+ 	XFREE(MTYPE_BGP_RPKI_REVALIDATE, rrp);
+ }
+ 
+-static void bgpd_sync_callback(struct thread *thread)
++static void revalidate_single_prefix(struct prefix prefix, afi_t afi)
+ {
+ 	struct bgp *bgp;
+ 	struct listnode *node;
+-	struct prefix prefix;
+-	struct pfx_record rec;
+-
+-	thread_add_read(bm->master, bgpd_sync_callback, NULL,
+-			rpki_sync_socket_bgpd, NULL);
+-
+-	if (atomic_load_explicit(&rtr_update_overflow, memory_order_seq_cst)) {
+-		while (read(rpki_sync_socket_bgpd, &rec,
+-			    sizeof(struct pfx_record)) != -1)
+-			;
+-
+-		atomic_store_explicit(&rtr_update_overflow, 0,
+-				      memory_order_seq_cst);
+-		revalidate_all_routes();
+-		return;
+-	}
+-
+-	int retval =
+-		read(rpki_sync_socket_bgpd, &rec, sizeof(struct pfx_record));
+-	if (retval != sizeof(struct pfx_record)) {
+-		RPKI_DEBUG("Could not read from rpki_sync_socket_bgpd");
+-		return;
+-	}
+-	pfx_record_to_prefix(&rec, &prefix);
+-
+-	afi_t afi = (rec.prefix.ver == LRTR_IPV4) ? AFI_IP : AFI_IP6;
+ 
+ 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
+ 		safi_t safi;
+@@ -467,6 +438,48 @@ static void bgpd_sync_callback(struct thread *thread)
+ 	}
+ }
+ 
++static void bgpd_sync_callback(struct thread *thread)
++{
++	struct prefix prefix;
++	struct pfx_record rec;
++	afi_t afi;
++	int retval;
++
++	if (atomic_load_explicit(&rtr_update_overflow, memory_order_seq_cst)) {
++		ssize_t size = 0;
++
++		retval = read(rpki_sync_socket_bgpd, &rec,
++			      sizeof(struct pfx_record));
++		while (retval != -1) {
++			if (retval != sizeof(struct pfx_record))
++				break;
++
++			size += retval;
++			pfx_record_to_prefix(&rec, &prefix);
++			afi = (rec.prefix.ver == LRTR_IPV4) ? AFI_IP : AFI_IP6;
++			revalidate_single_prefix(prefix, afi);
++
++			retval = read(rpki_sync_socket_bgpd, &rec,
++				      sizeof(struct pfx_record));
++		}
++
++		atomic_store_explicit(&rtr_update_overflow, 0,
++				      memory_order_seq_cst);
++		return;
++	}
++
++	retval = read(rpki_sync_socket_bgpd, &rec, sizeof(struct pfx_record));
++	if (retval != sizeof(struct pfx_record)) {
++		RPKI_DEBUG("Could not read from rpki_sync_socket_bgpd");
++		return;
++	}
++	pfx_record_to_prefix(&rec, &prefix);
++
++	afi = (rec.prefix.ver == LRTR_IPV4) ? AFI_IP : AFI_IP6;
++
++	revalidate_single_prefix(prefix, afi);
++}
++
+ static void revalidate_bgp_node(struct bgp_dest *bgp_dest, afi_t afi,
+ 				safi_t safi)
+ {
+@@ -514,48 +527,11 @@ static void bgp_rpki_revalidate_peer(struct thread *thread)
+ 	XFREE(MTYPE_BGP_RPKI_REVALIDATE, rvp);
+ }
+ 
+-static void revalidate_all_routes(void)
+-{
+-	struct bgp *bgp;
+-	struct listnode *node;
+-
+-	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
+-		struct peer *peer;
+-		struct listnode *peer_listnode;
+-
+-		for (ALL_LIST_ELEMENTS_RO(bgp->peer, peer_listnode, peer)) {
+-			afi_t afi;
+-			safi_t safi;
+-
+-			FOREACH_AFI_SAFI (afi, safi) {
+-				struct rpki_revalidate_peer *rvp;
+-
+-				if (!bgp->rib[afi][safi])
+-					continue;
+-
+-				if (!peer_established(peer))
+-					continue;
+-
+-				rvp = XCALLOC(MTYPE_BGP_RPKI_REVALIDATE,
+-					      sizeof(*rvp));
+-				rvp->peer = peer;
+-				rvp->afi = afi;
+-				rvp->safi = safi;
+-
+-				thread_add_event(
+-					bm->master, bgp_rpki_revalidate_peer,
+-					rvp, 0,
+-					&peer->t_revalidate_all[afi][safi]);
+-			}
+-		}
+-	}
+-}
+-
+ static void rpki_update_cb_sync_rtr(struct pfx_table *p __attribute__((unused)),
+ 				    const struct pfx_record rec,
+ 				    const bool added __attribute__((unused)))
+ {
+-	if (is_stopping() ||
++	if (rtr_is_stopping ||
+ 	    atomic_load_explicit(&rtr_update_overflow, memory_order_seq_cst))
+ 		return;
+ 
+diff --git a/bgpd/bgpd.c b/bgpd/bgpd.c
+index 1423529..e93cc7b 100644
+--- a/bgpd/bgpd.c
++++ b/bgpd/bgpd.c
+@@ -1167,8 +1167,6 @@ static void peer_free(struct peer *peer)
+ 	bgp_reads_off(peer);
+ 	bgp_writes_off(peer);
+ 	thread_cancel_event_ready(bm->master, peer);
+-	FOREACH_AFI_SAFI (afi, safi)
+-		THREAD_OFF(peer->t_revalidate_all[afi][safi]);
+ 	assert(!peer->t_write);
+ 	assert(!peer->t_read);
+ 	BGP_EVENT_FLUSH(peer);
+@@ -2535,8 +2533,6 @@ int peer_delete(struct peer *peer)
+ 	bgp_reads_off(peer);
+ 	bgp_writes_off(peer);
+ 	thread_cancel_event_ready(bm->master, peer);
+-	FOREACH_AFI_SAFI (afi, safi)
+-		THREAD_OFF(peer->t_revalidate_all[afi][safi]);
+ 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON));
+ 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_READS_ON));
+ 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_KEEPALIVES_ON));
+diff --git a/bgpd/bgpd.h b/bgpd/bgpd.h
+index 2c35c2a..675da29 100644
+--- a/bgpd/bgpd.h
++++ b/bgpd/bgpd.h
+@@ -1517,7 +1517,6 @@ struct peer {
+ 	struct thread *t_gr_restart;
+ 	struct thread *t_gr_stale;
+ 	struct thread *t_llgr_stale[AFI_MAX][SAFI_MAX];
+-	struct thread *t_revalidate_all[AFI_MAX][SAFI_MAX];
+ 	struct thread *t_generate_updgrp_packets;
+ 	struct thread *t_process_packet;
+ 	struct thread *t_process_packet_error;
+-- 
+2.45.3
+

--- a/SPECS/frr/frr.spec
+++ b/SPECS/frr/frr.spec
@@ -3,7 +3,7 @@
 Summary:        Routing daemon
 Name:           frr
 Version:        8.5.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,8 @@ Patch2:         0002-disable-eigrp-crypto.patch
 Patch3:         0003-fips-mode.patch
 Patch4:         0004-remove-grpc-test.patch
 Patch5:         CVE-2024-44070.patch
+Patch6:         CVE-2024-55553.patch
+
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  bison
@@ -198,6 +200,9 @@ rm tests/lib/*grpc*
 %{_sysusersdir}/%{name}.conf
 
 %changelog
+* Fri Jun 13 2025 Kanishk Bansal <kanbansal@microsoft.com> - 8.5.5-3
+- Backport Patch CVE-2024-55553
+
 * Wed Aug 21 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 8.5.5-2
 - Patch CVE-2024-44070
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Address CVE-2024-55553 by backport

######  Patch Summary
Removes "revalidate all routes" logic and associated thread fields.
Changes bgpd_sync_callback to only revalidate affected prefixes, not all routes.
Removes is_stopping() static function in favor of direct access to the rtr_is_stopping field.
Removes t_revalidate_all from peer struct and related thread logic.
Introduces revalidate_single_prefix.
Cleans up memory and thread handling accordingly.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2024-55553,

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-55553,

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=835318&view=results)
