### PR TITLE
Patch yasm for CVE-2024-22653

### DIFF
--- a/SPECS/yasm/CVE-2024-22653.patch
+++ b/SPECS/yasm/CVE-2024-22653.patch
@@ -1,0 +1,29 @@
+From c7d6244cd5cfba6245533b3843d605cb98eafaed Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 15:36:49 +0000
+Subject: [PATCH] Fix CVE CVE-2024-22653 in yasm
+
+Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/yasm/yasm/pull/263.diff
+---
+ libyasm/section.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libyasm/section.c b/libyasm/section.c
+index ba582bf..1c1ba71 100644
+--- a/libyasm/section.c
++++ b/libyasm/section.c
+@@ -611,6 +611,10 @@ yasm_bytecode *
+ yasm_section_bcs_append(yasm_section *sect, yasm_bytecode *bc)
+ {
+     if (bc) {
++        if (!sect) {
++            yasm_error_set(YASM_ERROR_VALUE, "Attempt to append bytecode to a NULL section or with a NULL bytecode");
++            return NULL;
++        }
+         if (bc->callback) {
+             bc->section = sect;     /* record parent section */
+             STAILQ_INSERT_TAIL(&sect->bcs, bc, link);
+-- 
+2.45.3
+

--- a/SPECS/yasm/yasm.spec
+++ b/SPECS/yasm/yasm.spec
@@ -1,7 +1,7 @@
 Summary:        Modular Assembler
 Name:           yasm
 Version:        1.3.0
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        BSD and (GPLv2+ or Artistic or LGPLv2+) and LGPLv2
 URL:            https://yasm.tortall.net/
 Vendor:         Microsoft Corporation
@@ -12,6 +12,7 @@ Patch2:         CVE-2023-31975.patch
 Patch3:         CVE-2021-33454.patch
 Patch4:         CVE-2023-51258.patch
 Patch5:         CVE-2023-37732.patch
+Patch6:         CVE-2024-22653.patch
 
 BuildRequires:  gcc
 BuildRequires:  bison
@@ -76,6 +77,9 @@ make install DESTDIR=%{buildroot}
 
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.3.0-17
+- Patch for CVE-2024-22653
+
 * Wed May 14 2025 Akhila Guruju <v-guakhila@microsoft.com> - 1.3.0-16
 - Patch CVE-2023-51258 and CVE-2023-37732
 


### PR DESCRIPTION
Auto Patch yasm for CVE-2024-22653.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853203&view=results