### PR TITLE
[High] Patch protobuf for CVE-2025-4565

### DIFF
--- a/SPECS/protobuf/CVE-2025-4565.patch
+++ b/SPECS/protobuf/CVE-2025-4565.patch
@@ -1,0 +1,315 @@
+From 638da75889980641f379ff0c5226dd997af7dba0 Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Thu, 19 Jun 2025 12:47:53 +0000
+Subject: [PATCH] Address CVE-2025-4565
+
+Upstream Patch reference: https://github.com/protocolbuffers/protobuf/commit/17838beda2943d08b8a9d4df5b68f5f04f26d901
+
+---
+ python/google/protobuf/internal/decoder.py    | 65 +++++++++++++++----
+ .../google/protobuf/internal/message_test.py  | 60 +++++++++++++++--
+ .../protobuf/internal/self_recursive.proto    | 24 +++++++
+ 3 files changed, 132 insertions(+), 17 deletions(-)
+ create mode 100644 python/google/protobuf/internal/self_recursive.proto
+
+diff --git a/python/google/protobuf/internal/decoder.py b/python/google/protobuf/internal/decoder.py
+index acb91aa..a3c06ee 100755
+--- a/python/google/protobuf/internal/decoder.py
++++ b/python/google/protobuf/internal/decoder.py
+@@ -623,7 +623,7 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+     tag_bytes = encoder.TagBytes(field_number,
+                                  wire_format.WIRETYPE_START_GROUP)
+     tag_len = len(tag_bytes)
+-    def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++    def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -632,7 +632,13 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+         if value is None:
+           value = field_dict.setdefault(key, new_default(message))
+         # Read sub-message.
+-        pos = value.add()._InternalParse(buffer, pos, end)
++        current_depth += 1
++        if current_depth > _recursion_limit:
++          raise _DecodeError(
++              'Error parsing message: too many levels of nesting.'
++          )
++        pos = value.add()._InternalParse(buffer, pos, end, current_depth)
++        current_depth -= 1
+         # Read end tag.
+         new_pos = pos+end_tag_len
+         if buffer[pos:new_pos] != end_tag_bytes or new_pos > end:
+@@ -644,12 +650,16 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+           return new_pos
+     return DecodeRepeatedField
+   else:
+-    def DecodeField(buffer, pos, end, message, field_dict):
++    def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+       # Read sub-message.
+-      pos = value._InternalParse(buffer, pos, end)
++      current_depth += 1
++      if current_depth > _recursion_limit:
++        raise _DecodeError('Error parsing message: too many levels of nesting.')
++      pos = value._InternalParse(buffer, pos, end, current_depth)
++      current_depth -= 1
+       # Read end tag.
+       new_pos = pos+end_tag_len
+       if buffer[pos:new_pos] != end_tag_bytes or new_pos > end:
+@@ -668,7 +678,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+     tag_bytes = encoder.TagBytes(field_number,
+                                  wire_format.WIRETYPE_LENGTH_DELIMITED)
+     tag_len = len(tag_bytes)
+-    def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++    def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -679,10 +689,16 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+         if new_pos > end:
+           raise _DecodeError('Truncated message.')
+         # Read sub-message.
+-        if value.add()._InternalParse(buffer, pos, new_pos) != new_pos:
++        current_depth += 1
++        if current_depth > _recursion_limit:
++          raise _DecodeError(
++              'Error parsing message: too many levels of nesting.'
++          )
++        if value.add()._InternalParse(buffer, pos, new_pos, current_depth) != new_pos:
+           # The only reason _InternalParse would return early is if it
+           # encountered an end-group tag.
+           raise _DecodeError('Unexpected end-group tag.')
++        current_depth -= 1
+         # Predict that the next tag is another copy of the same repeated field.
+         pos = new_pos + tag_len
+         if buffer[new_pos:pos] != tag_bytes or new_pos == end:
+@@ -690,7 +706,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+           return new_pos
+     return DecodeRepeatedField
+   else:
+-    def DecodeField(buffer, pos, end, message, field_dict):
++    def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -700,10 +716,14 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+       if new_pos > end:
+         raise _DecodeError('Truncated message.')
+       # Read sub-message.
+-      if value._InternalParse(buffer, pos, new_pos) != new_pos:
++      current_depth += 1
++      if current_depth > _recursion_limit:
++        raise _DecodeError('Error parsing message: too many levels of nesting.')
++      if value._InternalParse(buffer, pos, new_pos, current_depth) != new_pos:
+         # The only reason _InternalParse would return early is if it encountered
+         # an end-group tag.
+         raise _DecodeError('Unexpected end-group tag.')
++      current_depth -= 1
+       return new_pos
+     return DecodeField
+ 
+@@ -942,7 +962,7 @@ def _SkipGroup(buffer, pos, end):
+     pos = new_pos
+ 
+ 
+-def _DecodeUnknownFieldSet(buffer, pos, end_pos=None):
++def _DecodeUnknownFieldSet(buffer, pos, end_pos=None, current_depth=0):
+   """Decode UnknownFieldSet.  Returns the UnknownFieldSet and new position."""
+ 
+   unknown_field_set = containers.UnknownFieldSet()
+@@ -952,16 +972,15 @@ def _DecodeUnknownFieldSet(buffer, pos, end_pos=None):
+     field_number, wire_type = wire_format.UnpackTag(tag)
+     if wire_type == wire_format.WIRETYPE_END_GROUP:
+       break
+-    (data, pos) = _DecodeUnknownField(buffer, pos, wire_type)
++    (data, pos) = _DecodeUnknownField(buffer, pos, wire_type, current_depth)
+     # pylint: disable=protected-access
+     unknown_field_set._add(field_number, wire_type, data)
+ 
+   return (unknown_field_set, pos)
+ 
+ 
+-def _DecodeUnknownField(buffer, pos, wire_type):
++def _DecodeUnknownField(buffer, pos, end_pos, field_number, wire_type, current_depth=0):
+   """Decode a unknown field.  Returns the UnknownField and new position."""
+-
+   if wire_type == wire_format.WIRETYPE_VARINT:
+     (data, pos) = _DecodeVarint(buffer, pos)
+   elif wire_type == wire_format.WIRETYPE_FIXED64:
+@@ -973,12 +992,25 @@ def _DecodeUnknownField(buffer, pos, wire_type):
+     data = buffer[pos:pos+size].tobytes()
+     pos += size
+   elif wire_type == wire_format.WIRETYPE_START_GROUP:
+-    (data, pos) = _DecodeUnknownFieldSet(buffer, pos)
++    end_tag_bytes = encoder.TagBytes(
++        field_number, wire_format.WIRETYPE_END_GROUP
++    )
++    current_depth += 1
++    if current_depth >= _recursion_limit:
++      raise _DecodeError('Error parsing message: too many levels of nesting.')
++    data, pos = _DecodeUnknownFieldSet(buffer, pos, end_pos, current_depth)
++    current_depth -= 1
++    # Check end tag.
++    if buffer[pos - len(end_tag_bytes) : pos] != end_tag_bytes:
++      raise _DecodeError('Missing group end tag.')
+   elif wire_type == wire_format.WIRETYPE_END_GROUP:
+     return (0, -1)
+   else:
+     raise _DecodeError('Wrong wire type in tag.')
+ 
++  if pos > end_pos:
++    raise _DecodeError('Truncated message.')
++
+   return (data, pos)
+ 
+ 
+@@ -1002,6 +1034,13 @@ def _DecodeFixed32(buffer, pos):
+ 
+   new_pos = pos + 4
+   return (struct.unpack('<I', buffer[pos:new_pos])[0], new_pos)
++DEFAULT_RECURSION_LIMIT = 100
++_recursion_limit = DEFAULT_RECURSION_LIMIT
++
++
++def SetRecursionLimit(new_limit):
++  global _recursion_limit
++  _recursion_limit = new_limit
+ 
+ 
+ def _RaiseInvalidWireType(buffer, pos, end):
+diff --git a/python/google/protobuf/internal/message_test.py b/python/google/protobuf/internal/message_test.py
+index b0f1ae7..2b12c90 100755
+--- a/python/google/protobuf/internal/message_test.py
++++ b/python/google/protobuf/internal/message_test.py
+@@ -33,6 +33,7 @@ from google.protobuf.internal import encoder
+ from google.protobuf.internal import more_extensions_pb2
+ from google.protobuf.internal import more_messages_pb2
+ from google.protobuf.internal import packed_field_test_pb2
++from google.protobuf.internal import self_recursive_pb2
+ from google.protobuf.internal import test_proto3_optional_pb2
+ from google.protobuf.internal import test_util
+ from google.protobuf.internal import testing_refleaks
+@@ -1288,6 +1289,52 @@ class MessageTest(unittest.TestCase):
+     self.assertNotEqual(ComparesWithFoo(), m)
+ 
+ 
++@testing_refleaks.TestCase
++class TestRecursiveGroup(unittest.TestCase):
++
++  def _MakeRecursiveGroupMessage(self, n):
++    msg = self_recursive_pb2.SelfRecursive()
++    sub = msg
++    for _ in range(n):
++      sub = sub.sub_group
++    sub.i = 1
++    return msg.SerializeToString()
++
++  def testRecursiveGroups(self):
++    recurse_msg = self_recursive_pb2.SelfRecursive()
++    data = self._MakeRecursiveGroupMessage(100)
++    recurse_msg.ParseFromString(data)
++    self.assertTrue(recurse_msg.HasField('sub_group'))
++
++  def testRecursiveGroupsException(self):
++    if api_implementation.Type() != 'python':
++      api_implementation._c_module.SetAllowOversizeProtos(False)
++    recurse_msg = self_recursive_pb2.SelfRecursive()
++    data = self._MakeRecursiveGroupMessage(300)
++    with self.assertRaises(message.DecodeError) as context:
++      recurse_msg.ParseFromString(data)
++    self.assertIn('Error parsing message', str(context.exception))
++    if api_implementation.Type() == 'python':
++      self.assertIn('too many levels of nesting', str(context.exception))
++
++  def testRecursiveGroupsUnknownFields(self):
++    if api_implementation.Type() != 'python':
++      api_implementation._c_module.SetAllowOversizeProtos(False)
++    test_msg = unittest_pb2.TestAllTypes()
++    data = self._MakeRecursiveGroupMessage(300)  # unknown to test_msg
++    with self.assertRaises(message.DecodeError) as context:
++      test_msg.ParseFromString(data)
++    self.assertIn(
++        'Error parsing message',
++        str(context.exception),
++    )
++    if api_implementation.Type() == 'python':
++      self.assertIn('too many levels of nesting', str(context.exception))
++      decoder.SetRecursionLimit(310)
++      test_msg.ParseFromString(data)
++      decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
++
++
+ # Class to test proto2-only features (required, extensions, etc.)
+ @testing_refleaks.TestCase
+ class Proto2Test(unittest.TestCase):
+@@ -2635,8 +2682,6 @@ class PackedFieldTest(unittest.TestCase):
+     self.assertEqual(golden_data, message.SerializeToString())
+ 
+ 
+-@unittest.skipIf(api_implementation.Type() == 'python',
+-                 'explicit tests of the C++ implementation')
+ @testing_refleaks.TestCase
+ class OversizeProtosTest(unittest.TestCase):
+ 
+@@ -2653,16 +2698,23 @@ class OversizeProtosTest(unittest.TestCase):
+     msg.ParseFromString(self.GenerateNestedProto(100))
+ 
+   def testAssertOversizeProto(self):
+-    api_implementation._c_module.SetAllowOversizeProtos(False)
++    if api_implementation.Type() != 'python':
++      api_implementation._c_module.SetAllowOversizeProtos(False)
+     msg = unittest_pb2.TestRecursiveMessage()
+     with self.assertRaises(message.DecodeError) as context:
+       msg.ParseFromString(self.GenerateNestedProto(101))
+     self.assertIn('Error parsing message', str(context.exception))
+ 
+   def testSucceedOversizeProto(self):
+-    api_implementation._c_module.SetAllowOversizeProtos(True)
++
++    if api_implementation.Type() == 'python':
++      decoder.SetRecursionLimit(310)
++    else:
++      api_implementation._c_module.SetAllowOversizeProtos(True)
++
+     msg = unittest_pb2.TestRecursiveMessage()
+     msg.ParseFromString(self.GenerateNestedProto(101))
++    decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
+ 
+ 
+ if __name__ == '__main__':
+diff --git a/python/google/protobuf/internal/self_recursive.proto b/python/google/protobuf/internal/self_recursive.proto
+new file mode 100644
+index 0000000..db4d0c9
+--- /dev/null
++++ b/python/google/protobuf/internal/self_recursive.proto
+@@ -0,0 +1,24 @@
++// Protocol Buffers - Google's data interchange formatMore actions
++// Copyright 2024 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++edition = "2023";
++
++package google.protobuf.python.internal;
++
++message SelfRecursive {
++  SelfRecursive sub = 1;
++  int32 i = 2;
++  SelfRecursive sub_group = 3 [features.message_encoding = DELIMITED];
++}
++
++message IndirectRecursive {
++  IntermediateRecursive intermediate = 1;
++}
++
++message IntermediateRecursive {
++  IndirectRecursive indirect = 1;
++}
+-- 
+2.45.2
+

