### PR TITLE
[HIGH] Patch rubygem-webrick for CVE-2025-6442

### DIFF
--- a/SPECS/rubygem-webrick/CVE-2025-6442.patch
+++ b/SPECS/rubygem-webrick/CVE-2025-6442.patch
@@ -1,0 +1,501 @@
+From 08ce36008c6765b4f6b48fed9e4a05697bae20cf Mon Sep 17 00:00:00 2001
+From: SumitJenaHCL <v-sumitjena@microsoft.com>
+Date: Fri, 27 Jun 2025 12:05:58 +0000
+Subject: [PATCH] Patch CVE-2025-6442
+
+Upstream Patch Reference: https://github.com/ruby/webrick/commit/ee60354bcb84ec33b9245e1d1aa6e1f7e8132101
+---
+ lib/webrick/httprequest.rb       |   4 +-
+ lib/webrick/httputils.rb         |   7 +-
+ test/webrick/test_filehandler.rb |   2 +-
+ test/webrick/test_httprequest.rb | 202 +++++++++++++++++++++++++++----
+ 4 files changed, 188 insertions(+), 27 deletions(-)
+
+diff --git a/lib/webrick/httprequest.rb b/lib/webrick/httprequest.rb
+index d34eac7..03983fb 100644
+--- a/lib/webrick/httprequest.rb
++++ b/lib/webrick/httprequest.rb
+@@ -458,7 +458,7 @@ module WEBrick
+       end
+ 
+       @request_time = Time.now
+-      if /^(\S+)\s+(\S++)(?:\s+HTTP\/(\d+\.\d+))?\r?\n/mo =~ @request_line
++      if /^(\S+) (\S++)(?: +HTTP\/(\d+\.\d+))?\r\n/mo =~ @request_line
+         @request_method = $1
+         @unparsed_uri   = $2
+         @http_version   = HTTPVersion.new($3 ? $3 : "0.9")
+@@ -471,7 +471,7 @@ module WEBrick
+     def read_header(socket)
+       if socket
+         while line = read_line(socket)
+-          break if /\A(#{CRLF}|#{LF})\z/om =~ line
++          break if /\A#{CRLF}\z/om =~ line
+           if (@request_bytes += line.bytesize) > MAX_HEADER_LENGTH
+             raise HTTPStatus::RequestEntityTooLarge, 'headers too large'
+           end
+diff --git a/lib/webrick/httputils.rb b/lib/webrick/httputils.rb
+index f1b9ddf..cc1560d 100644
+--- a/lib/webrick/httputils.rb
++++ b/lib/webrick/httputils.rb
+@@ -147,16 +147,19 @@ module WEBrick
+       field = nil
+       raw.each_line{|line|
+         case line
+-        when /^([A-Za-z0-9!\#$%&'*+\-.^_`|~]+):\s*(.*?)\s*\z/om
++        when /^([A-Za-z0-9!\#$%&'*+\-.^_`|~]+):([^\r\n\0]*?)\r\n\z/om
+           field, value = $1, $2
+           field.downcase!
+           header[field] = [] unless header.has_key?(field)
+           header[field] << value
+-        when /^\s+(.*?)\s*\z/om
++	when /^\s+([^\r\n\0]*?)\r\n/om
+           value = $1
+           unless field
+             raise HTTPStatus::BadRequest, "bad header '#{line}'."
+           end
++          value = lineAdd commentMore actions
++          value.lstrip!
++          value.slice!(-2..-1)
+           header[field][-1] << " " << value
+         else
+           raise HTTPStatus::BadRequest, "bad header '#{line}'."
+diff --git a/test/webrick/test_filehandler.rb b/test/webrick/test_filehandler.rb
+index 998e03f..07f99f3 100644
+--- a/test/webrick/test_filehandler.rb
++++ b/test/webrick/test_filehandler.rb
+@@ -33,7 +33,7 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
+       Range: #{range_spec}
+ 
+     END_OF_REQUEST
+-    return StringIO.new(msg.gsub(/^ {6}/, ""))
++    return StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n"))
+   end
+ 
+   def make_range_response(file, range_spec)
+diff --git a/test/webrick/test_httprequest.rb b/test/webrick/test_httprequest.rb
+index 759ccbd..a1f33c7 100644
+--- a/test/webrick/test_httprequest.rb
++++ b/test/webrick/test_httprequest.rb
+@@ -11,7 +11,7 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
+ 
+   def test_simple_request
+     msg = <<-_end_of_message_
+-GET /
++GET /\r
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+@@ -24,7 +24,7 @@ GET /
+       foobar    # HTTP/0.9 request don't have header nor entity body.
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("GET", req.request_method)
+     assert_equal("/", req.unparsed_uri)
+     assert_equal(WEBrick::HTTPVersion.new("0.9"), req.http_version)
+@@ -41,7 +41,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("GET", req.request_method)
+     assert_equal("/", req.unparsed_uri)
+     assert_equal(WEBrick::HTTPVersion.new("1.0"), req.http_version)
+@@ -58,7 +58,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("GET", req.request_method)
+     assert_equal("/path", req.unparsed_uri)
+     assert_equal("", req.script_name)
+@@ -77,10 +77,125 @@ GET /
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     assert_raise(WEBrick::HTTPStatus::RequestURITooLarge){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
++    }
++  end
++
++  def test_invalid_content_length_header
++    ['', ' ', ' +1', ' -1', ' a'].each do |cl|
++      msg = <<-_end_of_message_
++        GET / HTTP/1.1
++        Content-Length:#{cl}
++      _end_of_message_
++      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++      assert_raise(WEBrick::HTTPStatus::BadRequest){
++        req.parse(StringIO.new(msg.gsub(/^ {8}/, "").gsub("\n", "\r\n")))
++      }
++    end
++  end
++
++  def test_bare_lf_request_line
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_bare_lf_header
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1\r
++      Content-Length: 0
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_bare_cr_request_line
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1\r\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
+       req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
+     }
+   end
+ 
++  def test_bare_cr_header
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1\r
++      Content-Type: foo\rbar\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_invalid_request_lines
++    msg = <<-_end_of_message_
++      GET  / HTTP/1.1\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++
++    msg = <<-_end_of_message_
++      GET /  HTTP/1.1\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++
++    msg = <<-_end_of_message_
++      GET /\r HTTP/1.1\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1 \r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_duplicate_content_length_header
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1
++      Content-Length: 1
++      Content-Length: 2
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
++    }
++  end
++
+   def test_parse_headers
+     msg = <<-_end_of_message_
+       GET /path HTTP/1.1
+@@ -93,13 +208,13 @@ GET /
+       Accept-Language: en;q=0.5, *; q=0
+       Accept-Language: ja
+       Content-Type: text/plain
+-      Content-Length: 7
++      Content-Length: 8
+       X-Empty-Header:
+ 
+       foobar
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(
+       URI.parse("http://test.ruby-lang.org:8080/path"), req.request_uri)
+     assert_equal("test.ruby-lang.org", req.host)
+@@ -110,9 +225,9 @@ GET /
+       req.accept)
+     assert_equal(%w(gzip compress identity *), req.accept_encoding)
+     assert_equal(%w(ja en *), req.accept_language)
+-    assert_equal(7, req.content_length)
++    assert_equal(8, req.content_length)
+     assert_equal("text/plain", req.content_type)
+-    assert_equal("foobar\n", req.body)
++    assert_equal("foobar\r\n", req.body)
+     assert_equal("", req["x-empty-header"])
+     assert_equal(nil, req["x-no-header"])
+     assert(req.query.empty?)
+@@ -121,7 +236,7 @@ GET /
+   def test_parse_header2()
+     msg = <<-_end_of_message_
+       POST /foo/bar/../baz?q=a HTTP/1.0
+-      Content-Length: 9
++      Content-Length: 10
+       User-Agent:
+         FOO   BAR
+         BAZ
+@@ -129,14 +244,14 @@ GET /
+       hogehoge
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("POST", req.request_method)
+     assert_equal("/foo/baz", req.path)
+     assert_equal("", req.script_name)
+     assert_equal("/foo/baz", req.path_info)
+-    assert_equal("9", req['content-length'])
++    assert_equal("10", req['content-length'])
+     assert_equal("FOO   BAR BAZ", req['user-agent'])
+-    assert_equal("hogehoge\n", req.body)
++    assert_equal("hogehoge\r\n", req.body)
+   end
+ 
+   def test_parse_headers3
+@@ -146,7 +261,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://test.ruby-lang.org/path"), req.request_uri)
+     assert_equal("test.ruby-lang.org", req.host)
+     assert_equal(80, req.port)
+@@ -157,7 +272,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://192.168.1.1/path"), req.request_uri)
+     assert_equal("192.168.1.1", req.host)
+     assert_equal(80, req.port)
+@@ -168,7 +283,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://[fe80::208:dff:feef:98c7]/path"),
+                  req.request_uri)
+     assert_equal("[fe80::208:dff:feef:98c7]", req.host)
+@@ -180,7 +295,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://192.168.1.1:8080/path"), req.request_uri)
+     assert_equal("192.168.1.1", req.host)
+     assert_equal(8080, req.port)
+@@ -191,7 +306,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://[fe80::208:dff:feef:98c7]:8080/path"),
+                  req.request_uri)
+     assert_equal("[fe80::208:dff:feef:98c7]", req.host)
+@@ -206,7 +321,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     query = req.query
+     assert_equal("1", query["foo"])
+     assert_equal(["1", "2", "3"], query["foo"].to_ary)
+@@ -226,7 +341,7 @@ GET /
+       #{param}
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     query = req.query
+     assert_equal("1", query["foo"])
+     assert_equal(["1", "2", "3"], query["foo"].to_ary)
+@@ -245,6 +360,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     open(__FILE__){|io|
+       while chunk = io.read(100)
+         msg << chunk.size.to_s(16) << crlf
+@@ -264,6 +380,40 @@ GET /
+     assert_equal(expect, dst.string)
+   end
+ 
++  def test_bad_chunked
++    msg = <<-_end_of_message_
++      POST /path HTTP/1.1\r
++      Transfer-Encoding: chunked\r
++      \r
++      01x1\r
++      \r
++      1
++    _end_of_message_
++    msg.gsub!(/^ {6}/, "")
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    req.parse(StringIO.new(msg))
++    assert_raise(WEBrick::HTTPStatus::BadRequest){ req.body }
++
++    # chunked req.body_reader
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    req.parse(StringIO.new(msg))
++    dst = StringIO.new
++    assert_raise(WEBrick::HTTPStatus::BadRequest) do
++      IO.copy_stream(req.body_reader, dst)
++    end
++  end
++
++  def test_null_byte_in_header
++    msg = <<-_end_of_message_
++      POST /path HTTP/1.1\r
++      Evil: evil\x00\r
++      \r
++    _end_of_message_
++    msg.gsub!(/^ {6}/, "")
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){ req.parse(StringIO.new(msg)) }
++  end
++
+   def test_forwarded
+     msg = <<-_end_of_message_
+       GET /foo HTTP/1.1
+@@ -276,6 +426,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server.example.com", req.server_name)
+@@ -296,6 +447,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server.example.com", req.server_name)
+@@ -318,6 +470,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server.example.com", req.server_name)
+@@ -340,6 +493,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server1.example.com", req.server_name)
+@@ -362,6 +516,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server1.example.com", req.server_name)
+@@ -384,6 +539,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server1.example.com", req.server_name)
+@@ -401,6 +557,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert req['expect']
+@@ -417,6 +574,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert !req['expect']
+@@ -448,7 +606,7 @@ GET /
+     _end_of_message_
+     assert_raise(WEBrick::HTTPStatus::LengthRequired){
+       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+       req.body
+     }
+ 
+@@ -461,7 +619,7 @@ GET /
+     _end_of_message_
+     assert_raise(WEBrick::HTTPStatus::BadRequest){
+       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+       req.body
+     }
+ 
+@@ -474,7 +632,7 @@ GET /
+     _end_of_message_
+     assert_raise(WEBrick::HTTPStatus::NotImplemented){
+       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+       req.body
+     }
+   end
+-- 
+2.45.2
+

--- a/SPECS/rubygem-webrick/rubygem-webrick.spec
+++ b/SPECS/rubygem-webrick/rubygem-webrick.spec
@@ -3,12 +3,13 @@
 Summary:        HTTP server toolkit
 Name:           rubygem-%{gem_name}
 Version:        1.7.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:	        Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/ruby/webrick
 Source0:        https://github.com/ruby/webrick/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
+Patch0:         CVE-2025-6442.patch
 BuildRequires:  git
 BuildRequires:  ruby
 Provides:       rubygem(%{gem_name}) = %{version}-%{release}
@@ -35,6 +36,9 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
+* Fri Jun 27 2025 Sumit Jena <v-sumitjena@microsoft.com> - 1.7.0-2
+- Patch CVE-2025-6442
+
 * Mon Jun 13 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.7.0-1
 - License verified
 - Original version for CBL-Mariner


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch rubygem-webrick for CVE-2025-6442
**CVE-2025-6442**
**Patch Details**
- Patch Modified: Yes. Patch is modified in test/webrick/test_httprequest.rb file for backporting.
- Astrolab Reference: https://github.com/ruby/webrick/commit/ee60354bcb84ec33b9245e1d1aa6e1f7e8132101
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/rubygem-webrick/CVE-2025-6442.patch
- SPECS/rubygem-webrick/rubygem-webrick.spec


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-6442

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
- Local Build
- [x] Patch Applies Successfully:
![Screenshot 2025-06-27 195702](https://github.com/user-attachments/assets/165d57db-7aa5-4040-8881-45c0d8faecf6)
- [x] Builds Successfully:
[rubygem-webrick-1.7.0-2.cm2.src.rpm.log](https://github.com/user-attachments/files/20950947/rubygem-webrick-1.7.0-2.cm2.src.rpm.log)
