### PR TITLE
[Medium] Patch xorg-x11-server for CVE-2025-49176, CVE-2025-49178, CVE-2025-49176, CVE-2025-49180

### DIFF
--- a/SPECS/xorg-x11-server/CVE-2025-49176.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49176.patch
@@ -1,0 +1,56 @@
+From 0aef94544400d8014db5a2ff89f71c9cf796a1e4 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 21:17:42 -0500
+Subject: [PATCH] Address CVE-2025-49176
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/03731b326a80b582e48d939fe62cb1e2b10400d9
+
+---
+ dix/dispatch.c | 9 +++++----
+ os/io.c        | 4 ++++
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/dix/dispatch.c b/dix/dispatch.c
+index cdec481..34cb34d 100644
+--- a/dix/dispatch.c
++++ b/dix/dispatch.c
+@@ -447,9 +447,10 @@ Dispatch(void)
+ 
+                 /* now, finally, deal with client requests */
+                 result = ReadRequestFromClient(client);
+-                if (result <= 0) {
+-                    if (result < 0)
+-                        CloseDownClient(client);
++                if (result == 0)
++                    break;
++                else if (result == -1) {
++                    CloseDownClient(client);
+                     break;
+                 }
+ 
+@@ -470,7 +471,7 @@ Dispatch(void)
+                                           client->index,
+                                           client->requestBuffer);
+ #endif
+-                if (result > (maxBigRequestSize << 2))
++                if (result < 0 || result > (maxBigRequestSize << 2))
+                     result = BadLength;
+                 else {
+                     result = XaceHookDispatch(client, client->majorOp);
+diff --git a/os/io.c b/os/io.c
+index 939f517..a053008 100644
+--- a/os/io.c
++++ b/os/io.c
+@@ -296,6 +296,10 @@ ReadRequestFromClient(ClientPtr client)
+                 needed = get_big_req_len(request, client);
+         }
+         client->req_len = needed;
++        if (needed > MAXINT >> 2) {
++            /* Check for potential integer overflow */
++            return -(BadLength);
++        }
+         needed <<= 2;           /* needed is in bytes now */
+     }
+     if (gotnow < needed) {
+-- 
+2.45.2
+

--- a/SPECS/xorg-x11-server/CVE-2025-49178.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49178.patch
@@ -1,0 +1,26 @@
+From 802a0db9ab3151c33904f90a1f28c386ec9a5644 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 21:19:23 -0500
+Subject: [PATCH] Address CVE-2025-49178
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/d55c54cecb5e83eaa2d56bed5cc4461f9ba318c2
+
+---
+ os/io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/os/io.c b/os/io.c
+index a053008..d1096d9 100644
+--- a/os/io.c
++++ b/os/io.c
+@@ -442,7 +442,7 @@ ReadRequestFromClient(ClientPtr client)
+      */
+ 
+     gotnow -= needed;
+-    if (!gotnow)
++    if (!gotnow && !oci->ignoreBytes)
+         AvailableInput = oc;
+     if (move_header) {
+         if (client->req_len < bytes_to_int32(sizeof(xBigReq) - sizeof(xReq))) {
+-- 
+2.45.2
+

--- a/SPECS/xorg-x11-server/CVE-2025-49179.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49179.patch
@@ -1,0 +1,39 @@
+From dc2a01eaa17374992688d6b4f5b351863c1c19f5 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 22:31:41 -0500
+Subject: [PATCH] Address CVE-2025-49179
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/2bde9ca49a8fd9a1e6697d5e7ef837870d66f5d4
+
+---
+ record/record.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/record/record.c b/record/record.c
+index 05d751a..9851677 100644
+--- a/record/record.c
++++ b/record/record.c
+@@ -1289,6 +1289,7 @@ RecordPadAlign(int size, int align)
+  *
+  * Side Effects: none.
+  */
++extern int LimitClients;
+ static int
+ RecordSanityCheckRegisterClients(RecordContextPtr pContext, ClientPtr client,
+                                  xRecordRegisterClientsReq * stuff)
+@@ -1298,6 +1299,13 @@ RecordSanityCheckRegisterClients(RecordContextPtr pContext, ClientPtr client,
+     int i;
+     XID recordingClient;
+ 
++    /* LimitClients is 2048 at max, way less that MAXINT */
++    if (stuff->nClients > LimitClients)
++        return BadValue;
++
++    if (stuff->nRanges > (MAXINT - 4 * stuff->nClients) / SIZEOF(xRecordRange))
++        return BadValue;
++
+     if (((client->req_len << 2) - SIZEOF(xRecordRegisterClientsReq)) !=
+         4 * stuff->nClients + SIZEOF(xRecordRange) * stuff->nRanges)
+         return BadLength;
+-- 
+2.45.2
+

--- a/SPECS/xorg-x11-server/CVE-2025-49180.patch
+++ b/SPECS/xorg-x11-server/CVE-2025-49180.patch
@@ -1,0 +1,27 @@
+From 14338a8cc031594f939f118e9a8f12caee78718d Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 23 Jun 2025 22:32:52 -0500
+Subject: [PATCH] Address CVE-2025-49180
+Upstream Patch Reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/3c3a4b767b16174d3213055947ea7f4f88e10ec6
+
+---
+ randr/rrproviderproperty.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/randr/rrproviderproperty.c b/randr/rrproviderproperty.c
+index 90c5a9a..0aa35ad 100644
+--- a/randr/rrproviderproperty.c
++++ b/randr/rrproviderproperty.c
+@@ -179,7 +179,8 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
+ 
+     if (mode == PropModeReplace || len > 0) {
+         void *new_data = NULL, *old_data = NULL;
+-
++        if (total_len > MAXINT / size_in_bytes)
++            return BadValue;
+         total_size = total_len * size_in_bytes;
+         new_value.data = (void *) malloc(total_size);
+         if (!new_value.data && total_size) {
+-- 
+2.45.2
+

--- a/SPECS/xorg-x11-server/xorg-x11-server.spec
+++ b/SPECS/xorg-x11-server/xorg-x11-server.spec
@@ -21,7 +21,7 @@
 Summary:        X.Org X11 X server
 Name:           xorg-x11-server
 Version:        1.20.10
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -78,6 +78,10 @@ Patch28:        CVE-2025-26598.patch
 Patch29:        CVE-2025-26599.patch
 Patch30:        CVE-2025-26600.patch
 Patch31:        CVE-2025-26601.patch
+Patch32:        CVE-2025-49176.patch
+Patch33:        CVE-2025-49178.patch
+Patch34:        CVE-2025-49179.patch
+Patch35:        CVE-2025-49180.patch
 
 # Backported Xwayland randr resolution change emulation support
 Patch501:       0001-dix-Add-GetCurrentClient-helper.patch
@@ -411,6 +415,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_datadir}/aclocal/xorg-server.m4
 
 %changelog
+* Mon Jun 23 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 1.20.10-16
+- Patch CVE-2025-49176, CVE-2025-49178, CVE-2025-49176, CVE-2025-49180
+
 * Tue Mar 04 2025 Kanishk Bansal <kanbansal@microsft.com> - 1.20.10-15
 - Patch CVE-2025-26594, CVE-2025-26595, CVE-2025-26596, CVE-2025-26597, CVE-2025-26598, CVE-2025-26599, CVE-2025-26600, CVE-2025-26601
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch xorg-x11-server for CVE-2025-49176, CVE-2025-49178, CVE-2025-49176, CVE-2025-49180
- CVE-2025-49176
Patch Modified: Yes

Astrolabe patch reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/03731b326a80b582e48d939fe62cb1e2b10400d9

- CVE-2025-49178
Patch Modified: Yes

Astrolabe patch reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/d55c54cecb5e83eaa2d56bed5cc4461f9ba318c2

- CVE-2025-49179
Patch Modified: Yes

Astrolabe patch reference: https://gitlab.freedesktop.org/xorg/xserver/-/commit/2bde9ca49a8fd9a1e6697d5e7ef837870d66f5d4

- CVE-2025-49180
Patch Modified: Yes

Astrolabe patch reference:  https://gitlab.freedesktop.org/xorg/xserver/-/commit/3c3a4b767b16174d3213055947ea7f4f88e10ec6

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: **SPECS/xorg-x11-server/CVE-2025-49176.patch**
- new file: **SPECS/xorg-x11-server/CVE-2025-49178.patch**
- new file: **SPECS/xorg-x11-server/CVE-2025-49179.patch**
- new file: **SPECS/xorg-x11-server/CVE-2025-49180.patch**
- modified: **SPECS/xorg-x11-server/xorg-x11-server.spec**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-49176
- https://nvd.nist.gov/vuln/detail/CVE-2025-49178
- https://nvd.nist.gov/vuln/detail/CVE-2025-49179
- https://nvd.nist.gov/vuln/detail/CVE-2025-49180

###### Test Methodology

- Verified: patches CVE-2025-49176, CVE-2025-49178, CVE-2025-49179, CVE-2025-49180 are applied as shown below
![image](https://github.com/user-attachments/assets/9fa5ef68-256d-4abb-924b-25ff09fdab7c)

- Local build