### PR TITLE
Modify git, include git-prompt in the package

### DIFF
--- a/SPECS/git/git.spec
+++ b/SPECS/git/git.spec
@@ -123,6 +123,8 @@ make %{?_smp_mflags} CFLAGS="%{optflags}" CXXFLAGS="%{optflags}"
 %make_install
 install -vdm 755 %{buildroot}%{_datadir}/bash-completion/completions
 install -m 0644 contrib/completion/git-completion.bash %{buildroot}%{_datadir}/bash-completion/completions/git
+install -vdm 755 %{buildroot}%{_datadir}/git-core/contrib/completion/
+install -m 0644 contrib/completion/git-prompt.sh %{buildroot}%{_datadir}/git-core/contrib/completion/git-prompt.sh
 %find_lang %{name}
 %{_fixperms} %{buildroot}/*
 
@@ -173,6 +175,9 @@ fi
 %endif
 
 %changelog
+* Mon Jun 23 2025 Victor Maznev <bullmastiffo@gmail.com> - 2.45.3-3
+- Add git-prompt.sh to git-core contrib/completion directory
+
 * Thu Apr 17 2025 Muhammad Falak <mwani@microsoft.com> - 2.45.3-2
 - Add dependency only for openssh-clients instead of openssh
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
added git-prompt.sh into package to be used in shell prompt.
azurelinux is often used as base for dev containers, e.g Microsoft Go containers, and in dev containers it's great to have git prompt showing the branch and other data. Thus included git-prompt.sh in the package as it's already provided by git.
e.g. in fedora package https://src.fedoraproject.org/rpms/git/blob/rawhide/f/git.spec


###### Change Log
Add git-prompt.sh to git-core/contrib/completion directory

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Local build with `sudo make build-packages -j$(nproc) REBUILD_TOOLS=y SRPM_PACK_LIST="git" RUN_CHECK=y`
- Installed built rpm package from file in latest azurelinux:3.0 docker container, confirmed git works and new script is usable 
