### PR TITLE
[Low] Patch cmake for CVE-2025-5916 & CVE-2025-5917 & CVE-2025-5918

### DIFF
--- a/SPECS/cmake/CVE-2025-5916.patch
+++ b/SPECS/cmake/CVE-2025-5916.patch
@@ -1,0 +1,37 @@
+From cb083a8451e8bb463512d7cd18d4698bf27c6fcf Mon Sep 17 00:00:00 2001
+From: dj_palli <v-dpalli@microsoft.com>
+Date: Thu, 19 Jun 2025 12:55:15 +0000
+Subject: [PATCH] Address CVE-2025-5916
+
+---
+ .../libarchive/archive_read_support_format_warc.c          | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/Utilities/cmlibarchive/libarchive/archive_read_support_format_warc.c b/Utilities/cmlibarchive/libarchive/archive_read_support_format_warc.c
+index 72977b8e..0f3ee8d1 100644
+--- a/Utilities/cmlibarchive/libarchive/archive_read_support_format_warc.c
++++ b/Utilities/cmlibarchive/libarchive/archive_read_support_format_warc.c
+@@ -363,7 +363,8 @@ start_over:
+ 		/* FALLTHROUGH */
+ 	default:
+ 		/* consume the content and start over */
+-		_warc_skip(a);
++		if (_warc_skip(a) < 0)
++			return (ARCHIVE_FATAL);
+ 		goto start_over;
+ 	}
+ 	return (ARCHIVE_OK);
+@@ -416,7 +417,9 @@ _warc_skip(struct archive_read *a)
+ {
+ 	struct warc_s *w = a->format->data;
+ 
+-	__archive_read_consume(a, w->cntlen + 4U/*\r\n\r\n separator*/);
++	if (__archive_read_consume(a, w->cntlen) < 0 ||
++	    __archive_read_consume(a, 4U/*\r\n\r\n separator*/) < 0)
++		return (ARCHIVE_FATAL);
+ 	w->cntlen = 0U;
+ 	w->cntoff = 0U;
+ 	return (ARCHIVE_OK);
+-- 
+2.45.2
+

--- a/SPECS/cmake/CVE-2025-5917.patch
+++ b/SPECS/cmake/CVE-2025-5917.patch
@@ -1,0 +1,34 @@
+From b211326905f20a8c9611911ebfef8a40c84757eb Mon Sep 17 00:00:00 2001
+From: dj_palli <v-dpalli@microsoft.com>
+Date: Thu, 19 Jun 2025 13:36:28 +0000
+Subject: [PATCH] Address CVE-2025-5917
+
+---
+ .../cmlibarchive/libarchive/archive_write_set_format_pax.c    | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Utilities/cmlibarchive/libarchive/archive_write_set_format_pax.c b/Utilities/cmlibarchive/libarchive/archive_write_set_format_pax.c
+index a2b27107..0e0c71eb 100644
+--- a/Utilities/cmlibarchive/libarchive/archive_write_set_format_pax.c
++++ b/Utilities/cmlibarchive/libarchive/archive_write_set_format_pax.c
+@@ -1542,7 +1542,7 @@ build_ustar_entry_name(char *dest, const char *src, size_t src_length,
+ 	const char *filename, *filename_end;
+ 	char *p;
+ 	int need_slash = 0; /* Was there a trailing slash? */
+-	size_t suffix_length = 99;
++	size_t suffix_length = 98; /* 99 - 1 for trailing slash */
+ 	size_t insert_length;
+ 
+ 	/* Length of additional dir element to be added. */
+@@ -1594,7 +1594,7 @@ build_ustar_entry_name(char *dest, const char *src, size_t src_length,
+ 	/* Step 2: Locate the "prefix" section of the dirname, including
+ 	 * trailing '/'. */
+ 	prefix = src;
+-	prefix_end = prefix + 155;
++	prefix_end = prefix + 154 /* 155 - 1 for trailing / */;
+ 	if (prefix_end > filename)
+ 		prefix_end = filename;
+ 	while (prefix_end > prefix && *prefix_end != '/')
+-- 
+2.45.2
+

--- a/SPECS/cmake/CVE-2025-5918.patch
+++ b/SPECS/cmake/CVE-2025-5918.patch
@@ -1,0 +1,172 @@
+From 296639ab7fff1ee29aa8ea9da855dda77f32b790 Mon Sep 17 00:00:00 2001
+From: dj_palli <v-dpalli@microsoft.com>
+Date: Thu, 19 Jun 2025 19:51:08 +0000
+Subject: [PATCH] Address CVE-2025-5918
+
+---
+ .../libarchive/archive_read_open_fd.c         | 12 +++++--
+ .../libarchive/archive_read_open_file.c       | 33 ++++++++++++++-----
+ .../libarchive/archive_read_open_filename.c   | 22 +++++++++----
+ 3 files changed, 50 insertions(+), 17 deletions(-)
+
+diff --git a/Utilities/cmlibarchive/libarchive/archive_read_open_fd.c b/Utilities/cmlibarchive/libarchive/archive_read_open_fd.c
+index f59cd07f..a36d5f87 100644
+--- a/Utilities/cmlibarchive/libarchive/archive_read_open_fd.c
++++ b/Utilities/cmlibarchive/libarchive/archive_read_open_fd.c
+@@ -53,6 +53,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_read_open_fd.c 201103 2009-12-28
+ struct read_fd_data {
+ 	int	 fd;
+ 	size_t	 block_size;
++	int64_t size;
+ 	char	 use_lseek;
+ 	void	*buffer;
+ };
+@@ -152,9 +153,14 @@ file_skip(struct archive *a, void *client_data, int64_t request)
+ 	if (request == 0)
+ 		return (0);
+ 
+-	if (((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0) &&
+-	    ((new_offset = lseek(mine->fd, skip, SEEK_CUR)) >= 0))
+-		return (new_offset - old_offset);
++	if ((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0) {
++		if (old_offset >= mine->size ||
++			skip > mine->size - old_offset) {
++			/* Do not seek past end of file. */
++			errno = ESPIPE;
++		} else if ((new_offset = lseek(mine->fd, skip, SEEK_CUR)) >= 0)
++			return (new_offset - old_offset);
++	}
+ 
+ 	/* If seek failed once, it will probably fail again. */
+ 	mine->use_lseek = 0;
+diff --git a/Utilities/cmlibarchive/libarchive/archive_read_open_file.c b/Utilities/cmlibarchive/libarchive/archive_read_open_file.c
+index 101dae6c..bb8bf523 100644
+--- a/Utilities/cmlibarchive/libarchive/archive_read_open_file.c
++++ b/Utilities/cmlibarchive/libarchive/archive_read_open_file.c
+@@ -53,6 +53,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_read_open_file.c 201093 2009-12-
+ struct read_FILE_data {
+ 	FILE    *f;
+ 	size_t	 block_size;
++	int64_t  size;
+ 	void	*buffer;
+ 	char	 can_skip;
+ };
+@@ -91,6 +92,7 @@ archive_read_open_FILE(struct archive *a, FILE *f)
+ 		archive_read_extract_set_skip_file(a, st.st_dev, st.st_ino);
+ 		/* Enable the seek optimization only for regular files. */
+ 		mine->can_skip = 1;
++		mine->size = st.st_size;
+ 	} else
+ 		mine->can_skip = 0;
+ 
+@@ -130,6 +132,7 @@ file_skip(struct archive *a, void *client_data, int64_t request)
+ #else
+ 	long skip = (long)request;
+ #endif
++    int64_t old_offset, new_offset;
+ 	int skip_bits = sizeof(skip) * 8 - 1;
+ 
+ 	(void)a; /* UNUSED */
+@@ -153,19 +156,33 @@ file_skip(struct archive *a, void *client_data, int64_t request)
+ 
+ #ifdef __ANDROID__
+         /* fileno() isn't safe on all platforms ... see above. */
+-	if (lseek(fileno(mine->f), skip, SEEK_CUR) < 0)
++	old_offset = lseek(fileno(mine->f), 0, SEEK_CUR);
+ #elif HAVE_FSEEKO
+-	if (fseeko(mine->f, skip, SEEK_CUR) != 0)
++	old_offset = ftello(mine->f);
+ #elif HAVE__FSEEKI64
+-	if (_fseeki64(mine->f, skip, SEEK_CUR) != 0)
++	old_offset = _ftelli64(mine->f);
+ #else
+-	if (fseek(mine->f, skip, SEEK_CUR) != 0)
++	old_offset = ftell(mine->f);
+ #endif
+-	{
+-		mine->can_skip = 0;
+-		return (0);
++	if (old_offset >= 0) {
++		if (old_offset < mine->size &&
++		    skip <= mine->size - old_offset) {
++#ifdef __ANDROID__
++			new_offset = lseek(fileno(mine->f), skip, SEEK_CUR);
++#elif HAVE__FSEEKI64
++			new_offset = _fseeki64(mine->f, skip, SEEK_CUR);
++#elif HAVE_FSEEKO
++			new_offset = fseeko(mine->f, skip, SEEK_CUR);
++#else
++			new_offset = fseek(mine->f, skip, SEEK_CUR);
++#endif
++			if (new_offset >= 0)
++				return (new_offset - old_offset);
++		}
+ 	}
+-	return (request);
++
++	mine->can_skip = 0;
++	return (0);
+ }
+ 
+ static int
+diff --git a/Utilities/cmlibarchive/libarchive/archive_read_open_filename.c b/Utilities/cmlibarchive/libarchive/archive_read_open_filename.c
+index 86635e21..425db5a1 100644
+--- a/Utilities/cmlibarchive/libarchive/archive_read_open_filename.c
++++ b/Utilities/cmlibarchive/libarchive/archive_read_open_filename.c
+@@ -75,6 +75,7 @@ struct read_file_data {
+ 	size_t	 block_size;
+ 	void	*buffer;
+ 	mode_t	 st_mode;  /* Mode bits for opened file. */
++	int64_t size;
+ 	char	 use_lseek;
+ 	enum fnt_e { FNT_STDIN, FNT_MBS, FNT_WCS } filename_type;
+ 	union {
+@@ -366,8 +367,10 @@ file_open(struct archive *a, void *client_data)
+ 	mine->st_mode = st.st_mode;
+ 
+ 	/* Disk-like inputs can use lseek(). */
+-	if (is_disk_like)
++	if (is_disk_like) {
+ 		mine->use_lseek = 1;
++		mine->size = st.st_size;
++	}
+ 
+ 	return (ARCHIVE_OK);
+ fail:
+@@ -445,11 +448,12 @@ file_skip_lseek(struct archive *a, void *client_data, int64_t request)
+ 	struct read_file_data *mine = (struct read_file_data *)client_data;
+ #if defined(_WIN32) && !defined(__CYGWIN__)
+ 	/* We use _lseeki64() on Windows. */
+-	int64_t old_offset, new_offset;
++	int64_t old_offset, new_offset, skip = request;;
+ #else
+-	off_t old_offset, new_offset;
++	off_t old_offset, new_offset, skip = (off_t)request;
+ #endif
+ 
++
+ 	/* We use off_t here because lseek() is declared that way. */
+ 
+ 	/* TODO: Deal with case where off_t isn't 64 bits.
+@@ -457,9 +461,15 @@ file_skip_lseek(struct archive *a, void *client_data, int64_t request)
+ 	 * systems, since the configuration logic for libarchive
+ 	 * tries to obtain a 64-bit off_t.
+ 	 */
+-	if ((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0 &&
+-	    (new_offset = lseek(mine->fd, request, SEEK_CUR)) >= 0)
+-		return (new_offset - old_offset);
++
++	if ((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0) {
++		if (old_offset >= mine->size ||
++		    skip > mine->size - old_offset) {
++			/* Do not seek past end of file. */
++			errno = ESPIPE;
++		} else if ((new_offset = lseek(mine->fd, skip, SEEK_CUR)) >= 0)
++			return (new_offset - old_offset);
++	}
+ 
+ 	/* If lseek() fails, don't bother trying again. */
+ 	mine->use_lseek = 0;
+-- 
+2.45.2
+

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -2,7 +2,7 @@
 Summary:        Cmake
 Name:           cmake
 Version:        3.21.4
-Release:        18%{?dist}
+Release:        19%{?dist}
 License:        BSD AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,10 @@ Patch21:        CVE-2024-11053.patch
 Patch22:        CVE-2024-9681.patch
 Patch23:	CVE-2024-48615.patch
 Patch24:	CVE-2024-8096.patch
+Patch25:	CVE-2025-5916.patch
+Patch26:	CVE-2025-5917.patch
+Patch27:	CVE-2025-5918.patch
+
 BuildRequires:  bzip2
 BuildRequires:  bzip2-devel
 BuildRequires:  curl
@@ -101,6 +105,11 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_prefix}/doc/%{name}-*/*
 
 %changelog
+* Fri Jun 20 2025 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 3.21.4-19
+- Add patch for CVE-2025-5916.patch
+- Add patch for CVE-2025-5917.patch
+- Add patch for CVE-2025-5918.patch
+
 * Mon May 12 2025 Archana Shettigar <v-shettigara@microsoft.com> - 3.21.4-18
 - Fix CVE-2024-8096 by backporting
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Patch cmake for CVE-2025-5916 & CVE-2025-5917 & CVE-2025-5918

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- New files: CVE-2025-5916 & CVE-2025-5917 & CVE-2025-5918
- Modified: cmake.spec
- Bump up the version

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-5916
- https://nvd.nist.gov/vuln/detail/CVE-2025-5917
- https://nvd.nist.gov/vuln/detail/CVE-2025-5918

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Patch applies cleanly.
<img width="646" alt="image" src="https://github.com/user-attachments/assets/d7c12da7-99fe-40a7-ab6c-21e662b263cf" />

