### PR TITLE
[Medium] Patch systemd for CVE-2025-4598

### DIFF
--- a/SPECS/systemd/CVE-2025-4598.patch
+++ b/SPECS/systemd/CVE-2025-4598.patch
@@ -1,0 +1,116 @@
+From 58b49e084aa2ce986d86b9402b2ad5ef080c7a68 Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Thu, 12 Jun 2025 10:59:46 +0000
+Subject: [PATCH] Address CVE-2025-4598
+
+Upstream Patch Reference: https://github.com/systemd/systemd-stable/commit/254ab8d2a7866679cee006d844d078774cbac3c9
+---
+ man/systemd-coredump.xml     | 12 ++++++++++++
+ src/coredump/coredump.c      | 21 ++++++++++++++++++---
+ sysctl.d/50-coredump.conf.in |  2 +-
+ 3 files changed, 31 insertions(+), 4 deletions(-)
+
+diff --git a/man/systemd-coredump.xml b/man/systemd-coredump.xml
+index cb9f477..ba7cad1 100644
+--- a/man/systemd-coredump.xml
++++ b/man/systemd-coredump.xml
+@@ -259,6 +259,18 @@ COREDUMP_FILENAME=/var/lib/systemd/coredump/core.Web….552351.….zst
+         </listitem>
+       </varlistentry>
+ 
++      <varlistentry>
++        <term><varname>COREDUMP_DUMPABLE=</varname></term>
++
++        <listitem><para>The <constant>PR_GET_DUMPABLE</constant> field as reported by the kernel, see
++        <citerefentry
++        project='man-pages'><refentrytitle>prctl</refentrytitle><manvolnum>2</manvolnum></citerefentry>.
++        </para>
++
++        <xi:include href="version-info.xml" xpointer="v258"/>
++        </listitem>
++      </varlistentry>
++
+       <varlistentry>
+         <term><varname>COREDUMP_OPEN_FDS=</varname></term>
+ 
+diff --git a/src/coredump/coredump.c b/src/coredump/coredump.c
+index 742a8bc..1b7d014 100644
+--- a/src/coredump/coredump.c
++++ b/src/coredump/coredump.c
+@@ -85,6 +85,7 @@ enum {
+         META_ARGV_TIMESTAMP,    /* %t: time of dump, expressed as seconds since the Epoch (we expand this to µs granularity) */
+         META_ARGV_RLIMIT,       /* %c: core file size soft resource limit */
+         META_ARGV_HOSTNAME,     /* %h: hostname */
++        META_ARGV_DUMPABLE,     /* %d: as set by the kernel */
+         _META_ARGV_MAX,
+ 
+         /* The following indexes are cached for a couple of special fields we use (and
+@@ -112,6 +113,7 @@ static const char * const meta_field_names[_META_MAX] = {
+         [META_ARGV_TIMESTAMP]    = "COREDUMP_TIMESTAMP=",
+         [META_ARGV_RLIMIT]       = "COREDUMP_RLIMIT=",
+         [META_ARGV_HOSTNAME]     = "COREDUMP_HOSTNAME=",
++        [META_ARGV_DUMPABLE]  = "COREDUMP_DUMPABLE=",
+         [META_COMM]              = "COREDUMP_COMM=",
+         [META_EXE]               = "COREDUMP_EXE=",
+         [META_UNIT]              = "COREDUMP_UNIT=",
+@@ -122,6 +124,7 @@ typedef struct Context {
+         const char *meta[_META_MAX];
+         size_t meta_size[_META_MAX];
+         pid_t pid;
++        unsigned dumpable;
+         bool is_pid1;
+         bool is_journald;
+ } Context;
+@@ -467,14 +470,16 @@ static int grant_user_access(int core_fd, const Context *context) {
+         if (r < 0)
+                 return r;
+ 
+-        /* We allow access if we got all the data and at_secure is not set and
+-         * the uid/gid matches euid/egid. */
++        /* We allow access if dumpable on the command line was exactly 1, we got all the data,
++         * at_secure is not set, and the uid/gid match euid/egid. */
+         bool ret =
++                context->dumpable == 1 &&
+                 at_secure == 0 &&
+                 uid != UID_INVALID && euid != UID_INVALID && uid == euid &&
+                 gid != GID_INVALID && egid != GID_INVALID && gid == egid;
+-        log_debug("Will %s access (uid="UID_FMT " euid="UID_FMT " gid="GID_FMT " egid="GID_FMT " at_secure=%s)",
++        log_debug("Will %s access (dumpable=%u uid="UID_FMT " euid="UID_FMT " gid="GID_FMT " egid="GID_FMT " at_secure=%s)",
+                   ret ? "permit" : "restrict",
++                  context->dumpable,
+                   uid, euid, gid, egid, yes_no(at_secure));
+         return ret;
+ }
+@@ -1103,6 +1108,16 @@ static int save_context(Context *context, const struct iovec_wrapper *iovw) {
+         if (r < 0)
+                 return log_error_errno(r, "Failed to parse PID \"%s\": %m", context->meta[META_ARGV_PID]);
+ 
++        /* The value is set to contents of /proc/sys/fs/suid_dumpable, which we set to 2,
++         * if the process is marked as not dumpable, see PR_SET_DUMPABLE(2const). */
++        if (context->meta[META_ARGV_DUMPABLE]) {
++                r = safe_atou(context->meta[META_ARGV_DUMPABLE], &context->dumpable);
++                if (r < 0)
++                        return log_error_errno(r, "Failed to parse dumpable field \"%s\": %m", context->meta[META_ARGV_DUMPABLE]);
++                if (context->dumpable > 2)
++                        log_notice("Got unexpected %%d/dumpable value %u.", context->dumpable);
++        }
++
+         unit = context->meta[META_UNIT];
+         context->is_pid1 = streq(context->meta[META_ARGV_PID], "1") || streq_ptr(unit, SPECIAL_INIT_SCOPE);
+         context->is_journald = streq_ptr(unit, SPECIAL_JOURNALD_SERVICE);
+diff --git a/sysctl.d/50-coredump.conf.in b/sysctl.d/50-coredump.conf.in
+index 5fb551a..9c10a89 100644
+--- a/sysctl.d/50-coredump.conf.in
++++ b/sysctl.d/50-coredump.conf.in
+@@ -13,7 +13,7 @@
+ # the core dump.
+ #
+ # See systemd-coredump(8) and core(5).
+-kernel.core_pattern=|{{ROOTLIBEXECDIR}}/systemd-coredump %P %u %g %s %t %c %h
++kernel.core_pattern=|{{ROOTLIBEXECDIR}}/systemd-coredump %P %u %g %s %t %c %h %d
+ 
+ # Allow 16 coredumps to be dispatched in parallel by the kernel.
+ # We collect metadata from /proc/%P/, and thus need to make sure the crashed
+-- 
+2.45.2
+

--- a/SPECS/systemd/CVE-2025-4598.patch
+++ b/SPECS/systemd/CVE-2025-4598.patch
@@ -3,7 +3,7 @@ From: akhila-guruju <v-guakhila@microsoft.com>
 Date: Thu, 12 Jun 2025 10:59:46 +0000
 Subject: [PATCH] Address CVE-2025-4598
 
-Upstream Patch Reference: https://github.com/systemd/systemd-stable/commit/254ab8d2a7866679cee006d844d078774cbac3c9
+Upstream Patch Reference: https://github.com/systemd/systemd-stable/commit/2eb46dce078334805c547cbcf5e6462cf9d2f9f0
 ---
  man/systemd-coredump.xml     | 12 ++++++++++++
  src/coredump/coredump.c      | 21 ++++++++++++++++++---

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -32,6 +32,7 @@ Patch9:         mariner-2-do-not-default-zstd-journal-files-for-backwards-compat
 Patch10:        mariner-2-force-use-of-lz4-for-coredump.patch
 Patch11:        networkd-default-use-domains.patch
 Patch12:	CVE-2023-7008.patch
+Patch13:        CVE-2025-4598.patch
 BuildRequires:  audit-devel
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
@@ -290,6 +291,9 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Mon Jun 16 2025 Guruju <v-guakhila@microsoft.com> - 250.3-23
+- Patch CVE-2025-4598
+
 * Thu May 22 2025 Akhila Guruju <v-guakhila@microsoft.com> - 250.3-22
 - Patch CVE-2023-7008
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -291,7 +291,7 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
-* Mon Jun 16 2025 Guruju <v-guakhila@microsoft.com> - 250.3-23
+* Mon Jun 16 2025 Akhila Guruju <v-guakhila@microsoft.com> - 250.3-23
 - Patch CVE-2025-4598
 
 * Thu May 22 2025 Akhila Guruju <v-guakhila@microsoft.com> - 250.3-22


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch systemd for CVE-2025-4598
- [x] Modification done for patch (Yes)
- Excluded patching for file `test/units/testsuite-74.coredump.sh` as this is not present in source tarball. Except this, every change in the files matches with the upstream patch.
- Taken patch https://github.com/systemd/systemd-stable/commit/2eb46dce078334805c547cbcf5e6462cf9d2f9f0 from upstream. NIST/Debian mentions here https://security-tracker.debian.org/tracker/CVE-2025-4598 that it fixes this CVE.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/systemd/CVE-2025-4598.patch
- modified:   SPECS/systemd/systemd.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4598

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- ptests are failing before applying the patch
- Patch applies cleanly
![image](https://github.com/user-attachments/assets/b4c5badb-6e20-4b37-b5e4-8275fd2058b1)

