### PR TITLE
[High] Patch protobuf for CVE-2025-4565

### DIFF
--- a/SPECS/protobuf/CVE-2025-4565.patch
+++ b/SPECS/protobuf/CVE-2025-4565.patch
@@ -1,0 +1,403 @@
+From 10b88b0fb8f6746017c5b6fefd17435910b613d9 Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Thu, 19 Jun 2025 08:36:47 +0000
+Subject: [PATCH] Address CVE-2025-4565
+
+Upstream Patch reference: https://github.com/protocolbuffers/protobuf/commit/17838beda2943d08b8a9d4df5b68f5f04f26d901
+
+---
+ python/google/protobuf/internal/decoder.py    |  66 ++++++--
+ .../google/protobuf/internal/message_test.py  | 149 +++++++++++-------
+ .../protobuf/internal/self_recursive.proto    |  24 +++
+ 3 files changed, 170 insertions(+), 69 deletions(-)
+ create mode 100644 python/google/protobuf/internal/self_recursive.proto
+
+diff --git a/python/google/protobuf/internal/decoder.py b/python/google/protobuf/internal/decoder.py
+index 6804986..49b8f53 100644
+--- a/python/google/protobuf/internal/decoder.py
++++ b/python/google/protobuf/internal/decoder.py
+@@ -674,7 +674,7 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+     tag_bytes = encoder.TagBytes(field_number,
+                                  wire_format.WIRETYPE_START_GROUP)
+     tag_len = len(tag_bytes)
+-    def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++    def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -683,7 +683,13 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+         if value is None:
+           value = field_dict.setdefault(key, new_default(message))
+         # Read sub-message.
+-        pos = value.add()._InternalParse(buffer, pos, end)
++        current_depth += 1
++        if current_depth > _recursion_limit:
++          raise _DecodeError(
++              'Error parsing message: too many levels of nesting.'
++          )
++        pos = value.add()._InternalParse(buffer, pos, end, current_depth)
++        current_depth -= 1
+         # Read end tag.
+         new_pos = pos+end_tag_len
+         if buffer[pos:new_pos] != end_tag_bytes or new_pos > end:
+@@ -695,12 +701,16 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+           return new_pos
+     return DecodeRepeatedField
+   else:
+-    def DecodeField(buffer, pos, end, message, field_dict):
++    def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+       # Read sub-message.
+-      pos = value._InternalParse(buffer, pos, end)
++      current_depth += 1
++      if current_depth > _recursion_limit:
++        raise _DecodeError('Error parsing message: too many levels of nesting.')
++      pos = value._InternalParse(buffer, pos, end, current_depth)
++      current_depth -= 1
+       # Read end tag.
+       new_pos = pos+end_tag_len
+       if buffer[pos:new_pos] != end_tag_bytes or new_pos > end:
+@@ -719,7 +729,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+     tag_bytes = encoder.TagBytes(field_number,
+                                  wire_format.WIRETYPE_LENGTH_DELIMITED)
+     tag_len = len(tag_bytes)
+-    def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++    def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -730,10 +740,16 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+         if new_pos > end:
+           raise _DecodeError('Truncated message.')
+         # Read sub-message.
+-        if value.add()._InternalParse(buffer, pos, new_pos) != new_pos:
++        current_depth += 1
++        if current_depth > _recursion_limit:
++          raise _DecodeError(
++              'Error parsing message: too many levels of nesting.'
++          )
++        if value.add()._InternalParse(buffer, pos, new_pos, current_depth) != new_pos:
+           # The only reason _InternalParse would return early is if it
+           # encountered an end-group tag.
+           raise _DecodeError('Unexpected end-group tag.')
++        current_depth -= 1
+         # Predict that the next tag is another copy of the same repeated field.
+         pos = new_pos + tag_len
+         if buffer[new_pos:pos] != tag_bytes or new_pos == end:
+@@ -741,7 +757,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+           return new_pos
+     return DecodeRepeatedField
+   else:
+-    def DecodeField(buffer, pos, end, message, field_dict):
++    def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -751,10 +767,14 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+       if new_pos > end:
+         raise _DecodeError('Truncated message.')
+       # Read sub-message.
+-      if value._InternalParse(buffer, pos, new_pos) != new_pos:
++      current_depth += 1
++      if current_depth > _recursion_limit:
++        raise _DecodeError('Error parsing message: too many levels of nesting.')
++      if value._InternalParse(buffer, pos, new_pos, current_depth) != new_pos:
+         # The only reason _InternalParse would return early is if it encountered
+         # an end-group tag.
+         raise _DecodeError('Unexpected end-group tag.')
++      current_depth -= 1
+       return new_pos
+     return DecodeField
+ 
+@@ -955,7 +975,7 @@ def _SkipGroup(buffer, pos, end):
+     pos = new_pos
+ 
+ 
+-def _DecodeUnknownFieldSet(buffer, pos, end_pos=None):
++def _DecodeUnknownFieldSet(buffer, pos, end_pos=None, current_depth=0):
+   """Decode UnknownFieldSet.  Returns the UnknownFieldSet and new position."""
+ 
+   unknown_field_set = containers.UnknownFieldSet()
+@@ -965,14 +985,13 @@ def _DecodeUnknownFieldSet(buffer, pos, end_pos=None):
+     field_number, wire_type = wire_format.UnpackTag(tag)
+     if wire_type == wire_format.WIRETYPE_END_GROUP:
+       break
+-    (data, pos) = _DecodeUnknownField(buffer, pos, wire_type)
++    (data, pos) = _DecodeUnknownField(buffer, pos, end_pos, field_number, wire_type, current_depth)
+     # pylint: disable=protected-access
+     unknown_field_set._add(field_number, wire_type, data)
+ 
+   return (unknown_field_set, pos)
+ 
+-
+-def _DecodeUnknownField(buffer, pos, wire_type):
++def _DecodeUnknownField(buffer, pos, end_pos, field_number, wire_type, current_depth=0):
+   """Decode a unknown field.  Returns the UnknownField and new position."""
+ 
+   if wire_type == wire_format.WIRETYPE_VARINT:
+@@ -986,14 +1005,26 @@ def _DecodeUnknownField(buffer, pos, wire_type):
+     data = buffer[pos:pos+size].tobytes()
+     pos += size
+   elif wire_type == wire_format.WIRETYPE_START_GROUP:
+-    (data, pos) = _DecodeUnknownFieldSet(buffer, pos)
++    end_tag_bytes = encoder.TagBytes(
++        field_number, wire_format.WIRETYPE_END_GROUP
++    )
++    current_depth += 1
++    if current_depth >= _recursion_limit:
++      raise _DecodeError('Error parsing message: too many levels of nesting.')
++    data, pos = _DecodeUnknownFieldSet(buffer, pos, end_pos, current_depth)
++    current_depth -= 1
++    # Check end tag.
++    if buffer[pos - len(end_tag_bytes) : pos] != end_tag_bytes:
++      raise _DecodeError('Missing group end tag.')
+   elif wire_type == wire_format.WIRETYPE_END_GROUP:
+     return (0, -1)
+   else:
+     raise _DecodeError('Wrong wire type in tag.')
+ 
+-  return (data, pos)
++  if pos > end_pos:
++    raise _DecodeError('Truncated message.')
+ 
++  return (data, pos)
+ 
+ def _EndGroup(buffer, pos, end):
+   """Skipping an END_GROUP tag returns -1 to tell the parent loop to break."""
+@@ -1021,6 +1052,13 @@ def _RaiseInvalidWireType(buffer, pos, end):
+   """Skip function for unknown wire types.  Raises an exception."""
+ 
+   raise _DecodeError('Tag had invalid wire type.')
++DEFAULT_RECURSION_LIMIT = 100
++_recursion_limit = DEFAULT_RECURSION_LIMIT
++
++
++def SetRecursionLimit(new_limit):
++  global _recursion_limit
++  _recursion_limit = new_limit
+ 
+ def _FieldSkipper():
+   """Constructs the SkipField function."""
+diff --git a/python/google/protobuf/internal/message_test.py b/python/google/protobuf/internal/message_test.py
+index 77122a2..a6a3de2 100755
+--- a/python/google/protobuf/internal/message_test.py
++++ b/python/google/protobuf/internal/message_test.py
+@@ -82,6 +82,7 @@ from google.protobuf.internal import api_implementation
+ from google.protobuf.internal import encoder
+ from google.protobuf.internal import more_extensions_pb2
+ from google.protobuf.internal import packed_field_test_pb2
++from google.protobuf.internal import self_recursive_pb2
+ from google.protobuf.internal import test_util
+ from google.protobuf.internal import test_proto3_optional_pb2
+ from google.protobuf.internal import testing_refleaks
+@@ -1320,6 +1321,51 @@ class MessageTest(unittest.TestCase):
+     self.assertEqual(bool, type(m.repeated_bool[0]))
+     self.assertEqual(True, m.repeated_bool[0])
+ 
++@testing_refleaks.TestCase
++class TestRecursiveGroup(unittest.TestCase):
++
++  def _MakeRecursiveGroupMessage(self, n):
++    msg = self_recursive_pb2.SelfRecursive()
++    sub = msg
++    for _ in range(n):
++      sub = sub.sub_group
++    sub.i = 1
++    return msg.SerializeToString()
++
++  def testRecursiveGroups(self):
++    recurse_msg = self_recursive_pb2.SelfRecursive()
++    data = self._MakeRecursiveGroupMessage(100)
++    recurse_msg.ParseFromString(data)
++    self.assertTrue(recurse_msg.HasField('sub_group'))
++
++  def testRecursiveGroupsException(self):
++    if api_implementation.Type() != 'python':
++      api_implementation._c_module.SetAllowOversizeProtos(False)
++    recurse_msg = self_recursive_pb2.SelfRecursive()
++    data = self._MakeRecursiveGroupMessage(300)
++    with self.assertRaises(message.DecodeError) as context:
++      recurse_msg.ParseFromString(data)
++    self.assertIn('Error parsing message', str(context.exception))
++    if api_implementation.Type() == 'python':
++      self.assertIn('too many levels of nesting', str(context.exception))
++
++  def testRecursiveGroupsUnknownFields(self):
++    if api_implementation.Type() != 'python':
++      api_implementation._c_module.SetAllowOversizeProtos(False)
++    test_msg = unittest_pb2.TestAllTypes()
++    data = self._MakeRecursiveGroupMessage(300)  # unknown to test_msg
++    with self.assertRaises(message.DecodeError) as context:
++      test_msg.ParseFromString(data)
++    self.assertIn(
++        'Error parsing message',
++        str(context.exception),
++    )
++    if api_implementation.Type() == 'python':
++      self.assertIn('too many levels of nesting', str(context.exception))
++      decoder.SetRecursionLimit(310)
++      test_msg.ParseFromString(data)
++      decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
++
+ 
+ # Class to test proto2-only features (required, extensions, etc.)
+ @testing_refleaks.TestCase
+@@ -1732,6 +1778,27 @@ class Proto3Test(unittest.TestCase):
+ 
+     self.assertEqual(msg.WhichOneof('_optional_int32'), None)
+ 
++    # Test has presence:More actions
++    for field in test_proto3_optional_pb2.TestProto3Optional.DESCRIPTOR.fields:
++      if field.name.startswith('optional_'):
++        self.assertTrue(field.has_presence)
++    for field in unittest_pb2.TestAllTypes.DESCRIPTOR.fields:
++      if field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
++        self.assertFalse(field.has_presence)
++      else:
++        self.assertTrue(field.has_presence)
++    proto3_descriptor = unittest_proto3_arena_pb2.TestAllTypes.DESCRIPTOR
++    repeated_field = proto3_descriptor.fields_by_name['repeated_int32']
++    self.assertFalse(repeated_field.has_presence)
++    singular_field = proto3_descriptor.fields_by_name['optional_int32']
++    self.assertFalse(singular_field.has_presence)
++    optional_field = proto3_descriptor.fields_by_name['proto3_optional_int32']
++    self.assertTrue(optional_field.has_presence)
++    message_field = proto3_descriptor.fields_by_name['optional_nested_message']
++    self.assertTrue(message_field.has_presence)
++    oneof_field = proto3_descriptor.fields_by_name['oneof_uint32']
++    self.assertTrue(oneof_field.has_presence)
++
+   def testAssignUnknownEnum(self):
+     """Assigning an unknown enum value is allowed and preserves the value."""
+     m = unittest_proto3_arena_pb2.TestAllTypes()
+@@ -2635,68 +2702,40 @@ class PackedFieldTest(unittest.TestCase):
+                    b'\x70\x01')
+     self.assertEqual(golden_data, message.SerializeToString())
+ 
+-
+-@unittest.skipIf(api_implementation.Type() != 'cpp' or
+-                 sys.version_info < (2, 7),
+-                 'explicit tests of the C++ implementation for PY27 and above')
+ @testing_refleaks.TestCase
+ class OversizeProtosTest(unittest.TestCase):
+ 
+-  @classmethod
+-  def setUpClass(cls):
+-    # At the moment, reference cycles between DescriptorPool and Message classes
+-    # are not detected and these objects are never freed.
+-    # To avoid errors with ReferenceLeakChecker, we create the class only once.
+-    file_desc = """
+-      name: "f/f.msg2"
+-      package: "f"
+-      message_type {
+-        name: "msg1"
+-        field {
+-          name: "payload"
+-          number: 1
+-          label: LABEL_OPTIONAL
+-          type: TYPE_STRING
+-        }
+-      }
+-      message_type {
+-        name: "msg2"
+-        field {
+-          name: "field"
+-          number: 1
+-          label: LABEL_OPTIONAL
+-          type: TYPE_MESSAGE
+-          type_name: "msg1"
+-        }
+-      }
+-    """
+-    pool = descriptor_pool.DescriptorPool()
+-    desc = descriptor_pb2.FileDescriptorProto()
+-    text_format.Parse(file_desc, desc)
+-    pool.Add(desc)
+-    cls.proto_cls = message_factory.MessageFactory(pool).GetPrototype(
+-        pool.FindMessageTypeByName('f.msg2'))
+-
+-  def setUp(self):
+-    self.p = self.proto_cls()
+-    self.p.field.payload = 'c' * (1024 * 1024 * 64 + 1)
+-    self.p_serialized = self.p.SerializeToString()
++  def GenerateNestedProto(self, n):
++    msg = unittest_pb2.TestRecursiveMessage()
++    sub = msg
++    for _ in range(n):
++      sub = sub.a
++    sub.i = 0
++    return msg.SerializeToString()
++
++  def testSucceedOkSizedProto(self):
++    msg = unittest_pb2.TestRecursiveMessage()
++    msg.ParseFromString(self.GenerateNestedProto(100))
+ 
+   def testAssertOversizeProto(self):
+-    from google.protobuf.pyext._message import SetAllowOversizeProtos
+-    SetAllowOversizeProtos(False)
+-    q = self.proto_cls()
+-    try:
+-      q.ParseFromString(self.p_serialized)
+-    except message.DecodeError as e:
+-      self.assertEqual(str(e), 'Error parsing message')
++    if api_implementation.Type() != 'python':
++      api_implementation._c_module.SetAllowOversizeProtos(False)
++    msg = unittest_pb2.TestRecursiveMessage()
++    with self.assertRaises(message.DecodeError) as context:
++      msg.ParseFromString(self.GenerateNestedProto(101))
++    self.assertIn('Error parsing message', str(context.exception))
+ 
+   def testSucceedOversizeProto(self):
+-    from google.protobuf.pyext._message import SetAllowOversizeProtos
+-    SetAllowOversizeProtos(True)
+-    q = self.proto_cls()
+-    q.ParseFromString(self.p_serialized)
+-    self.assertEqual(self.p.field.payload, q.field.payload)
++
++    if api_implementation.Type() == 'python':
++      decoder.SetRecursionLimit(310)
++    else:
++      api_implementation._c_module.SetAllowOversizeProtos(True)
++
++    msg = unittest_pb2.TestRecursiveMessage()
++    msg.ParseFromString(self.GenerateNestedProto(101))
++    decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
++
+ 
+ if __name__ == '__main__':
+   unittest.main()
+diff --git a/python/google/protobuf/internal/self_recursive.proto b/python/google/protobuf/internal/self_recursive.proto
+new file mode 100644
+index 0000000..db4d0c9
+--- /dev/null
++++ b/python/google/protobuf/internal/self_recursive.proto
+@@ -0,0 +1,24 @@
++// Protocol Buffers - Google's data interchange formatMore actions
++// Copyright 2024 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++edition = "2023";
++
++package google.protobuf.python.internal;
++
++message SelfRecursive {
++  SelfRecursive sub = 1;
++  int32 i = 2;
++  SelfRecursive sub_group = 3 [features.message_encoding = DELIMITED];
++}
++
++message IndirectRecursive {
++  IntermediateRecursive intermediate = 1;
++}
++
++message IntermediateRecursive {
++  IndirectRecursive indirect = 1;
++}
+-- 
+2.45.2
+

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -1,7 +1,7 @@
 Summary:        Google's data interchange format
 Name:           protobuf
 Version:        3.17.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          Development/Libraries
 URL:            https://developers.google.com/protocol-buffers/
 Source0:        https://github.com/protocolbuffers/protobuf/releases/download/v%{version}/%{name}-all-%{version}.tar.gz
 Patch0:         CVE-2022-1941.patch
