### PR TITLE
Patch gdk-pixbuf2 for CVE-2025-6199

### DIFF
--- a/SPECS/gdk-pixbuf2/CVE-2025-6199.patch
+++ b/SPECS/gdk-pixbuf2/CVE-2025-6199.patch
@@ -1,0 +1,27 @@
+From b9f3eaf2f3b2dba4fa57ed384529ea42f1c6462f Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 16:19:11 +0000
+Subject: [PATCH] Fix CVE CVE-2025-6199 in gdk-pixbuf2
+
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/191.patch
+---
+ gdk-pixbuf/lzw.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdk-pixbuf/lzw.c b/gdk-pixbuf/lzw.c
+index 1529356..4f3dd8b 100644
+--- a/gdk-pixbuf/lzw.c
++++ b/gdk-pixbuf/lzw.c
+@@ -208,7 +208,7 @@ lzw_decoder_feed (LZWDecoder *self,
+                                 /* Invalid code received - just stop here */
+                                 if (self->code >= self->code_table_size) {
+                                         self->last_code = self->eoi_code;
+-                                        return output_length;
++                                        return n_written;
+                                 }
+ 
+                                 /* Convert codeword into indexes */
+-- 
+2.45.3
+

--- a/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
+++ b/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
@@ -2,13 +2,14 @@
 Summary:        An image loading library
 Name:           gdk-pixbuf2
 Version:        2.42.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://gitlab.gnome.org/GNOME/gdk-pixbuf
 Source0:        https://download.gnome.org/sources/gdk-pixbuf/2.42/gdk-pixbuf-%{version}.tar.xz
 Patch0:         CVE-2022-48622.patch
+Patch1:         CVE-2025-6199.patch
 BuildRequires:  %{_bindir}/rst2man
 BuildRequires:  gettext
 BuildRequires:  libjpeg-devel
@@ -58,6 +59,7 @@ the functionality of the installed %{name} package.
 
 %prep
 %autosetup -n gdk-pixbuf-%{version} -p1
+%patch1 -p1
 
 %build
 %meson \
@@ -115,6 +117,9 @@ gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
 %{_datadir}/installed-tests
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.42.10-3
+- Patch for CVE-2025-6199
+
 * Thu Sep 19 2024 Sumedh Sharma <sumsharma@microsoft.com> - 2.42.10-2
 - Add patch for CVE-2022-48622
 

--- a/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
+++ b/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
@@ -59,7 +59,6 @@ the functionality of the installed %{name} package.
 
 %prep
 %autosetup -n gdk-pixbuf-%{version} -p1
-%patch1 -p1
 
 %build
 %meson \


### PR DESCRIPTION
Auto Patch gdk-pixbuf2 for CVE-2025-6199.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853229&view=results