### PR TITLE
[High] Patch ruby for CVE-2025-6442

### DIFF
--- a/SPECS/ruby/CVE-2025-6442.patch
+++ b/SPECS/ruby/CVE-2025-6442.patch
@@ -1,0 +1,440 @@
+From 8b2fde21395a7978e3f469cbb6ea035e4061e06e Mon Sep 17 00:00:00 2001
+From: Kevin Lockwood <v-klockwood@microsoft.com>
+Date: Mon, 30 Jun 2025 12:46:29 -0700
+Subject: [PATCH] Patch CVE-2025-6442
+
+Upstream Patch Link: https://github.com/ruby/webrick/commit/ee60354bcb84ec33b9245e1d1aa6e1f7e8132101.patch
+---
+ tool/lib/webrick/httprequest.rb       |   4 +-
+ tool/lib/webrick/httputils.rb         |   7 +-
+ tool/test/webrick/test_filehandler.rb |   2 +-
+ tool/test/webrick/test_httprequest.rb | 145 ++++++++++++++++++++++----
+ 4 files changed, 130 insertions(+), 28 deletions(-)
+
+diff --git a/tool/lib/webrick/httprequest.rb b/tool/lib/webrick/httprequest.rb
+index d34eac7..fa3ba6b 100644
+--- a/tool/lib/webrick/httprequest.rb
++++ b/tool/lib/webrick/httprequest.rb
+@@ -458,7 +458,7 @@ module WEBrick
+       end
+ 
+       @request_time = Time.now
+-      if /^(\S+)\s+(\S++)(?:\s+HTTP\/(\d+\.\d+))?\r?\n/mo =~ @request_line
++      if /^(\S+) (\S++)(?: HTTP\/(\d+\.\d+))?\r\n/mo =~ @request_line
+         @request_method = $1
+         @unparsed_uri   = $2
+         @http_version   = HTTPVersion.new($3 ? $3 : "0.9")
+@@ -471,7 +471,7 @@ module WEBrick
+     def read_header(socket)
+       if socket
+         while line = read_line(socket)
+-          break if /\A(#{CRLF}|#{LF})\z/om =~ line
++          break if /\A#{CRLF}\z/om =~ line
+           if (@request_bytes += line.bytesize) > MAX_HEADER_LENGTH
+             raise HTTPStatus::RequestEntityTooLarge, 'headers too large'
+           end
+diff --git a/tool/lib/webrick/httputils.rb b/tool/lib/webrick/httputils.rb
+index f1b9ddf..ec0c621 100644
+--- a/tool/lib/webrick/httputils.rb
++++ b/tool/lib/webrick/httputils.rb
+@@ -147,16 +147,19 @@ module WEBrick
+       field = nil
+       raw.each_line{|line|
+         case line
+-        when /^([A-Za-z0-9!\#$%&'*+\-.^_`|~]+):\s*(.*?)\s*\z/om
++        when /^([A-Za-z0-9!\#$%&'*+\-.^_`|~]+):([^\r\n\0]*?)\r\n\z/om
+           field, value = $1, $2
+           field.downcase!
+           header[field] = [] unless header.has_key?(field)
+           header[field] << value
+-        when /^\s+(.*?)\s*\z/om
++        when /^\s+([^\r\n\0]*?)\r\n/om
+           value = $1
+           unless field
+             raise HTTPStatus::BadRequest, "bad header '#{line}'."
+           end
++          value = line
++          value.lstrip!
++          value.slice!(-2..-1)
+           header[field][-1] << " " << value
+         else
+           raise HTTPStatus::BadRequest, "bad header '#{line}'."
+diff --git a/tool/test/webrick/test_filehandler.rb b/tool/test/webrick/test_filehandler.rb
+index 146d8ce..bd4b041 100644
+--- a/tool/test/webrick/test_filehandler.rb
++++ b/tool/test/webrick/test_filehandler.rb
+@@ -33,7 +33,7 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
+       Range: #{range_spec}
+ 
+     END_OF_REQUEST
+-    return StringIO.new(msg.gsub(/^ {6}/, ""))
++    return StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n"))
+   end
+ 
+   def make_range_response(file, range_spec)
+diff --git a/tool/test/webrick/test_httprequest.rb b/tool/test/webrick/test_httprequest.rb
+index 759ccbd..c52333e 100644
+--- a/tool/test/webrick/test_httprequest.rb
++++ b/tool/test/webrick/test_httprequest.rb
+@@ -11,7 +11,7 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
+ 
+   def test_simple_request
+     msg = <<-_end_of_message_
+-GET /
++GET /\r
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+@@ -24,7 +24,7 @@ GET /
+       foobar    # HTTP/0.9 request don't have header nor entity body.
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("GET", req.request_method)
+     assert_equal("/", req.unparsed_uri)
+     assert_equal(WEBrick::HTTPVersion.new("0.9"), req.http_version)
+@@ -41,7 +41,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("GET", req.request_method)
+     assert_equal("/", req.unparsed_uri)
+     assert_equal(WEBrick::HTTPVersion.new("1.0"), req.http_version)
+@@ -58,7 +58,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("GET", req.request_method)
+     assert_equal("/path", req.unparsed_uri)
+     assert_equal("", req.script_name)
+@@ -77,7 +77,7 @@ GET /
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     assert_raise(WEBrick::HTTPStatus::RequestURITooLarge){
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     }
+   end
+ 
+@@ -93,13 +93,13 @@ GET /
+       Accept-Language: en;q=0.5, *; q=0
+       Accept-Language: ja
+       Content-Type: text/plain
+-      Content-Length: 7
++      Content-Length: 8
+       X-Empty-Header:
+ 
+       foobar
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(
+       URI.parse("http://test.ruby-lang.org:8080/path"), req.request_uri)
+     assert_equal("test.ruby-lang.org", req.host)
+@@ -110,9 +110,9 @@ GET /
+       req.accept)
+     assert_equal(%w(gzip compress identity *), req.accept_encoding)
+     assert_equal(%w(ja en *), req.accept_language)
+-    assert_equal(7, req.content_length)
++    assert_equal(8, req.content_length)
+     assert_equal("text/plain", req.content_type)
+-    assert_equal("foobar\n", req.body)
++    assert_equal("foobar\r\n", req.body)
+     assert_equal("", req["x-empty-header"])
+     assert_equal(nil, req["x-no-header"])
+     assert(req.query.empty?)
+@@ -121,7 +121,7 @@ GET /
+   def test_parse_header2()
+     msg = <<-_end_of_message_
+       POST /foo/bar/../baz?q=a HTTP/1.0
+-      Content-Length: 9
++      Content-Length: 10
+       User-Agent:
+         FOO   BAR
+         BAZ
+@@ -129,14 +129,14 @@ GET /
+       hogehoge
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal("POST", req.request_method)
+     assert_equal("/foo/baz", req.path)
+     assert_equal("", req.script_name)
+     assert_equal("/foo/baz", req.path_info)
+-    assert_equal("9", req['content-length'])
++    assert_equal("10", req['content-length'])
+     assert_equal("FOO   BAR BAZ", req['user-agent'])
+-    assert_equal("hogehoge\n", req.body)
++    assert_equal("hogehoge\r\n", req.body)
+   end
+ 
+   def test_parse_headers3
+@@ -146,7 +146,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://test.ruby-lang.org/path"), req.request_uri)
+     assert_equal("test.ruby-lang.org", req.host)
+     assert_equal(80, req.port)
+@@ -157,7 +157,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://192.168.1.1/path"), req.request_uri)
+     assert_equal("192.168.1.1", req.host)
+     assert_equal(80, req.port)
+@@ -168,7 +168,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://[fe80::208:dff:feef:98c7]/path"),
+                  req.request_uri)
+     assert_equal("[fe80::208:dff:feef:98c7]", req.host)
+@@ -180,7 +180,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://192.168.1.1:8080/path"), req.request_uri)
+     assert_equal("192.168.1.1", req.host)
+     assert_equal(8080, req.port)
+@@ -191,7 +191,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     assert_equal(URI.parse("http://[fe80::208:dff:feef:98c7]:8080/path"),
+                  req.request_uri)
+     assert_equal("[fe80::208:dff:feef:98c7]", req.host)
+@@ -206,7 +206,7 @@ GET /
+ 
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     query = req.query
+     assert_equal("1", query["foo"])
+     assert_equal(["1", "2", "3"], query["foo"].to_ary)
+@@ -226,7 +226,7 @@ GET /
+       #{param}
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     query = req.query
+     assert_equal("1", query["foo"])
+     assert_equal(["1", "2", "3"], query["foo"].to_ary)
+@@ -235,6 +235,96 @@ GET /
+     assert_equal(["x"], query["bar"].list)
+   end
+ 
++  def test_bare_lf_request_line
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_bare_lf_header
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1\r
++      Content-Length: 0
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_bare_cr_request_line
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1\r\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_bare_cr_header
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1\r
++      Content-Type: foo\rbar\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
++  def test_invalid_request_lines
++    msg = <<-_end_of_message_
++      GET  / HTTP/1.1\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++
++    msg = <<-_end_of_message_
++      GET /  HTTP/1.1\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++
++    msg = <<-_end_of_message_
++      GET /\r HTTP/1.1\r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1 \r
++      Content-Length: 0\r
++      \r
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
+   def test_chunked
+     crlf = "\x0d\x0a"
+     expect = File.binread(__FILE__).freeze
+@@ -245,6 +335,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     open(__FILE__){|io|
+       while chunk = io.read(100)
+         msg << chunk.size.to_s(16) << crlf
+@@ -276,6 +367,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server.example.com", req.server_name)
+@@ -296,6 +388,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server.example.com", req.server_name)
+@@ -318,6 +411,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server.example.com", req.server_name)
+@@ -340,6 +434,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server1.example.com", req.server_name)
+@@ -362,6 +457,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server1.example.com", req.server_name)
+@@ -384,6 +480,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert_equal("server1.example.com", req.server_name)
+@@ -401,6 +498,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert req['expect']
+@@ -417,6 +515,7 @@ GET /
+ 
+     _end_of_message_
+     msg.gsub!(/^ {6}/, "")
++    msg.gsub!("\n", "\r\n")
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     req.parse(StringIO.new(msg))
+     assert !req['expect']
+@@ -448,7 +547,7 @@ GET /
+     _end_of_message_
+     assert_raise(WEBrick::HTTPStatus::LengthRequired){
+       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+       req.body
+     }
+ 
+@@ -461,7 +560,7 @@ GET /
+     _end_of_message_
+     assert_raise(WEBrick::HTTPStatus::BadRequest){
+       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+       req.body
+     }
+ 
+@@ -474,7 +573,7 @@ GET /
+     _end_of_message_
+     assert_raise(WEBrick::HTTPStatus::NotImplemented){
+       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+       req.body
+     }
+   end
+-- 
+2.34.1
+

--- a/SPECS/ruby/CVE-2025-6442.patch
+++ b/SPECS/ruby/CVE-2025-6442.patch
@@ -1,7 +1,17 @@
-From 8b2fde21395a7978e3f469cbb6ea035e4061e06e Mon Sep 17 00:00:00 2001
-From: Kevin Lockwood <v-klockwood@microsoft.com>
-Date: Mon, 30 Jun 2025 12:46:29 -0700
-Subject: [PATCH] Patch CVE-2025-6442
+From ee60354bcb84ec33b9245e1d1aa6e1f7e8132101 Mon Sep 17 00:00:00 2001
+From: Jeremy Evans <code@jeremyevans.net>
+Date: Tue, 25 Jun 2024 14:39:04 -0700
+Subject: [PATCH] Require CRLF line endings in request line and headers
+
+Disallow bare CR, LF, NUL in header and request lines. Tighten
+parsing of request lines to only allow single spaces, as specified
+in the RFCs.
+
+Forcing this RFC-compliant behavior breaks a lot of tests, so
+fix the tests to correctly use CRLF instead of LF for requests
+(other than the specific checks for handling of bad requests).
+
+Fixes #137
 
 Upstream Patch Link: https://github.com/ruby/webrick/commit/ee60354bcb84ec33b9245e1d1aa6e1f7e8132101.patch
 ---

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -83,7 +83,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        3.1.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -99,6 +99,7 @@ Source6:        rubygems.req
 Source7:        macros.rubygems
 # Updates default ruby-uri to 0.12.2 and vendored one to 0.10.3. Remove once ruby gets updated to a version that comes with both lib/uri/version.rb and lib/bundler/vendor/uri/lib/uri/version.rb versions >= 0.12.2 or == 0.10.3
 Patch0:         CVE-2023-36617.patch
+Patch1:         CVE-2025-6442.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline
 BuildRequires:  readline-devel
@@ -401,6 +402,9 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
+* Mon Jun 30 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 3.1.7-2
+- Patch CVE-2025-6442
+
 * Wed May 14 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 3.1.7-1
 - Patch CVE-2024-39908 by upgrading to 3.1.7
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch `ruby` for CVE-2025-6442

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch found in astrolabe, modified by me so that it would apply. Link: https://github.com/ruby/webrick/commit/ee60354bcb84ec33b9245e1d1aa6e1f7e8132101.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-6442

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Patch applies:
  ![image](https://github.com/user-attachments/assets/c0143630-0661-431d-82b5-41236da94928)