### PR TITLE
[HIGH] Patch cloud-init for CVE-2024-6174 & [MEDIUM] CVE-2024-11584

### DIFF
--- a/SPECS/cloud-init/CVE-2024-11584.patch
+++ b/SPECS/cloud-init/CVE-2024-11584.patch
@@ -1,0 +1,60 @@
+From 4761429040c00f69f4d29503697093a36b81b199 Mon Sep 17 00:00:00 2001
+From: archana25-ms <v-shettigara@microsoft.com>
+Date: Sat, 28 Jun 2025 08:34:37 +0000
+Subject: [PATCH] Address CVE-2024-11584
+Upstream Patch Reference: https://github.com/canonical/cloud-init/pull/6265/commits/6e10240a7f0a2d6110b398640b3fd46cfa9a7cf3
+
+---
+ systemd/cloud-init-hotplugd.service | 2 +-
+ systemd/cloud-init-hotplugd.socket  | 5 +++--
+ tools/hook-hotplug                  | 2 +-
+ 3 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/systemd/cloud-init-hotplugd.service b/systemd/cloud-init-hotplugd.service
+index 598c647..a6f41d1 100644
+--- a/systemd/cloud-init-hotplugd.service
++++ b/systemd/cloud-init-hotplugd.service
+@@ -1,5 +1,5 @@
+ # Paired with cloud-init-hotplugd.socket to read from the FIFO
+-# /run/cloud-init/hook-hotplug-cmd which is created during a udev network
++# hook-hotplug-cmd which is created during a udev network
+ # add or remove event as processed by 10-cloud-init-hook-hotplug.rules.
+ 
+ # On start, read args from the FIFO, process and provide structured arguments
+diff --git a/systemd/cloud-init-hotplugd.socket b/systemd/cloud-init-hotplugd.socket
+index aa09301..80386ca 100644
+--- a/systemd/cloud-init-hotplugd.socket
++++ b/systemd/cloud-init-hotplugd.socket
+@@ -1,5 +1,5 @@
+ # cloud-init-hotplugd.socket listens on the FIFO file
+-# /run/cloud-init/hook-hotplug-cmd which is created during a udev network
++# hook-hotplug-cmd which is created during a udev network
+ # add or remove event as processed by 10-cloud-init-hook-hotplug.rules.
+ 
+ # Known bug with an enforcing SELinux policy: LP: #1936229
+@@ -7,7 +7,8 @@
+ Description=cloud-init hotplug hook socket
+ 
+ [Socket]
+-ListenFIFO=/run/cloud-init/hook-hotplug-cmd
++ListenFIFO=/run/cloud-init/share/hook-hotplug-cmd
++SocketMode=0600
+ 
+ [Install]
+ WantedBy=cloud-init.target
+diff --git a/tools/hook-hotplug b/tools/hook-hotplug
+index 35bd3da..2a2ed48 100755
+--- a/tools/hook-hotplug
++++ b/tools/hook-hotplug
+@@ -10,7 +10,7 @@ is_finished() {
+ 
+ if is_finished; then
+     # open cloud-init's hotplug-hook fifo rw
+-    exec 3<>/run/cloud-init/hook-hotplug-cmd
++    exec 3<>/run/cloud-init/share/hook-hotplug-cmd
+     env_params=(
+         --subsystem="${SUBSYSTEM}"
+         handle
+-- 
+2.45.3
+

--- a/SPECS/cloud-init/CVE-2024-6174.patch
+++ b/SPECS/cloud-init/CVE-2024-6174.patch
@@ -1,0 +1,86 @@
+From 96e4f3dc6d907cc8e45ed2d98c3cc99438208138 Mon Sep 17 00:00:00 2001
+From: archana25-ms <v-shettigara@microsoft.com>
+Date: Sat, 28 Jun 2025 07:59:48 +0000
+Subject: [PATCH] Address CVE-2024-6174
+Upstream Patch Reference: https://github.com/canonical/cloud-init/commit/8c3ae1bb9f1d80fbf217b41a222ee434e7f58900
+
+---
+ tests/unittests/test_ds_identify.py | 13 ++++++-------
+ tools/ds-identify                   |  8 ++++----
+ 2 files changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/tests/unittests/test_ds_identify.py b/tests/unittests/test_ds_identify.py
+index 80813fc..099803a 100644
+--- a/tests/unittests/test_ds_identify.py
++++ b/tests/unittests/test_ds_identify.py
+@@ -58,9 +58,9 @@ BLKID_UEFI_UBUNTU = [
+ 
+ 
+ POLICY_FOUND_ONLY = "search,found=all,maybe=none,notfound=disabled"
+-POLICY_FOUND_OR_MAYBE = "search,found=all,maybe=all,notfound=disabled"
+-DI_DEFAULT_POLICY = "search,found=all,maybe=all,notfound=disabled"
+-DI_DEFAULT_POLICY_NO_DMI = "search,found=all,maybe=all,notfound=enabled"
++POLICY_FOUND_OR_MAYBE = "search,found=all,maybe=none,notfound=disabled"
++DI_DEFAULT_POLICY = "search,found=all,maybe=none,notfound=disabled"
++DI_DEFAULT_POLICY_NO_DMI = "search,found=all,maybe=none,notfound=enabled"
+ DI_EC2_STRICT_ID_DEFAULT = "true"
+ OVF_MATCH_STRING = "http://schemas.dmtf.org/ovf/environment/1"
+ 
+@@ -570,7 +570,7 @@ class TestDsIdentify(DsIdentifyBase):
+         self._test_ds_found("OpenStack-AssetTag-Compute")
+ 
+     def test_openstack_on_non_intel_is_maybe(self):
+-        """On non-Intel, openstack without dmi info is maybe.
++        """On non-Intel, openstack without dmi info is none.
+ 
+         nova does not identify itself on platforms other than intel.
+            https://bugs.launchpad.net/cloud-init/+bugs?field.tag=dsid-nova"""
+@@ -590,10 +590,9 @@ class TestDsIdentify(DsIdentifyBase):
+ 
+         # updating the uname to ppc64 though should get a maybe.
+         data.update({"mocks": [MOCK_VIRT_IS_KVM, MOCK_UNAME_IS_PPC64]})
+-        (_, _, err, _, _) = self._check_via_dict(
+-            data, RC_FOUND, dslist=["OpenStack", "None"]
+-        )
++        (_, _, err, _, _) = self._check_via_dict(data, RC_NOT_FOUND)
+         self.assertIn("check for 'OpenStack' returned maybe", err)
++        self.assertIn("No ds found", err)
+ 
+     def test_default_ovf_is_found(self):
+         """OVF is identified found when ovf/ovf-env.xml seed file exists."""
+diff --git a/tools/ds-identify b/tools/ds-identify
+index e5120ac..39b139b 100755
+--- a/tools/ds-identify
++++ b/tools/ds-identify
+@@ -14,7 +14,7 @@
+ #   The format is:
+ #        <mode>,found=value,maybe=value,notfound=value
+ #   default setting is:
+-#     search,found=all,maybe=all,notfound=disabled
++#     search,found=all,maybe=none,notfound=disabled
+ #
+ #   kernel command line option: ci.di.policy=<policy>
+ #   example line in /etc/cloud/ds-identify.cfg:
+@@ -40,7 +40,7 @@
+ #         first: use the first found do no further checking
+ #         all: enable all DS_FOUND
+ #
+-#      maybe: (default=all)
++#      maybe: (default=none)
+ #       if nothing returned 'found', then how to handle maybe.
+ #       no network sources are allowed to return 'maybe'.
+ #         all: enable all DS_MAYBE
+@@ -94,8 +94,8 @@ DI_MAIN=${DI_MAIN:-main}
+ 
+ DI_BLKID_EXPORT_OUT=""
+ DI_GEOM_LABEL_STATUS_OUT=""
+-DI_DEFAULT_POLICY="search,found=all,maybe=all,notfound=${DI_DISABLED}"
+-DI_DEFAULT_POLICY_NO_DMI="search,found=all,maybe=all,notfound=${DI_ENABLED}"
++DI_DEFAULT_POLICY="search,found=all,maybe=none,notfound=${DI_DISABLED}"
++DI_DEFAULT_POLICY_NO_DMI="search,found=all,maybe=none,notfound=${DI_ENABLED}"
+ DI_DMI_BOARD_NAME=""
+ DI_DMI_CHASSIS_ASSET_TAG=""
+ DI_DMI_PRODUCT_NAME=""
+-- 
+2.45.3
+

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -5,7 +5,7 @@ Summary:        Cloud instance init scripts
 Name:           cloud-init
 Epoch:          1
 Version:        %{package_version}
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -22,6 +22,8 @@ Patch3:         0001-feat-azure-Add-ProvisionGuestProxyAgent-OVF-setting.patch
 Patch4:         0002-feat-azure-parse-ProvisionGuestProxyAgent-as-bool-51.patch
 Patch5:         0003-feat-azure-add-support-for-azure-proxy-agent.patch
 Patch6:         0001-add-PPS-support-for-azure-proxy-agent.patch
+Patch7:         CVE-2024-6174.patch
+Patch8:         CVE-2024-11584.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus
@@ -163,6 +165,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Sat Jun 28 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1:23.3-7
+- Patch CVE-2024-6174 & CVE-2024-11584
+
 * Tue Dec 10 2024 Minghe Ren <mingheren@microsoft.com> - 1:23.3-6
 - Add module-setup.sh to prevent an intermittent issue where ephemeral disk not being formatted on Azure
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
 Patch cloud-init for CVE-2024-6174 & CVE-2024-11584

- Patches are considered from Astrolabe

- CVE-2024-6174 patch is modifed:  `doc/rtd/reference/breaking_changes.rst` file is removed since the file is not present
Upstream Patch Reference: canonical/cloud-init@8c3ae1b

- CVE-2024-11584 is modified: 
  - `cloudinit/cmd/devel/logs.py` not present hence removed from patch
  - `tools/cloud-init-hotplugd` not present hence removed from patch
  - `tools/hook-hotplug` backported as per the source contents
Upstream Patch Reference: canonical/cloud-init@6e10240

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/cloud-init/CVE-2024-11584.patch
- SPECS/cloud-init/CVE-2024-6174.patch
- SPECS/cloud-init/cloud-init.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
