### PR TITLE
Patch libssh for CVE-2025-5318

### DIFF
--- a/SPECS/libssh/CVE-2025-5318.patch
+++ b/SPECS/libssh/CVE-2025-5318.patch
@@ -1,0 +1,27 @@
+From 714bb4b91a8b4d0e22fe7b6c62b1c82b8a87f942 Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 16:09:34 +0000
+Subject: [PATCH] Fix CVE CVE-2025-5318 in libssh
+
+[Backported] Upstream Patch Reference: https://git.libssh.org/projects/libssh.git/commit/?id=5f4ffda88770f95482fd0e66aa44106614dbf466
+---
+ src/sftpserver.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/sftpserver.c b/src/sftpserver.c
+index 9117f15..b3349e1 100644
+--- a/src/sftpserver.c
++++ b/src/sftpserver.c
+@@ -538,7 +538,7 @@ void *sftp_handle(sftp_session sftp, ssh_string handle){
+ 
+   memcpy(&val, ssh_string_data(handle), sizeof(uint32_t));
+ 
+-  if (val > SFTP_HANDLES) {
++  if (val >= SFTP_HANDLES) {
+     return NULL;
+   }
+ 
+-- 
+2.45.3
+

--- a/SPECS/libssh/libssh.spec
+++ b/SPECS/libssh/libssh.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           libssh
 Version:        0.10.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A library implementing the SSH protocol
 License:        LGPLv2+
 URL:            http://www.libssh.org
@@ -12,6 +12,7 @@ Source1:        https://www.libssh.org/files/0.10/%{name}-%{version}.tar.xz.asc
 Source2:        https://cryptomilk.org/gpgkey-8DFF53E18F2ABC8D8F3C92237EE0FC4DCC014E3D.gpg#/%{name}.keyring
 Source3:        libssh_client.config
 Source4:        libssh_server.config
+Patch0:         CVE-2025-5318.patch
 
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
@@ -144,6 +145,9 @@ popd
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/libssh/libssh_server.config
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.10.6-2
+- Patch for CVE-2025-5318
+
 * Fri Dec 29 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 0.10.6-1
 - Upgrade to 0.10.6 to fix CVE-2023-48795
 


### PR DESCRIPTION
Auto Patch libssh for CVE-2025-5318.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853221&view=results