### PR TITLE
[Medium] Patch libxml2 for CVE-2025-6021

### DIFF
--- a/SPECS/libxml2/CVE-2025-6021.patch
+++ b/SPECS/libxml2/CVE-2025-6021.patch
@@ -1,0 +1,47 @@
+From 477f542a5910f86b092f653b007d03bd9c63949d Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 17:06:59 -0500
+Subject: [PATCH] Address CVE-2025-6021
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781
+
+---
+ tree.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/tree.c b/tree.c
+index 8910dd8..5c841c9 100644
+--- a/tree.c
++++ b/tree.c
+@@ -16,6 +16,7 @@
+ #endif
+ 
+ #define IN_LIBXML
++#include <stdint.h>
+ #include "libxml.h"
+ 
+ #include <string.h> /* for memset() only ! */
+@@ -221,16 +222,18 @@ xmlGetParameterEntityFromDtd(const xmlDtd *dtd, const xmlChar *name) {
+ xmlChar *
+ xmlBuildQName(const xmlChar *ncname, const xmlChar *prefix,
+ 	      xmlChar *memory, int len) {
+-    int lenn, lenp;
++    size_t lenn, lenp;
+     xmlChar *ret;
+ 
+-    if (ncname == NULL) return(NULL);
++    if ((ncname == NULL) || (len < 0)) return(NULL);
+     if (prefix == NULL) return((xmlChar *) ncname);
+ 
+     lenn = strlen((char *) ncname);
+     lenp = strlen((char *) prefix);
++    if (lenn >= SIZE_MAX - lenp - 1)
++        return(NULL);
+ 
+-    if ((memory == NULL) || (len < lenn + lenp + 2)) {
++    if ((memory == NULL) || ((size_t) len < lenn + lenp + 2)) {
+ 	ret = (xmlChar *) xmlMallocAtomic(lenn + lenp + 2);
+ 	if (ret == NULL) {
+ 	    xmlTreeErrMemory("building QName");
+-- 
+2.45.2
+

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.11.5
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -17,6 +17,7 @@ Patch5:         CVE-2024-25062.patch
 Patch6:         CVE-2025-27113.patch
 Patch7:         CVE-2025-32414.patch
 Patch8:         CVE-2025-32415.patch
+Patch9:         CVE-2025-6021.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -87,6 +88,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Mon Jun 23 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.11.5-6
+- Patch CVE-2025-6021
+
 * Mon May 05 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.11.5-5
 - Patch CVE-2025-32414 and CVE-2025-32415
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -203,8 +203,8 @@ curl-8.11.1-3.azl3.aarch64.rpm
 curl-devel-8.11.1-3.azl3.aarch64.rpm
 curl-libs-8.11.1-3.azl3.aarch64.rpm
 createrepo_c-1.0.3-1.azl3.aarch64.rpm
-libxml2-2.11.5-5.azl3.aarch64.rpm
-libxml2-devel-2.11.5-5.azl3.aarch64.rpm
+libxml2-2.11.5-6.azl3.aarch64.rpm
+libxml2-devel-2.11.5-6.azl3.aarch64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 libsepol-3.6-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -203,8 +203,8 @@ curl-8.11.1-3.azl3.x86_64.rpm
 curl-devel-8.11.1-3.azl3.x86_64.rpm
 curl-libs-8.11.1-3.azl3.x86_64.rpm
 createrepo_c-1.0.3-1.azl3.x86_64.rpm
-libxml2-2.11.5-5.azl3.x86_64.rpm
-libxml2-devel-2.11.5-5.azl3.x86_64.rpm
+libxml2-2.11.5-6.azl3.x86_64.rpm
+libxml2-devel-2.11.5-6.azl3.x86_64.rpm
 docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 libsepol-3.6-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -242,9 +242,9 @@ libtool-debuginfo-2.4.7-1.azl3.aarch64.rpm
 libxcrypt-4.4.36-2.azl3.aarch64.rpm
 libxcrypt-debuginfo-4.4.36-2.azl3.aarch64.rpm
 libxcrypt-devel-4.4.36-2.azl3.aarch64.rpm
-libxml2-2.11.5-5.azl3.aarch64.rpm
-libxml2-debuginfo-2.11.5-5.azl3.aarch64.rpm
-libxml2-devel-2.11.5-5.azl3.aarch64.rpm
+libxml2-2.11.5-6.azl3.aarch64.rpm
+libxml2-debuginfo-2.11.5-6.azl3.aarch64.rpm
+libxml2-devel-2.11.5-6.azl3.aarch64.rpm
 libxslt-1.1.43-1.azl3.aarch64.rpm
 libxslt-debuginfo-1.1.43-1.azl3.aarch64.rpm
 libxslt-devel-1.1.43-1.azl3.aarch64.rpm
@@ -543,7 +543,7 @@ python3-gpg-1.23.2-2.azl3.aarch64.rpm
 python3-jinja2-3.1.2-3.azl3.noarch.rpm
 python3-libcap-ng-0.8.4-1.azl3.aarch64.rpm
 python3-libs-3.12.9-2.azl3.aarch64.rpm
-python3-libxml2-2.11.5-5.azl3.aarch64.rpm
+python3-libxml2-2.11.5-6.azl3.aarch64.rpm
 python3-lxml-4.9.3-1.azl3.aarch64.rpm
 python3-magic-5.45-1.azl3.noarch.rpm
 python3-markupsafe-2.1.3-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -247,9 +247,9 @@ libtasn1-debuginfo-4.19.0-2.azl3.x86_64.rpm
 libtasn1-devel-4.19.0-2.azl3.x86_64.rpm
 libtool-2.4.7-1.azl3.x86_64.rpm
 libtool-debuginfo-2.4.7-1.azl3.x86_64.rpm
-libxml2-2.11.5-5.azl3.x86_64.rpm
-libxml2-debuginfo-2.11.5-5.azl3.x86_64.rpm
-libxml2-devel-2.11.5-5.azl3.x86_64.rpm
+libxml2-2.11.5-6.azl3.x86_64.rpm
+libxml2-debuginfo-2.11.5-6.azl3.x86_64.rpm
+libxml2-devel-2.11.5-6.azl3.x86_64.rpm
 libxcrypt-4.4.36-2.azl3.x86_64.rpm
 libxcrypt-debuginfo-4.4.36-2.azl3.x86_64.rpm
 libxcrypt-devel-4.4.36-2.azl3.x86_64.rpm
@@ -551,7 +551,7 @@ python3-gpg-1.23.2-2.azl3.x86_64.rpm
 python3-jinja2-3.1.2-3.azl3.noarch.rpm
 python3-libcap-ng-0.8.4-1.azl3.x86_64.rpm
 python3-libs-3.12.9-2.azl3.x86_64.rpm
-python3-libxml2-2.11.5-5.azl3.x86_64.rpm
+python3-libxml2-2.11.5-6.azl3.x86_64.rpm
 python3-lxml-4.9.3-1.azl3.x86_64.rpm
 python3-magic-5.45-1.azl3.noarch.rpm
 python3-markupsafe-2.1.3-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
libxml2: Patch for CVE-2025-6021
Patch Modified: Yes

Astrolabe patch reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781
From Upstream patch, Added "include <stdinc.h>" header file in to the patch file, required for definition of SIZE_MAX.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: **SPECS/libxml2/CVE-2025-6021.patch**
- modified: **SPECS/libxml2/libxml2.spec**
- modified: **toolkit/resources/manifests/package/pkggen_core_aarch64.txt**
- modified: **toolkit/resources/manifests/package/pkggen_core_x86_64.txt**
- modified: **toolkit/resources/manifests/package/toolchain_aarch64.txt**
- modified: **toolkit/resources/manifests/package/toolchain_x86_64.txt**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-6021

###### Test Methodology

- Verified: patch `CVE-2025-6021.patch` is applied as shown below
![Screenshot 2025-06-23 173205](https://github.com/user-attachments/assets/58e1e54c-dbf9-489f-9d97-39f32781279d)

<!-- How was this test validated? i.e. local build, pipeline build etc. -->

- Local build.
