### PR TITLE
Patch nbdkit for CVE-2025-47712, CVE-2025-47711

### DIFF
--- a/SPECS/nbdkit/CVE-2025-47711.patch
+++ b/SPECS/nbdkit/CVE-2025-47711.patch
@@ -1,0 +1,27 @@
+From d874064d8e96946d8d9bc9d86360f342998b09b4 Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 14:34:53 +0000
+Subject: [PATCH] Fix CVE CVE-2025-47711 in nbdkit
+
+Upstream Patch Reference: {real_patch_url}
+---
+ server/protocol.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/server/protocol.c b/server/protocol.c
+index d9a5e28..c32fec8 100644
+--- a/server/protocol.c
++++ b/server/protocol.c
+@@ -493,7 +493,7 @@ extents_to_block_descriptors (struct nbdkit_extents *extents,
+       (*nr_blocks)++;
+ 
+       pos += length;
+-      if (pos > offset + count) /* this must be the last block */
++      if (pos >= offset + count) /* this must be the last block */
+         break;
+ 
+       /* If we reach here then we must have consumed this whole
+-- 
+2.45.3
+

--- a/SPECS/nbdkit/CVE-2025-47712.patch
+++ b/SPECS/nbdkit/CVE-2025-47712.patch
@@ -1,0 +1,30 @@
+From 3596c4568890feac1c65c35c440f963de1943bca Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 14:34:59 +0000
+Subject: [PATCH] Fix CVE CVE-2025-47712 in nbdkit
+
+Upstream Patch Reference: {real_patch_url}
+---
+ filters/blocksize/blocksize.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/filters/blocksize/blocksize.c b/filters/blocksize/blocksize.c
+index 09195ce..e5c8b74 100644
+--- a/filters/blocksize/blocksize.c
++++ b/filters/blocksize/blocksize.c
+@@ -482,8 +482,9 @@ blocksize_extents (nbdkit_next *next,
+     return -1;
+   }
+ 
+-  if (nbdkit_extents_aligned (next, MIN (ROUND_UP (count, h->minblock),
+-                                         h->maxlen),
++  if (nbdkit_extents_aligned (next,
++                              MIN (ROUND_UP ((uint64_t) count, h->minblock),
++                                   h->maxlen),
+                               ROUND_DOWN (offset, h->minblock), flags,
+                               h->minblock, extents2, err) == -1)
+     return -1;
+-- 
+2.45.3
+

--- a/SPECS/nbdkit/nbdkit.spec
+++ b/SPECS/nbdkit/nbdkit.spec
@@ -51,13 +51,15 @@ Distribution:   Azure Linux
 
 Name:           nbdkit
 Version:        1.35.3
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        NBD server
 
 License:        BSD
 URL:            https://gitlab.com/nbdkit/nbdkit
 
 Source0:        http://libguestfs.org/download/nbdkit/%{source_directory}/%{name}-%{version}.tar.gz
+Patch0:         CVE-2025-47712.patch
+Patch1:         CVE-2025-47711.patch
 
 BuildRequires: make
 %if 0%{patches_touch_autotools}
@@ -1195,6 +1197,9 @@ export LIBGUESTFS_TRACE=1
 
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.35.3-7
+- Patch for CVE-2025-47712, CVE-2025-47711
+
 * Thu Aug 29 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.35.3-6
 - Fixed test-time dependencies to match correct AZL paths.
 


### PR DESCRIPTION
Auto Patch nbdkit for CVE-2025-47712, CVE-2025-47711.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853131&view=results