+Patch1:         CVE-2025-4565.patch
 BuildRequires:  curl
 BuildRequires:  libstdc++
 BuildRequires:  make
@@ -109,6 +110,9 @@ popd
 %{python3_sitelib}/*
 
 %changelog
+* Thu Jun 19 2025 Akhila Guruju <v-guakhila@microsoft.com> - 3.17.3-4
+- Patch CVE-2025-4565
+
 * Tue Jul 16 2024 Archana Choudhary <archana1@microsoft.com> - 3.17.3-3
 - Add patch for CVE-2022-1941
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch protobuf for CVE-2025-4565
Patch Modified: Yes
- the func `_DecodeUnknownField` has been backported from upstream patch and a new argument `current_depth` has been added into some functions. All the changes from upstream patch reflect in the modified patch.
- `python/google/protobuf/internal/decoder_test.py` is not present in source tarball. So, patch is not applied.

Astrolabe Patch Reference: https://github.com/protocolbuffers/protobuf/commit/17838beda2943d08b8a9d4df5b68f5f04f26d901


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified:   SPECS/protobuf/protobuf.spec
- new file:   SPECS/protobuf/CVE-2025-4565.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4565

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Patch applies cleanly
<img width="672" alt="image" src="https://github.com/user-attachments/assets/3183ab6a-74b7-44ab-bccc-7cb7184203a4" />
