### PR TITLE
[Medium] Patch qtbase for CVE-2025-5455

### DIFF
--- a/SPECS/qtbase/CVE-2025-5455.patch
+++ b/SPECS/qtbase/CVE-2025-5455.patch
@@ -1,14 +1,13 @@
-From 0ddfeb1fa7f353dea40c59b75cacd133cbc33122 Mon Sep 17 00:00:00 2001
+From ef7e22fcd69faa54c2792aa36ac9d5e96009a19f Mon Sep 17 00:00:00 2001
 From: akhila-guruju <v-guakhila@microsoft.com>
-Date: Sat, 28 Jun 2025 08:43:34 +0000
+Date: Mon, 30 Jun 2025 07:59:40 +0000
 Subject: [PATCH] Address CVE-2025-5455
 
-Upstream Patch reference: https://codereview.qt-project.org/c/qt/qtbase/+/642006/7/src/corelib/io/qdataurl.cpp#b50
-
 ---
- src/corelib/io/qdataurl.cpp       | 12 +++++++-----
- src/corelib/text/qbytearrayview.h |  6 ++++++
- 2 files changed, 13 insertions(+), 5 deletions(-)
+ src/corelib/io/qdataurl.cpp                     | 12 +++++++-----
+ src/corelib/text/qbytearrayview.h               |  6 ++++++
+ tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp |  2 ++
+ 3 files changed, 15 insertions(+), 5 deletions(-)
 
 diff --git a/src/corelib/io/qdataurl.cpp b/src/corelib/io/qdataurl.cpp
 index 92c6f541..e5f6f549 100644
@@ -50,6 +49,19 @@ index f822a2ca..1fd0d0c3 100644
      [[nodiscard]] constexpr QByteArrayView chopped(qsizetype len) const
      { Q_ASSERT(len >= 0); Q_ASSERT(len <= size()); return first(size() - len); }
  
+diff --git a/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp b/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
+index 8cc1b0ae..c1db6d59 100644
+--- a/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
++++ b/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
+@@ -34,6 +34,8 @@ void tst_QDataUrl::decode_data()
+         "text/plain"_L1, QByteArray::fromPercentEncoding("%E2%88%9A"));
+     row("everythingIsCaseInsensitive", "Data:texT/PlaiN;charSet=iSo-8859-1;Base64,SGVsbG8=", true,
+         "texT/PlaiN;charSet=iSo-8859-1"_L1, QByteArrayLiteral("Hello"));
++    row("prematureCharsetEnd", "data:charset,", true,
++        "charset", ""); // nonsense result, but don't crash
+ }
+ 
+ void tst_QDataUrl::decode()
 -- 
 2.45.2
 

