### PR TITLE
[Medium] Patch xorg-x11-server-Xwayland for CVE-2025-49175, CVE-2025-49177, CVE-2025-49178, CVE-2025-49179, CVE-2025-49180

### DIFF
--- a/SPECS/xorg-x11-server-Xwayland/CVE-2025-49175.patch
+++ b/SPECS/xorg-x11-server-Xwayland/CVE-2025-49175.patch
@@ -1,0 +1,89 @@
+From 0885e0b26225c90534642fe911632ec0779eebee Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Fri, 28 Mar 2025 09:43:52 +0100
+Subject: [PATCH] render: Avoid 0 or less animated cursors
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upstream Patch Link: https://gitlab.freedesktop.org/xorg/xserver/-/commit/0885e0b26225c90534642fe911632ec0779eebee.patch
+
+Animated cursors use a series of cursors that the client can set.
+
+By default, the Xserver assumes at least one cursor is specified
+while a client may actually pass no cursor at all.
+
+That causes an out-of-bound read creating the animated cursor and a
+crash of the Xserver:
+
+ | Invalid read of size 8
+ |    at 0x5323F4: AnimCursorCreate (animcur.c:325)
+ |    by 0x52D4C5: ProcRenderCreateAnimCursor (render.c:1817)
+ |    by 0x52DC80: ProcRenderDispatch (render.c:1999)
+ |    by 0x4A1E9D: Dispatch (dispatch.c:560)
+ |    by 0x4B0169: dix_main (main.c:284)
+ |    by 0x4287F5: main (stubmain.c:34)
+ |  Address 0x59aa010 is 0 bytes after a block of size 0 alloc'd
+ |    at 0x48468D3: reallocarray (vg_replace_malloc.c:1803)
+ |    by 0x52D3DA: ProcRenderCreateAnimCursor (render.c:1802)
+ |    by 0x52DC80: ProcRenderDispatch (render.c:1999)
+ |    by 0x4A1E9D: Dispatch (dispatch.c:560)
+ |    by 0x4B0169: dix_main (main.c:284)
+ |    by 0x4287F5: main (stubmain.c:34)
+ |
+ | Invalid read of size 2
+ |    at 0x5323F7: AnimCursorCreate (animcur.c:325)
+ |    by 0x52D4C5: ProcRenderCreateAnimCursor (render.c:1817)
+ |    by 0x52DC80: ProcRenderDispatch (render.c:1999)
+ |    by 0x4A1E9D: Dispatch (dispatch.c:560)
+ |    by 0x4B0169: dix_main (main.c:284)
+ |    by 0x4287F5: main (stubmain.c:34)
+ |  Address 0x8 is not stack'd, malloc'd or (recently) free'd
+
+To avoid the issue, check the number of cursors specified and return a
+BadValue error in both the proc handler (early) and the animated cursor
+creation (as this is a public function) if there is 0 or less cursor.
+
+CVE-2025-49175
+
+This issue was discovered by Nils Emmerich <nemmerich@ernw.de> and
+reported by Julian Suleder via ERNW Vulnerability Disclosure.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Reviewed-by: José Expósito <jexposit@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
+---
+ render/animcur.c | 3 +++
+ render/render.c  | 2 ++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/render/animcur.c b/render/animcur.c
+index f906cd8130..1194cee7e7 100644
+--- a/render/animcur.c
++++ b/render/animcur.c
+@@ -305,6 +305,9 @@ AnimCursorCreate(CursorPtr *cursors, CARD32 *deltas, int ncursor,
+     int rc = BadAlloc, i;
+     AnimCurPtr ac;
+ 
++    if (ncursor <= 0)
++        return BadValue;
++
+     for (i = 0; i < screenInfo.numScreens; i++)
+         if (!GetAnimCurScreen(screenInfo.screens[i]))
+             return BadImplementation;
+diff --git a/render/render.c b/render/render.c
+index 113f6e0c5a..fe9f03c8c8 100644
+--- a/render/render.c
++++ b/render/render.c
+@@ -1799,6 +1799,8 @@ ProcRenderCreateAnimCursor(ClientPtr client)
+     ncursor =
+         (client->req_len -
+          (bytes_to_int32(sizeof(xRenderCreateAnimCursorReq)))) >> 1;
++    if (ncursor <= 0)
++        return BadValue;
+     cursors = xallocarray(ncursor, sizeof(CursorPtr) + sizeof(CARD32));
+     if (!cursors)
+         return BadAlloc;
+-- 
+GitLab
+

--- a/SPECS/xorg-x11-server-Xwayland/CVE-2025-49177.patch
+++ b/SPECS/xorg-x11-server-Xwayland/CVE-2025-49177.patch
@@ -1,0 +1,39 @@
+From fec15c9463b629600306a25fb01801353b6a9bf6 Mon Sep 17 00:00:00 2001
+From: Kevin Lockwood <v-klockwood@microsoft.com>
+Date: Mon, 23 Jun 2025 15:22:44 -0700
+Subject: [PATCH] [Medium] Patch xorg-x11-server-Xwayland for CVE-2025-49177
+
+Upstream Patch Link: https://gitlab.freedesktop.org/xorg/xserver/-/commit/ab02fb96b1c701c3bb47617d965522c34befa6af.patch
+
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
+
+Only edit to the upstream patch was because the patcher could not find
+where to position a hunk
+---
+ xfixes/disconnect.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/xfixes/disconnect.c b/xfixes/disconnect.c
+index e412942..b3529af 100644
+--- a/xfixes/disconnect.c
++++ b/xfixes/disconnect.c
+@@ -69,6 +69,7 @@ ProcXFixesSetClientDisconnectMode(ClientPtr client)
+     ClientDisconnectPtr pDisconnect = GetClientDisconnect(client);
+ 
+     REQUEST(xXFixesSetClientDisconnectModeReq);
++    REQUEST_SIZE_MATCH(xXFixesSetClientDisconnectModeReq);
+ 
+     pDisconnect->disconnect_mode = stuff->disconnect_mode;
+ 
+@@ -82,7 +83,7 @@ SProcXFixesSetClientDisconnectMode(ClientPtr client)
+ 
+     swaps(&stuff->length);
+ 
+-    REQUEST_AT_LEAST_SIZE(xXFixesSetClientDisconnectModeReq);
++    REQUEST_SIZE_MATCH(xXFixesSetClientDisconnectModeReq);
+ 
+     swapl(&stuff->disconnect_mode);
+ 
+-- 
+2.34.1
+

--- a/SPECS/xorg-x11-server-Xwayland/CVE-2025-49178.patch
+++ b/SPECS/xorg-x11-server-Xwayland/CVE-2025-49178.patch
@@ -1,0 +1,47 @@
+From d55c54cecb5e83eaa2d56bed5cc4461f9ba318c2 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Mon, 28 Apr 2025 10:46:03 +0200
+Subject: [PATCH] os: Account for bytes to ignore when sharing input buffer
+
+Upstream Patch Link: https://gitlab.freedesktop.org/xorg/xserver/-/commit/d55c54cecb5e83eaa2d56bed5cc4461f9ba318c2.patch
+
+When reading requests from the clients, the input buffer might be shared
+and used between different clients.
+
+If a given client sends a full request with non-zero bytes to ignore,
+the bytes to ignore may still be non-zero even though the request is
+full, in which case the buffer could be shared with another client who's
+request will not be processed because of those bytes to ignore, leading
+to a possible hang of the other client request.
+
+To avoid the issue, make sure we have zero bytes to ignore left in the
+input request when sharing the input buffer with another client.
+
+CVE-2025-49178
+
+This issue was discovered by Nils Emmerich <nemmerich@ernw.de> and
+reported by Julian Suleder via ERNW Vulnerability Disclosure.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Reviewed-by: Peter Hutterer <peter.hutterer@who-t.net>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
+---
+ os/io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/os/io.c b/os/io.c
+index 3e39c10e6f..e7b76b9cea 100644
+--- a/os/io.c
++++ b/os/io.c
+@@ -441,7 +441,7 @@ ReadRequestFromClient(ClientPtr client)
+      */
+ 
+     gotnow -= needed;
+-    if (!gotnow)
++    if (!gotnow && !oci->ignoreBytes)
+         AvailableInput = oc;
+     if (move_header) {
+         if (client->req_len < bytes_to_int32(sizeof(xBigReq) - sizeof(xReq))) {
+-- 
+GitLab
+

--- a/SPECS/xorg-x11-server-Xwayland/CVE-2025-49179.patch
+++ b/SPECS/xorg-x11-server-Xwayland/CVE-2025-49179.patch
@@ -1,0 +1,41 @@
+From dcf8726020de572e28ae4f9b0b40be2a6ea27a2c Mon Sep 17 00:00:00 2001
+From: Kevin Lockwood <v-klockwood@microsoft.com>
+Date: Mon, 23 Jun 2025 14:21:55 -0700
+Subject: [PATCH] Patch xorg-x11-server-Xwayland for CVE-2025-49179
+
+Upstream Patch Link: https://gitlab.freedesktop.org/xorg/xserver/-/commit/2bde9ca49a8fd9a1e6697d5e7ef837870d66f5d4.patch
+
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
+---
+ record/record.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/record/record.c b/record/record.c
+index ca9254c..311ec1a 100644
+--- a/record/record.c
++++ b/record/record.c
+@@ -46,6 +46,7 @@ and Jim Haggerty of Metheus.
+ #include "swaprep.h"
+ #include "inputstr.h"
+ #include "scrnintstr.h"
++#include "include/opaque.h"
+ 
+ #include <stdio.h>
+ #include <assert.h>
+@@ -1299,6 +1300,13 @@ RecordSanityCheckRegisterClients(RecordContextPtr pContext, ClientPtr client,
+     int i;
+     XID recordingClient;
+ 
++    /* LimitClients is 2048 at max, way less that MAXINT */
++    if (stuff->nClients > LimitClients)
++        return BadValue;
++
++    if (stuff->nRanges > (MAXINT - 4 * stuff->nClients) / SIZEOF(xRecordRange))
++        return BadValue;
++
+     if (((client->req_len << 2) - SIZEOF(xRecordRegisterClientsReq)) !=
+         4 * stuff->nClients + SIZEOF(xRecordRange) * stuff->nRanges)
+         return BadLength;
+-- 
+2.34.1
+

--- a/SPECS/xorg-x11-server-Xwayland/CVE-2025-49180.patch
+++ b/SPECS/xorg-x11-server-Xwayland/CVE-2025-49180.patch
@@ -1,0 +1,42 @@
+From 3c3a4b767b16174d3213055947ea7f4f88e10ec6 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Tue, 20 May 2025 15:18:19 +0200
+Subject: [PATCH] randr: Check for overflow in RRChangeProviderProperty()
+
+Upstream Patch Link: https://gitlab.freedesktop.org/xorg/xserver/-/commit/3c3a4b767b16174d3213055947ea7f4f88e10ec6.patch
+
+A client might send a request causing an integer overflow when computing
+the total size to allocate in RRChangeProviderProperty().
+
+To avoid the issue, check that total length in bytes won't exceed the
+maximum integer value.
+
+CVE-2025-49180
+
+This issue was discovered by Nils Emmerich <nemmerich@ernw.de> and
+reported by Julian Suleder via ERNW Vulnerability Disclosure.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Reviewed-by: Peter Hutterer <peter.hutterer@who-t.net>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
+---
+ randr/rrproviderproperty.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/randr/rrproviderproperty.c b/randr/rrproviderproperty.c
+index 69f66ed278..0c3dcd1bc5 100644
+--- a/randr/rrproviderproperty.c
++++ b/randr/rrproviderproperty.c
+@@ -182,7 +182,8 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
+ 
+     if (mode == PropModeReplace || len > 0) {
+         void *new_data = NULL, *old_data = NULL;
+-
++        if (total_len > MAXINT / size_in_bytes)
++            return BadValue;
+         total_size = total_len * size_in_bytes;
+         new_value.data = (void *) malloc(total_size);
+         if (!new_value.data && total_size) {
+-- 
+GitLab
+

--- a/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
+++ b/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
@@ -92,6 +92,7 @@ Patch0:        CVE-2025-49175.patch
 Patch1:        CVE-2025-49177.patch
 Patch2:        CVE-2025-49178.patch
 Patch3:        CVE-2025-49179.patch
+Patch4:        CVE-2025-49180.patch
 
 %description
 Xwayland is an X server for running X clients under Wayland.
@@ -147,6 +148,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 - Add patch for CVE-2025-49177
 - Add patch for CVE-2025-49178
 - Add patch for CVE-2025-49179
+- Add patch for CVE-2025-49180
 
 * Tue Mar 04 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 24.1.6-1
 - Auto-upgrade to 24.1.6 - to fix CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601[High]

--- a/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
+++ b/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
@@ -91,6 +91,7 @@ BuildRequires: pkgconfig(xcb-renderutil)
 Patch0:        CVE-2025-49175.patch
 Patch1:        CVE-2025-49177.patch
 Patch2:        CVE-2025-49178.patch
+Patch3:        CVE-2025-49179.patch
 
 %description
 Xwayland is an X server for running X clients under Wayland.
@@ -145,6 +146,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 - Add patch for CVE-2025-49175
 - Add patch for CVE-2025-49177
 - Add patch for CVE-2025-49178
+- Add patch for CVE-2025-49179
 
 * Tue Mar 04 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 24.1.6-1
 - Auto-upgrade to 24.1.6 - to fix CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601[High]

--- a/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
+++ b/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
@@ -89,6 +89,7 @@ BuildRequires: pkgconfig(xcb-keysyms)
 BuildRequires: pkgconfig(xcb-renderutil)
 
 Patch0:        CVE-2025-49175.patch
+Patch1:        CVE-2025-49177.patch
 
 %description
 Xwayland is an X server for running X clients under Wayland.
@@ -141,6 +142,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %changelog
 * Mon Jun 23 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 24.1.6-2
 - Add patch for CVE-2025-49175
+- Add patch for CVE-2025-49177
 
 * Tue Mar 04 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 24.1.6-1
 - Auto-upgrade to 24.1.6 - to fix CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601[High]

--- a/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
+++ b/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
@@ -90,6 +90,7 @@ BuildRequires: pkgconfig(xcb-renderutil)
 
 Patch0:        CVE-2025-49175.patch
 Patch1:        CVE-2025-49177.patch
+Patch2:        CVE-2025-49178.patch
 
 %description
 Xwayland is an X server for running X clients under Wayland.
@@ -143,6 +144,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 * Mon Jun 23 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 24.1.6-2
 - Add patch for CVE-2025-49175
 - Add patch for CVE-2025-49177
+- Add patch for CVE-2025-49178
 
 * Tue Mar 04 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 24.1.6-1
 - Auto-upgrade to 24.1.6 - to fix CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601[High]

--- a/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
+++ b/SPECS/xorg-x11-server-Xwayland/xorg-x11-server-Xwayland.spec
@@ -11,7 +11,7 @@ Distribution:  Azure Linux
 Summary:       Xwayland
 Name:          xorg-x11-server-Xwayland
 Version:       24.1.6
-Release:       1%{?dist}
+Release:       2%{?dist}
  
 License:       MIT
 URL:           http://www.x.org
@@ -87,7 +87,9 @@ BuildRequires: pkgconfig(xcb-aux)
 BuildRequires: pkgconfig(xcb-image)
 BuildRequires: pkgconfig(xcb-keysyms)
 BuildRequires: pkgconfig(xcb-renderutil)
- 
+
+Patch0:        CVE-2025-49175.patch
+
 %description
 Xwayland is an X server for running X clients under Wayland.
  
@@ -137,6 +139,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_libdir}/pkgconfig/xwayland.pc
  
 %changelog
+* Mon Jun 23 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 24.1.6-2
+- Add patch for CVE-2025-49175
+
 * Tue Mar 04 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 24.1.6-1
 - Auto-upgrade to 24.1.6 - to fix CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601[High]
 - Remove older applied patch for CVE-2024-9632


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch `xorg-x11-server-Xwayland` for CVE-2025-49175, CVE-2025-49177, CVE-2025-49178, CVE-2025-49179, CVE-2025-49180

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->

**All patches sourced from Astrolabe**

- Add patch for CVE-2025-49175
	* Patch unchanged from upstream besides adding upstream patch link
	* Patch applied cleanly:
	  ![image](https://github.com/user-attachments/assets/f6b7dafb-26e3-44fb-a9d2-3c89774ef682)
- Add patch for CVE-2025-49177
	* Only edit to the upstream patch was because the patcher could not find where to position a hunk
	* Patch applied cleanly:
	  ![image](https://github.com/user-attachments/assets/bcffa87c-5804-46ab-b580-48a01e67c651)
- Add patch for CVE-2025-49178
	* Patch unchanged from upstream besides adding upstream patch link
	* Patch applied cleanly:
	  ![image](https://github.com/user-attachments/assets/f7e7d0ff-2aea-46ef-8e6d-648b93b64bdd)
- Add patch for CVE-2025-49179
	* Edited the include as compared with upstream because upstream moved
	  the include in a prior commit.
	* Patch applied cleanly:
	  ![image](https://github.com/user-attachments/assets/8aeb71e6-5a32-4af3-a182-9d7d0b80105f)
- Add patch for CVE-2025-49180
	* Patch unchanged from upstream besides adding upstream patch link
	* Patch applied cleanly:
	  ![image](https://github.com/user-attachments/assets/8882926e-3d8e-4342-bac0-5eca318daf89)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-49175
- https://nvd.nist.gov/vuln/detail/CVE-2025-49177
- https://nvd.nist.gov/vuln/detail/CVE-2025-49178
- https://nvd.nist.gov/vuln/detail/CVE-2025-49179
- https://nvd.nist.gov/vuln/detail/CVE-2025-49180

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
