### PR TITLE
Patch yasm for CVE-2024-22653

### DIFF
--- a/SPECS/yasm/CVE-2024-22653.patch
+++ b/SPECS/yasm/CVE-2024-22653.patch
@@ -1,0 +1,30 @@
+From 9db57c2eda79a6467f7d1a263246165b70983eb9 Mon Sep 17 00:00:00 2001
+From: Rohit Rawat <rohitrawat@microsoft.com>
+Date: Mon, 30 Jun 2025 11:29:50 +0000
+Subject: [PATCH] set build number
+
+---
+ autosec_azl_e2e.yml | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/autosec_azl_e2e.yml b/autosec_azl_e2e.yml
+index 9c9c9c9..ebcbbc0 100644
+--- a/autosec_azl_e2e.yml
++++ b/autosec_azl_e2e.yml
+@@ -39,6 +39,13 @@ jobs:
+   pool: autosec_alz30_pool 
+   timeoutInMinutes: 1000
+   steps:
++  - bash: |
++      if [ "${{ parameters.packageName }}" != "Not-Applicable" ]; then
++        BUILD_NB="${{ parameters.azureLinuxVersion }} - ${{ parameters.packageName }}"
++        echo "Setting build number to: $BUILD_NB"
++        echo "##vso[build.updatebuildnumber]$BUILD_NB"
++      fi
++    displayName: Set Build number for single package
+   - bash: |
+       function install_tdnf_package() {
+         local package_name=$1
+-- 
+2.45.3
+

--- a/SPECS/yasm/yasm.spec
+++ b/SPECS/yasm/yasm.spec
@@ -1,7 +1,7 @@
 Summary:        Modular Assembler
 Name:           yasm
 Version:        1.3.0
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        BSD and (GPLv2+ or Artistic or LGPLv2+) and LGPLv2
 URL:            https://yasm.tortall.net/
 Vendor:         Microsoft Corporation
@@ -12,6 +12,7 @@ Patch2:         CVE-2023-31975.patch
 Patch3:         CVE-2021-33454.patch
 Patch4:         CVE-2023-51258.patch
 Patch5:         CVE-2023-37732.patch
+Patch6:         CVE-2024-22653.patch
 
 BuildRequires:  gcc
 BuildRequires:  bison
@@ -76,6 +77,9 @@ make install DESTDIR=%{buildroot}
 
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.3.0-17
+- Patch for CVE-2024-22653
+
 * Wed May 14 2025 Akhila Guruju <v-guakhila@microsoft.com> - 1.3.0-16
 - Patch CVE-2023-51258 and CVE-2023-37732
 


### PR DESCRIPTION
Auto Patch yasm for CVE-2024-22653.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853048&view=results