### PR TITLE
Build 64k aarch64 ISO from Azure Linux

### DIFF
--- a/toolkit/imageconfigs/full-aarch64-64k.json
+++ b/toolkit/imageconfigs/full-aarch64-64k.json
@@ -1,0 +1,46 @@
+{
+    "SystemConfigs": [
+        {
+            "Name": "Azure Linux Full",
+            "PackageLists": [
+                "packagelists/hyperv-packages.json",
+                "packagelists/developer-packages.json",
+                "packagelists/virtualization-host-packages.json",
+                "packagelists/core-packages-image-aarch64.json",
+                "packagelists/core-tools-packages.json",
+                "packagelists/selinux-full.json",
+                "packagelists/virt-guest-packages.json"
+            ],
+            "KernelCommandLine": {
+                "SELinux": "permissive"
+            },
+            "KernelOptions": {
+                "default": "kernel-64k"
+            },
+            "KernelCommandLine": {
+                "ExtraCommandLine": "efi_mmap_nr_slack_slots=256"
+            },
+            "AdditionalFiles": {
+                "additionalconfigs/99-dhcp-en.network": "/etc/systemd/network/99-dhcp-en.network"
+            }
+        },
+        {
+            "Name": "Azure Linux Core",
+            "PackageLists": [
+                "packagelists/hyperv-packages.json",
+                "packagelists/core-packages-image-aarch64.json",
+                "packagelists/virt-guest-packages.json",
+                "packagelists/ssh-server.json"
+            ],
+            "KernelOptions": {
+                "default": "kernel-64k"
+            },
+            "KernelCommandLine": {
+                "ExtraCommandLine": "efi_mmap_nr_slack_slots=256"
+            },
+            "AdditionalFiles": {
+                "additionalconfigs/99-dhcp-en.network": "/etc/systemd/network/99-dhcp-en.network"
+            }
+        }
+    ]
+}

--- a/toolkit/resources/imageconfigs/additionalfiles/custom_grub_64k/grub.cfg
+++ b/toolkit/resources/imageconfigs/additionalfiles/custom_grub_64k/grub.cfg
@@ -1,0 +1,11 @@
+set timeout=0
+
+# Add efi_mmap_nr_slack_slots=256 to grub kernel cmdline
+# for slack slots size allocation at runtime
+# The use of mariner.media=CDROM is a workaround that our installer does not require
+# but it is observed to be needed to boot on some hardware/SoCs.
+menuentry "Azure Linux" {
+    search --label CDROM --set root
+    linux /isolinux/vmlinuz root=/dev/ram0 mariner.media=CDROM lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 console=tty0 console=ttyS0,115200n8 efi_mmap_nr_slack_slots=256
+    initrd /isolinux/initrd.img
+}

--- a/toolkit/resources/imageconfigs/iso_initrd_arm64_64k.json
+++ b/toolkit/resources/imageconfigs/iso_initrd_arm64_64k.json
@@ -1,0 +1,50 @@
+{
+    "Disks": [
+        {
+            "Artifacts": [
+                {
+                    "Name": "iso-initrd",
+                    "Type": "initrd",
+                    "Compression": "tar.gz"
+                }
+            ]
+        }
+    ],
+    "SystemConfigs": [
+        {
+            "Name": "ISO initrd",
+            "PackageLists": [
+                "packagelists/accessibility-kernel-64k-packages.json",
+                "packagelists/iso-initrd-packages-arm64.json"
+            ],
+            "KernelOptions": {
+                "default": "kernel-64k"
+            },
+            "KernelCommandLine": {
+                "ExtraCommandLine": "efi_mmap_nr_slack_slots=256"
+            },
+            "AdditionalFiles": {
+                "../../out/tools/imager": "/installer/imager",
+                "../../out/tools/liveinstaller": "/installer/liveinstaller",
+                "additionalfiles/iso_initrd/init": "/init",
+                "additionalfiles/iso_initrd/installer/calamares-EULA.txt": "/etc/calamares/azl-eula",
+                "additionalfiles/iso_initrd/installer/terminal-EULA.txt": "/installer/EULA.txt",
+                "additionalfiles/iso_initrd/root/asoundrc": "/root/.asoundrc",
+                "additionalfiles/iso_initrd/root/runliveinstaller": "/root/runliveinstaller",
+                "additionalfiles/iso_initrd/root/silence.wav": "/root/silence.wav",
+                "additionalfiles/iso_initrd/usr/lib/mariner/terminfo/mariner-installer": "/usr/lib/mariner/terminfo/m/mariner-installer",
+                "additionalfiles/iso_initrd/usr/lib/systemd/system/getty@.service": "/usr/lib/systemd/system/getty@.service",
+                "additionalfiles/iso_initrd/usr/lib/systemd/system/serial-getty@.service": "/usr/lib/systemd/system/serial-getty@.service",
+                "../manifests/image/local.repo": "/etc/yum.repos.d/mariner-iso.repo"
+            },           
+            "Users": [
+                {
+                    "Name": "root",
+                    "PasswordExpiresDays": 99999,
+                    "StartupCommand": "/root/runliveinstaller"
+                }
+            ],
+            "DisableRpmDocs": true
+        }
+    ]
+}

--- a/toolkit/resources/imageconfigs/packagelists/accessibility-kernel-64k-packages.json
+++ b/toolkit/resources/imageconfigs/packagelists/accessibility-kernel-64k-packages.json
@@ -1,0 +1,9 @@
+{
+    "packages": [
+        "alsa-lib",
+        "espeak-ng",
+        "pcaudiolib",
+        "kernel-64k-drivers-accessibility",
+        "kernel-64k-drivers-sound"
+    ]
+}

