### PR TITLE
[Medium] Patch python-urllib3 for CVE-2025-50181

### DIFF
--- a/SPECS/python-urllib3/CVE-2025-50181.patch
+++ b/SPECS/python-urllib3/CVE-2025-50181.patch
@@ -3,6 +3,8 @@ From: dj_palli <v-dpalli@microsoft.com>
 Date: Thu, 26 Jun 2025 20:53:40 +0000
 Subject: [PATCH] Address CVE-2025-50181
 
+Upstream Patch reference: https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857
+
 ---
  CHANGES.rst                               |   2 +
  src/urllib3/poolmanager.py                |  18 +++-

--- a/SPECS/python-urllib3/CVE-2025-50181.patch
+++ b/SPECS/python-urllib3/CVE-2025-50181.patch
@@ -1,0 +1,200 @@
+From 61549f2dba1beba27073f21b67c971a27e5c4708 Mon Sep 17 00:00:00 2001
+From: dj_palli <v-dpalli@microsoft.com>
+Date: Thu, 26 Jun 2025 20:53:40 +0000
+Subject: [PATCH] Address CVE-2025-50181
+
+---
+ CHANGES.rst                               |   2 +
+ src/urllib3/poolmanager.py                |  18 +++-
+ test/test_poolmanager.py                  |   5 +-
+ test/with_dummyserver/test_poolmanager.py | 101 ++++++++++++++++++++++
+ 4 files changed, 123 insertions(+), 3 deletions(-)
+
+diff --git a/CHANGES.rst b/CHANGES.rst
+index c45b3d1..616b801 100644
+--- a/CHANGES.rst
++++ b/CHANGES.rst
+@@ -7,6 +7,8 @@ Changes
+ - Added the ``Proxy-Authorization`` header to the list of headers to strip from requests when redirecting to a different host. As before, different headers can be set via ``Retry.remove_headers_on_redirect``.
+ - Fixed handling of OpenSSL 3.2.0 new error message for misconfiguring an HTTP proxy as HTTPS. (`#3405 <https://github.com/urllib3/urllib3/issues/3405>`__)
+ 
++- Fixed a security issue where restricting the maximum number of followed redirects at the urllib3.PoolManager level via the retries parameter did not work.
++- TODO: add other entries in the release PR.
+ 
+ 1.26.18 (2023-10-17)
+ --------------------
+diff --git a/src/urllib3/poolmanager.py b/src/urllib3/poolmanager.py
+index fb51bf7..a8de7c6 100644
+--- a/src/urllib3/poolmanager.py
++++ b/src/urllib3/poolmanager.py
+@@ -170,6 +170,22 @@ class PoolManager(RequestMethods):
+ 
+     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
+         RequestMethods.__init__(self, headers)
++        if "retries" in connection_pool_kw:
++            retries = connection_pool_kw["retries"]
++            if not isinstance(retries, Retry):
++                # When Retry is initialized, raise_on_redirect is based
++                # on a redirect boolean value.
++                # But requests made via a pool manager always set
++                # redirect to False, and raise_on_redirect always ends
++                # up being False consequently.
++                # Here we fix the issue by setting raise_on_redirect to
++                # a value needed by the pool manager without considering
++                # the redirect boolean.
++                raise_on_redirect = retries is not False
++                retries = Retry.from_int(retries, redirect=False)
++                retries.raise_on_redirect = raise_on_redirect
++                connection_pool_kw = connection_pool_kw.copy()
++                connection_pool_kw["retries"] = retries
+         self.connection_pool_kw = connection_pool_kw
+         self.pools = RecentlyUsedContainer(num_pools)
+ 
+@@ -389,7 +405,7 @@ class PoolManager(RequestMethods):
+             kw["body"] = None
+             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
+ 
+-        retries = kw.get("retries")
++        retries = kw.get("retries", response.retries)
+         if not isinstance(retries, Retry):
+             retries = Retry.from_int(retries, redirect=redirect)
+ 
+diff --git a/test/test_poolmanager.py b/test/test_poolmanager.py
+index 61715e9..ded7b38 100644
+--- a/test/test_poolmanager.py
++++ b/test/test_poolmanager.py
+@@ -322,9 +322,10 @@ class TestPoolManager(object):
+ 
+     def test_merge_pool_kwargs(self):
+         """Assert _merge_pool_kwargs works in the happy case"""
+-        p = PoolManager(strict=True)
++        retries = retry.Retry(total=100)
++        p = PoolManager(retries=retries)
+         merged = p._merge_pool_kwargs({"new_key": "value"})
+-        assert {"strict": True, "new_key": "value"} == merged
++        assert {"strict": retries, "new_key": "value"} == merged
+ 
+     def test_merge_pool_kwargs_none(self):
+         """Assert false-y values to _merge_pool_kwargs result in defaults"""
+diff --git a/test/with_dummyserver/test_poolmanager.py b/test/with_dummyserver/test_poolmanager.py
+index 02e3de5..6cb3474 100644
+--- a/test/with_dummyserver/test_poolmanager.py
++++ b/test/with_dummyserver/test_poolmanager.py
+@@ -82,6 +82,89 @@ class TestPoolManager(HTTPDummyServerTestCase):
+             assert r.status == 200
+             assert r.data == b"Dummy server!"
+ 
++    @pytest.mark.parametrize(
++        "retries",
++        (0, Retry(total=0), Retry(redirect=0), Retry(total=0, redirect=0)),
++    )
++    def test_redirects_disabled_for_pool_manager_with_0(
++        self, retries: typing.Literal[0] | Retry
++    ) -> None:
++        """
++        Check handling redirects when retries is set to 0 on the pool
++        manager.
++        """
++        with PoolManager(retries=retries) as http:
++            with pytest.raises(MaxRetryError):
++                http.request("GET", f"{self.base_url}/redirect")
++
++            # Setting redirect=True should not change the behavior.
++            with pytest.raises(MaxRetryError):
++                http.request("GET", f"{self.base_url}/redirect", redirect=True)
++
++            # Setting redirect=False should not make it follow the redirect,
++            # but MaxRetryError should not be raised.
++            response = http.request("GET", f"{self.base_url}/redirect", redirect=False)
++            assert response.status == 303
++
++    @pytest.mark.parametrize(
++        "retries",
++        (
++            False,
++            Retry(total=False),
++            Retry(redirect=False),
++            Retry(total=False, redirect=False),
++        ),
++    )
++    def test_redirects_disabled_for_pool_manager_with_false(
++        self, retries: typing.Literal[False] | Retry
++    ) -> None:
++        """
++        Check that setting retries set to False on the pool manager disables
++        raising MaxRetryError and redirect=True does not change the
++        behavior.
++        """
++        with PoolManager(retries=retries) as http:
++            response = http.request("GET", f"{self.base_url}/redirect")
++            assert response.status == 303
++
++            response = http.request("GET", f"{self.base_url}/redirect", redirect=True)
++            assert response.status == 303
++
++            response = http.request("GET", f"{self.base_url}/redirect", redirect=False)
++            assert response.status == 303
++
++    def test_redirects_disabled_for_individual_request(self) -> None:
++        """
++        Check handling redirects when they are meant to be disabled
++        on the request level.
++        """
++        with PoolManager() as http:
++            # Check when redirect is not passed.
++            with pytest.raises(MaxRetryError):
++                http.request("GET", f"{self.base_url}/redirect", retries=0)
++            response = http.request("GET", f"{self.base_url}/redirect", retries=False)
++            assert response.status == 303
++
++            # Check when redirect=True.
++            with pytest.raises(MaxRetryError):
++                http.request(
++                    "GET", f"{self.base_url}/redirect", retries=0, redirect=True
++                )
++            response = http.request(
++                "GET", f"{self.base_url}/redirect", retries=False, redirect=True
++            )
++            assert response.status == 303
++
++            # Check when redirect=False.
++            response = http.request(
++                "GET", f"{self.base_url}/redirect", retries=0, redirect=False
++            )
++            assert response.status == 303
++            response = http.request(
++                "GET", f"{self.base_url}/redirect", retries=False, redirect=False
++            )
++            assert response.status == 303
++
+     def test_cross_host_redirect(self):
+         with PoolManager() as http:
+             cross_host_location = "%s/echo?a=b" % self.base_url_alt
+@@ -136,6 +219,24 @@ class TestPoolManager(HTTPDummyServerTestCase):
+             pool = http.connection_from_host(self.host, self.port)
+             assert pool.num_connections == 1
+ 
++        # Check when retries are configured for the pool manager.
++        with PoolManager(retries=1) as http:
++            with pytest.raises(MaxRetryError):
++                http.request(
++                    "GET",
++                    f"{self.base_url}/redirect",
++                    fields={"target": f"/redirect?target={self.base_url}/"},
++                )
++
++            # Here we allow more retries for the request.
++            response = http.request(
++                "GET",
++                f"{self.base_url}/redirect",
++                fields={"target": f"/redirect?target={self.base_url}/"},
++                retries=2,
++            )
++            assert response.status == 200
++
+     def test_redirect_cross_host_remove_headers(self):
+         with PoolManager() as http:
+             r = http.request(
+-- 
+2.45.2
+

--- a/SPECS/python-urllib3/python-urllib3.spec
+++ b/SPECS/python-urllib3/python-urllib3.spec
@@ -25,7 +25,7 @@ BuildRequires:  python3-pip
 %endif
 Requires:       python3
 
-Patch1: CVE-2025-50181.patch
+Patch0: CVE-2025-50181.patch
 
 %description -n python3-urllib3
 urllib3 is a powerful, sanity-friendly HTTP client for Python. Much of the Python ecosystem already uses urllib3 and you should too.

--- a/SPECS/python-urllib3/python-urllib3.spec
+++ b/SPECS/python-urllib3/python-urllib3.spec
@@ -1,7 +1,7 @@
 Summary:        A powerful, sanity-friendly HTTP client for Python.
 Name:           python-urllib3
 Version:        1.26.19
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -24,6 +24,8 @@ BuildRequires:  python3-xml
 BuildRequires:  python3-pip
 %endif
 Requires:       python3
+
+Patch1: CVE-2025-50181.patch
 
 %description -n python3-urllib3
 urllib3 is a powerful, sanity-friendly HTTP client for Python. Much of the Python ecosystem already uses urllib3 and you should too.
@@ -51,6 +53,9 @@ nox --reuse-existing-virtualenvs --sessions test-%{python3_version}
 %{python3_sitelib}/*
 
 %changelog
+* Thu Jun 26 2025 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 1.26.19-2
+- Patch CVE-2025-50181
+
 * Thu Jun 20 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.26.19-1
 - Auto-upgrade to 1.26.19 - patch CVE-2024-37891
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
 [Medium] Patch python-urllib3 for CVE-2025-50181
 Astrolabe patch reference:  https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857
Patch Modified: Yes
  - The bug fix change details are added in v1.26.19 instead of v2.5.0. Because the azure linux source version is v1.26.19. Here, the upstream patch is for v2.5.0
  - Two files are not available: emscripten.rst, app.py.
  - And one test file also not available: test_emscripten.py
 
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Modified File: python-urllib3.spec
- New file: CVE-2025-50181.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-50181

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- This Patch has been applied cleanly.
- This is the log before i applied my patches, this also appears to be test failing.
- <img width="439" alt="image" src="https://github.com/user-attachments/assets/5bad8902-8dcd-442f-aacd-133857789a66" />
- [python-urllib3-1.26.19-1.cm2.src.rpm.test.log](https://github.com/user-attachments/files/20934169/python-urllib3-1.26.19-1.cm2.src.rpm.test.log)

- And This is the log after i applied my patch, this also appears to be test  failing.
- ![image](https://github.com/user-attachments/assets/27a73c61-0578-413e-b4a4-ab5f2fea2cf2)
- [python-urllib3-1.26.19-2.cm2.src.rpm.test.log](https://github.com/user-attachments/files/20934139/python-urllib3-1.26.19-2.cm2.src.rpm.test.log)


