### PR TITLE
Update Precacher to No Longer Fatally Error by Default

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -134,6 +134,9 @@ SRPMS_DIR       ?= $(OUT_DIR)/SRPMS
 IMAGES_DIR      ?= $(OUT_DIR)/images
 
 PRECACHER_SNAPSHOT   ?= $(rpms_snapshot)
+# Turning on non-fatal mode by default. The precacher is not critical to the build
+# if the user is depending on failures from the precacher, it can be turned off with this option or with the tool directly.
+PRECACHER_NON_FATAL ?= y
 
 # External source server
 SOURCE_URL         ?= https://azurelinuxsrcstorage.blob.core.windows.net/sources/core

--- a/toolkit/scripts/precache.mk
+++ b/toolkit/scripts/precache.mk
@@ -49,6 +49,7 @@ $(STATUS_FLAGS_DIR)/precache.flag: $(go-precacher) $(chroot_worker) $(PRECACHER_
 		$(if $(filter y,$(ENABLE_CPU_PROFILE)),--enable-cpu-prof) \
 		$(if $(filter y,$(ENABLE_MEM_PROFILE)),--enable-mem-prof) \
 		$(if $(filter y,$(ENABLE_TRACE)),--enable-trace) \
+		$(if $(filter y,$(PRECACHER_NON_FATAL)),--non-fatal-mode) \
 		--timestamp-file=$(TIMESTAMP_DIR)/precacher.jsonl && \
 	if [ ! -f $@ ] || [ -s "$(precache_downloaded_files)" ]; then \
 		touch $@; \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The precacher is not required for a build to complete, even if enabled. This change allows the precacher to fail without causing the build to fail in tandem. 
The precacher should not be blocking builds which it is enabled for.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update precacher to run in new non-fatal mode by default
    - `PRECACHER_NON_FATAL` set to `y` by default
- Add option `PRECACHER_NON_FATAL` to maintain current precacher behavior

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Add small go snippet to precacher.go to simulate network failures during precacher
```	// randomly fail 1/100 times for testing purposes
	if rand.Intn(100) == 0 {
		return false, fmt.Errorf("test failure: download failed intentionally")
	}
```
- run test using lkg toolchain with the following command
`sudo make build-packages REBUILD_TOOLCHAIN=n REBUILD_TOOLS=y SRPM_PACK_LIST=words PACKAGE_REBUILD_LIST=words -j100 PRECACHE=y`
- Additionally run the following command to ensure the that fatal errors are still existant:
`sudo make build-packages REBUILD_TOOLCHAIN=n REBUILD_TOOLS=y SRPM_PACK_LIST=words PACKAGE_REBUILD_LIST=words -j100 PRECACHE=y PRECACHER_NON_FATAL=n`
