### PR TITLE
Addressed multiple grub2 CVEs

### DIFF
--- a/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
@@ -12,7 +12,7 @@
 Summary:        Signed GRand Unified Bootloader for %{buildarch} systems
 Name:           grub2-efi-binary-signed-%{buildarch}
 Version:        2.06
-Release:        14%{?dist}
+Release:        15%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -77,6 +77,9 @@ cp %{SOURCE3} %{buildroot}/boot/efi/EFI/BOOT/%{grubpxeefiname}
 /boot/efi/EFI/BOOT/%{grubpxeefiname}
 
 %changelog
+* Tue Jun 17 2025 Kshitiz Godara <kgodara@microsoft.com> - 2.06-15
+- Bump release number to match grub release
+
 * Mon Jun 02 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 2.06-14
 - Bump release number to match grub release
 

--- a/SPECS/grub2/CVE-2014-3591.patch
+++ b/SPECS/grub2/CVE-2014-3591.patch
@@ -1,0 +1,79 @@
+From 25e4ae28da960baec315e0c10e9f70cd46a89a2e Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 13:30:22 +0000
+Subject: [PATCH] Fix for CVE-2014-3591
+
+Upstream reference:
+https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=patch;h=ff53cf06e966dce0daba5f2c84e03ab9db2c3c8b
+---
+ grub-core/lib/libgcrypt/cipher/elgamal.c | 45 +++++++++++++++++++++---
+ 1 file changed, 41 insertions(+), 4 deletions(-)
+
+diff --git a/grub-core/lib/libgcrypt/cipher/elgamal.c b/grub-core/lib/libgcrypt/cipher/elgamal.c
+index ce4be85..47ba882 100644
+--- a/grub-core/lib/libgcrypt/cipher/elgamal.c
++++ b/grub-core/lib/libgcrypt/cipher/elgamal.c
+@@ -29,6 +29,11 @@
+ #include "g10lib.h"
+ #include "mpi.h"
+ #include "cipher.h"
++/* Blinding is used to mitigate side-channel attacks.  You may undef
++   this to speed up the operation in case the system is secured
++   against physical and network mounted side-channel attacks.  */
++#define USE_BLINDING 1
++
+ 
+ typedef struct
+ {
+@@ -486,12 +491,44 @@ do_encrypt(gcry_mpi_t a, gcry_mpi_t b, gcry_mpi_t input, ELG_public_key *pkey )
+ static void
+ decrypt(gcry_mpi_t output, gcry_mpi_t a, gcry_mpi_t b, ELG_secret_key *skey )
+ {
+-  gcry_mpi_t t1 = mpi_alloc_secure( mpi_get_nlimbs( skey->p ) );
++  MPI t1, t2, r;
++  unsigned int nbits = mpi_get_nbits (skey->p);
++
++  mpi_normalize (a);
++  mpi_normalize (b);
++
++  t1 = mpi_alloc_secure (mpi_nlimb_hint_from_nbits (nbits));
++#ifdef USE_BLINDING
++
++  t2 = mpi_alloc_secure (mpi_nlimb_hint_from_nbits (nbits));
++  r  = mpi_alloc (mpi_nlimb_hint_from_nbits (nbits));
++
++  /* We need a random number of about the prime size.  The random
++     number merely needs to be unpredictable; thus we use level 0.  */
++  randomize_mpi (r, nbits, 0);
++
++  /* t1 = r^x mod p */
++  mpi_powm (t1, r, skey->x, skey->p);
++  /* t2 = (a * r)^-x mod p */
++  mpi_mulm (t2, a, r, skey->p);
++  mpi_powm (t2, t2, skey->x, skey->p);
++  mpi_invm (t2, t2, skey->p);
++  /* t1 = (t1 * t2) mod p*/
++  mpi_mulm (t1, t1, t2, skey->p);
++
++  mpi_free (r);
++  mpi_free (t2);
++
++#else /*!USE_BLINDING*/
+ 
+   /* output = b/(a^x) mod p */
+-  gcry_mpi_powm( t1, a, skey->x, skey->p );
+-  mpi_invm( t1, t1, skey->p );
+-  mpi_mulm( output, b, t1, skey->p );
++  mpi_powm (t1, a, skey->x, skey->p);
++  mpi_invm (t1, t1, skey->p);
++
++#endif  /*!USE_BLINDING*/
++
++  mpi_mulm (output, b, t1, skey->p);
++
+ #if 0
+   if( DBG_CIPHER )
+     {
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2017-7526.patch
+++ b/SPECS/grub2/CVE-2017-7526.patch
@@ -1,0 +1,133 @@
+From 352e78a73c6b92155038f341095ab06753f965ea Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 14:38:07 +0000
+Subject: [PATCH] Fix for CVE-2017-7526
+
+Upstream reference:
+https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=patch;h=e6a3dc9900433bbc8ad362a595a3837318c28fa9
+---
+ grub-core/lib/libgcrypt/cipher/rsa.c | 85 ++++++++++++++++++----------
+ 1 file changed, 54 insertions(+), 31 deletions(-)
+
+diff --git a/grub-core/lib/libgcrypt/cipher/rsa.c b/grub-core/lib/libgcrypt/cipher/rsa.c
+index ccc9f96..43309f4 100644
+--- a/grub-core/lib/libgcrypt/cipher/rsa.c
++++ b/grub-core/lib/libgcrypt/cipher/rsa.c
+@@ -685,53 +685,75 @@ stronger_key_check ( RSA_secret_key *skey )
+ 
+ 
+ 
+-/****************
+- * Secret key operation. Encrypt INPUT with SKEY and put result into OUTPUT.
++/* Secret key operation - standard version.
+  *
+  *	m = c^d mod n
+- *
+- * Or faster:
++ */
++static void
++secret_core_std (gcry_mpi_t M, gcry_mpi_t C,
++                 gcry_mpi_t D, gcry_mpi_t N)
++{
++  mpi_powm (M, C, D, N);
++}
++
++
++/* Secret key operation - using the CRT.
+  *
+  *      m1 = c ^ (d mod (p-1)) mod p
+  *      m2 = c ^ (d mod (q-1)) mod q
+  *      h = u * (m2 - m1) mod q
+  *      m = m1 + h * p
+- *
+- * Where m is OUTPUT, c is INPUT and d,n,p,q,u are elements of SKEY.
++ */
++static void
++secret_core_crt (gcry_mpi_t M, gcry_mpi_t C,
++                 gcry_mpi_t D, unsigned int Nlimbs,
++                 gcry_mpi_t P, gcry_mpi_t Q, gcry_mpi_t U)
++{
++  gcry_mpi_t m1 = mpi_alloc_secure ( Nlimbs + 1 );
++  gcry_mpi_t m2 = mpi_alloc_secure ( Nlimbs + 1 );
++  gcry_mpi_t h  = mpi_alloc_secure ( Nlimbs + 1 );
++
++  /* m1 = c ^ (d mod (p-1)) mod p */
++  mpi_sub_ui ( h, P, 1 );
++  mpi_fdiv_r ( h, D, h );
++  mpi_powm ( m1, C, h, P );
++
++  /* m2 = c ^ (d mod (q-1)) mod q */
++  mpi_sub_ui ( h, Q, 1  );
++  mpi_fdiv_r ( h, D, h );
++  mpi_powm ( m2, C, h, Q );
++
++  /* h = u * ( m2 - m1 ) mod q */
++  mpi_sub ( h, m2, m1 );
++  if ( mpi_has_sign ( h ) )
++    mpi_add ( h, h, Q );
++  mpi_mulm ( h, U, h, Q );
++
++  /* m = m1 + h * p */
++  mpi_mul ( h, h, P );
++  mpi_add ( M, m1, h );
++
++  mpi_free ( h );
++  mpi_free ( m1 );
++  mpi_free ( m2 );
++}
++
++
++/* Secret key operation.
++ * Encrypt INPUT with SKEY and put result into
++ * OUTPUT.  SKEY has the secret key parameters.
+  */
+ static void
+ secret(gcry_mpi_t output, gcry_mpi_t input, RSA_secret_key *skey )
+ {
+   if (!skey->p || !skey->q || !skey->u)
+     {
+-      mpi_powm (output, input, skey->d, skey->n);
++      secret_core_std (output, input, skey->d, skey->n);
+     }
+   else
+     {
+-      gcry_mpi_t m1 = mpi_alloc_secure( mpi_get_nlimbs(skey->n)+1 );
+-      gcry_mpi_t m2 = mpi_alloc_secure( mpi_get_nlimbs(skey->n)+1 );
+-      gcry_mpi_t h  = mpi_alloc_secure( mpi_get_nlimbs(skey->n)+1 );
+-
+-      /* m1 = c ^ (d mod (p-1)) mod p */
+-      mpi_sub_ui( h, skey->p, 1  );
+-      mpi_fdiv_r( h, skey->d, h );
+-      mpi_powm( m1, input, h, skey->p );
+-      /* m2 = c ^ (d mod (q-1)) mod q */
+-      mpi_sub_ui( h, skey->q, 1  );
+-      mpi_fdiv_r( h, skey->d, h );
+-      mpi_powm( m2, input, h, skey->q );
+-      /* h = u * ( m2 - m1 ) mod q */
+-      mpi_sub( h, m2, m1 );
+-      if ( mpi_is_neg( h ) )
+-        mpi_add ( h, h, skey->q );
+-      mpi_mulm( h, skey->u, h, skey->q );
+-      /* m = m2 + h * p */
+-      mpi_mul ( h, h, skey->p );
+-      mpi_add ( output, m1, h );
+-
+-      mpi_free ( h );
+-      mpi_free ( m1 );
+-      mpi_free ( m2 );
++      secret_core_crt (output, input, skey->d, mpi_get_nlimbs (skey->n),
++                       skey->p, skey->q, skey->u);
+     }
+ }
+ 
+@@ -778,6 +800,7 @@ rsa_unblind (gcry_mpi_t x, gcry_mpi_t ri, gcry_mpi_t n)
+   return y;
+ }
+ 
++
+ /*********************************************
+  **************  interface  ******************
+  *********************************************/
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2019-13627.patch
+++ b/SPECS/grub2/CVE-2019-13627.patch
@@ -1,0 +1,68 @@
+From ec78ea01c197d46ed44c226613536490a6b0c87f Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 14:01:28 +0000
+Subject: [PATCH] Fix for CVE-2019-13627
+
+Upstream reference:
+https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commit;h=db4e9976cc31b314aafad6626b2894e86ee44d60
+---
+ grub-core/lib/libgcrypt/cipher/dsa.c | 14 ++++++++++++--
+ grub-core/lib/libgcrypt/mpi/ec.c     |  6 +++++-
+ 2 files changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/lib/libgcrypt/cipher/dsa.c b/grub-core/lib/libgcrypt/cipher/dsa.c
+index 883a815..1d77305 100644
+--- a/grub-core/lib/libgcrypt/cipher/dsa.c
++++ b/grub-core/lib/libgcrypt/cipher/dsa.c
+@@ -600,8 +600,6 @@ check_secret_key( DSA_secret_key *sk )
+   return rc;
+ }
+ 
+-
+-
+ /*
+    Make a DSA signature from HASH and put it into r and s.
+  */
+@@ -611,10 +609,22 @@ sign(gcry_mpi_t r, gcry_mpi_t s, gcry_mpi_t hash, DSA_secret_key *skey )
+   gcry_mpi_t k;
+   gcry_mpi_t kinv;
+   gcry_mpi_t tmp;
++  unsigned int qbits = mpi_get_nbits (skey->q);
+ 
+   /* Select a random k with 0 < k < q */
+   k = gen_k( skey->q );
+ 
++  /* Originally, ECDSA computation requires k where 0 < k < n.
++   * Here, we add n (the order of curve), to keep k in a
++   * range: n < k < 2*n, or, addming more n, keep k in a range:
++   * 2*n < k < 3*n, so that timing difference of the EC
++   * multiply operation can be small.  The result is same.
++   */
++  mpi_add (k, k, skey->E.n);
++  if (!mpi_test_bit (k, qbits))
++    mpi_add (k, k, skey->E.n);
++
++
+   /* r = (a^k mod p) mod q */
+   gcry_mpi_powm( r, skey->g, k, skey->p );
+   mpi_fdiv_r( r, r, skey->q );
+diff --git a/grub-core/lib/libgcrypt/mpi/ec.c b/grub-core/lib/libgcrypt/mpi/ec.c
+index fa00818..0089347 100644
+--- a/grub-core/lib/libgcrypt/mpi/ec.c
++++ b/grub-core/lib/libgcrypt/mpi/ec.c
+@@ -617,7 +617,11 @@ _gcry_mpi_ec_mul_point (mpi_point_t *result,
+   unsigned int nbits;
+   int i;
+ 
+-  nbits = mpi_get_nbits (scalar);
++  if (mpi_cmp (scalar, ctx->p) >= 0)
++    nbits = mpi_get_nbits (scalar);
++  else
++    nbits = mpi_get_nbits (ctx->p);
++
+   mpi_set_ui (result->x, 1);
+   mpi_set_ui (result->y, 1);
+   mpi_set_ui (result->z, 0);
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45774.patch
+++ b/SPECS/grub2/CVE-2024-45774.patch
@@ -1,0 +1,29 @@
+From 78297135895384a0653a6748f1af4b9f50609fec Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 14:53:20 +0000
+Subject: [PATCH] Fix for CVE-2024-45774
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=2c34af908ebf4856051ed29e46d88abd2b20387f
+---
+ grub-core/video/readers/jpeg.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/grub-core/video/readers/jpeg.c b/grub-core/video/readers/jpeg.c
+index 97a533b..80c5bd7 100644
+--- a/grub-core/video/readers/jpeg.c
++++ b/grub-core/video/readers/jpeg.c
+@@ -333,6 +333,10 @@ grub_jpeg_decode_sof (struct grub_jpeg_data *data)
+   if (grub_errno != GRUB_ERR_NONE)
+     return grub_errno;
+ 
++  if (data->image_height != 0 || data->image_width != 0)
++    return grub_error (GRUB_ERR_BAD_FILE_TYPE,
++		       "jpeg: cannot have duplicate SOF0 markers");
++
+   if (grub_jpeg_get_byte (data) != 8)
+     return grub_error (GRUB_ERR_BAD_FILE_TYPE,
+ 		       "jpeg: only 8-bit precision is supported");
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45775.patch
+++ b/SPECS/grub2/CVE-2024-45775.patch
@@ -1,0 +1,28 @@
+From 3451d40564b03136222abd225d2408794c98e57a Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 15:51:34 +0000
+Subject: [PATCH] Fix for CVE-2024-45775
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=05be856a8c3aae41f5df90cab7796ab7ee34b872
+---
+ grub-core/commands/extcmd.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/grub-core/commands/extcmd.c b/grub-core/commands/extcmd.c
+index 90a5ca2..c236be1 100644
+--- a/grub-core/commands/extcmd.c
++++ b/grub-core/commands/extcmd.c
+@@ -49,6 +49,9 @@ grub_extcmd_dispatcher (struct grub_command *cmd, int argc, char **args,
+     }
+ 
+   state = grub_arg_list_alloc (ext, argc, args);
++  if (state == NULL)
++    return grub_errno;
++
+   if (grub_arg_parse (ext, argc, args, state, &new_args, &new_argc))
+     {
+       context.state = state;
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45776.patch
+++ b/SPECS/grub2/CVE-2024-45776.patch
@@ -1,0 +1,29 @@
+From cba3d3966de27f3de803205de897df407603441a Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 16:43:45 +0000
+Subject: [PATCH] Fix for CVE-2024-45776
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=09bd6eb58b0f71ec273916070fa1e2de16897a91
+---
+ grub-core/gettext/gettext.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/grub-core/gettext/gettext.c b/grub-core/gettext/gettext.c
+index 16ebc20..85ea44a 100644
+--- a/grub-core/gettext/gettext.c
++++ b/grub-core/gettext/gettext.c
+@@ -328,8 +328,8 @@ grub_mofile_open (struct grub_gettext_context *ctx,
+   for (ctx->grub_gettext_max_log = 0; ctx->grub_gettext_max >> ctx->grub_gettext_max_log;
+        ctx->grub_gettext_max_log++);
+ 
+-  ctx->grub_gettext_msg_list = grub_zalloc (ctx->grub_gettext_max
+-					    * sizeof (ctx->grub_gettext_msg_list[0]));
++  ctx->grub_gettext_msg_list = grub_calloc (ctx->grub_gettext_max,
++					    sizeof (ctx->grub_gettext_msg_list[0]));
+   if (!ctx->grub_gettext_msg_list)
+     {
+       grub_file_close (fd);
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45777.patch
+++ b/SPECS/grub2/CVE-2024-45777.patch
@@ -1,0 +1,46 @@
+From 17009606a2a666352f157955d7a0e983a240c222 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 16:39:55 +0000
+Subject: [PATCH] Fix for CVE-2024-45777
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=b970a5ed967816bbca8225994cd0ee2557bad515
+---
+ grub-core/gettext/gettext.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/grub-core/gettext/gettext.c b/grub-core/gettext/gettext.c
+index 4d02e62..16ebc20 100644
+--- a/grub-core/gettext/gettext.c
++++ b/grub-core/gettext/gettext.c
+@@ -26,6 +26,7 @@
+ #include <grub/file.h>
+ #include <grub/kernel.h>
+ #include <grub/i18n.h>
++#include <grub/safemath.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -99,6 +100,7 @@ grub_gettext_getstr_from_position (struct grub_gettext_context *ctx,
+   char *translation;
+   struct string_descriptor desc;
+   grub_err_t err;
++  grub_size_t alloc_sz;
+ 
+   internal_position = (off + position * sizeof (desc));
+ 
+@@ -109,7 +111,10 @@ grub_gettext_getstr_from_position (struct grub_gettext_context *ctx,
+   length = grub_cpu_to_le32 (desc.length);
+   offset = grub_cpu_to_le32 (desc.offset);
+ 
+-  translation = grub_malloc (length + 1);
++  if (grub_add (length, 1, &alloc_sz))
++    return NULL;
++
++  translation = grub_malloc (alloc_sz);
+   if (!translation)
+     return NULL;
+ 
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45778-CVE-2024-45779.patch
+++ b/SPECS/grub2/CVE-2024-45778-CVE-2024-45779.patch
@@ -1,0 +1,46 @@
+From 3d13b94d7a0417c40d78f0c336c21163ed4dfeba Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Tue, 17 Jun 2025 02:58:39 +0000
+Subject: [PATCH] Fix for CVE-2024-45778 CVE-2024-45779
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=26db6605036bd9e5b16d9068a8cc75be63b8b630
+---
+ grub-core/fs/bfs.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/grub-core/fs/bfs.c b/grub-core/fs/bfs.c
+index 47dbe20..8d704e2 100644
+--- a/grub-core/fs/bfs.c
++++ b/grub-core/fs/bfs.c
+@@ -30,6 +30,7 @@
+ #include <grub/types.h>
+ #include <grub/i18n.h>
+ #include <grub/fshelp.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -1104,7 +1105,10 @@ GRUB_MOD_INIT (bfs)
+ {
+   COMPILE_TIME_ASSERT (1 << LOG_EXTENT_SIZE ==
+ 		       sizeof (struct grub_bfs_extent));
+-  grub_fs_register (&grub_bfs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_bfs_fs);
++    }
+ }
+ 
+ #ifdef MODE_AFS
+@@ -1113,5 +1117,6 @@ GRUB_MOD_FINI (afs)
+ GRUB_MOD_FINI (bfs)
+ #endif
+ {
+-  grub_fs_unregister (&grub_bfs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_bfs_fs);
+ }
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45780.patch
+++ b/SPECS/grub2/CVE-2024-45780.patch
@@ -1,0 +1,82 @@
+From e38852e0aeee802b86507a4e95b016d3add6dd94 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Tue, 17 Jun 2025 03:26:37 +0000
+Subject: [PATCH] Fix for CVE-2024-45780
+
+Upstream reference:
+https://gitweb.git.savannah.gnu.org/gitweb/?p=grub.git;a=patch;h=0087bc6902182fe5cedce2d034c75a79cf6dd4f3
+---
+ grub-core/fs/tar.c | 23 ++++++++++++++++++-----
+ 1 file changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/grub-core/fs/tar.c b/grub-core/fs/tar.c
+index c551ed6..a9e39b0 100644
+--- a/grub-core/fs/tar.c
++++ b/grub-core/fs/tar.c
+@@ -25,6 +25,7 @@
+ #include <grub/mm.h>
+ #include <grub/dl.h>
+ #include <grub/i18n.h>
++#include <grub/safemath.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -76,6 +77,7 @@ grub_cpio_find_file (struct grub_archelp_data *data, char **name,
+ {
+   struct head hd;
+   int reread = 0, have_longname = 0, have_longlink = 0;
++  grub_size_t sz;
+ 
+   data->hofs = data->next_hofs;
+ 
+@@ -97,7 +99,11 @@ grub_cpio_find_file (struct grub_archelp_data *data, char **name,
+ 	{
+ 	  grub_err_t err;
+ 	  grub_size_t namesize = read_number (hd.size, sizeof (hd.size));
+-	  *name = grub_malloc (namesize + 1);
++
++	  if (grub_add (namesize, 1, &sz))
++	    return grub_error (GRUB_ERR_BAD_FS, N_("name size overflow"));
++
++	  *name = grub_malloc (sz);
+ 	  if (*name == NULL)
+ 	    return grub_errno;
+ 	  err = grub_disk_read (data->disk, 0,
+@@ -117,15 +123,19 @@ grub_cpio_find_file (struct grub_archelp_data *data, char **name,
+ 	{
+ 	  grub_err_t err;
+ 	  grub_size_t linksize = read_number (hd.size, sizeof (hd.size));
+-	  if (data->linkname_alloc < linksize + 1)
++
++	  if (grub_add (linksize, 1, &sz))
++	    return grub_error (GRUB_ERR_BAD_FS, N_("link size overflow"));
++
++	  if (data->linkname_alloc < sz)
+ 	    {
+ 	      char *n;
+-	      n = grub_calloc (2, linksize + 1);
++	      n = grub_calloc (2, sz);
+ 	      if (!n)
+ 		return grub_errno;
+ 	      grub_free (data->linkname);
+ 	      data->linkname = n;
+-	      data->linkname_alloc = 2 * (linksize + 1);
++	      data->linkname_alloc = 2 * (sz);
+ 	    }
+ 
+ 	  err = grub_disk_read (data->disk, 0,
+@@ -148,7 +158,10 @@ grub_cpio_find_file (struct grub_archelp_data *data, char **name,
+ 	  while (extra_size < sizeof (hd.prefix)
+ 		 && hd.prefix[extra_size])
+ 	    extra_size++;
+-	  *name = grub_malloc (sizeof (hd.name) + extra_size + 2);
++
++	  if (grub_add (sizeof (hd.name) + 2, extra_size, &sz))
++	    return grub_error (GRUB_ERR_BAD_FS, N_("long name size overflow"));
++	  *name = grub_malloc (sz);
+ 	  if (*name == NULL)
+ 	    return grub_errno;
+ 	  if (hd.prefix[0])
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45781.patch
+++ b/SPECS/grub2/CVE-2024-45781.patch
@@ -1,0 +1,27 @@
+From 7ff0403a60ca37050a387708364a301d1f64e0bc Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 15:45:51 +0000
+Subject: [PATCH] Fix for CVE-2024-45781
+
+Upstream reference:
+https://brave-ocean-0baeae310.5.azurestaticapps.net/#/cve/CVE-2024-45781
+---
+ grub-core/fs/ufs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/fs/ufs.c b/grub-core/fs/ufs.c
+index 34a698b..4727266 100644
+--- a/grub-core/fs/ufs.c
++++ b/grub-core/fs/ufs.c
+@@ -463,7 +463,7 @@ grub_ufs_lookup_symlink (struct grub_ufs_data *data, int ino)
+   /* Check against zero is paylindromic, no need to swap.  */
+   if (data->inode.nblocks == 0
+       && INODE_SIZE (data) <= sizeof (data->inode.symlink))
+-    grub_strcpy (symlink, (char *) data->inode.symlink);
++    grub_strlcpy (symlink, (char *) data->inode.symlink, sz);
+   else
+     {
+       if (grub_ufs_read_file (data, 0, 0, 0, sz, symlink) < 0)
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-45783.patch
+++ b/SPECS/grub2/CVE-2024-45783.patch
@@ -1,0 +1,27 @@
+From f98f594b204e1922afd1c2714f6d5651a9208f1d Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 16:48:17 +0000
+Subject: [PATCH] Fix for CVE-2024-45783
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=f7c070a2e28dfab7137db0739fb8db1dc02d8898
+---
+ grub-core/fs/hfsplus.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/fs/hfsplus.c b/grub-core/fs/hfsplus.c
+index 19c7b33..e7fd98a 100644
+--- a/grub-core/fs/hfsplus.c
++++ b/grub-core/fs/hfsplus.c
+@@ -393,7 +393,7 @@ grub_hfsplus_mount (grub_disk_t disk)
+ 
+  fail:
+ 
+-  if (grub_errno == GRUB_ERR_OUT_OF_RANGE)
++  if (grub_errno == GRUB_ERR_OUT_OF_RANGE || grub_errno == GRUB_ERR_NONE)
+     grub_error (GRUB_ERR_BAD_FS, "not a HFS+ filesystem");
+ 
+   grub_free (data);
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2024-56737-and-CVE-2024-45782.patch
+++ b/SPECS/grub2/CVE-2024-56737-and-CVE-2024-45782.patch
@@ -1,0 +1,27 @@
+From f00677a840dcb8d9c335f9c544b414a87aea56f6 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 14:46:54 +0000
+Subject: [PATCH] Fix for CVE-2024-56737 and CVE-2024-45782
+
+Upstream reference:
+https://lists.gnu.org/archive/html/grub-devel/2025-02/msg00026.html
+---
+ grub-core/fs/hfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/fs/hfs.c b/grub-core/fs/hfs.c
+index f419965..bb7af5f 100644
+--- a/grub-core/fs/hfs.c
++++ b/grub-core/fs/hfs.c
+@@ -379,7 +379,7 @@ grub_hfs_mount (grub_disk_t disk)
+      volume name.  */
+   key.parent_dir = grub_cpu_to_be32_compile_time (1);
+   key.strlen = data->sblock.volname[0];
+-  grub_strcpy ((char *) key.str, (char *) (data->sblock.volname + 1));
++  grub_strlcpy ((char *) key.str, (char *) (data->sblock.volname + 1), sizeof (key.str));
+ 
+   if (grub_hfs_find_node (data, (char *) &key, data->cat_root,
+ 			  0, (char *) &dir, sizeof (dir)) == 0)
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2025-0677_CVE-2025-0684_CVE-2025-0685_CVE-2025-0686_CVE-2025-0689.patch
+++ b/SPECS/grub2/CVE-2025-0677_CVE-2025-0684_CVE-2025-0685_CVE-2025-0686_CVE-2025-0689.patch
@@ -1,0 +1,360 @@
+From 1452ed13eddc9d81e8db22f07dbdafb5f59993f0 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 16:22:38 +0000
+Subject: [PATCH] Fix for CVE-2025-0677 CVE-2025-0684 CVE-2025-0685
+ CVE-2025-0686 CVE-2025-0689
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=c4bc55da28543d2522a939ba4ee0acde45f2fa74
+---
+ grub-core/fs/affs.c     | 9 +++++++--
+ grub-core/fs/cbfs.c     | 9 +++++++--
+ grub-core/fs/jfs.c      | 9 +++++++--
+ grub-core/fs/minix.c    | 9 +++++++--
+ grub-core/fs/nilfs2.c   | 9 +++++++--
+ grub-core/fs/ntfs.c     | 9 +++++++--
+ grub-core/fs/reiserfs.c | 9 +++++++--
+ grub-core/fs/romfs.c    | 9 +++++++--
+ grub-core/fs/sfs.c      | 9 +++++++--
+ grub-core/fs/udf.c      | 9 +++++++--
+ grub-core/fs/ufs.c      | 9 +++++++--
+ 11 files changed, 77 insertions(+), 22 deletions(-)
+
+diff --git a/grub-core/fs/affs.c b/grub-core/fs/affs.c
+index cafcd0f..d676532 100644
+--- a/grub-core/fs/affs.c
++++ b/grub-core/fs/affs.c
+@@ -26,6 +26,7 @@
+ #include <grub/types.h>
+ #include <grub/fshelp.h>
+ #include <grub/charset.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -699,11 +700,15 @@ static struct grub_fs grub_affs_fs =
+ 
+ GRUB_MOD_INIT(affs)
+ {
+-  grub_fs_register (&grub_affs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_affs_fs);
++    }
+   my_mod = mod;
+ }
+ 
+ GRUB_MOD_FINI(affs)
+ {
+-  grub_fs_unregister (&grub_affs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_affs_fs);
+ }
+diff --git a/grub-core/fs/cbfs.c b/grub-core/fs/cbfs.c
+index 581215e..477a14e 100644
+--- a/grub-core/fs/cbfs.c
++++ b/grub-core/fs/cbfs.c
+@@ -26,6 +26,7 @@
+ #include <grub/dl.h>
+ #include <grub/i18n.h>
+ #include <grub/cbfs_core.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -390,12 +391,16 @@ GRUB_MOD_INIT (cbfs)
+ #if (defined (__i386__) || defined (__x86_64__)) && !defined (GRUB_UTIL) && !defined (GRUB_MACHINE_EMU) && !defined (GRUB_MACHINE_XEN)
+   init_cbfsdisk ();
+ #endif
+-  grub_fs_register (&grub_cbfs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_cbfs_fs);
++    }
+ }
+ 
+ GRUB_MOD_FINI (cbfs)
+ {
+-  grub_fs_unregister (&grub_cbfs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_cbfs_fs);
+ #if (defined (__i386__) || defined (__x86_64__)) && !defined (GRUB_UTIL) && !defined (GRUB_MACHINE_EMU) && !defined (GRUB_MACHINE_XEN)
+   fini_cbfsdisk ();
+ #endif
+diff --git a/grub-core/fs/jfs.c b/grub-core/fs/jfs.c
+index 6f7c439..c0bbab8 100644
+--- a/grub-core/fs/jfs.c
++++ b/grub-core/fs/jfs.c
+@@ -26,6 +26,7 @@
+ #include <grub/types.h>
+ #include <grub/charset.h>
+ #include <grub/i18n.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -963,11 +964,15 @@ static struct grub_fs grub_jfs_fs =
+ 
+ GRUB_MOD_INIT(jfs)
+ {
+-  grub_fs_register (&grub_jfs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_jfs_fs);
++    }
+   my_mod = mod;
+ }
+ 
+ GRUB_MOD_FINI(jfs)
+ {
+-  grub_fs_unregister (&grub_jfs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_jfs_fs);
+ }
+diff --git a/grub-core/fs/minix.c b/grub-core/fs/minix.c
+index 3cd18c8..7588835 100644
+--- a/grub-core/fs/minix.c
++++ b/grub-core/fs/minix.c
+@@ -25,6 +25,7 @@
+ #include <grub/dl.h>
+ #include <grub/types.h>
+ #include <grub/i18n.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -732,7 +733,10 @@ GRUB_MOD_INIT(minix)
+ #endif
+ #endif
+ {
+-  grub_fs_register (&grub_minix_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_minix_fs);
++    }
+   my_mod = mod;
+ }
+ 
+@@ -754,5 +758,6 @@ GRUB_MOD_FINI(minix)
+ #endif
+ #endif
+ {
+-  grub_fs_unregister (&grub_minix_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_minix_fs);
+ }
+diff --git a/grub-core/fs/nilfs2.c b/grub-core/fs/nilfs2.c
+index 3c248a9..3f8e495 100644
+--- a/grub-core/fs/nilfs2.c
++++ b/grub-core/fs/nilfs2.c
+@@ -34,6 +34,7 @@
+ #include <grub/dl.h>
+ #include <grub/types.h>
+ #include <grub/fshelp.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -1231,11 +1232,15 @@ GRUB_MOD_INIT (nilfs2)
+ 				  grub_nilfs2_dat_entry));
+   COMPILE_TIME_ASSERT (1 << LOG_INODE_SIZE
+ 		       == sizeof (struct grub_nilfs2_inode));
+-  grub_fs_register (&grub_nilfs2_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_nilfs2_fs);
++    }
+   my_mod = mod;
+ }
+ 
+ GRUB_MOD_FINI (nilfs2)
+ {
+-  grub_fs_unregister (&grub_nilfs2_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_nilfs2_fs);
+ }
+diff --git a/grub-core/fs/ntfs.c b/grub-core/fs/ntfs.c
+index deb058a..5b342da 100644
+--- a/grub-core/fs/ntfs.c
++++ b/grub-core/fs/ntfs.c
+@@ -27,6 +27,7 @@
+ #include <grub/fshelp.h>
+ #include <grub/ntfs.h>
+ #include <grub/charset.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -1316,11 +1317,15 @@ static struct grub_fs grub_ntfs_fs =
+ 
+ GRUB_MOD_INIT (ntfs)
+ {
+-  grub_fs_register (&grub_ntfs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_ntfs_fs);
++    }
+   my_mod = mod;
+ }
+ 
+ GRUB_MOD_FINI (ntfs)
+ {
+-  grub_fs_unregister (&grub_ntfs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_ntfs_fs);
+ }
+diff --git a/grub-core/fs/reiserfs.c b/grub-core/fs/reiserfs.c
+index af6a226..76cb231 100644
+--- a/grub-core/fs/reiserfs.c
++++ b/grub-core/fs/reiserfs.c
+@@ -39,6 +39,7 @@
+ #include <grub/types.h>
+ #include <grub/fshelp.h>
+ #include <grub/i18n.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -1417,11 +1418,15 @@ static struct grub_fs grub_reiserfs_fs =
+ 
+ GRUB_MOD_INIT(reiserfs)
+ {
+-  grub_fs_register (&grub_reiserfs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_reiserfs_fs);
++    }
+   my_mod = mod;
+ }
+ 
+ GRUB_MOD_FINI(reiserfs)
+ {
+-  grub_fs_unregister (&grub_reiserfs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_reiserfs_fs);
+ }
+diff --git a/grub-core/fs/romfs.c b/grub-core/fs/romfs.c
+index d97b8fb..d174449 100644
+--- a/grub-core/fs/romfs.c
++++ b/grub-core/fs/romfs.c
+@@ -23,6 +23,7 @@
+ #include <grub/disk.h>
+ #include <grub/fs.h>
+ #include <grub/fshelp.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -475,10 +476,14 @@ static struct grub_fs grub_romfs_fs =
+ 
+ GRUB_MOD_INIT(romfs)
+ {
+-  grub_fs_register (&grub_romfs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_romfs_fs);
++    }
+ }
+ 
+ GRUB_MOD_FINI(romfs)
+ {
+-  grub_fs_unregister (&grub_romfs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_romfs_fs);
+ }
+diff --git a/grub-core/fs/sfs.c b/grub-core/fs/sfs.c
+index 983e880..f64bdd2 100644
+--- a/grub-core/fs/sfs.c
++++ b/grub-core/fs/sfs.c
+@@ -26,6 +26,7 @@
+ #include <grub/types.h>
+ #include <grub/fshelp.h>
+ #include <grub/charset.h>
++#include <grub/lockdown.h>
+ #include <grub/safemath.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+@@ -779,11 +780,15 @@ static struct grub_fs grub_sfs_fs =
+ 
+ GRUB_MOD_INIT(sfs)
+ {
+-  grub_fs_register (&grub_sfs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_sfs_fs);
++    }
+   my_mod = mod;
+ }
+ 
+ GRUB_MOD_FINI(sfs)
+ {
+-  grub_fs_unregister (&grub_sfs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_sfs_fs);
+ }
+diff --git a/grub-core/fs/udf.c b/grub-core/fs/udf.c
+index 2ac5c1d..f89c6b0 100644
+--- a/grub-core/fs/udf.c
++++ b/grub-core/fs/udf.c
+@@ -27,6 +27,7 @@
+ #include <grub/fshelp.h>
+ #include <grub/charset.h>
+ #include <grub/datetime.h>
++#include <grub/lockdown.h>
+ #include <grub/udf.h>
+ #include <grub/safemath.h>
+ 
+@@ -1382,11 +1383,15 @@ static struct grub_fs grub_udf_fs = {
+ 
+ GRUB_MOD_INIT (udf)
+ {
+-  grub_fs_register (&grub_udf_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_udf_fs);
++    }
+   my_mod = mod;
+ }
+ 
+ GRUB_MOD_FINI (udf)
+ {
+-  grub_fs_unregister (&grub_udf_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_udf_fs);
+ }
+diff --git a/grub-core/fs/ufs.c b/grub-core/fs/ufs.c
+index 4727266..90fda07 100644
+--- a/grub-core/fs/ufs.c
++++ b/grub-core/fs/ufs.c
+@@ -25,6 +25,7 @@
+ #include <grub/dl.h>
+ #include <grub/types.h>
+ #include <grub/i18n.h>
++#include <grub/lockdown.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -899,7 +900,10 @@ GRUB_MOD_INIT(ufs1)
+ #endif
+ #endif
+ {
+-  grub_fs_register (&grub_ufs_fs);
++  if (!grub_is_lockdown ())
++    {
++      grub_fs_register (&grub_ufs_fs);
++    }
+   my_mod = mod;
+ }
+ 
+@@ -913,6 +917,7 @@ GRUB_MOD_FINI(ufs1)
+ #endif
+ #endif
+ {
+-  grub_fs_unregister (&grub_ufs_fs);
++  if (!grub_is_lockdown ())
++    grub_fs_unregister (&grub_ufs_fs);
+ }
+ 
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2025-0678-CVE-2025-1125.patch
+++ b/SPECS/grub2/CVE-2025-0678-CVE-2025-1125.patch
@@ -1,0 +1,76 @@
+From 99fc7bef2d0ae92fe52095a104715b787e39a7e5 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Tue, 17 Jun 2025 03:19:13 +0000
+Subject: [PATCH] Fix for CVE-2025-0678 CVE-2025-1125
+
+Upstream reference:
+https://gitweb.git.savannah.gnu.org/gitweb/?p=grub.git;a=patch;h=84bc0a9a68835952ae69165c11709811dae7634e
+---
+ grub-core/fs/btrfs.c       | 4 ++--
+ grub-core/fs/hfspluscomp.c | 9 +++++++--
+ grub-core/fs/squash4.c     | 8 ++++----
+ 3 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/grub-core/fs/btrfs.c b/grub-core/fs/btrfs.c
+index 54a46b8..0c8d45c 100644
+--- a/grub-core/fs/btrfs.c
++++ b/grub-core/fs/btrfs.c
+@@ -1276,8 +1276,8 @@ grub_btrfs_mount (grub_device_t dev)
+     }
+ 
+   data->n_devices_allocated = 16;
+-  data->devices_attached = grub_malloc (sizeof (data->devices_attached[0])
+-					* data->n_devices_allocated);
++  data->devices_attached = grub_calloc (data->n_devices_allocated,
++					sizeof (data->devices_attached[0]));
+   if (!data->devices_attached)
+     {
+       grub_free (data);
+diff --git a/grub-core/fs/hfspluscomp.c b/grub-core/fs/hfspluscomp.c
+index d76f3f1..4965ef1 100644
+--- a/grub-core/fs/hfspluscomp.c
++++ b/grub-core/fs/hfspluscomp.c
+@@ -244,14 +244,19 @@ hfsplus_open_compressed_real (struct grub_hfsplus_file *node)
+ 	  return 0;
+ 	}
+       node->compress_index_size = grub_le_to_cpu32 (index_size);
+-      node->compress_index = grub_malloc (node->compress_index_size
+-					  * sizeof (node->compress_index[0]));
++      node->compress_index = grub_calloc (node->compress_index_size,
++					  sizeof (node->compress_index[0]));
+       if (!node->compress_index)
+ 	{
+ 	  node->compressed = 0;
+ 	  grub_free (attr_node);
+ 	  return grub_errno;
+ 	}
++
++      /*
++       * The node->compress_index_size * sizeof (node->compress_index[0]) is safe here
++       * due to relevant checks done in grub_calloc() above.
++       */
+       if (grub_hfsplus_read_file (node, 0, 0,
+ 				  0x104 + sizeof (index_size),
+ 				  node->compress_index_size
+diff --git a/grub-core/fs/squash4.c b/grub-core/fs/squash4.c
+index 6dd731e..f79fc75 100644
+--- a/grub-core/fs/squash4.c
++++ b/grub-core/fs/squash4.c
+@@ -804,10 +804,10 @@ direct_read (struct grub_squash_data *data,
+ 	  break;
+ 	}
+       total_blocks = ((total_size + data->blksz - 1) >> data->log2_blksz);
+-      ino->block_sizes = grub_malloc (total_blocks
+-				      * sizeof (ino->block_sizes[0]));
+-      ino->cumulated_block_sizes = grub_malloc (total_blocks
+-						* sizeof (ino->cumulated_block_sizes[0]));
++      ino->block_sizes = grub_calloc (total_blocks,
++				      sizeof (ino->block_sizes[0]));
++      ino->cumulated_block_sizes = grub_calloc (total_blocks,
++						sizeof (ino->cumulated_block_sizes[0]));
+       if (!ino->block_sizes || !ino->cumulated_block_sizes)
+ 	{
+ 	  grub_free (ino->block_sizes);
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2025-0690.patch
+++ b/SPECS/grub2/CVE-2025-0690.patch
@@ -1,0 +1,62 @@
+From ed31abc5a78639d6b5f9b73352fbf1b3e83d4af9 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Tue, 17 Jun 2025 02:34:17 +0000
+Subject: [PATCH] Fix for CVE-2025-0690
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=dad8f502974ed9ad0a70ae6820d17b4b142558fc
+---
+ grub-core/commands/read.c | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/grub-core/commands/read.c b/grub-core/commands/read.c
+index fe3e88b..f3ff826 100644
+--- a/grub-core/commands/read.c
++++ b/grub-core/commands/read.c
+@@ -25,19 +25,21 @@
+ #include <grub/types.h>
+ #include <grub/command.h>
+ #include <grub/i18n.h>
++#include <grub/safemath.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+ static char *
+ grub_getline (void)
+ {
+-  int i;
++  grub_size_t i;
+   char *line;
+   char *tmp;
+   char c;
++  grub_size_t alloc_size;
+ 
+   i = 0;
+-  line = grub_malloc (1 + i + sizeof('\0'));
++  line = grub_malloc (1 + sizeof('\0'));
+   if (! line)
+     return NULL;
+ 
+@@ -50,8 +52,17 @@ grub_getline (void)
+       line[i] = c;
+       if (grub_isprint (c))
+ 	grub_printf ("%c", c);
+-      i++;
+-      tmp = grub_realloc (line, 1 + i + sizeof('\0'));
++      if (grub_add (i, 1, &i))
++        {
++          grub_error (GRUB_ERR_OUT_OF_RANGE, N_("overflow is detected"));
++          return NULL;
++        }
++      if (grub_add (i, 1 + sizeof('\0'), &alloc_size))
++        {
++          grub_error (GRUB_ERR_OUT_OF_RANGE, N_("overflow is detected"));
++          return NULL;
++        }
++      tmp = grub_realloc (line, alloc_size);
+       if (! tmp)
+ 	{
+ 	  grub_free (line);
+-- 
+2.45.3
+

--- a/SPECS/grub2/CVE-2025-1118.patch
+++ b/SPECS/grub2/CVE-2025-1118.patch
@@ -1,0 +1,29 @@
+From 6c823e608a8ca4e261ff29ca9b6d67dd8b20c009 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 16 Jun 2025 15:55:46 +0000
+Subject: [PATCH] Fix for CVE-2025-1118
+
+Upstream reference:
+https://cgit.git.savannah.gnu.org/cgit/grub.git/patch/?id=34824806ac6302f91e8cabaa41308eaced25725f
+---
+ grub-core/commands/minicmd.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/grub-core/commands/minicmd.c b/grub-core/commands/minicmd.c
+index fa49893..903af33 100644
+--- a/grub-core/commands/minicmd.c
++++ b/grub-core/commands/minicmd.c
+@@ -203,8 +203,8 @@ GRUB_MOD_INIT(minicmd)
+     grub_register_command ("help", grub_mini_cmd_help,
+ 			   0, N_("Show this message."));
+   cmd_dump =
+-    grub_register_command ("dump", grub_mini_cmd_dump,
+-			   N_("ADDR [SIZE]"), N_("Show memory contents."));
++    grub_register_command_lockdown ("dump", grub_mini_cmd_dump,
++				    N_("ADDR [SIZE]"), N_("Show memory contents."));
+   cmd_rmmod =
+     grub_register_command ("rmmod", grub_mini_cmd_rmmod,
+ 			   N_("MODULE"), N_("Remove a module."));
+-- 
+2.45.3
+

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -6,7 +6,7 @@
 Summary:        GRand Unified Bootloader
 Name:           grub2
 Version:        2.06
-Release:        14%{?dist}
+Release:        15%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -104,6 +104,25 @@ Patch:          sbat-4-0004-fs-ntfs-Fix-an-OOB-read-when-parsing-bitmaps-for-ind
 Patch:          sbat-4-0005-fs-ntfs-Fix-an-OOB-read-when-parsing-a-volume-label.patch
 Patch:          sbat-4-0006-fs-ntfs-Make-code-more-readable.patch
 Patch:          CVE-2025-0624.patch
+
+# Additional bulk CVEs
+Patch:          CVE-2014-3591.patch
+Patch:          CVE-2019-13627.patch
+Patch:          CVE-2017-7526.patch
+Patch:          CVE-2024-56737-and-CVE-2024-45782.patch
+Patch:          CVE-2024-45774.patch
+Patch:          CVE-2024-45781.patch
+Patch:          CVE-2024-45775.patch
+Patch:          CVE-2025-1118.patch
+Patch:          CVE-2025-0677_CVE-2025-0684_CVE-2025-0685_CVE-2025-0686_CVE-2025-0689.patch
+Patch:          CVE-2024-45777.patch
+Patch:          CVE-2024-45776.patch
+Patch:          CVE-2024-45783.patch
+Patch:          CVE-2025-0690.patch
+Patch:          CVE-2024-45778-CVE-2024-45779.patch
+Patch:          CVE-2025-0678-CVE-2025-1125.patch
+Patch:          CVE-2024-45780.patch
+
 BuildRequires:  autoconf
 BuildRequires:  device-mapper-devel
 BuildRequires:  python3
@@ -406,6 +425,9 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 %{_sysconfdir}/default/grub.d
 
 %changelog
+* Tue Jun 17 2025 Kshitiz Godara <kgodara@microsoft.com> - 2.06-15
+- Patch Multiple CVEs
+
 * Mon Jun 02 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 2.06-14
 - Patch CVE-2025-0624
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Addressing Grub2 multiple CVEs

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Addressed multiple grub2 CVEs
- Modified grub2 spec for the same

- CVE-2025-0684
- CVE-2024-45782
- CVE-2024-45778
- CVE-2025-0686
- CVE-2025-0678
- CVE-2025-0685
- CVE-2024-45779
- CVE-2025-0689
- CVE-2024-45780
- CVE-2025-1125
- CVE-2025-0690
- CVE-2024-45783
- CVE-2024-45776
- CVE-2024-45777
- CVE-2025-0677
- CVE-2025-1118
- CVE-2024-45775
- CVE-2024-45781
- CVE-2024-45774
- CVE-2024-56737
- CVE-2017-7526
- CVE-2019-13627
- CVE-2014-3591


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-0684
- https://nvd.nist.gov/vuln/detail/CVE-2024-45782
- https://nvd.nist.gov/vuln/detail/CVE-2024-45778
- https://nvd.nist.gov/vuln/detail/CVE-2025-0686
- https://nvd.nist.gov/vuln/detail/CVE-2025-0678
- https://nvd.nist.gov/vuln/detail/CVE-2025-0685
- https://nvd.nist.gov/vuln/detail/CVE-2024-45779
- https://nvd.nist.gov/vuln/detail/CVE-2025-0689
- https://nvd.nist.gov/vuln/detail/CVE-2024-45780
- https://nvd.nist.gov/vuln/detail/CVE-2025-1125
- https://nvd.nist.gov/vuln/detail/CVE-2025-0690
- https://nvd.nist.gov/vuln/detail/CVE-2024-45783
- https://nvd.nist.gov/vuln/detail/CVE-2024-45776
- https://nvd.nist.gov/vuln/detail/CVE-2024-45777
- https://nvd.nist.gov/vuln/detail/CVE-2025-0677
- https://nvd.nist.gov/vuln/detail/CVE-2025-1118
- https://nvd.nist.gov/vuln/detail/CVE-2024-45775
- https://nvd.nist.gov/vuln/detail/CVE-2024-45781
- https://nvd.nist.gov/vuln/detail/CVE-2024-45774
- https://nvd.nist.gov/vuln/detail/CVE-2024-56737
- https://nvd.nist.gov/vuln/detail/CVE-2017-7526
- https://nvd.nist.gov/vuln/detail/CVE-2019-13627
- https://nvd.nist.gov/vuln/detail/CVE-2014-3591


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [xxxxxx](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=838703&view=results)