--- a/SPECS/qtbase/CVE-2025-5455.patch
+++ b/SPECS/qtbase/CVE-2025-5455.patch
@@ -1,0 +1,55 @@
+From 0ddfeb1fa7f353dea40c59b75cacd133cbc33122 Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Sat, 28 Jun 2025 08:43:34 +0000
+Subject: [PATCH] Address CVE-2025-5455
+
+Upstream Patch reference: https://codereview.qt-project.org/c/qt/qtbase/+/642006/7/src/corelib/io/qdataurl.cpp#b50
+
+---
+ src/corelib/io/qdataurl.cpp       | 12 +++++++-----
+ src/corelib/text/qbytearrayview.h |  6 ++++++
+ 2 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/src/corelib/io/qdataurl.cpp b/src/corelib/io/qdataurl.cpp
+index 92c6f541..e5f6f549 100644
+--- a/src/corelib/io/qdataurl.cpp
++++ b/src/corelib/io/qdataurl.cpp
+@@ -41,11 +41,13 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
+             data.chop(7);
+         }
+ 
+-        if (QLatin1StringView{data}.startsWith("charset"_L1, Qt::CaseInsensitive)) {
+-            qsizetype i = 7;      // strlen("charset")
+-            while (data.at(i) == ' ')
+-                ++i;
+-            if (data.at(i) == '=')
++        QLatin1StringView textPlain;
++        constexpr auto charset = "charset"_L1;
++        if (QLatin1StringView{data}.startsWith(charset, Qt::CaseInsensitive)) {
++            QByteArrayView copy = data.sliced(charset.size());
++            while (copy.startsWith(' '))
++                copy.slice(1);
++            if (copy.startsWith('='))
+                 data.prepend("text/plain;");
+         }
+ 
+diff --git a/src/corelib/text/qbytearrayview.h b/src/corelib/text/qbytearrayview.h
+index f822a2ca..1fd0d0c3 100644
+--- a/src/corelib/text/qbytearrayview.h
++++ b/src/corelib/text/qbytearrayview.h
+@@ -195,6 +195,12 @@ public:
+     { Q_ASSERT(pos >= 0); Q_ASSERT(pos <= size()); return QByteArrayView(data() + pos, size() - pos); }
+     [[nodiscard]] constexpr QByteArrayView sliced(qsizetype pos, qsizetype n) const
+     { Q_ASSERT(pos >= 0); Q_ASSERT(n >= 0); Q_ASSERT(size_t(pos) + size_t(n) <= size_t(size())); return QByteArrayView(data() + pos, n); }
++
++     constexpr QByteArrayView &slice(qsizetype pos)
++    { *this = sliced(pos); return *this; }
++     constexpr QByteArrayView &slice(qsizetype pos, qsizetype n)
++    { *this = sliced(pos, n); return *this; }
++
+     [[nodiscard]] constexpr QByteArrayView chopped(qsizetype len) const
+     { Q_ASSERT(len >= 0); Q_ASSERT(len <= size()); return first(size() - len); }
+ 
+-- 
+2.45.2
+

--- a/SPECS/qtbase/CVE-2025-5455.patch
+++ b/SPECS/qtbase/CVE-2025-5455.patch
@@ -1,64 +1,35 @@
-From 7cf5db1c5976767981aadfd1212efcf7842039f5 Mon Sep 17 00:00:00 2001
+From 25c4ed587ff4b16ea682721ffad16031bb91f03e Mon Sep 17 00:00:00 2001
 From: akhila-guruju <v-guakhila@microsoft.com>
-Date: Mon, 30 Jun 2025 07:59:40 +0000
+Date: Tue, 15 Jul 2025 06:19:38 +0000
 Subject: [PATCH] Address CVE-2025-5455
 
-Upstream Patch Reference:
- 1. https://codereview.qt-project.org/c/qt/qtbase/+/642006/7/src/corelib/io/qdataurl.cpp
+Upstream patch reference:
+ 1. https://download.qt.io/official_releases/qt/6.5/CVE-2025-5455-qtbase-6.5.patch
  2. for test: https://codereview.qt-project.org/c/qt/qtbase/+/642006/7/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
-
 ---
- src/corelib/io/qdataurl.cpp                     | 16 +++++++++-------
- src/corelib/text/qbytearrayview.h               |  6 ++++++
- tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp |  2 ++
- 3 files changed, 17 insertions(+), 7 deletions(-)
+ src/corelib/io/qdataurl.cpp                     | 9 +++++----
+ tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp | 2 ++
+ 2 files changed, 7 insertions(+), 4 deletions(-)
 
 diff --git a/src/corelib/io/qdataurl.cpp b/src/corelib/io/qdataurl.cpp
-index 92c6f541..225bc115 100644
+index 92c6f541..9ace4e1f 100644
 --- a/src/corelib/io/qdataurl.cpp
 +++ b/src/corelib/io/qdataurl.cpp
-@@ -41,16 +41,18 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
-             data.chop(7);
+@@ -42,10 +42,11 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
          }
  