--- a/SPECS/protobuf/CVE-2025-4565.patch
+++ b/SPECS/protobuf/CVE-2025-4565.patch
@@ -1,22 +1,184 @@
-From 638da75889980641f379ff0c5226dd997af7dba0 Mon Sep 17 00:00:00 2001
+From ba0c3b2cc3489833ef3b6a7901ac586b46762514 Mon Sep 17 00:00:00 2001
 From: akhila-guruju <v-guakhila@microsoft.com>
-Date: Thu, 19 Jun 2025 12:47:53 +0000
-Subject: [PATCH] Address CVE-2025-4565
+Date: Sat, 21 Jun 2025 10:38:15 +0000
+Subject: [PATCH] CVE-2025-4565
 
-Upstream Patch reference: https://github.com/protocolbuffers/protobuf/commit/17838beda2943d08b8a9d4df5b68f5f04f26d901
-
+Upstream Patch reference: https://github.com/protocolbuffers/protobuf/commit/17838beda2943d08b8a9d4df5b68f5f04f2
 ---
- python/google/protobuf/internal/decoder.py    | 65 +++++++++++++++----
- .../google/protobuf/internal/message_test.py  | 60 +++++++++++++++--
- .../protobuf/internal/self_recursive.proto    | 24 +++++++
- 3 files changed, 132 insertions(+), 17 deletions(-)
+ python/google/protobuf/internal/decoder.py    | 111 +++++++++++-------
+ .../google/protobuf/internal/message_test.py  |  60 +++++++++-
+ .../protobuf/internal/python_message.py       |  39 +-----
+ .../protobuf/internal/self_recursive.proto    |  24 ++++
+ 4 files changed, 152 insertions(+), 82 deletions(-)
  create mode 100644 python/google/protobuf/internal/self_recursive.proto
 
 diff --git a/python/google/protobuf/internal/decoder.py b/python/google/protobuf/internal/decoder.py
