### PR TITLE
Patch kubernetes for CVE-2025-4563

### DIFF
--- a/SPECS/kubernetes/CVE-2025-4563.patch
+++ b/SPECS/kubernetes/CVE-2025-4563.patch
@@ -1,0 +1,38 @@
+From c7ef08e0fd2763ba2a47485f7f514dfbf6802e6e Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 11:37:38 +0000
+Subject: [PATCH] Fix CVE CVE-2025-4563 in kubernetes
+
+Upstream Patch Reference: https://github.com/kubernetes/kubernetes/commit/1fde2b884c7110c5e253db7143b24bfd91202c4d.patch
+---
+ pkg/kubelet/config/common.go | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/pkg/kubelet/config/common.go b/pkg/kubelet/config/common.go
+index 69d6712..a73d637 100644
+--- a/pkg/kubelet/config/common.go
++++ b/pkg/kubelet/config/common.go
+@@ -106,6 +106,9 @@ type defaultFunc func(pod *api.Pod) error
+ // A static pod tried to use a ClusterTrustBundle projected volume source.
+ var ErrStaticPodTriedToUseClusterTrustBundle = errors.New("static pods may not use ClusterTrustBundle projected volume sources")
+ 
++// A static pod tried to use a resource claim.
++var ErrStaticPodTriedToUseResourceClaims = errors.New("static pods may not use ResourceClaims")
++
+ // tryDecodeSinglePod takes data and tries to extract valid Pod config information from it.
+ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *v1.Pod, err error) {
+ 	// JSON is valid YAML, so this should work for everything.
+@@ -152,6 +155,9 @@ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *v
+ 			}
+ 		}
+ 	}
++	if len(v1Pod.Spec.ResourceClaims) > 0 {
++		return true, nil, ErrStaticPodTriedToUseResourceClaims
++	}
+ 
+ 	return true, v1Pod, nil
+ }
+-- 
+2.45.3
+

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.30.10
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -26,6 +26,7 @@ Patch4:         CVE-2025-22869.patch
 Patch5:         CVE-2024-51744.patch
 Patch6:         CVE-2025-30204.patch
 Patch7:         CVE-2025-22872.patch
+Patch8:         CVE-2025-4563.patch
 BuildRequires:  flex-devel
 BuildRequires:  glibc-static >= 2.38-10%{?dist}
 BuildRequires:  golang
@@ -277,6 +278,9 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.30.10-8
+- Patch for CVE-2025-4563
+
 * Tue May 13 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 1.30-10-7
 - Patch CVE-2025-22872
 


### PR DESCRIPTION
Auto Patch kubernetes for CVE-2025-4563; These patches apply cleanly like upstream