--        if (QLatin1StringView{data}.startsWith("charset"_L1, Qt::CaseInsensitive)) {
+         if (QLatin1StringView{data}.startsWith("charset"_L1, Qt::CaseInsensitive)) {
 -            qsizetype i = 7;      // strlen("charset")
 -            while (data.at(i) == ' ')
 -                ++i;
 -            if (data.at(i) == '=')
--                data.prepend("text/plain;");
-+        QLatin1StringView textPlain;
-+        constexpr auto charset = "charset"_L1;
-+        if (QLatin1StringView{data}.startsWith(charset, Qt::CaseInsensitive)) {
-+            QByteArrayView copy = data.sliced(charset.size());
++            qsizetype prefixSize = 7; // strlen("charset")
++            QByteArrayView copy(data.constData() + prefixSize, data.size() - prefixSize);
 +            while (copy.startsWith(' '))
-+                copy.slice(1);
++                copy = copy.sliced(1);
 +            if (copy.startsWith('='))
-+                textPlain = "text/plain;"_L1;
+                 data.prepend("text/plain;");
          }
- 
-         if (!data.isEmpty())
--            mimeType = QString::fromLatin1(data.trimmed());
-+            mimeType = textPlain + QLatin1StringView(data.trimmed());
- 
-     }
- 
-diff --git a/src/corelib/text/qbytearrayview.h b/src/corelib/text/qbytearrayview.h
-index f822a2ca..1fd0d0c3 100644
---- a/src/corelib/text/qbytearrayview.h
-+++ b/src/corelib/text/qbytearrayview.h
-@@ -195,6 +195,12 @@ public:
-     { Q_ASSERT(pos >= 0); Q_ASSERT(pos <= size()); return QByteArrayView(data() + pos, size() - pos); }
-     [[nodiscard]] constexpr QByteArrayView sliced(qsizetype pos, qsizetype n) const
-     { Q_ASSERT(pos >= 0); Q_ASSERT(n >= 0); Q_ASSERT(size_t(pos) + size_t(n) <= size_t(size())); return QByteArrayView(data() + pos, n); }
-+
-+     constexpr QByteArrayView &slice(qsizetype pos)
-+    { *this = sliced(pos); return *this; }
-+     constexpr QByteArrayView &slice(qsizetype pos, qsizetype n)
-+    { *this = sliced(pos, n); return *this; }
-+
-     [[nodiscard]] constexpr QByteArrayView chopped(qsizetype len) const
-     { Q_ASSERT(len >= 0); Q_ASSERT(len <= size()); return first(size() - len); }
  
 diff --git a/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp b/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
 index 8cc1b0ae..c1db6d59 100644

--- a/SPECS/qtbase/CVE-2025-5455.patch
+++ b/SPECS/qtbase/CVE-2025-5455.patch
@@ -1,19 +1,23 @@
-From ef7e22fcd69faa54c2792aa36ac9d5e96009a19f Mon Sep 17 00:00:00 2001
+From 7cf5db1c5976767981aadfd1212efcf7842039f5 Mon Sep 17 00:00:00 2001
 From: akhila-guruju <v-guakhila@microsoft.com>
 Date: Mon, 30 Jun 2025 07:59:40 +0000
 Subject: [PATCH] Address CVE-2025-5455
 
+Upstream Patch Reference:
+ 1. https://codereview.qt-project.org/c/qt/qtbase/+/642006/7/src/corelib/io/qdataurl.cpp
+ 2. for test: https://codereview.qt-project.org/c/qt/qtbase/+/642006/7/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
+
 ---
- src/corelib/io/qdataurl.cpp                     | 12 +++++++-----
+ src/corelib/io/qdataurl.cpp                     | 16 +++++++++-------
  src/corelib/text/qbytearrayview.h               |  6 ++++++
  tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp |  2 ++
- 3 files changed, 15 insertions(+), 5 deletions(-)
+ 3 files changed, 17 insertions(+), 7 deletions(-)
 
 diff --git a/src/corelib/io/qdataurl.cpp b/src/corelib/io/qdataurl.cpp
-index 92c6f541..e5f6f549 100644
+index 92c6f541..225bc115 100644
 --- a/src/corelib/io/qdataurl.cpp
 +++ b/src/corelib/io/qdataurl.cpp
-@@ -41,11 +41,13 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
+@@ -41,16 +41,18 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
              data.chop(7);
          }
  
