### PR TITLE
[Low] Patch libarchive for CVE-2025-5914, CVE-2025-5915, CVE-2025-5916, CVE-2025-5917, CVE-5918

### DIFF
--- a/SPECS/libarchive/CVE-2025-5914.patch
+++ b/SPECS/libarchive/CVE-2025-5914.patch
@@ -1,0 +1,37 @@
+From 758e703c7b552032336ec49debd9323602e34b37 Mon Sep 17 00:00:00 2001
+From: SumitJenaHCL <v-sumitjena@microsoft.com>
+Date: Thu, 26 Jun 2025 20:30:27 +0000
+Subject: [PATCH] Patch CVE-2025-5914
+
+Upstream Patch Reference: https://github.com/libarchive/libarchive/pull/2598/commits/196029dd0a17cd17c916eada9085839032b76ec9
+---
+ libarchive/archive_read_support_format_rar.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index cf448b0..c1c1690 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -335,8 +335,8 @@ struct rar
+   int found_first_header;
+   char has_endarc_header;
+   struct data_block_offsets *dbo;
+-  unsigned int cursor;
+-  unsigned int nodes;
++  size_t cursor;
++  size_t nodes;
+   char filename_must_match;
+ 
+   /* LZSS members */
+@@ -1182,7 +1182,7 @@ archive_read_format_rar_seek_data(struct archive_read *a, int64_t offset,
+     int whence)
+ {
+   int64_t client_offset, ret;
+-  unsigned int i;
++  size_t i;
+   struct rar *rar = (struct rar *)(a->format->data);
+ 
+   if (rar->compression_method == COMPRESS_METHOD_STORE)
+-- 
+2.45.2
+

--- a/SPECS/libarchive/CVE-2025-5915.patch
+++ b/SPECS/libarchive/CVE-2025-5915.patch
@@ -1,0 +1,198 @@
+From 70f9b100b509c1424b09d897cb9e85cac8b54405 Mon Sep 17 00:00:00 2001
+From: SumitJenaHCL <v-sumitjena@microsoft.com>
+Date: Mon, 23 Jun 2025 17:34:07 +0000
+Subject: [PATCH] Patch CVE-2025-5915
+
+Upstream Patch Reference: https://github.com/libarchive/libarchive/pull/2599
+---
+ Makefile.am                                   |  2 +
+ libarchive/archive_read_support_format_rar.c  | 17 ++++---
+ libarchive/test/CMakeLists.txt                |  1 +
+ .../test/test_read_format_rar_overflow.c      | 48 +++++++++++++++++++
+ .../test/test_read_format_rar_overflow.rar.uu | 11 +++++
+ 5 files changed, 72 insertions(+), 7 deletions(-)
+ create mode 100644 libarchive/test/test_read_format_rar_overflow.c
+ create mode 100644 libarchive/test/test_read_format_rar_overflow.rar.uu
+
+diff --git a/Makefile.am b/Makefile.am
+index a36126c..a4cc312 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -517,6 +517,7 @@ libarchive_test_SOURCES= \
+ 	libarchive/test/test_read_format_rar_encryption_header.c \
+ 	libarchive/test/test_read_format_rar_filter.c \
+ 	libarchive/test/test_read_format_rar_invalid1.c \
++	libarchive/test/test_read_format_rar_overflow.c \
+ 	libarchive/test/test_read_format_rar5.c \
+ 	libarchive/test/test_read_format_raw.c \
+ 	libarchive/test/test_read_format_tar.c \
+@@ -883,6 +884,7 @@ libarchive_test_EXTRA_DIST=\
+ 	libarchive/test/test_read_format_rar_multivolume.part0003.rar.uu \
+ 	libarchive/test/test_read_format_rar_multivolume.part0004.rar.uu \
+ 	libarchive/test/test_read_format_rar_noeof.rar.uu \
++	libarchive/test/test_read_format_rar_overflow.rar.uu \
+ 	libarchive/test/test_read_format_rar_ppmd_lzss_conversion.rar.uu \
+ 	libarchive/test/test_read_format_rar_ppmd_use_after_free.rar.uu \
+ 	libarchive/test/test_read_format_rar_ppmd_use_after_free2.rar.uu \
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index ff1ea9c..bb06f76 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -451,7 +451,7 @@ static int read_filter(struct archive_read *, int64_t *);
+ static int rar_decode_byte(struct archive_read*, uint8_t *);
+ static int execute_filter(struct archive_read*, struct rar_filter *,
+                           struct rar_virtual_machine *, size_t);
+-static int copy_from_lzss_window(struct archive_read *, void *, int64_t, int);
++static int copy_from_lzss_window(struct archive_read *, uint8_t *, int64_t, int);
+ static inline void vm_write_32(struct rar_virtual_machine*, size_t, uint32_t);
+ static inline uint32_t vm_read_32(struct rar_virtual_machine*, size_t);
+ 
+@@ -2929,7 +2929,7 @@ expand(struct archive_read *a, int64_t *end)
+     }
+ 
+     if ((symbol = read_next_symbol(a, &rar->maincode)) < 0)
+-      return (ARCHIVE_FATAL);
++      goto bad_data;
+ 
+     if (symbol < 256)
+     {
+@@ -2956,14 +2956,14 @@ expand(struct archive_read *a, int64_t *end)
+       else
+       {
+         if (parse_codes(a) != ARCHIVE_OK)
+-          return (ARCHIVE_FATAL);
++          goto bad_data;
+         continue;
+       }
+     }
+     else if(symbol==257)
+     {
+       if (!read_filter(a, end))
+-          return (ARCHIVE_FATAL);
++          goto bad_data;
+       continue;
+     }
+     else if(symbol==258)
+@@ -3048,7 +3048,7 @@ expand(struct archive_read *a, int64_t *end)
+           {
+             if ((lowoffsetsymbol =
+               read_next_symbol(a, &rar->lowoffsetcode)) < 0)
+-              return (ARCHIVE_FATAL);
++              goto bad_data;
+             if(lowoffsetsymbol == 16)
+             {
+               rar->numlowoffsetrepeats = 15;
+@@ -3096,7 +3096,7 @@ bad_data:
+ }
+ 
+ static int
+-copy_from_lzss_window(struct archive_read *a, void *buffer,
++copy_from_lzss_window(struct archive_read *a, uint8_t *buffer,
+                       int64_t startpos, int length)
+ {
+   int windowoffs, firstpart;
+@@ -3111,7 +3111,7 @@ copy_from_lzss_window(struct archive_read *a, void *buffer,
+   }
+   if (firstpart < length) {
+     memcpy(buffer, &rar->lzss.window[windowoffs], firstpart);
+-    memcpy(buffer, &rar->lzss.window[0], length - firstpart);
++    memcpy(buffer + firstpart, &rar->lzss.window[0], length - firstpart);
+   } else {
+     memcpy(buffer, &rar->lzss.window[windowoffs], length);
+   }
+@@ -3266,6 +3266,9 @@ parse_filter(struct archive_read *a, const uint8_t *bytes, uint16_t length, uint
+   else
+     blocklength = prog ? prog->oldfilterlength : 0;
+ 
++  if (blocklength > rar->dictionary_size)
++    return 0;
++
+   registers[3] = PROGRAM_SYSTEM_GLOBAL_ADDRESS;
+   registers[4] = blocklength;
+   registers[5] = prog ? prog->usagecount : 0;
+diff --git a/libarchive/test/CMakeLists.txt b/libarchive/test/CMakeLists.txt
+index 314c972..74d2abd 100644
+--- a/libarchive/test/CMakeLists.txt
++++ b/libarchive/test/CMakeLists.txt
+@@ -161,6 +161,7 @@ IF(ENABLE_TEST)
+     test_read_format_rar_encryption_partially.c
+     test_read_format_rar_invalid1.c
+     test_read_format_rar_filter.c
++    test_read_format_rar_overflow.c
+     test_read_format_rar5.c
+     test_read_format_raw.c
+     test_read_format_tar.c
+diff --git a/libarchive/test/test_read_format_rar_overflow.c b/libarchive/test/test_read_format_rar_overflow.c
+new file mode 100644
+index 0000000..b39ed6b
+--- /dev/null
++++ b/libarchive/test/test_read_format_rar_overflow.c
+@@ -0,0 +1,48 @@
++/*-
++ * Copyright (c) 2003-2025 Tim Kientzle
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
++ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
++ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
++ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
++ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
++ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++#include "test.h"
++
++DEFINE_TEST(test_read_format_rar_overflow)
++{
++    struct archive *a;
++    struct archive_entry *ae;
++    const char reffile[] = "test_read_format_rar_overflow.rar";
++    const void *buff;
++    size_t size;
++    int64_t offset;
++
++    extract_reference_file(reffile);
++    assert((a = archive_read_new()) != NULL);
++    assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
++    assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
++    assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, reffile, 1024));
++    assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
++    assertEqualInt(48, archive_entry_size(ae));
++    /* The next call should reproduce Issue #2565 */
++    assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data_block(a, &buff, &size, &offset));
++
++    assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
++    assertEqualInt(ARCHIVE_OK, archive_read_free(a));
++}
+diff --git a/libarchive/test/test_read_format_rar_overflow.rar.uu b/libarchive/test/test_read_format_rar_overflow.rar.uu
+new file mode 100644
+index 0000000..48fd3fd
+--- /dev/null
++++ b/libarchive/test/test_read_format_rar_overflow.rar.uu
+@@ -0,0 +1,11 @@
++begin 644 test_read_format_rar_overflow.rar
++M4F%R(1H'`,($=```(0`@`0``,`````(````````````S`0``````,`"_B%_:
++MZ?^[:7``?S!!,`@P,KB@,T@RN33)MTEB@5Z3<`DP`K35`.0P63@P<,Q&0?#,
++MA##,,",S,(@P,#,@##`&,#":(3`!,#"(`9HPS,,S13`P,#`P,*`PHPS,,S1A
++M,!,!,#","9H@S12D#$PP!C`P`*'F03":,,T8H`@\,/DPJS!/,"30,#`3N%LP
++MCQ6:S3"!,#LP22<-,$5%B"5B$S!)(&*>G#+@!`E`%0ODC])62=DO,)BYJX'P
++M=/LPZ3!!008?%S`P,#`P,#`P,#`P,#`P,#`P,#`P2$PP,#`P03!(,#`P,#`&
++M,`7),#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P
++-,#`P,#`P,#`P,#`P,```
++`
++end
+-- 
+2.45.2
+

--- a/SPECS/libarchive/CVE-2025-5916.patch
+++ b/SPECS/libarchive/CVE-2025-5916.patch
@@ -1,0 +1,102 @@
+From 82fbedafced6e9b00350efd1b27e5cadc1539ea1 Mon Sep 17 00:00:00 2001
+From: SumitJenaHCL <v-sumitjena@microsoft.com>
+Date: Thu, 26 Jun 2025 21:47:40 +0000
+Subject: [PATCH] Patch CVE-2025-5916
+
+Upstream Patch Reference: https://github.com/libarchive/libarchive/pull/2568/commits/bce70c4c26864df2a8d6953e7db6e4b156253508
+---
+ Makefile.am                                   |  1 +
+ libarchive/archive_read_support_format_warc.c |  7 ++++--
+ libarchive/test/test_read_format_warc.c       | 24 +++++++++++++++++++
+ .../test_read_format_warc_incomplete.warc.uu  | 10 ++++++++
+ 4 files changed, 40 insertions(+), 2 deletions(-)
+ create mode 100644 libarchive/test/test_read_format_warc_incomplete.warc.uu
+
+diff --git a/Makefile.am b/Makefile.am
+index a36126c..1f8c529 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -956,6 +956,7 @@ libarchive_test_EXTRA_DIST=\
+ 	libarchive/test/test_read_format_ustar_filename_eucjp.tar.Z.uu \
+ 	libarchive/test/test_read_format_ustar_filename_koi8r.tar.Z.uu \
+ 	libarchive/test/test_read_format_warc.warc.uu \
++	libarchive/test/test_read_format_warc_incomplete.warc.uu \
+ 	libarchive/test/test_read_format_xar_doublelink.xar.uu \
+ 	libarchive/test/test_read_format_xar_duplicate_filename_node.xar.uu \
+ 	libarchive/test/test_read_format_zip.zip.uu \
+diff --git a/libarchive/archive_read_support_format_warc.c b/libarchive/archive_read_support_format_warc.c
+index fcec5bc..696f959 100644
+--- a/libarchive/archive_read_support_format_warc.c
++++ b/libarchive/archive_read_support_format_warc.c
+@@ -386,7 +386,8 @@ start_over:
+ 	case LAST_WT:
+ 	default:
+ 		/* consume the content and start over */
+-		_warc_skip(a);
++		if (_warc_skip(a) < 0)
++			return (ARCHIVE_FATAL);
+ 		goto start_over;
+ 	}
+ 	return (ARCHIVE_OK);
+@@ -439,7 +440,9 @@ _warc_skip(struct archive_read *a)
+ {
+ 	struct warc_s *w = a->format->data;
+ 
+-	__archive_read_consume(a, w->cntlen + 4U/*\r\n\r\n separator*/);
++	if (__archive_read_consume(a, w->cntlen) < 0 ||
++	    __archive_read_consume(a, 4U/*\r\n\r\n separator*/) < 0)
++		return (ARCHIVE_FATAL);
+ 	w->cntlen = 0U;
+ 	w->cntoff = 0U;
+ 	return (ARCHIVE_OK);
+diff --git a/libarchive/test/test_read_format_warc.c b/libarchive/test/test_read_format_warc.c
+index 91e6dc6..745aabf 100644
+--- a/libarchive/test/test_read_format_warc.c
++++ b/libarchive/test/test_read_format_warc.c
+@@ -78,3 +78,27 @@ DEFINE_TEST(test_read_format_warc)
+ 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+ 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+ }
++
++DEFINE_TEST(test_read_format_warc_incomplete)
++{
++	const char reffile[] = "test_read_format_warc_incomplete.warc";
++	struct archive_entry *ae;
++	struct archive *a;
++
++	extract_reference_file(reffile);
++	assert((a = archive_read_new()) != NULL);
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
++	assertEqualIntA(a, ARCHIVE_OK,
++	    archive_read_open_filename(a, reffile, 10240));
++
++	/* Entry cannot be parsed */
++	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
++
++	/* Verify archive format. */
++	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
++
++	/* Verify closing and resource freeing */
++	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
++	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
++}
+diff --git a/libarchive/test/test_read_format_warc_incomplete.warc.uu b/libarchive/test/test_read_format_warc_incomplete.warc.uu
+new file mode 100644
+index 0000000..b91b97e
+--- /dev/null
++++ b/libarchive/test/test_read_format_warc_incomplete.warc.uu
+@@ -0,0 +1,10 @@
++begin 644 test_read_format_warc_incomplete.warc
++M5T%20R\Q+C`-"E=!4D,M5'EP93H@8V]N=F5R<VEO;@T*5T%20RU$871E.B`R
++M,#(U+3`S+3,P5#$U.C`P.C0P6@T*0V]N=&5N="U,96YG=&@Z(#DR,C,S-S(P
++M,S8X-30W-S4X,#<-"@T*5T%20R\Q+C`-"E=!4D,M5'EP93H@<F5S;W5R8V4-
++M"E=!4D,M5&%R9V5T+55223H@9FEL93HO+W)E861M92YT>'0-"E=!4D,M1&%T
++M93H@,C`R-2TP,RTS,%0Q-3HP,#HT,%H-"D-O;G1E;G0M5'EP93H@=&5X="]P
++M;&%I;@T*0V]N=&5N="U,96YG=&@Z(#,X#0H-"E1H92!R96%D;64N='AT('-H
++4;W5L9"!N;W0@8F4@=FES:6)L90H`
++`
++end
+-- 
+2.45.2
+

--- a/SPECS/libarchive/CVE-2025-5917.patch
+++ b/SPECS/libarchive/CVE-2025-5917.patch
@@ -1,0 +1,35 @@
+From d6e69750b8472476381401830c06b4f17332f380 Mon Sep 17 00:00:00 2001
+From: SumitJenaHCL <v-sumitjena@microsoft.com>
+Date: Mon, 23 Jun 2025 12:30:00 +0000
+Subject: [PATCH] Patch CVE-2025-5917
+
+Upstream Patch Reference: https://github.com/libarchive/libarchive/commit/7c02cde37a63580cd1859183fbbd2cf04a89be85
+---
+ libarchive/archive_write_set_format_pax.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libarchive/archive_write_set_format_pax.c b/libarchive/archive_write_set_format_pax.c
+index 6e35f70..b2ba959 100644
+--- a/libarchive/archive_write_set_format_pax.c
++++ b/libarchive/archive_write_set_format_pax.c
+@@ -1571,7 +1571,7 @@ build_ustar_entry_name(char *dest, const char *src, size_t src_length,
+ 	const char *filename, *filename_end;
+ 	char *p;
+ 	int need_slash = 0; /* Was there a trailing slash? */
+-	size_t suffix_length = 99;
++	size_t suffix_length = 98; /* 99 - 1 for trailing slash */
+ 	size_t insert_length;
+ 
+ 	/* Length of additional dir element to be added. */
+@@ -1623,7 +1623,7 @@ build_ustar_entry_name(char *dest, const char *src, size_t src_length,
+ 	/* Step 2: Locate the "prefix" section of the dirname, including
+ 	 * trailing '/'. */
+ 	prefix = src;
+-	prefix_end = prefix + 155;
++	prefix_end = prefix + 154 /* 155 - 1 for trailing / */;
+ 	if (prefix_end > filename)
+ 		prefix_end = filename;
+ 	while (prefix_end > prefix && *prefix_end != '/')
+-- 
+2.45.2
+

--- a/SPECS/libarchive/CVE-2025-5918.patch
+++ b/SPECS/libarchive/CVE-2025-5918.patch
@@ -1,0 +1,339 @@
+From f62faf0c77f4869b0edac45a95f08a875162e212 Mon Sep 17 00:00:00 2001
+From: SumitJenaHCL <v-sumitjena@microsoft.com>
+Date: Thu, 26 Jun 2025 21:39:34 +0000
+Subject: [PATCH] Patch CVE-2025-5918
+
+Upstream Patch Reference: https://github.com/libarchive/libarchive/commit/dcbf1e0ededa95849f098d154a25876ed5754bcf
+---
+ libarchive/archive_read_open_fd.c       | 13 +++-
+ libarchive/archive_read_open_file.c     | 95 +++++++++++++++++++++----
+ libarchive/archive_read_open_filename.c | 34 ++++++---
+ libarchive/test/test_open_file.c        |  9 +--
+ libarchive/test/test_read_format_rar.c  |  6 +-
+ 5 files changed, 122 insertions(+), 35 deletions(-)
+
+diff --git a/libarchive/archive_read_open_fd.c b/libarchive/archive_read_open_fd.c
+index debfde2..67844c4 100644
+--- a/libarchive/archive_read_open_fd.c
++++ b/libarchive/archive_read_open_fd.c
+@@ -52,6 +52,7 @@
+ struct read_fd_data {
+ 	int	 fd;
+ 	size_t	 block_size;
++	int64_t	 size;
+ 	char	 use_lseek;
+ 	void	*buffer;
+ };
+@@ -95,6 +96,7 @@ archive_read_open_fd(struct archive *a, int fd, size_t block_size)
+ 	if (S_ISREG(st.st_mode)) {
+ 		archive_read_extract_set_skip_file(a, st.st_dev, st.st_ino);
+ 		mine->use_lseek = 1;
++		mine->size = st.st_size;
+ 	}
+ #if defined(__CYGWIN__) || defined(_WIN32)
+ 	setmode(mine->fd, O_BINARY);
+@@ -151,9 +153,14 @@ file_skip(struct archive *a, void *client_data, int64_t request)
+ 	if (request == 0)
+ 		return (0);
+ 
+-	if (((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0) &&
+-	    ((new_offset = lseek(mine->fd, skip, SEEK_CUR)) >= 0))
+-		return (new_offset - old_offset);
++	if ((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0) {
++		if (old_offset >= mine->size ||
++		    skip > mine->size - old_offset) {
++			/* Do not seek past end of file. */
++			errno = ESPIPE;
++		} else if ((new_offset = lseek(mine->fd, skip, SEEK_CUR)) >= 0)
++			return (new_offset - old_offset);
++	}
+ 
+ 	/* If seek failed once, it will probably fail again. */
+ 	mine->use_lseek = 0;
+diff --git a/libarchive/archive_read_open_file.c b/libarchive/archive_read_open_file.c
+index cf49ebd..bb0e195 100644
+--- a/libarchive/archive_read_open_file.c
++++ b/libarchive/archive_read_open_file.c
+@@ -52,13 +52,15 @@
+ struct read_FILE_data {
+ 	FILE    *f;
+ 	size_t	 block_size;
++	int64_t	 size;
+ 	void	*buffer;
+ 	char	 can_skip;
+ };
+ 
+ static int	file_close(struct archive *, void *);
+ static ssize_t	file_read(struct archive *, void *, const void **buff);
+-static int64_t	file_skip(struct archive *, void *, int64_t request);
++static int64_t	file_seek(struct archive *, void *, int64_t, int);
++static int64_t	file_skip(struct archive *, void *, int64_t);
+ 
+ int
+ archive_read_open_FILE(struct archive *a, FILE *f)
+@@ -69,7 +71,7 @@ archive_read_open_FILE(struct archive *a, FILE *f)
+ 	void *b;
+ 
+ 	archive_clear_error(a);
+-	mine = malloc(sizeof(*mine));
++	mine = calloc(1, sizeof(*mine));
+ 	b = malloc(block_size);
+ 	if (mine == NULL || b == NULL) {
+ 		archive_set_error(a, ENOMEM, "No memory");
+@@ -90,6 +92,7 @@ archive_read_open_FILE(struct archive *a, FILE *f)
+ 		archive_read_extract_set_skip_file(a, st.st_dev, st.st_ino);
+ 		/* Enable the seek optimization only for regular files. */
+ 		mine->can_skip = 1;
++		mine->size = st.st_size;
+ 	} else
+ 		mine->can_skip = 0;
+ 
+@@ -99,6 +102,7 @@ archive_read_open_FILE(struct archive *a, FILE *f)
+ 
+ 	archive_read_set_read_callback(a, file_read);
+ 	archive_read_set_skip_callback(a, file_skip);
++	archive_read_set_seek_callback(a, file_seek);
+ 	archive_read_set_close_callback(a, file_close);
+ 	archive_read_set_callback_data(a, mine);
+ 	return (archive_read_open1(a));
+@@ -122,13 +126,14 @@ static int64_t
+ file_skip(struct archive *a, void *client_data, int64_t request)
+ {
+ 	struct read_FILE_data *mine = (struct read_FILE_data *)client_data;
+-#if HAVE_FSEEKO
+-	off_t skip = (off_t)request;
+-#elif HAVE__FSEEKI64
++#if HAVE__FSEEKI64
+ 	int64_t skip = request;
++#elif HAVE_FSEEKO
++	off_t skip = (off_t)request;
+ #else
+ 	long skip = (long)request;
+ #endif
++	int64_t old_offset, new_offset;
+ 	int skip_bits = sizeof(skip) * 8 - 1;
+ 
+ 	(void)a; /* UNUSED */
+@@ -152,19 +157,81 @@ file_skip(struct archive *a, void *client_data, int64_t request)
+ 
+ #ifdef __ANDROID__
+         /* fileno() isn't safe on all platforms ... see above. */
+-	if (lseek(fileno(mine->f), skip, SEEK_CUR) < 0)
++	old_offset = lseek(fileno(mine->f), 0, SEEK_CUR);
+ #elif HAVE__FSEEKI64
+-	if (_fseeki64(mine->f, skip, SEEK_CUR) != 0)
++	old_offset = _ftelli64(mine->f);
+ #elif HAVE_FSEEKO
+-	if (fseeko(mine->f, skip, SEEK_CUR) != 0)
++	old_offset = ftello(mine->f);
+ #else
+-	if (fseek(mine->f, skip, SEEK_CUR) != 0)
++	old_offset = ftell(mine->f);
+ #endif
+-	{
+-		mine->can_skip = 0;
+-		return (0);
++	if (old_offset >= 0) {
++		if (old_offset < mine->size &&
++		    skip <= mine->size - old_offset) {
++#ifdef __ANDROID__
++			new_offset = lseek(fileno(mine->f), skip, SEEK_CUR);
++#elif HAVE__FSEEKI64
++			new_offset = _fseeki64(mine->f, skip, SEEK_CUR);
++#elif HAVE_FSEEKO
++			new_offset = fseeko(mine->f, skip, SEEK_CUR);
++#else
++			new_offset = fseek(mine->f, skip, SEEK_CUR);
++#endif
++			if (new_offset >= 0)
++				return (new_offset - old_offset);
++		}
++ 	}
++	mine->can_skip = 0;
++	return (0);
++}
++
++/*
++ * TODO: Store the offset and use it in the read callback.
++ */
++static int64_t
++file_seek(struct archive *a, void *client_data, int64_t request, int whence)
++{
++	struct read_FILE_data *mine = (struct read_FILE_data *)client_data;
++#if HAVE__FSEEKI64
++	int64_t skip = request;
++#elif HAVE_FSEEKO
++	off_t skip = (off_t)request;
++#else
++	long skip = (long)request;
++#endif
++	int skip_bits = sizeof(skip) * 8 - 1;
++	(void)a; /* UNUSED */
++
++	/* If request is too big for a long or an off_t, reduce it. */
++	if (sizeof(request) > sizeof(skip)) {
++		int64_t max_skip =
++		    (((int64_t)1 << (skip_bits - 1)) - 1) * 2 + 1;
++		if (request > max_skip)
++			skip = max_skip;
+ 	}
+-	return (request);
++
++#ifdef __ANDROID__
++	/* Newer Android versions have fseeko...to meditate. */
++	int64_t ret = lseek(fileno(mine->f), skip, whence);
++	if (ret >= 0) {
++		return ret;
++	}
++#elif HAVE__FSEEKI64
++	if (_fseeki64(mine->f, skip, whence) == 0) {
++		return _ftelli64(mine->f);
++	}
++#elif HAVE_FSEEKO
++	if (fseeko(mine->f, skip, whence) == 0) {
++		return ftello(mine->f);
++	}
++#else
++	if (fseek(mine->f, skip, whence) == 0) {
++		return ftell(mine->f);
++	}
++#endif
++	/* If we arrive here, the input is corrupted or truncated so fail. */
++	archive_set_error(a, errno, "Error seeking in FILE* pointer");
++	return (ARCHIVE_FATAL);
+ }
+ 
+ static int
+@@ -176,4 +243,4 @@ file_close(struct archive *a, void *client_data)
+ 	free(mine->buffer);
+ 	free(mine);
+ 	return (ARCHIVE_OK);
+-}
++}
+\ No newline at end of file
+diff --git a/libarchive/archive_read_open_filename.c b/libarchive/archive_read_open_filename.c
+index 8def020..da6f7f1 100644
+--- a/libarchive/archive_read_open_filename.c
++++ b/libarchive/archive_read_open_filename.c
+@@ -74,6 +74,7 @@ struct read_file_data {
+ 	size_t	 block_size;
+ 	void	*buffer;
+ 	mode_t	 st_mode;  /* Mode bits for opened file. */
++	int64_t	 size;
+ 	char	 use_lseek;
+ 	enum fnt_e { FNT_STDIN, FNT_MBS, FNT_WCS } filename_type;
+ 	union {
+@@ -400,8 +401,10 @@ file_open(struct archive *a, void *client_data)
+ 	mine->st_mode = st.st_mode;
+ 
+ 	/* Disk-like inputs can use lseek(). */
+-	if (is_disk_like)
++	if (is_disk_like) {
+ 		mine->use_lseek = 1;
++		mine->size = st.st_size;
++	}
+ 
+ 	return (ARCHIVE_OK);
+ fail:
+@@ -479,21 +482,30 @@ file_skip_lseek(struct archive *a, void *client_data, int64_t request)
+ 	struct read_file_data *mine = (struct read_file_data *)client_data;
+ #if defined(_WIN32) && !defined(__CYGWIN__)
+ 	/* We use _lseeki64() on Windows. */
+-	int64_t old_offset, new_offset;
++	int64_t old_offset, new_offset, skip = request;
+ #else
+-	off_t old_offset, new_offset;
++	off_t old_offset, new_offset, skip = (off_t)request;
+ #endif
++	int skip_bits = sizeof(skip) * 8 - 1;
+ 
+ 	/* We use off_t here because lseek() is declared that way. */
+ 
+-	/* TODO: Deal with case where off_t isn't 64 bits.
+-	 * This shouldn't be a problem on Linux or other POSIX
+-	 * systems, since the configuration logic for libarchive
+-	 * tries to obtain a 64-bit off_t.
+-	 */
+-	if ((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0 &&
+-	    (new_offset = lseek(mine->fd, request, SEEK_CUR)) >= 0)
+-		return (new_offset - old_offset);
++	/* Reduce a request that would overflow the 'skip' variable. */
++	if (sizeof(request) > sizeof(skip)) {
++		const int64_t max_skip =
++		    (((int64_t)1 << (skip_bits - 1)) - 1) * 2 + 1;
++		if (request > max_skip)
++			skip = max_skip;
++	}
++
++	if ((old_offset = lseek(mine->fd, 0, SEEK_CUR)) >= 0) {
++		if (old_offset >= mine->size ||
++		    skip > mine->size - old_offset) {
++			/* Do not seek past end of file. */
++			errno = ESPIPE;
++		} else if ((new_offset = lseek(mine->fd, skip, SEEK_CUR)) >= 0)
++			return (new_offset - old_offset);
++	}
+ 
+ 	/* If lseek() fails, don't bother trying again. */
+ 	mine->use_lseek = 0;
+diff --git a/libarchive/test/test_open_file.c b/libarchive/test/test_open_file.c
+index f4ca82b..cc6b04d 100644
+--- a/libarchive/test/test_open_file.c
++++ b/libarchive/test/test_open_file.c
+@@ -31,14 +31,14 @@ DEFINE_TEST(test_open_file)
+ 	struct archive *a;
+ 	FILE *f;
+ 
+-	f = fopen("test.tar", "wb");
++	f = fopen("test.7z", "wb");
+ 	assert(f != NULL);
+ 	if (f == NULL)
+ 		return;
+ 
+ 	/* Write an archive through this FILE *. */
+ 	assert((a = archive_write_new()) != NULL);
+-	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
++	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_7zip(a));
+ 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+ 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_FILE(a, f));
+ 
+@@ -70,9 +70,10 @@ DEFINE_TEST(test_open_file)
+ 	fclose(f);
+ 
+ 	/*
+-	 * Now, read the data back.
++	 * Now, read the data back. 7z requiring seeking, that also
++	 * tests that the seeking support works.
+ 	 */
+-	f = fopen("test.tar", "rb");
++	f = fopen("test.7z", "rb");
+ 	assert(f != NULL);
+ 	if (f == NULL)
+ 		return;
+diff --git a/libarchive/test/test_read_format_rar.c b/libarchive/test/test_read_format_rar.c
+index dce567a..fce44a9 100644
+--- a/libarchive/test/test_read_format_rar.c
++++ b/libarchive/test/test_read_format_rar.c
+@@ -3829,8 +3829,8 @@ DEFINE_TEST(test_read_format_rar_ppmd_use_after_free)
+   assertA(ARCHIVE_OK == archive_read_next_header(a, &ae));
+   assertA(archive_read_data(a, buf, sizeof(buf)) <= 0);
+ 
+-  /* Test EOF */
+-  assertA(1 == archive_read_next_header(a, &ae));
++  /* Test for truncation */
++  assertA(ARCHIVE_FATAL == archive_read_next_header(a, &ae));
+ 
+   assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+@@ -3856,7 +3856,7 @@ DEFINE_TEST(test_read_format_rar_ppmd_use_after_free2)
+   assertA(archive_read_data(a, buf, sizeof(buf)) <= 0);
+ 
+   /* Test EOF */
+-  assertA(1 == archive_read_next_header(a, &ae));
++  assertA(ARCHIVE_FATAL == archive_read_next_header(a, &ae));
+ 
+   assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+-- 
+2.45.2
+

--- a/SPECS/libarchive/libarchive.spec
+++ b/SPECS/libarchive/libarchive.spec
@@ -1,7 +1,7 @@
 Summary:        Multi-format archive and compression library
 Name:           libarchive
 Version:        3.7.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 # Certain files have individual licenses. For more details see contents of "COPYING".
 License:        BSD AND Public Domain AND (ASL 2.0 OR CC0 1.0 OR OpenSSL)
 Vendor:         Microsoft Corporation
@@ -10,6 +10,11 @@ URL:            https://www.libarchive.org/
 Source0:        https://github.com/libarchive/libarchive/releases/download/v%{version}/%{name}-%{version}.tar.gz
 Patch0:         CVE-2025-1632.patch
 Patch1:         CVE-2025-25724.patch
+Patch2:         CVE-2025-5914.patch
+Patch3:         CVE-2025-5915.patch
+Patch4:         CVE-2025-5916.patch
+Patch5:         CVE-2025-5917.patch
+Patch6:         CVE-2025-5918.patch
 Provides:       bsdtar = %{version}-%{release}
 
 BuildRequires:  xz-libs
@@ -62,6 +67,9 @@ make %{?_smp_mflags} check
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Thu Jun 26 2025 Sumit Jena <v-v-sumitjena@microsoft.com> - 3.7.7-3
+- Patch CVE-2025-5914, CVE-2025-5915, CVE-2025-5916, CVE-2025-5917, CVE-5918
+
 * Tue Mar 11 2025 Kanishk Bansal <kanbansal@microsoft.com> - 3.7.7-2
 - Patch CVE-2025-1632, CVE-2025-25724
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -178,8 +178,8 @@ openssl-static-3.3.3-2.azl3.aarch64.rpm
 libcap-2.69-5.azl3.aarch64.rpm
 libcap-devel-2.69-5.azl3.aarch64.rpm
 debugedit-5.0-2.azl3.aarch64.rpm
-libarchive-3.7.7-2.azl3.aarch64.rpm
-libarchive-devel-3.7.7-2.azl3.aarch64.rpm
+libarchive-3.7.7-3.azl3.aarch64.rpm
+libarchive-devel-3.7.7-3.azl3.aarch64.rpm
 rpm-4.18.2-1.azl3.aarch64.rpm
 rpm-build-4.18.2-1.azl3.aarch64.rpm
 rpm-build-libs-4.18.2-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -178,8 +178,8 @@ openssl-static-3.3.3-2.azl3.x86_64.rpm
 libcap-2.69-5.azl3.x86_64.rpm
 libcap-devel-2.69-5.azl3.x86_64.rpm
 debugedit-5.0-2.azl3.x86_64.rpm
-libarchive-3.7.7-2.azl3.x86_64.rpm
-libarchive-devel-3.7.7-2.azl3.x86_64.rpm
+libarchive-3.7.7-3.azl3.x86_64.rpm
+libarchive-devel-3.7.7-3.azl3.x86_64.rpm
 rpm-4.18.2-1.azl3.x86_64.rpm
 rpm-build-4.18.2-1.azl3.x86_64.rpm
 rpm-build-libs-4.18.2-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -168,9 +168,9 @@ krb5-devel-1.21.3-2.azl3.aarch64.rpm
 krb5-lang-1.21.3-2.azl3.aarch64.rpm
 libacl-2.3.1-2.azl3.aarch64.rpm
 libacl-devel-2.3.1-2.azl3.aarch64.rpm
-libarchive-3.7.7-2.azl3.aarch64.rpm
-libarchive-debuginfo-3.7.7-2.azl3.aarch64.rpm
-libarchive-devel-3.7.7-2.azl3.aarch64.rpm
+libarchive-3.7.7-3.azl3.aarch64.rpm
+libarchive-debuginfo-3.7.7-3.azl3.aarch64.rpm
+libarchive-devel-3.7.7-3.azl3.aarch64.rpm
 libassuan-2.5.6-1.azl3.aarch64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.aarch64.rpm
 libassuan-devel-2.5.6-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -176,9 +176,9 @@ krb5-devel-1.21.3-2.azl3.x86_64.rpm
 krb5-lang-1.21.3-2.azl3.x86_64.rpm
 libacl-2.3.1-2.azl3.x86_64.rpm
 libacl-devel-2.3.1-2.azl3.x86_64.rpm
-libarchive-3.7.7-2.azl3.x86_64.rpm
-libarchive-debuginfo-3.7.7-2.azl3.x86_64.rpm
-libarchive-devel-3.7.7-2.azl3.x86_64.rpm
+libarchive-3.7.7-3.azl3.x86_64.rpm
+libarchive-debuginfo-3.7.7-3.azl3.x86_64.rpm
+libarchive-devel-3.7.7-3.azl3.x86_64.rpm
 libassuan-2.5.6-1.azl3.x86_64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.x86_64.rpm
 libassuan-devel-2.5.6-1.azl3.x86_64.rpm


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch libarchive for CVE-2025-5914, CVE-2025-5915, CVE-2025-5916, CVE-2025-5917, CVE-5918.
**CVE-2025-5914**
**Patch Details: **
- Patch Modified: No
- Patch applies cleanly without any modification.
- Astrolab Reference: https://github.com/libarchive/libarchive/pull/2598/commits/196029dd0a17cd17c916eada9085839032b76ec9. Going with this reference for obtaining the patch.

**CVE-2025-5915**
**Patch Details: **
- Patch Modified: Yes. The patch introduces a new test for testing rar format read overflow under `Makefile.am`. The patch is modified by removing few tests as we dont support tests introduced in the version from which the patch is taken from. 
- Astrolab Reference: https://github.com/libarchive/libarchive/pull/2599.

**CVE-2025-5916**
**Patch Details: **
- Patch Modified: No
- Patch applies cleanly without any modification.
- Astrolab Reference: https://github.com/libarchive/libarchive/pull/2568/commits/bce70c4c26864df2a8d6953e7db6e4b156253508. Going with this reference for obtaining the patch.

**CVE-2025-5917**
**Patch Details: **
- Patch Modified: No
- Patch applies cleanly without any modification.
- Astrolab Reference: https://github.com/libarchive/libarchive/commit/7c02cde37a63580cd1859183fbbd2cf04a89be85. Going with this reference for obtaining the patch.

**CVE-2025-5918**
**Patch Details: **
- Patch Modified: Yes. Edited function syntax from `FILE` to `file` for read, skip and close function for `archive_read_open_file` also added seek support. Added new `skip` variable to `archive_read_open_filename`. Added 7zip file based testing under `test_open_file` to address the test failures.
- Astrolab Reference: https://github.com/libarchive/libarchive/commit/dcbf1e0ededa95849f098d154a25876ed5754bcf.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/libarchive/CVE-2025-5914.patch
- SPECS/libarchive/CVE-2025-5915.patch
- SPECS/libarchive/CVE-2025-5916.patch
- SPECS/libarchive/CVE-2025-5917.patch
- SPECS/libarchive/CVE-2025-5918.patch
- SPECS/libarchive/libarchive.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-5914
- https://nvd.nist.gov/vuln/detail/CVE-2025-5915
- https://nvd.nist.gov/vuln/detail/CVE-2025-5916
- https://nvd.nist.gov/vuln/detail/CVE-2025-5917
- https://nvd.nist.gov/vuln/detail/CVE-2025-5918

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
- Local Build
- [ ] Patches apply cleanly
![image](https://github.com/user-attachments/assets/5f254d66-cac1-4c72-ba90-1682130eb2ce)
- [ ] Build is successful -
[libarchive-3.7.7-2.azl3.src.rpm.log](https://github.com/user-attachments/files/20935142/libarchive-3.7.7-2.azl3.src.rpm.log)
- [ ] Test is successful - 
[libarchive-3.7.7-2.azl3.src.rpm.test.log](https://github.com/user-attachments/files/20935143/libarchive-3.7.7-2.azl3.src.rpm.test.log)



