### PR TITLE
Patch ceph for CVE-2025-52555

### DIFF
--- a/SPECS/ceph/CVE-2025-52555.patch
+++ b/SPECS/ceph/CVE-2025-52555.patch
@@ -1,0 +1,51 @@
+From d98c7d60b11d47c24e5ba1fbeb935b1085eb020a Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 17:39:51 +0000
+Subject: [PATCH] Fix CVE CVE-2025-52555 in ceph
+
+Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/ceph/ceph/pull/60314.patch
+---
+ src/client/Client.cc | 24 ++++++++++++++----------
+ 1 file changed, 14 insertions(+), 10 deletions(-)
+
+diff --git a/src/client/Client.cc b/src/client/Client.cc
+index 2b7db5a89..eca980a25 100644
+--- a/src/client/Client.cc
++++ b/src/client/Client.cc
+@@ -5949,18 +5949,22 @@ int Client::may_setattr(Inode *in, struct ceph_statx *stx, int mask,
+   }
+ 
+   if (mask & CEPH_SETATTR_MODE) {
++    bool allowed = false;
++    /*
++     * Currently the kernel fuse and libfuse code is buggy and
++     * won't pass the ATTR_KILL_SUID/ATTR_KILL_SGID to ceph-fuse.
++     * But will just set the ATTR_MODE and at the same time by
++     * clearing the suid/sgid bits.
++     *
++     * Only allow unprivileged users to clear S_ISUID and S_ISUID.
++     */
++    if ((in->mode & (S_ISUID | S_ISGID)) != (stx->stx_mode & (S_ISUID | S_ISGID)) &&
++        (in->mode & ~(S_ISUID | S_ISGID)) == (stx->stx_mode & ~(S_ISUID | S_ISGID))) {
++      allowed = true;
++    }
+     uint32_t m = ~stx->stx_mode & in->mode; // mode bits removed
+     ldout(cct, 20) << __func__ << " " << *in << " = " << hex << m << dec <<  dendl;
+-    if (perms.uid() != 0 && perms.uid() != in->uid &&
+-	/*
+-	 * Currently the kernel fuse and libfuse code is buggy and
+-	 * won't pass the ATTR_KILL_SUID/ATTR_KILL_SGID to ceph-fuse.
+-	 * But will just set the ATTR_MODE and at the same time by
+-	 * clearing the suid/sgid bits.
+-	 *
+-	 * Only allow unprivileged users to clear S_ISUID and S_ISUID.
+-	 */
+-	(m & ~(S_ISUID | S_ISGID)))
++    if (perms.uid() != 0 && perms.uid() != in->uid && !allowed)
+       goto out;
+ 
+     gid_t i_gid = (mask & CEPH_SETATTR_GID) ? stx->stx_gid : in->gid;
+-- 
+2.45.3
+

--- a/SPECS/ceph/ceph.spec
+++ b/SPECS/ceph/ceph.spec
@@ -5,7 +5,7 @@
 Summary:        User space components of the Ceph file system
 Name:           ceph
 Version:        18.2.2
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        LGPLv2 and LGPLv3 and CC-BY-SA and GPLv2 and Boost and BSD and MIT and Public Domain and GPLv3 and ASL-2.0
 URL:            https://ceph.io/
 Vendor:         Microsoft Corporation
@@ -28,6 +28,7 @@ Patch13:        CVE-2020-10724.patch
 Patch14:        CVE-2025-1744.patch
 Patch15:        CVE-2021-28361.patch
 Patch16:        CVE-2020-14378.patch
+Patch17:        CVE-2025-52555.patch
 #
 # Copyright (C) 2004-2019 The Ceph Project Developers. See COPYING file
 # at the top-level directory of this distribution and at
@@ -2018,6 +2019,9 @@ exit 0
 %config %{_sysconfdir}/prometheus/ceph/ceph_default_alerts.yml
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 18.2.2-9
+- Patch for CVE-2025-52555
+
 * Wed 16 Apr 2025 Archana Shettigar <v-shettigara@microsoft.com> - 18.2.2-8
 - Patch CVE-2020-14378
 


### PR DESCRIPTION
Auto Patch ceph for CVE-2025-52555.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853262&view=results