### PR TITLE
[HIGH] Patch msft-golang for CVE-2025-22874 & [MEDIUM] CVE-2025-4673

### DIFF
--- a/SPECS/msft-golang/CVE-2025-22874.patch
+++ b/SPECS/msft-golang/CVE-2025-22874.patch
@@ -1,0 +1,117 @@
+From 994e7f622d698fb5e27137cdf78df3fa0389b929 Mon Sep 17 00:00:00 2001
+From: archana25-ms <v-shettigara@microsoft.com>
+Date: Mon, 30 Jun 2025 06:38:58 +0000
+Subject: [PATCH] Address CVE-2025-22874
+Upstream Patch Reference: https://go.googlesource.com/go/+/9bba799955e68972041c4f340ee4ea2d267e5c0e
+
+---
+ src/crypto/x509/verify.go      | 32 +++++++++++++++++++++---------
+ src/crypto/x509/verify_test.go | 36 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 59 insertions(+), 9 deletions(-)
+
+diff --git a/src/crypto/x509/verify.go b/src/crypto/x509/verify.go
+index 5fe93c6..7cc0fb2 100644
+--- a/src/crypto/x509/verify.go
++++ b/src/crypto/x509/verify.go
+@@ -841,31 +841,45 @@ func (c *Certificate) Verify(opts VerifyOptions) (chains [][]*Certificate, err e
+ 		}
+ 	}
+ 
+-	if len(opts.KeyUsages) == 0 {
+-		opts.KeyUsages = []ExtKeyUsage{ExtKeyUsageServerAuth}
++	chains = make([][]*Certificate, 0, len(candidateChains))
++
++	var invalidPoliciesChains int
++	for _, candidate := range candidateChains {
++		if !policiesValid(candidate, opts) {
++			invalidPoliciesChains++
++			continue
++		}
++		chains = append(chains, candidate)
++	}
++
++	if len(chains) == 0 {
++		return nil, CertificateInvalidError{c, NoValidChains, "all candidate chains have invalid policies"}
+ 	}
+ 
+ 	for _, eku := range opts.KeyUsages {
+ 		if eku == ExtKeyUsageAny {
+ 			// If any key usage is acceptable, no need to check the chain for
+ 			// key usages.
+-			return candidateChains, nil
++			return chains, nil
+ 		}
+ 	}
+ 
+-	chains = make([][]*Certificate, 0, len(candidateChains))
+-	var incompatibleKeyUsageChains, invalidPoliciesChains int
++	if len(opts.KeyUsages) == 0 {
++		opts.KeyUsages = []ExtKeyUsage{ExtKeyUsageServerAuth}
++	}
++
++	candidateChains = chains
++	chains = chains[:0]
++
++	var incompatibleKeyUsageChains int
+ 	for _, candidate := range candidateChains {
+ 		if !checkChainForKeyUsage(candidate, opts.KeyUsages) {
+ 			incompatibleKeyUsageChains++
+ 			continue
+ 		}
+-		if !policiesValid(candidate, opts) {
+-			invalidPoliciesChains++
+-			continue
+-		}
+ 		chains = append(chains, candidate)
+ 	}
++
+ 	if len(chains) == 0 {
+ 		var details []string
+ 		if incompatibleKeyUsageChains > 0 {
+diff --git a/src/crypto/x509/verify_test.go b/src/crypto/x509/verify_test.go
+index 1175e7d..7991f49 100644
+--- a/src/crypto/x509/verify_test.go
++++ b/src/crypto/x509/verify_test.go
+@@ -3012,3 +3012,39 @@ func TestPoliciesValid(t *testing.T) {
+ 		})
+ 	}
+ }
++
++func TestInvalidPolicyWithAnyKeyUsage(t *testing.T) {
++	loadTestCert := func(t *testing.T, path string) *Certificate {
++		b, err := os.ReadFile(path)
++		if err != nil {
++			t.Fatal(err)
++		}
++		p, _ := pem.Decode(b)
++		c, err := ParseCertificate(p.Bytes)
++		if err != nil {
++			t.Fatal(err)
++		}
++		return c
++	}
++
++	testOID3 := mustNewOIDFromInts([]uint64{1, 2, 840, 113554, 4, 1, 72585, 2, 3})
++	root, intermediate, leaf := loadTestCert(t, "testdata/policy_root.pem"), loadTestCert(t, "testdata/policy_intermediate_require.pem"), loadTestCert(t, "testdata/policy_leaf.pem")
++
++	expectedErr := "x509: no valid chains built: all candidate chains have invalid policies"
++
++	roots, intermediates := NewCertPool(), NewCertPool()
++	roots.AddCert(root)
++	intermediates.AddCert(intermediate)
++
++	_, err := leaf.Verify(VerifyOptions{
++		Roots:               roots,
++		Intermediates:       intermediates,
++		KeyUsages:           []ExtKeyUsage{ExtKeyUsageAny},
++		CertificatePolicies: []OID{testOID3},
++	})
++	if err == nil {
++		t.Fatal("unexpected success, invalid policy shouldn't be bypassed by passing VerifyOptions.KeyUsages with ExtKeyUsageAny")
++	} else if err.Error() != expectedErr {
++		t.Fatalf("unexpected error, got %q, want %q", err, expectedErr)
++	}
++}
+-- 
+2.45.3
+

