### PR TITLE
Patch libssh for CVE-2025-5318

### DIFF
--- a/SPECS/libssh/CVE-2025-5318.patch
+++ b/SPECS/libssh/CVE-2025-5318.patch
@@ -1,0 +1,27 @@
+From b556ef308c13004a5ff35585a092deb382d1aa55 Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 15:29:26 +0000
+Subject: [PATCH] Fix CVE CVE-2025-5318 in libssh
+
+[Backported] Upstream Patch Reference: {real_patch_url}
+---
+ src/sftpserver.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/sftpserver.c b/src/sftpserver.c
+index 9117f15..b3349e1 100644
+--- a/src/sftpserver.c
++++ b/src/sftpserver.c
+@@ -538,7 +538,7 @@ void *sftp_handle(sftp_session sftp, ssh_string handle){
+ 
+   memcpy(&val, ssh_string_data(handle), sizeof(uint32_t));
+ 
+-  if (val > SFTP_HANDLES) {
++  if (val >= SFTP_HANDLES) {
+     return NULL;
+   }
+ 
+-- 
+2.45.3
+

--- a/SPECS/libssh/libssh.spec
+++ b/SPECS/libssh/libssh.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Name:           libssh
 Version:        0.10.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A library implementing the SSH protocol
 License:        LGPLv2+
 URL:            http://www.libssh.org
@@ -12,6 +12,7 @@ Source1:        https://www.libssh.org/files/0.10/%{name}-%{version}.tar.xz.asc
 Source2:        https://cryptomilk.org/gpgkey-8DFF53E18F2ABC8D8F3C92237EE0FC4DCC014E3D.gpg#/%{name}.keyring
 Source3:        libssh_client.config
 Source4:        libssh_server.config
+Patch0:         CVE-2025-5318.patch
 
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
@@ -144,6 +145,9 @@ popd
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/libssh/libssh_server.config
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.10.6-2
+- Patch for CVE-2025-5318
+
 * Tue Feb 25 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.10.6-1
 - Auto-upgrade to 0.10.6 - for CVE-2023-6004, CVE-2023-6918 & CVE-2023-48795 [Medium]
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -193,8 +193,8 @@ e2fsprogs-1.47.0-2.azl3.aarch64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.aarch64.rpm
 libsolv-0.7.28-3.azl3.aarch64.rpm
 libsolv-devel-0.7.28-3.azl3.aarch64.rpm
-libssh2-1.11.1-1.azl3.aarch64.rpm
-libssh2-devel-1.11.1-1.azl3.aarch64.rpm
+libssh2-0.10.6-2.azl3.aarch64.rpm
+libssh2-devel-0.10.6-2.azl3.aarch64.rpm
 krb5-1.21.3-2.azl3.aarch64.rpm
 krb5-devel-1.21.3-2.azl3.aarch64.rpm
 nghttp2-1.61.0-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -193,8 +193,8 @@ e2fsprogs-1.47.0-2.azl3.x86_64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.x86_64.rpm
 libsolv-0.7.28-3.azl3.x86_64.rpm
 libsolv-devel-0.7.28-3.azl3.x86_64.rpm
-libssh2-1.11.1-1.azl3.x86_64.rpm
-libssh2-devel-1.11.1-1.azl3.x86_64.rpm
+libssh2-0.10.6-2.azl3.x86_64.rpm
+libssh2-devel-0.10.6-2.azl3.x86_64.rpm
 krb5-1.21.3-2.azl3.x86_64.rpm
 krb5-devel-1.21.3-2.azl3.x86_64.rpm
 nghttp2-1.61.0-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -229,9 +229,9 @@ libsolv-0.7.28-3.azl3.aarch64.rpm
 libsolv-debuginfo-0.7.28-3.azl3.aarch64.rpm
 libsolv-devel-0.7.28-3.azl3.aarch64.rpm
 libsolv-tools-0.7.28-3.azl3.aarch64.rpm
-libssh2-1.11.1-1.azl3.aarch64.rpm
-libssh2-debuginfo-1.11.1-1.azl3.aarch64.rpm
-libssh2-devel-1.11.1-1.azl3.aarch64.rpm
+libssh2-0.10.6-2.azl3.aarch64.rpm
+libssh2-debuginfo-0.10.6-2.azl3.aarch64.rpm
+libssh2-devel-0.10.6-2.azl3.aarch64.rpm
 libstdc++-13.2.0-7.azl3.aarch64.rpm
 libstdc++-devel-13.2.0-7.azl3.aarch64.rpm
 libtasn1-4.19.0-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -237,9 +237,9 @@ libsolv-0.7.28-3.azl3.x86_64.rpm
 libsolv-debuginfo-0.7.28-3.azl3.x86_64.rpm
 libsolv-devel-0.7.28-3.azl3.x86_64.rpm
 libsolv-tools-0.7.28-3.azl3.x86_64.rpm
-libssh2-1.11.1-1.azl3.x86_64.rpm
-libssh2-debuginfo-1.11.1-1.azl3.x86_64.rpm
-libssh2-devel-1.11.1-1.azl3.x86_64.rpm
+libssh2-0.10.6-2.azl3.x86_64.rpm
+libssh2-debuginfo-0.10.6-2.azl3.x86_64.rpm
+libssh2-devel-0.10.6-2.azl3.x86_64.rpm
 libstdc++-13.2.0-7.azl3.x86_64.rpm
 libstdc++-devel-13.2.0-7.azl3.x86_64.rpm
 libtasn1-4.19.0-2.azl3.x86_64.rpm


### PR DESCRIPTION
Auto Patch libssh for CVE-2025-5318.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853193&view=results