@@ -22,6 +26,7 @@ index 92c6f541..e5f6f549 100644
 -            while (data.at(i) == ' ')
 -                ++i;
 -            if (data.at(i) == '=')
+-                data.prepend("text/plain;");
 +        QLatin1StringView textPlain;
 +        constexpr auto charset = "charset"_L1;
 +        if (QLatin1StringView{data}.startsWith(charset, Qt::CaseInsensitive)) {
@@ -29,8 +34,14 @@ index 92c6f541..e5f6f549 100644
 +            while (copy.startsWith(' '))
 +                copy.slice(1);
 +            if (copy.startsWith('='))
-                 data.prepend("text/plain;");
++                textPlain = "text/plain;"_L1;
          }
+ 
+         if (!data.isEmpty())
+-            mimeType = QString::fromLatin1(data.trimmed());
++            mimeType = textPlain + QLatin1StringView(data.trimmed());
+ 
+     }
  
 diff --git a/src/corelib/text/qbytearrayview.h b/src/corelib/text/qbytearrayview.h
 index f822a2ca..1fd0d0c3 100644

--- a/SPECS/qtbase/qtbase.spec
+++ b/SPECS/qtbase/qtbase.spec
@@ -704,7 +704,7 @@ fi
 
 %changelog
 * Fri Jun 27 2025 Akhila Guruju <v-guakhila@microsoft.com> - 6.6.3-4
-- Patch CVE-2025-5455.patch
+- Patch CVE-2025-5455
 
 * Wed Mar 26 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 6.6.3-3
 - Fix CVE-2025-30348

--- a/SPECS/qtbase/qtbase.spec
+++ b/SPECS/qtbase/qtbase.spec
@@ -35,7 +35,7 @@
 Name:         qtbase
 Summary:      Qt6 - QtBase components
 Version:      6.6.3
-Release:      3%{?dist}
+Release:      4%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:      GFDL AND LGPLv3 AND GPLv2 AND GPLv3 with exceptions AND QT License Agreement 4.0
 Vendor:       Microsoft Corporation
@@ -98,6 +98,7 @@ Patch61: qtbase-cxxflag.patch
 # fix for new mariadb
 Patch65: qtbase-mysql.patch
 Patch66: CVE-2025-30348.patch
+Patch67: CVE-2025-5455.patch
 
 # Do not check any files in %%{_qt_plugindir}/platformthemes/ for requires.
 # Those themes are there for platform integration. If the required libraries are
@@ -702,6 +703,9 @@ fi
 %{_qt_plugindir}/platformthemes/libqxdgdesktopportal.so
 
 %changelog
+* Fri Jun 27 2025 Akhila Guruju <v-guakhila@microsoft.com> - 6.6.3-4
+- Patch CVE-2025-5455.patch
+
 * Wed Mar 26 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 6.6.3-3
 - Fix CVE-2025-30348
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch qtbase for CVE-2025-5455
Upstream Patch reference: https://www.qt.io/blog/security-advisory-recently-discovered-issue-in-qdecodedataurl-in-qtcore-impacts-qt (v6.5)
Astrolabe Patch Reference:
for test: https://codereview.qt-project.org/c/qt/qtbase/+/642006/7/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
Patches Modified: No

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/qtbase/CVE-2025-5455.patch
- modified:   SPECS/qtbase/qtbase.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-5455

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Patch applies cleanly
<img width="615" alt="image" src="https://github.com/user-attachments/assets/5df4d8b8-1f15-44f7-b529-86aba912a9c6" />