--- a/SPECS/msft-golang/CVE-2025-4673.patch
+++ b/SPECS/msft-golang/CVE-2025-4673.patch
@@ -1,0 +1,49 @@
+From a31f74f619397c1a381a881d997c7b4d99221dc6 Mon Sep 17 00:00:00 2001
+From: archana25-ms <v-shettigara@microsoft.com>
+Date: Mon, 30 Jun 2025 06:42:03 +0000
+Subject: [PATCH] Address CVE-2025-4673
+Upstream Patch Reference: https://go.googlesource.com/go/+/4d1c255f159d90557b43ede07f8b9a209e1fb49c
+
+---
+ src/net/http/client.go      | 3 ++-
+ src/net/http/client_test.go | 3 +++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/net/http/client.go b/src/net/http/client.go
+index 9231f63..a814cf3 100644
+--- a/src/net/http/client.go
++++ b/src/net/http/client.go
+@@ -805,7 +805,8 @@ func (c *Client) makeHeadersCopier(ireq *Request) func(req *Request, stripSensit
+ 		for k, vv := range ireqhdr {
+ 			sensitive := false
+ 			switch CanonicalHeaderKey(k) {
+-			case "Authorization", "Www-Authenticate", "Cookie", "Cookie2":
++			case "Authorization", "Www-Authenticate", "Cookie", "Cookie2",
++				"Proxy-Authorization", "Proxy-Authenticate":
+ 				sensitive = true
+ 			}
+ 			if !(sensitive && stripSensitiveHeaders) {
+diff --git a/src/net/http/client_test.go b/src/net/http/client_test.go
+index 1ce9539..c637dba 100644
+--- a/src/net/http/client_test.go
++++ b/src/net/http/client_test.go
+@@ -1547,6 +1547,8 @@ func testClientStripHeadersOnRepeatedRedirect(t *testing.T, mode testMode) {
+ 		if r.Host+r.URL.Path != "a.example.com/" {
+ 			if h := r.Header.Get("Authorization"); h != "" {
+ 				t.Errorf("on request to %v%v, Authorization=%q, want no header", r.Host, r.URL.Path, h)
++			} else if h := r.Header.Get("Proxy-Authorization"); h != "" {
+++				t.Errorf("on request to %v%v, Proxy-Authorization=%q, want no header", r.Host, r.URL.Path, h)
+ 			}
+ 		}
+ 		// Follow a chain of redirects from a to b and back to a.
+@@ -1575,6 +1577,7 @@ func testClientStripHeadersOnRepeatedRedirect(t *testing.T, mode testMode) {
+ 	req, _ := NewRequest("GET", proto+"://a.example.com/", nil)
+ 	req.Header.Add("Cookie", "foo=bar")
+ 	req.Header.Add("Authorization", "secretpassword")
++	req.Header.Add("Proxy-Authorization", "secretpassword")
+ 	res, err := c.Do(req)
+ 	if err != nil {
+ 		t.Fatal(err)
+-- 
+2.45.3
+

--- a/SPECS/msft-golang/msft-golang.spec
+++ b/SPECS/msft-golang/msft-golang.spec
@@ -15,7 +15,7 @@
 Summary:        Go
 Name:           msft-golang
 Version:        1.24.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -32,6 +32,8 @@ Source3:        https://github.com/microsoft/go/releases/download/v1.20.14-1/go.
 Source4:        https://github.com/microsoft/go/releases/download/v1.22.12-2/go1.22.12-20250211.4.src.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
 Patch1:         CVE-2025-22871.patch
+Patch2:         CVE-2025-22874.patch
+Patch3:         CVE-2025-4673.patch
 Conflicts:      go
 Conflicts:      golang
 
@@ -55,6 +57,8 @@ mv -v go go-bootstrap-03
 
 %setup -q -n go
 patch -Np1 --ignore-whitespace < %{PATCH1}
+patch -Np1 --ignore-whitespace < %{PATCH2}
+patch -Np1 --ignore-whitespace < %{PATCH3}
 %build
 # go 1.4 bootstraps with C.
 # go 1.20 bootstraps with go >= 1.17.13
@@ -160,7 +164,10 @@ fi
 %{_bindir}/*
 
 %changelog
-Mon Apr 14 2025 Bhagyashri Pathak <bhapathak@microsoft.com> - 1.24.1-2
+* Mon Jun 30 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.24.1-3
+- Patch CVE-2025-22874 & CVE-2025-4673
+
+* Mon Apr 14 2025 Bhagyashri Pathak <bhapathak@microsoft.com> - 1.24.1-2
 - Patch to address CVE-2025-22871
 
 * Mon Mar 31 2025 Andrew Phelps <anphel@microsoft.com> - 1.24.1-1


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch msft-golang for CVE-2025-22874 & CVE-2025-4673

- Patches are considered from Astrolabe
- No modifications are done for both CVE patches
- CVE-2025-22874.patch reference: https://go.googlesource.com/go/+/9bba799955e68972041c4f340ee4ea2d267e5c0e
- CVE-2025-4673.patch reference: https://go.googlesource.com/go/+/4d1c255f159d90557b43ede07f8b9a209e1fb49c

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/msft-golang/CVE-2025-22874.patch
- SPECS/msft-golang/CVE-2025-4673.patch
- SPECS/msft-golang/msft-golang.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-22874
- https://nvd.nist.gov/vuln/detail/CVE-2025-4673

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
- Patch applies cleanly
![image](https://github.com/user-attachments/assets/664e50d4-a07d-4ed4-8ca8-ad6a5e58c909)

- Builds successfully - 
[msft-golang-1.24.1-3.cm2.src.rpm.log](https://github.com/user-attachments/files/20975131/msft-golang-1.24.1-3.cm2.src.rpm.log)

