### PR TITLE
[MEDIUM] Patch xorg-x11-server for CVE-2025-49175, CVE-2025-49176, CVE-2025-49178, CVE-2025-49179 & CVE-2025-49180

### DIFF
--- a/SPECS/xorg-x11-server/CVE-2025-49175.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49175.patch
@@ -1,0 +1,88 @@
+From 0885e0b26225c90534642fe911632ec0779eebee Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Fri, 28 Mar 2025 09:43:52 +0100
+Subject: [PATCH] render: Avoid 0 or less animated cursors
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/0885e0b26225c90534642fe911632ec0779eebee
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Animated cursors use a series of cursors that the client can set.
+
+By default, the Xserver assumes at least one cursor is specified
+while a client may actually pass no cursor at all.
+
+That causes an out-of-bound read creating the animated cursor and a
+crash of the Xserver:
+
+ | Invalid read of size 8
+ |    at 0x5323F4: AnimCursorCreate (animcur.c:325)
+ |    by 0x52D4C5: ProcRenderCreateAnimCursor (render.c:1817)
+ |    by 0x52DC80: ProcRenderDispatch (render.c:1999)
+ |    by 0x4A1E9D: Dispatch (dispatch.c:560)
+ |    by 0x4B0169: dix_main (main.c:284)
+ |    by 0x4287F5: main (stubmain.c:34)
+ |  Address 0x59aa010 is 0 bytes after a block of size 0 alloc'd
+ |    at 0x48468D3: reallocarray (vg_replace_malloc.c:1803)
+ |    by 0x52D3DA: ProcRenderCreateAnimCursor (render.c:1802)
+ |    by 0x52DC80: ProcRenderDispatch (render.c:1999)
+ |    by 0x4A1E9D: Dispatch (dispatch.c:560)
+ |    by 0x4B0169: dix_main (main.c:284)
+ |    by 0x4287F5: main (stubmain.c:34)
+ |
+ | Invalid read of size 2
+ |    at 0x5323F7: AnimCursorCreate (animcur.c:325)
+ |    by 0x52D4C5: ProcRenderCreateAnimCursor (render.c:1817)
+ |    by 0x52DC80: ProcRenderDispatch (render.c:1999)
+ |    by 0x4A1E9D: Dispatch (dispatch.c:560)
+ |    by 0x4B0169: dix_main (main.c:284)
+ |    by 0x4287F5: main (stubmain.c:34)
+ |  Address 0x8 is not stack'd, malloc'd or (recently) free'd
+
+To avoid the issue, check the number of cursors specified and return a
+BadValue error in both the proc handler (early) and the animated cursor
+creation (as this is a public function) if there is 0 or less cursor.
+
+CVE-2025-49175
+
+This issue was discovered by Nils Emmerich <nemmerich@ernw.de> and
+reported by Julian Suleder via ERNW Vulnerability Disclosure.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Reviewed-by: José Expósito <jexposit@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
+---
+ render/animcur.c | 3 +++
+ render/render.c  | 2 ++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/render/animcur.c b/render/animcur.c
+index f906cd8130..1194cee7e7 100644
+--- a/render/animcur.c
++++ b/render/animcur.c
+@@ -305,6 +305,9 @@ AnimCursorCreate(CursorPtr *cursors, CARD32 *deltas, int ncursor,
+     int rc = BadAlloc, i;
+     AnimCurPtr ac;
+ 
++    if (ncursor <= 0)
++        return BadValue;
++
+     for (i = 0; i < screenInfo.numScreens; i++)
+         if (!GetAnimCurScreen(screenInfo.screens[i]))
+             return BadImplementation;
+diff --git a/render/render.c b/render/render.c
+index 113f6e0c5a..fe9f03c8c8 100644
+--- a/render/render.c
++++ b/render/render.c
+@@ -1799,6 +1799,8 @@ ProcRenderCreateAnimCursor(ClientPtr client)
+     ncursor =
+         (client->req_len -
+          (bytes_to_int32(sizeof(xRenderCreateAnimCursorReq)))) >> 1;
++    if (ncursor <= 0)
++        return BadValue;
+     cursors = xallocarray(ncursor, sizeof(CursorPtr) + sizeof(CARD32));
+     if (!cursors)
+         return BadAlloc;
+-- 
+GitLab
+

--- a/SPECS/xorg-x11-server/CVE-2025-49176.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49176.patch
@@ -1,52 +1,19 @@
-From 03731b326a80b582e48d939fe62cb1e2b10400d9 Mon Sep 17 00:00:00 2001
-From: Olivier Fourdan <ofourdan@redhat.com>
-Date: Mon, 7 Apr 2025 16:13:34 +0200
-Subject: [PATCH] os: Do not overflow the integer size with BigRequest
+From 0aef94544400d8014db5a2ff89f71c9cf796a1e4 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 21:17:42 -0500
+Subject: [PATCH] Address CVE-2025-49176
 Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/03731b326a80b582e48d939fe62cb1e2b10400d9
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
 
-The BigRequest extension allows requests larger than the 16-bit length
-limit.
-
-It uses integers for the request length and checks for the size not to
-exceed the maxBigRequestSize limit, but does so after translating the
-length to integer by multiplying the given size in bytes by 4.
-
-In doing so, it might overflow the integer size limit before actually
-checking for the overflow, defeating the purpose of the test.
-
-To avoid the issue, make sure to check that the request size does not
-overflow the maxBigRequestSize limit prior to any conversion.
-
-The caller Dispatch() function however expects the return value to be in
-bytes, so we cannot just return the converted value in case of error, as
-that would also overflow the integer size.
-
-To preserve the existing API, we use a negative value for the X11 error
-code BadLength as the function only return positive values, 0 or -1 and
-update the caller Dispatch() function to take that case into account to
-return the error code to the offending client.
-
-CVE-2025-49176
-
-This issue was discovered by Nils Emmerich <nemmerich@ernw.de> and
-reported by Julian Suleder via ERNW Vulnerability Disclosure.
-
-Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
-Reviewed-by: Michel Dänzer <mdaenzer@redhat.com>
-Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
 ---
  dix/dispatch.c | 9 +++++----
  os/io.c        | 4 ++++
  2 files changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/dix/dispatch.c b/dix/dispatch.c
-index b3e5feacc2..2308cfe6d1 100644
+index cdec481..34cb34d 100644
 --- a/dix/dispatch.c
 +++ b/dix/dispatch.c
-@@ -527,9 +527,10 @@ Dispatch(void)
+@@ -447,9 +447,10 @@ Dispatch(void)
  
                  /* now, finally, deal with client requests */
                  result = ReadRequestFromClient(client);
@@ -60,7 +27,7 @@ index b3e5feacc2..2308cfe6d1 100644
                      break;
                  }
  