-index acb91aa..a3c06ee 100755
+index acb91aa..e16c5a5 100755
 --- a/python/google/protobuf/internal/decoder.py
 +++ b/python/google/protobuf/internal/decoder.py
-@@ -623,7 +623,7 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+@@ -172,7 +172,8 @@ def _SimpleDecoder(wire_type, decode_value):
+                       clear_if_default=False):
+     if is_packed:
+       local_DecodeVarint = _DecodeVarint
+-      def DecodePackedField(buffer, pos, end, message, field_dict):
++      def DecodePackedField(buffer, pos, end, message, field_dict, current_depth=0):
++        del current_depth  # unused
+         value = field_dict.get(key)
+         if value is None:
+           value = field_dict.setdefault(key, new_default(message))
+@@ -191,7 +192,8 @@ def _SimpleDecoder(wire_type, decode_value):
+     elif is_repeated:
+       tag_bytes = encoder.TagBytes(field_number, wire_type)
+       tag_len = len(tag_bytes)
+-      def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++      def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
++        del current_depth  # unused
+         value = field_dict.get(key)
+         if value is None:
+           value = field_dict.setdefault(key, new_default(message))
+@@ -208,7 +210,8 @@ def _SimpleDecoder(wire_type, decode_value):
+             return new_pos
+       return DecodeRepeatedField
+     else:
+-      def DecodeField(buffer, pos, end, message, field_dict):
++      def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
++        del current_depth  # unused
+         (new_value, pos) = decode_value(buffer, pos)
+         if pos > end:
+           raise _DecodeError('Truncated message.')
+@@ -352,7 +355,7 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+   enum_type = key.enum_type
+   if is_packed:
+     local_DecodeVarint = _DecodeVarint
+-    def DecodePackedField(buffer, pos, end, message, field_dict):
++    def DecodePackedField(buffer, pos, end, message, field_dict, current_depth=0):
+       """Decode serialized packed enum to its value and a new position.
+ 
+       Args:
+@@ -365,6 +368,7 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+       Returns:
+         int, new position in serialized data.
+       """
++      del current_depth  # unused
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -386,18 +390,12 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+ 
+           message._unknown_fields.append(
+               (tag_bytes, buffer[value_start_pos:pos].tobytes()))
+-          if message._unknown_field_set is None:
+-            message._unknown_field_set = containers.UnknownFieldSet()
+-          message._unknown_field_set._add(
+-              field_number, wire_format.WIRETYPE_VARINT, element)
+           # pylint: enable=protected-access
+       if pos > endpoint:
+         if element in enum_type.values_by_number:
+           del value[-1]   # Discard corrupt value.
+         else:
+           del message._unknown_fields[-1]
+-          # pylint: disable=protected-access
+-          del message._unknown_field_set._values[-1]
+           # pylint: enable=protected-access
+         raise _DecodeError('Packed element was truncated.')
+       return pos
+@@ -405,7 +403,7 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+   elif is_repeated:
+     tag_bytes = encoder.TagBytes(field_number, wire_format.WIRETYPE_VARINT)
+     tag_len = len(tag_bytes)
+-    def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++    def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
+       """Decode serialized repeated enum to its value and a new position.
+ 
+       Args:
+@@ -418,6 +416,7 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+       Returns:
+         int, new position in serialized data.
+       """
++      del current_depth  # unused
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -431,10 +430,6 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+             message._unknown_fields = []
+           message._unknown_fields.append(
+               (tag_bytes, buffer[pos:new_pos].tobytes()))
+-          if message._unknown_field_set is None:
+-            message._unknown_field_set = containers.UnknownFieldSet()
+-          message._unknown_field_set._add(
+-              field_number, wire_format.WIRETYPE_VARINT, element)
+         # pylint: enable=protected-access
+         # Predict that the next tag is another copy of the same repeated
+         # field.
+@@ -446,7 +441,7 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+           return new_pos
+     return DecodeRepeatedField
+   else:
+-    def DecodeField(buffer, pos, end, message, field_dict):
++    def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
+       """Decode serialized repeated enum to its value and a new position.
+ 
+       Args:
+@@ -459,6 +454,7 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+       Returns:
+         int, new position in serialized data.
+       """
++      del current_depth  # unused
+       value_start_pos = pos
+       (enum_value, pos) = _DecodeSignedVarint32(buffer, pos)
+       if pos > end:
+@@ -476,10 +472,6 @@ def EnumDecoder(field_number, is_repeated, is_packed, key, new_default,
+                                      wire_format.WIRETYPE_VARINT)
+         message._unknown_fields.append(
+             (tag_bytes, buffer[value_start_pos:pos].tobytes()))
+-        if message._unknown_field_set is None:
+-          message._unknown_field_set = containers.UnknownFieldSet()
+-        message._unknown_field_set._add(
+-            field_number, wire_format.WIRETYPE_VARINT, enum_value)
+         # pylint: enable=protected-access
+       return pos
+     return DecodeField
+@@ -540,7 +532,8 @@ def StringDecoder(field_number, is_repeated, is_packed, key, new_default,
+     tag_bytes = encoder.TagBytes(field_number,
+                                  wire_format.WIRETYPE_LENGTH_DELIMITED)
+     tag_len = len(tag_bytes)
+-    def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++    def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
++      del current_depth  # unused
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -557,7 +550,8 @@ def StringDecoder(field_number, is_repeated, is_packed, key, new_default,
+           return new_pos
+     return DecodeRepeatedField
+   else:
+-    def DecodeField(buffer, pos, end, message, field_dict):
++    def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
++      del current_depth  # unused
+       (size, pos) = local_DecodeVarint(buffer, pos)
+       new_pos = pos + size
+       if new_pos > end:
+@@ -581,7 +575,8 @@ def BytesDecoder(field_number, is_repeated, is_packed, key, new_default,
+     tag_bytes = encoder.TagBytes(field_number,
+                                  wire_format.WIRETYPE_LENGTH_DELIMITED)
+     tag_len = len(tag_bytes)
+-    def DecodeRepeatedField(buffer, pos, end, message, field_dict):
++    def DecodeRepeatedField(buffer, pos, end, message, field_dict, current_depth=0):
++      del current_depth  # unused
+       value = field_dict.get(key)
+       if value is None:
+         value = field_dict.setdefault(key, new_default(message))
+@@ -598,7 +593,8 @@ def BytesDecoder(field_number, is_repeated, is_packed, key, new_default,
+           return new_pos
+     return DecodeRepeatedField
+   else:
+-    def DecodeField(buffer, pos, end, message, field_dict):
++    def DecodeField(buffer, pos, end, message, field_dict, current_depth=0):
++      del current_depth  # unused
+       (size, pos) = local_DecodeVarint(buffer, pos)
+       new_pos = pos + size
+       if new_pos > end:
+@@ -623,7 +619,7 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
      tag_bytes = encoder.TagBytes(field_number,
                                   wire_format.WIRETYPE_START_GROUP)
      tag_len = len(tag_bytes)
@@ -25,7 +187,7 @@ index acb91aa..a3c06ee 100755
        value = field_dict.get(key)
        if value is None:
          value = field_dict.setdefault(key, new_default(message))
-@@ -632,7 +632,13 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+@@ -632,7 +628,13 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
          if value is None:
            value = field_dict.setdefault(key, new_default(message))
          # Read sub-message.
@@ -40,7 +202,7 @@ index acb91aa..a3c06ee 100755
          # Read end tag.
          new_pos = pos+end_tag_len
          if buffer[pos:new_pos] != end_tag_bytes or new_pos > end:
-@@ -644,12 +650,16 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
+@@ -644,12 +646,16 @@ def GroupDecoder(field_number, is_repeated, is_packed, key, new_default):
            return new_pos
      return DecodeRepeatedField
    else:
@@ -59,7 +221,7 @@ index acb91aa..a3c06ee 100755
        # Read end tag.
        new_pos = pos+end_tag_len
        if buffer[pos:new_pos] != end_tag_bytes or new_pos > end:
-@@ -668,7 +678,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+@@ -668,7 +674,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
      tag_bytes = encoder.TagBytes(field_number,
                                   wire_format.WIRETYPE_LENGTH_DELIMITED)
      tag_len = len(tag_bytes)
@@ -68,7 +230,7 @@ index acb91aa..a3c06ee 100755
        value = field_dict.get(key)
        if value is None:
          value = field_dict.setdefault(key, new_default(message))
-@@ -679,10 +689,16 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+@@ -679,10 +685,16 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
          if new_pos > end:
            raise _DecodeError('Truncated message.')
          # Read sub-message.
@@ -86,7 +248,7 @@ index acb91aa..a3c06ee 100755
          # Predict that the next tag is another copy of the same repeated field.
          pos = new_pos + tag_len
          if buffer[new_pos:pos] != tag_bytes or new_pos == end:
-@@ -690,7 +706,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+@@ -690,7 +702,7 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
            return new_pos
      return DecodeRepeatedField
    else:
@@ -95,7 +257,7 @@ index acb91aa..a3c06ee 100755
        value = field_dict.get(key)
        if value is None:
          value = field_dict.setdefault(key, new_default(message))
-@@ -700,10 +716,14 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
+@@ -700,10 +712,14 @@ def MessageDecoder(field_number, is_repeated, is_packed, key, new_default):
        if new_pos > end:
          raise _DecodeError('Truncated message.')
        # Read sub-message.
@@ -111,11 +273,43 @@ index acb91aa..a3c06ee 100755
        return new_pos
      return DecodeField
  
-@@ -942,7 +962,7 @@ def _SkipGroup(buffer, pos, end):
+@@ -795,12 +811,6 @@ def MessageSetItemDecoder(descriptor):
+         message._unknown_fields = []
+       message._unknown_fields.append(
+           (MESSAGE_SET_ITEM_TAG, buffer[message_set_item_start:pos].tobytes()))
+-      if message._unknown_field_set is None:
+-        message._unknown_field_set = containers.UnknownFieldSet()
+-      message._unknown_field_set._add(
+-          type_id,
+-          wire_format.WIRETYPE_LENGTH_DELIMITED,
+-          buffer[message_start:message_end].tobytes())
+       # pylint: enable=protected-access
+ 
+     return pos
+@@ -859,7 +869,8 @@ def MapDecoder(field_descriptor, new_default, is_message_map):
+   # Can't read _concrete_class yet; might not be initialized.
+   message_type = field_descriptor.message_type
+ 
+-  def DecodeMap(buffer, pos, end, message, field_dict):
++  def DecodeMap(buffer, pos, end, message, field_dict, current_depth=0):
++    del current_depth  # unused
+     submsg = message_type._concrete_class()
+     value = field_dict.get(key)
+     if value is None:
+@@ -942,7 +953,16 @@ def _SkipGroup(buffer, pos, end):
      pos = new_pos
  
  
 -def _DecodeUnknownFieldSet(buffer, pos, end_pos=None):
++DEFAULT_RECURSION_LIMIT = 100
++_recursion_limit = DEFAULT_RECURSION_LIMIT
++
++
++def SetRecursionLimit(new_limit):
++  global _recursion_limit
++  _recursion_limit = new_limit
++
++
 +def _DecodeUnknownFieldSet(buffer, pos, end_pos=None, current_depth=0):
    """Decode UnknownFieldSet.  Returns the UnknownFieldSet and new position."""
  
@@ -133,53 +327,25 @@ index acb91aa..a3c06ee 100755
  
  
 -def _DecodeUnknownField(buffer, pos, wire_type):
-+def _DecodeUnknownField(buffer, pos, end_pos, field_number, wire_type, current_depth=0):
++def _DecodeUnknownField(buffer, pos, wire_type, current_depth=0):
    """Decode a unknown field.  Returns the UnknownField and new position."""
 -
    if wire_type == wire_format.WIRETYPE_VARINT:
      (data, pos) = _DecodeVarint(buffer, pos)
    elif wire_type == wire_format.WIRETYPE_FIXED64:
-@@ -973,12 +992,25 @@ def _DecodeUnknownField(buffer, pos, wire_type):
+@@ -973,7 +992,11 @@ def _DecodeUnknownField(buffer, pos, wire_type):
      data = buffer[pos:pos+size].tobytes()
      pos += size
    elif wire_type == wire_format.WIRETYPE_START_GROUP:
 -    (data, pos) = _DecodeUnknownFieldSet(buffer, pos)
-+    end_tag_bytes = encoder.TagBytes(
-+        field_number, wire_format.WIRETYPE_END_GROUP
-+    )
 +    current_depth += 1
 +    if current_depth >= _recursion_limit:
 +      raise _DecodeError('Error parsing message: too many levels of nesting.')
-+    data, pos = _DecodeUnknownFieldSet(buffer, pos, end_pos, current_depth)
++    data, pos = _DecodeUnknownFieldSet(buffer, pos, None, current_depth)
 +    current_depth -= 1
-+    # Check end tag.
-+    if buffer[pos - len(end_tag_bytes) : pos] != end_tag_bytes:
-+      raise _DecodeError('Missing group end tag.')
    elif wire_type == wire_format.WIRETYPE_END_GROUP:
      return (0, -1)
    else:
-     raise _DecodeError('Wrong wire type in tag.')
- 
-+  if pos > end_pos:
-+    raise _DecodeError('Truncated message.')
-+
-   return (data, pos)
- 
- 
-@@ -1002,6 +1034,13 @@ def _DecodeFixed32(buffer, pos):
- 
-   new_pos = pos + 4
-   return (struct.unpack('<I', buffer[pos:new_pos])[0], new_pos)
-+DEFAULT_RECURSION_LIMIT = 100
-+_recursion_limit = DEFAULT_RECURSION_LIMIT
-+
-+
-+def SetRecursionLimit(new_limit):
-+  global _recursion_limit
-+  _recursion_limit = new_limit
- 
- 
- def _RaiseInvalidWireType(buffer, pos, end):
 diff --git a/python/google/protobuf/internal/message_test.py b/python/google/protobuf/internal/message_test.py
 index b0f1ae7..2b12c90 100755
 --- a/python/google/protobuf/internal/message_test.py
@@ -280,6 +446,129 @@ index b0f1ae7..2b12c90 100755
  
  
  if __name__ == '__main__':
+diff --git a/python/google/protobuf/internal/python_message.py b/python/google/protobuf/internal/python_message.py
+index 40c7764..4451477 100755
+--- a/python/google/protobuf/internal/python_message.py
++++ b/python/google/protobuf/internal/python_message.py
+@@ -240,7 +240,6 @@ def _AddSlots(message_descriptor, dictionary):
+                              '_cached_byte_size_dirty',
+                              '_fields',
+                              '_unknown_fields',
+-                             '_unknown_field_set',
+                              '_is_present_in_parent',
+                              '_listener',
+                              '_listener_for_children',
+@@ -503,9 +502,6 @@ def _AddInitMethod(message_descriptor, cls):
+     # _unknown_fields is () when empty for efficiency, and will be turned into
+     # a list if fields are added.
+     self._unknown_fields = ()
+-    # _unknown_field_set is None when empty for efficiency, and will be
+-    # turned into UnknownFieldSet struct if fields are added.
+-    self._unknown_field_set = None      # pylint: disable=protected-access
+     self._is_present_in_parent = False
+     self._listener = message_listener_mod.NullMessageListener()
+     self._listener_for_children = _Listener(self)
+@@ -1136,7 +1132,7 @@ def _AddMergeFromStringMethod(message_descriptor, cls):
+   fields_by_tag = cls._fields_by_tag
+   message_set_decoders_by_tag = cls._message_set_decoders_by_tag
+ 
+-  def InternalParse(self, buffer, pos, end):
++  def InternalParse(self, buffer, pos, end, current_depth=0):
+     """Create a message from serialized bytes.
+ 
+     Args:
+@@ -1153,8 +1149,6 @@ def _AddMergeFromStringMethod(message_descriptor, cls):
+     assert isinstance(buffer, memoryview)
+     self._Modified()
+     field_dict = self._fields
+-    # pylint: disable=protected-access
+-    unknown_field_set = self._unknown_field_set
+     while pos != end:
+       (tag_bytes, new_pos) = local_ReadTag(buffer, pos)
+       field_decoder, field_des = message_set_decoders_by_tag.get(
+@@ -1167,11 +1161,6 @@ def _AddMergeFromStringMethod(message_descriptor, cls):
+       if field_des is None:
+         if not self._unknown_fields:   # pylint: disable=protected-access
+           self._unknown_fields = []    # pylint: disable=protected-access
+-        if unknown_field_set is None:
+-          # pylint: disable=protected-access
+-          self._unknown_field_set = containers.UnknownFieldSet()
+-          # pylint: disable=protected-access
+-          unknown_field_set = self._unknown_field_set
+         # pylint: disable=protected-access
+         (tag, _) = decoder._DecodeVarint(tag_bytes, 0)
+         field_number, wire_type = wire_format.UnpackTag(tag)
+@@ -1183,8 +1172,6 @@ def _AddMergeFromStringMethod(message_descriptor, cls):
+             buffer, new_pos, wire_type)  # pylint: disable=protected-access
+         if new_pos == -1:
+           return pos
+-        # pylint: disable=protected-access
+-        unknown_field_set._add(field_number, wire_type, data)
+         # TODO: remove _unknown_fields.
+         new_pos = local_SkipField(buffer, old_pos, end, tag_bytes)
+         if new_pos == -1:
+@@ -1195,7 +1182,7 @@ def _AddMergeFromStringMethod(message_descriptor, cls):
+       else:
+         _MaybeAddDecoder(cls, field_des)
+         field_decoder = field_des._decoders[is_packed]
+-        pos = field_decoder(buffer, new_pos, end, self, field_dict)
++        pos = field_decoder(buffer, new_pos, end, self, field_dict, current_depth)
+         if field_des.containing_oneof:
+           self._UpdateOneofState(field_des)
+     return pos
+@@ -1345,10 +1332,6 @@ def _AddMergeFromMethod(cls):
+       if not self._unknown_fields:
+         self._unknown_fields = []
+       self._unknown_fields.extend(msg._unknown_fields)
+-      # pylint: disable=protected-access
+-      if self._unknown_field_set is None:
+-        self._unknown_field_set = containers.UnknownFieldSet()
+-      self._unknown_field_set._extend(msg._unknown_field_set)
+ 
+   cls.MergeFrom = MergeFrom
+ 
+@@ -1375,30 +1358,19 @@ def _Clear(self):
+   # Clear fields.
+   self._fields = {}
+   self._unknown_fields = ()
+-  # pylint: disable=protected-access
+-  if self._unknown_field_set is not None:
+-    self._unknown_field_set._clear()
+-    self._unknown_field_set = None
+ 
+   self._oneofs = {}
+   self._Modified()
+ 
+ 
+ def _UnknownFields(self):
+-  warnings.warn(
+-      'message.UnknownFields() is deprecated. Please use the add one '
+-      'feature unknown_fields.UnknownFieldSet(message) in '
+-      'unknown_fields.py instead.'
+-  )
+-  if self._unknown_field_set is None:  # pylint: disable=protected-access
+-    # pylint: disable=protected-access
+-    self._unknown_field_set = containers.UnknownFieldSet()
+-  return self._unknown_field_set    # pylint: disable=protected-access
++  raise NotImplementedError('Please use the add-on feaure '
++                            'unknown_fields.UnknownFieldSet(message) in '
++                            'unknown_fields.py instead.')
+ 
+ 
+ def _DiscardUnknownFields(self):
+   self._unknown_fields = []
+-  self._unknown_field_set = None      # pylint: disable=protected-access
+   for field, value in self.ListFields():
+     if field.cpp_type == _FieldDescriptor.CPPTYPE_MESSAGE:
+       if _IsMapField(field):
+@@ -1440,7 +1412,6 @@ def _AddMessageMethods(message_descriptor, cls):
+   _AddWhichOneofMethod(message_descriptor, cls)
+   # Adds methods which do not depend on cls.
+   cls.Clear = _Clear
+-  cls.UnknownFields = _UnknownFields
+   cls.DiscardUnknownFields = _DiscardUnknownFields
+   cls._SetListener = _SetListener
+ 
 diff --git a/python/google/protobuf/internal/self_recursive.proto b/python/google/protobuf/internal/self_recursive.proto
 new file mode 100644
 index 0000000..db4d0c9

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -1,13 +1,14 @@
 Summary:        Google's data interchange format
 Name:           protobuf
 Version:        25.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Development/Libraries
 URL:            https://developers.google.com/protocol-buffers/
 Source0:        https://github.com/protocolbuffers/protobuf/releases/download/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         CVE-2025-4565.patch
 BuildRequires:  curl
 BuildRequires:  libstdc++
 BuildRequires:  cmake
@@ -62,7 +63,7 @@ Provides:       %{name}-python3 = %{version}-%{release}
 This contains protobuf python3 libraries.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 %{cmake} \
@@ -122,6 +123,9 @@ popd
 %{python3_sitelib}/*
 
 %changelog
+* Thu Jun 19 2025 Akhila Guruju <v-guakhila@microsoft.com> - 25.3-5
+- Patch CVE-2025-4565
+
 * Thu Jul 25 2024 Devin Anderson <danderson@microsoft.com> - 25.3-4
 - Bump release to rebuild with latest 'abseil-cpp'.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch protobuf for CVE-2025-4565
Patch Modified: Yes
- A new parameter `current_depth` has been added for the  files `decoder.py` and `python_message.py` from upstream v29.5 for proper application of patch.
- Apart from upstream patch, a file `python_message.py` was also backported to fix the build for `python-tensorboard`
- `python/google/protobuf/internal/decoder_test.py` is not present in source tarball. So, patch is not applied for that file.
- Some changes in the upstream patch are already included in the source tarball, so they won't appear in the modified patch.

Astrolabe Patch Reference: https://github.com/protocolbuffers/protobuf/commit/17838beda2943d08b8a9d4df5b68f5f04f26d901 .
NIST mentions here https://nvd.nist.gov/vuln/detail/CVE-2025-4565 that it fixes this CVE.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/protobuf/CVE-2025-4565.patch
- modified:   SPECS/protobuf/protobuf.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4565

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Patch applies cleanly
<img width="598" alt="image" src="https://github.com/user-attachments/assets/9a0a2b98-6240-4695-b4c7-8d934a640ac0" />
