### PR TITLE
[Low] Patch libxml2 for CVE-2025-6170

### DIFF
--- a/SPECS/libxml2/CVE-2025-6170.patch
+++ b/SPECS/libxml2/CVE-2025-6170.patch
@@ -1,0 +1,61 @@
+From af4d4fd3e12fc9553b532f66c3717fe5dedfae98 Mon Sep 17 00:00:00 2001
+From: BinduSri-6522866 <v-badabala@microsoft.com>
+Date: Fri, 4 Jul 2025 11:04:50 +0000
+Subject: [PATCH] Address CVE-2025-6170
+
+Upstream Patch reference: https://gitlab.gnome.org/GNOME/libxml2/-/issues/941
+---
+ debugXML.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/debugXML.c b/debugXML.c
+index 3bb1930..2d11213 100644
+--- a/debugXML.c
++++ b/debugXML.c
+@@ -2781,6 +2781,10 @@ xmlShellPwd(xmlShellCtxtPtr ctxt ATTRIBUTE_UNUSED, char *buffer,
+     return (0);
+ }
+ 
++#define MAX_PROMPT_SIZE     500
++#define MAX_ARG_SIZE        400
++#define MAX_COMMAND_SIZE    100
++
+ /**
+  * xmlShell:
+  * @doc:  the initial document
+@@ -2796,10 +2800,10 @@ void
+ xmlShell(xmlDocPtr doc, char *filename, xmlShellReadlineFunc input,
+          FILE * output)
+ {
+-    char prompt[500] = "/ > ";
++    char prompt[MAX_PROMPT_SIZE] = "/ > ";
+     char *cmdline = NULL, *cur;
+-    char command[100];
+-    char arg[400];
++    char command[MAX_COMMAND_SIZE];
++    char arg[MAX_ARG_SIZE];
+     int i;
+     xmlShellCtxtPtr ctxt;
+     xmlXPathObjectPtr list;
+@@ -2857,7 +2861,8 @@ xmlShell(xmlDocPtr doc, char *filename, xmlShellReadlineFunc input,
+             cur++;
+         i = 0;
+         while ((*cur != ' ') && (*cur != '\t') &&
+-               (*cur != '\n') && (*cur != '\r')) {
++               (*cur != '\n') && (*cur != '\r') &&
++               (i < (MAX_COMMAND_SIZE - 1))) {
+             if (*cur == 0)
+                 break;
+             command[i++] = *cur++;
+@@ -2872,7 +2877,7 @@ xmlShell(xmlDocPtr doc, char *filename, xmlShellReadlineFunc input,
+         while ((*cur == ' ') || (*cur == '\t'))
+             cur++;
+         i = 0;
+-        while ((*cur != '\n') && (*cur != '\r') && (*cur != 0)) {
++        while ((*cur != '\n') && (*cur != '\r') && (*cur != 0) && (i < (MAX_ARG_SIZE-1))) {
+             if (*cur == 0)
+                 break;
+             arg[i++] = *cur++;
+-- 
+2.45.3
+

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.10.4
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,7 @@ Patch5:         CVE-2025-24928.patch
 Patch6:         CVE-2025-27113.patch
 Patch7:         CVE-2025-32414.patch
 Patch8:         CVE-2025-32415.patch
+Patch9:         CVE-2025-6170.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -87,6 +88,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Mon Jul 7 2025 BinduSri Adabala <v-badabala@microsoft.com> - 2.10.4-8
+- Patch CVE-2025-6170
+
 * Mon May 05 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-7
 - Patch CVE-2025-32414 and CVE-2025-32415
 

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -88,7 +88,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
-* Mon Jul 7 2025 BinduSri Adabala <v-badabala@microsoft.com> - 2.10.4-8
+* Mon Jul 07 2025 BinduSri Adabala <v-badabala@microsoft.com> - 2.10.4-8
 - Patch CVE-2025-6170
 
 * Mon May 05 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-7

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.aarch64.rpm
 curl-devel-8.8.0-6.cm2.aarch64.rpm
 curl-libs-8.8.0-6.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
-libxml2-2.10.4-7.cm2.aarch64.rpm
-libxml2-devel-2.10.4-7.cm2.aarch64.rpm
+libxml2-2.10.4-8.cm2.aarch64.rpm
+libxml2-devel-2.10.4-8.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.x86_64.rpm
 curl-devel-8.8.0-6.cm2.x86_64.rpm
 curl-libs-8.8.0-6.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
-libxml2-2.10.4-7.cm2.x86_64.rpm
-libxml2-devel-2.10.4-7.cm2.x86_64.rpm
+libxml2-2.10.4-8.cm2.x86_64.rpm
+libxml2-devel-2.10.4-8.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -209,9 +209,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.aarch64.rpm
 libtasn1-devel-4.19.0-2.cm2.aarch64.rpm
 libtool-2.4.6-8.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-8.cm2.aarch64.rpm
-libxml2-2.10.4-7.cm2.aarch64.rpm
-libxml2-debuginfo-2.10.4-7.cm2.aarch64.rpm
-libxml2-devel-2.10.4-7.cm2.aarch64.rpm
+libxml2-2.10.4-8.cm2.aarch64.rpm
+libxml2-debuginfo-2.10.4-8.cm2.aarch64.rpm
+libxml2-devel-2.10.4-8.cm2.aarch64.rpm
 libxslt-1.1.34-8.cm2.aarch64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.aarch64.rpm
 libxslt-devel-1.1.34-8.cm2.aarch64.rpm
@@ -521,7 +521,7 @@ python3-gpg-1.16.0-2.cm2.aarch64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.aarch64.rpm
 python3-libs-3.9.19-14.cm2.aarch64.rpm
-python3-libxml2-2.10.4-7.cm2.aarch64.rpm
+python3-libxml2-2.10.4-8.cm2.aarch64.rpm
 python3-lxml-4.9.1-1.cm2.aarch64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -215,9 +215,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.x86_64.rpm
 libtasn1-devel-4.19.0-2.cm2.x86_64.rpm
 libtool-2.4.6-8.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-8.cm2.x86_64.rpm
-libxml2-2.10.4-7.cm2.x86_64.rpm
-libxml2-debuginfo-2.10.4-7.cm2.x86_64.rpm
-libxml2-devel-2.10.4-7.cm2.x86_64.rpm
+libxml2-2.10.4-8.cm2.x86_64.rpm
+libxml2-debuginfo-2.10.4-8.cm2.x86_64.rpm
+libxml2-devel-2.10.4-8.cm2.x86_64.rpm
 libxslt-1.1.34-8.cm2.x86_64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.x86_64.rpm
 libxslt-devel-1.1.34-8.cm2.x86_64.rpm
@@ -527,7 +527,7 @@ python3-gpg-1.16.0-2.cm2.x86_64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.x86_64.rpm
 python3-libs-3.9.19-14.cm2.x86_64.rpm
-python3-libxml2-2.10.4-7.cm2.x86_64.rpm
+python3-libxml2-2.10.4-8.cm2.x86_64.rpm
 python3-lxml-4.9.1-1.cm2.x86_64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch libxml2 for CVE-2025-6170
Patch modified: Yes

- `result/scripts/long_command`, `test/scripts/long_command.script` and `test/scripts/long_command.xml` files are not - present in source tar ball. So, patch is not applied for these files.
- Affected code present in existing libxml2 version ( debugXML.c ) '2.10.4' and available patch version '2.14.x' ( shell.c ) file and function names are different. Hence, modified affected code in xmlShell ( xmllintShell in upstream patch) function.
- Astrolabe patch reference link: https://gitlab.gnome.org/GNOME/libxml2/-/issues/941 navigates to https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/321/diffs

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/libxml2/CVE-2025-6170.patch
- modified:   SPECS/libxml2/libxml2.spec
- modified:   toolkit/resources/manifests/package/pkggen_core_aarch64.txt
- modified:   toolkit/resources/manifests/package/pkggen_core_x86_64.txt
- modified:   toolkit/resources/manifests/package/toolchain_aarch64.txt
- modified:   toolkit/resources/manifests/package/toolchain_x86_64.txt

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-6170

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Patch applies cleanly
![image](https://github.com/user-attachments/assets/b244831f-8267-4b04-ab1c-32dda6473a03)

- Build is successful -
[libxml2-2.10.4-8.cm2.src.rpm.log](https://github.com/user-attachments/files/21101329/libxml2-2.10.4-8.cm2.src.rpm.log)

- Test is successful -
[libxml2-2.10.4-8.cm2.src.rpm.test.log](https://github.com/user-attachments/files/21101337/libxml2-2.10.4-8.cm2.src.rpm.test.log)