--- a/toolkit/tools/isomaker/isomaker.go
+++ b/toolkit/tools/isomaker/isomaker.go
@@ -24,6 +24,7 @@ var (
 	releaseVersion    = app.Flag("release-version", "The repository OS release version").Required().String()
 	resourcesDirPath  = app.Flag("resources", "Path to 'resources' directory").Required().ExistingDir()
 	outputDir         = app.Flag("output-dir", "Path to directory to place final image").Required().String()
+        isoGrubCfg        = app.Flag("custom-iso-grub-cfg", "Path to iso grub.cfg to place final image").String()
 	repoSnapshotTime  = app.Flag("repo-snapshot-time", "Optional: tdnf image repo snapshot time").String()
 
 	imageTag = app.Flag("image-tag", "Tag (text) appended to the image name. Empty by default.").String()
@@ -47,6 +48,7 @@ func main() {
 		*initrdPath,
 		*isoRepoDirPath,
 		*outputDir,
+                *isoGrubCfg,
 		*imageTag,
 		*repoSnapshotTime)
 	if err != nil {

--- a/toolkit/tools/isomaker/isomaker.go
+++ b/toolkit/tools/isomaker/isomaker.go
@@ -24,7 +24,7 @@ var (
 	releaseVersion    = app.Flag("release-version", "The repository OS release version").Required().String()
 	resourcesDirPath  = app.Flag("resources", "Path to 'resources' directory").Required().ExistingDir()
 	outputDir         = app.Flag("output-dir", "Path to directory to place final image").Required().String()
-        isoGrubCfg        = app.Flag("custom-iso-grub-cfg", "Path to custom iso grub.cfg to place in final image").String()
+	isoGrubCfg        = app.Flag("custom-iso-grub-cfg", "Path to custom iso grub.cfg to place in final image").String()
 	repoSnapshotTime  = app.Flag("repo-snapshot-time", "Optional: tdnf image repo snapshot time").String()
 
 	imageTag = app.Flag("image-tag", "Tag (text) appended to the image name. Empty by default.").String()
@@ -48,7 +48,7 @@ func main() {
 		*initrdPath,
 		*isoRepoDirPath,
 		*outputDir,
-                *isoGrubCfg,
+		*isoGrubCfg,
 		*imageTag,
 		*repoSnapshotTime)
 	if err != nil {

--- a/toolkit/tools/isomaker/isomaker.go
+++ b/toolkit/tools/isomaker/isomaker.go
@@ -24,7 +24,7 @@ var (
 	releaseVersion    = app.Flag("release-version", "The repository OS release version").Required().String()
 	resourcesDirPath  = app.Flag("resources", "Path to 'resources' directory").Required().ExistingDir()
 	outputDir         = app.Flag("output-dir", "Path to directory to place final image").Required().String()
-        isoGrubCfg        = app.Flag("custom-iso-grub-cfg", "Path to iso grub.cfg to place final image").String()
+        isoGrubCfg        = app.Flag("custom-iso-grub-cfg", "Path to custom iso grub.cfg to place in final image").String()
 	repoSnapshotTime  = app.Flag("repo-snapshot-time", "Optional: tdnf image repo snapshot time").String()
 
 	imageTag = app.Flag("image-tag", "Tag (text) appended to the image name. Empty by default.").String()

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -63,7 +63,7 @@ type IsoMaker struct {
 }
 
 // NewIsoMaker returns a new ISO maker.
-func NewIsoMaker(unattendedInstall bool, baseDirPath, buildDirPath, releaseVersion, resourcesDirPath, configFilePath, initrdPath, isoRepoDirPath, outputDir, imageNameTag, isoRepoSnapshotTime string) (isoMaker *IsoMaker, err error) {
+func NewIsoMaker(unattendedInstall bool, baseDirPath, buildDirPath, releaseVersion, resourcesDirPath, configFilePath, initrdPath, isoRepoDirPath, outputDir, isoGrubCfg, imageNameTag, isoRepoSnapshotTime string) (isoMaker *IsoMaker, err error) {
 	if baseDirPath == "" {
 		baseDirPath = filepath.Dir(configFilePath)
 	}
@@ -92,6 +92,7 @@ func NewIsoMaker(unattendedInstall bool, baseDirPath, buildDirPath, releaseVersi
 		fetchedRepoDirPath: isoRepoDirPath,
 		outputDirPath:      outputDir,
 		imageNameBase:      imageNameBase,
+                grubCfgPath:        isoGrubCfg,
 		imageNameTag:       imageNameTag,
 		osFilesPath:        defaultOSFilesPath,
 		repoSnapshotTime:   isoRepoSnapshotTime,

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -92,7 +92,7 @@ func NewIsoMaker(unattendedInstall bool, baseDirPath, buildDirPath, releaseVersi
 		fetchedRepoDirPath: isoRepoDirPath,
 		outputDirPath:      outputDir,
 		imageNameBase:      imageNameBase,
-                grubCfgPath:        isoGrubCfg,
+		grubCfgPath:        isoGrubCfg,
 		imageNameTag:       imageNameTag,
 		osFilesPath:        defaultOSFilesPath,
 		repoSnapshotTime:   isoRepoSnapshotTime,


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Build 64k aarch64 ISO from Azure Linux
We need to add `efi_mmap_nr_slack_slots=256` to the grub kernel command line for slack slots size allocation at runtime. This is necessary for both the ISO grub and the installed OS grub to boot on specific hardware like GB200F and above.
There are some limitations when it comes to customizing the ISO grub using post install task or extra command line. Leveraging the interface which was added from MIC to overwrite the customized grub from the toolkit ISO maker.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
  Build 64k aarch64 ISO from Azure Linux

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