-@@ -550,7 +551,7 @@ Dispatch(void)
+@@ -470,7 +471,7 @@ Dispatch(void)
                                            client->index,
                                            client->requestBuffer);
  #endif
@@ -70,10 +37,10 @@ index b3e5feacc2..2308cfe6d1 100644
                  else {
                      result = XaceHookDispatch(client, client->majorOp);
 diff --git a/os/io.c b/os/io.c
-index 1fffaf62c7..3e39c10e6f 100644
+index 939f517..a053008 100644
 --- a/os/io.c
 +++ b/os/io.c
-@@ -300,6 +300,10 @@ ReadRequestFromClient(ClientPtr client)
+@@ -296,6 +296,10 @@ ReadRequestFromClient(ClientPtr client)
                  needed = get_big_req_len(request, client);
          }
          client->req_len = needed;
@@ -85,5 +52,5 @@ index 1fffaf62c7..3e39c10e6f 100644
      }
      if (gotnow < needed) {
 -- 
-GitLab
+2.45.2
 

--- a/SPECS/xorg-x11-server/CVE-2025-49176.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49176.patch
@@ -1,0 +1,89 @@
+From 03731b326a80b582e48d939fe62cb1e2b10400d9 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Mon, 7 Apr 2025 16:13:34 +0200
+Subject: [PATCH] os: Do not overflow the integer size with BigRequest
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/03731b326a80b582e48d939fe62cb1e2b10400d9
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The BigRequest extension allows requests larger than the 16-bit length
+limit.
+
+It uses integers for the request length and checks for the size not to
+exceed the maxBigRequestSize limit, but does so after translating the
+length to integer by multiplying the given size in bytes by 4.
+
+In doing so, it might overflow the integer size limit before actually
+checking for the overflow, defeating the purpose of the test.
+
+To avoid the issue, make sure to check that the request size does not
+overflow the maxBigRequestSize limit prior to any conversion.
+
+The caller Dispatch() function however expects the return value to be in
+bytes, so we cannot just return the converted value in case of error, as
+that would also overflow the integer size.
+
+To preserve the existing API, we use a negative value for the X11 error
+code BadLength as the function only return positive values, 0 or -1 and
+update the caller Dispatch() function to take that case into account to
+return the error code to the offending client.
+
+CVE-2025-49176
+
+This issue was discovered by Nils Emmerich <nemmerich@ernw.de> and
+reported by Julian Suleder via ERNW Vulnerability Disclosure.
+
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+Reviewed-by: Michel Dänzer <mdaenzer@redhat.com>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024>
+---
+ dix/dispatch.c | 9 +++++----
+ os/io.c        | 4 ++++
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/dix/dispatch.c b/dix/dispatch.c
+index b3e5feacc2..2308cfe6d1 100644
+--- a/dix/dispatch.c
++++ b/dix/dispatch.c
+@@ -527,9 +527,10 @@ Dispatch(void)
+ 
+                 /* now, finally, deal with client requests */
+                 result = ReadRequestFromClient(client);
+-                if (result <= 0) {
+-                    if (result < 0)
+-                        CloseDownClient(client);
++                if (result == 0)
++                    break;
++                else if (result == -1) {
++                    CloseDownClient(client);
+                     break;
+                 }
+ 
+@@ -550,7 +551,7 @@ Dispatch(void)
+                                           client->index,
+                                           client->requestBuffer);
+ #endif
+-                if (result > (maxBigRequestSize << 2))
++                if (result < 0 || result > (maxBigRequestSize << 2))
+                     result = BadLength;
+                 else {
+                     result = XaceHookDispatch(client, client->majorOp);
+diff --git a/os/io.c b/os/io.c
+index 1fffaf62c7..3e39c10e6f 100644
+--- a/os/io.c
++++ b/os/io.c
+@@ -300,6 +300,10 @@ ReadRequestFromClient(ClientPtr client)
+                 needed = get_big_req_len(request, client);
+         }
+         client->req_len = needed;
++        if (needed > MAXINT >> 2) {
++            /* Check for potential integer overflow */
++            return -(BadLength);
++        }
+         needed <<= 2;           /* needed is in bytes now */
+     }
+     if (gotnow < needed) {
+-- 
+GitLab
+

--- a/SPECS/xorg-x11-server/CVE-2025-49178.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49178.patch
@@ -1,0 +1,26 @@
+From 802a0db9ab3151c33904f90a1f28c386ec9a5644 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 21:19:23 -0500
+Subject: [PATCH] Address CVE-2025-49178
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/d55c54cecb5e83eaa2d56bed5cc4461f9ba318c2
+
+---
+ os/io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/os/io.c b/os/io.c
+index a053008..d1096d9 100644
+--- a/os/io.c
++++ b/os/io.c
+@@ -442,7 +442,7 @@ ReadRequestFromClient(ClientPtr client)
+      */
+ 
+     gotnow -= needed;
+-    if (!gotnow)
++    if (!gotnow && !oci->ignoreBytes)
+         AvailableInput = oc;
+     if (move_header) {
+         if (client->req_len < bytes_to_int32(sizeof(xBigReq) - sizeof(xReq))) {
+-- 
+2.45.2
+

--- a/SPECS/xorg-x11-server/CVE-2025-49179.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49179.patch
@@ -1,0 +1,39 @@
+From dc2a01eaa17374992688d6b4f5b351863c1c19f5 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 22:31:41 -0500
+Subject: [PATCH] Address CVE-2025-49179
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/2bde9ca49a8fd9a1e6697d5e7ef837870d66f5d4
+
+---
+ record/record.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/record/record.c b/record/record.c
+index 05d751a..9851677 100644
+--- a/record/record.c
++++ b/record/record.c
+@@ -1289,6 +1289,7 @@ RecordPadAlign(int size, int align)
+  *
+  * Side Effects: none.
+  */
++extern int LimitClients;
+ static int
+ RecordSanityCheckRegisterClients(RecordContextPtr pContext, ClientPtr client,
+                                  xRecordRegisterClientsReq * stuff)
+@@ -1298,6 +1299,13 @@ RecordSanityCheckRegisterClients(RecordContextPtr pContext, ClientPtr client,
+     int i;
+     XID recordingClient;
+ 
++    /* LimitClients is 2048 at max, way less that MAXINT */
++    if (stuff->nClients > LimitClients)
++        return BadValue;
++
++    if (stuff->nRanges > (MAXINT - 4 * stuff->nClients) / SIZEOF(xRecordRange))
++        return BadValue;
++
+     if (((client->req_len << 2) - SIZEOF(xRecordRegisterClientsReq)) !=
+         4 * stuff->nClients + SIZEOF(xRecordRange) * stuff->nRanges)
+         return BadLength;
+-- 
+2.45.2
+

--- a/SPECS/xorg-x11-server/CVE-2025-49180.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49180.patch
@@ -1,0 +1,27 @@
+From 14338a8cc031594f939f118e9a8f12caee78718d Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 22:32:52 -0500
+Subject: [PATCH] Address CVE-2025-49180
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/3c3a4b767b16174d3213055947ea7f4f88e10ec6
+
+---
+ randr/rrproviderproperty.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/randr/rrproviderproperty.c b/randr/rrproviderproperty.c
+index 90c5a9a..0aa35ad 100644
+--- a/randr/rrproviderproperty.c
++++ b/randr/rrproviderproperty.c
+@@ -179,7 +179,8 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
+ 
+     if (mode == PropModeReplace || len > 0) {
+         void *new_data = NULL, *old_data = NULL;
+-
++        if (total_len > MAXINT / size_in_bytes)
++            return BadValue;
+         total_size = total_len * size_in_bytes;
+         new_value.data = (void *) malloc(total_size);
+         if (!new_value.data && total_size) {
+-- 
+2.45.2
+

--- a/SPECS/xorg-x11-server/xorg-x11-server.spec
+++ b/SPECS/xorg-x11-server/xorg-x11-server.spec
@@ -21,7 +21,7 @@
 Summary:        X.Org X11 X server
 Name:           xorg-x11-server
 Version:        1.20.10
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -78,6 +78,8 @@ Patch28:        CVE-2025-26598.patch
 Patch29:        CVE-2025-26599.patch
 Patch30:        CVE-2025-26600.patch
 Patch31:        CVE-2025-26601.patch
+Patch32:        CVE-2025-49175.patch
+Patch33:        CVE-2025-49176.patch
 
 # Backported Xwayland randr resolution change emulation support
 Patch501:       0001-dix-Add-GetCurrentClient-helper.patch
@@ -411,6 +413,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_datadir}/aclocal/xorg-server.m4
 
 %changelog
+* Mon Jun 24 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.20.10-16
+- Patch CVE-2025-49175 & CVE-2025-49176
+
 * Tue Mar 04 2025 Kanishk Bansal <kanbansal@microsft.com> - 1.20.10-15
 - Patch CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601
 

--- a/SPECS/xorg-x11-server/xorg-x11-server.spec
+++ b/SPECS/xorg-x11-server/xorg-x11-server.spec
@@ -80,6 +80,9 @@ Patch30:        CVE-2025-26600.patch
 Patch31:        CVE-2025-26601.patch
 Patch32:        CVE-2025-49175.patch
 Patch33:        CVE-2025-49176.patch
+Patch34:        CVE-2025-49178.patch
+Patch35:        CVE-2025-49179.patch
+Patch36:        CVE-2025-49180.patch
 
 # Backported Xwayland randr resolution change emulation support
 Patch501:       0001-dix-Add-GetCurrentClient-helper.patch
@@ -413,8 +416,8 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_datadir}/aclocal/xorg-server.m4
 
 %changelog
-* Mon Jun 24 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.20.10-16
-- Patch CVE-2025-49175 & CVE-2025-49176
+* Mon Jun 23 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.20.10-16
+- Patch CVE-2025-49175, CVE-2025-49176, CVE-2025-49178, CVE-2025-49179 & CVE-2025-49180
 
 * Tue Mar 04 2025 Kanishk Bansal <kanbansal@microsft.com> - 1.20.10-15
 - Patch CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch xorg-x11-server for CVE-2025-49175, CVE-2025-49176, CVE-2025-49178, CVE-2025-49179 & CVE-2025-49180

- Patches are all taken from Astrolabe
   - CVE-2025-49175 - https://gitlab.freedesktop.org/xorg/xserver/-/commit/0885e0b26225c90534642fe911632ec0779eebee
   - CVE-2025-49176 - https://gitlab.freedesktop.org/xorg/xserver/-/commit/03731b326a80b582e48d939fe62cb1e2b10400d9
   - CVE-2025-49178 - https://gitlab.freedesktop.org/xorg/xserver/-/commit/d55c54cecb5e83eaa2d56bed5cc4461f9ba318c2
   - CVE-2025-49179 - https://gitlab.freedesktop.org/xorg/xserver/-/commit/2bde9ca49a8fd9a1e6697d5e7ef837870d66f5d4
   - CVE-2025-49180 - https://gitlab.freedesktop.org/xorg/xserver/-/commit/3c3a4b767b16174d3213055947ea7f4f88e10ec6

- No modifications are done to the patch. 

###### Change Log  <!-- REQUIRED -->
-  new file: SPECS/xorg-x11-server/CVE-2025-49175.patch
-  new file: SPECS/xorg-x11-server/CVE-2025-49176.patch
- new file: SPECS/xorg-x11-server/CVE-2025-49178.patch
- new file: SPECS/xorg-x11-server/CVE-2025-49179.patch
- new file: SPECS/xorg-x11-server/CVE-2025-49180.patch
- modified: SPECS/xorg-x11-server/xorg-x11-server.spec


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-49175
- https://nvd.nist.gov/vuln/detail/CVE-2025-49176
- https://nvd.nist.gov/vuln/detail/CVE-2025-49178
- https://nvd.nist.gov/vuln/detail/CVE-2025-49179
- https://nvd.nist.gov/vuln/detail/CVE-2025-49180

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [x] Patch applies cleanly
![image](https://github.com/user-attachments/assets/45a144bf-f96c-4136-b260-1ee1987260cf)

- [x] Build is successful - 
[xorg-x11-server-1.20.10-16.cm2.build.rpm.log](https://github.com/user-attachments/files/20877619/xorg-x11-server-1.20.10-16.cm2.src.rpm.log)


- Pipeline build id: xxxx
