### PR TITLE
[MEDIUM] Patch for python-virtualenv CVE-2025-50181

### DIFF
--- a/SPECS/python-virtualenv/CVE-2025-50181v0.patch
+++ b/SPECS/python-virtualenv/CVE-2025-50181v0.patch
@@ -1,0 +1,48 @@
+From e942dd93a09e2eb8a52097c76075d0a42be20f39 Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Tue, 8 Jul 2025 10:53:14 -0400
+Subject: [PATCH] Address CVE-2025-50181-1
+Upstream Patch Reference: https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857
+---
+ pip/_vendor/urllib3/poolmanager.py | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/pip/_vendor/urllib3/poolmanager.py b/pip/_vendor/urllib3/poolmanager.py
+index 14b10da..574b7de 100644
+--- a/pip/_vendor/urllib3/poolmanager.py
++++ b/pip/_vendor/urllib3/poolmanager.py
+@@ -170,6 +170,22 @@ class PoolManager(RequestMethods):
+ 
+     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
+         RequestMethods.__init__(self, headers)
++        if "retries" in connection_pool_kw:
++            retries = connection_pool_kw["retries"]
++            if not isinstance(retries, Retry):
++                # When Retry is initialized, raise_on_redirect is based
++                # on a redirect boolean value.
++                # But requests made via a pool manager always set
++                # redirect to False, and raise_on_redirect always ends
++                # up being False consequently.
++                # Here we fix the issue by setting raise_on_redirect to
++                # a value needed by the pool manager without considering
++                # the redirect boolean.
++                raise_on_redirect = retries is not False
++                retries = Retry.from_int(retries, redirect=False)
++                retries.raise_on_redirect = raise_on_redirect
++                connection_pool_kw = connection_pool_kw.copy()
++                connection_pool_kw["retries"] = retries
+         self.connection_pool_kw = connection_pool_kw
+         self.pools = RecentlyUsedContainer(num_pools)
+ 
+@@ -386,7 +402,7 @@ class PoolManager(RequestMethods):
+         if response.status == 303:
+             method = "GET"
+ 
+-        retries = kw.get("retries")
++        retries = kw.get("retries", response.retries)
+         if not isinstance(retries, Retry):
+             retries = Retry.from_int(retries, redirect=redirect)
+ 
+-- 
+2.34.1
+

--- a/SPECS/python-virtualenv/CVE-2025-50181v1.patch
+++ b/SPECS/python-virtualenv/CVE-2025-50181v1.patch
@@ -1,0 +1,48 @@
+From 8275bde7d461c4d6cd44397529fcb75847eee97c Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Wed, 9 Jul 2025 22:12:03 -0400
+Subject: [PATCH] Address CVE-xxxx-yyyy
+Upstream Patch Reference: https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857
+---
+ pip/_vendor/urllib3/poolmanager.py | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/pip/_vendor/urllib3/poolmanager.py b/pip/_vendor/urllib3/poolmanager.py
+index fb51bf7..a8de7c6 100644
+--- a/pip/_vendor/urllib3/poolmanager.py
++++ b/pip/_vendor/urllib3/poolmanager.py
+@@ -170,6 +170,22 @@ class PoolManager(RequestMethods):
+ 
+     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
+         RequestMethods.__init__(self, headers)
++        if "retries" in connection_pool_kw:
++            retries = connection_pool_kw["retries"]
++            if not isinstance(retries, Retry):
++                # When Retry is initialized, raise_on_redirect is based
++                # on a redirect boolean value.
++                # But requests made via a pool manager always set
++                # redirect to False, and raise_on_redirect always ends
++                # up being False consequently.
++                # Here we fix the issue by setting raise_on_redirect to
++                # a value needed by the pool manager without considering
++                # the redirect boolean.
++                raise_on_redirect = retries is not False
++                retries = Retry.from_int(retries, redirect=False)
++                retries.raise_on_redirect = raise_on_redirect
++                connection_pool_kw = connection_pool_kw.copy()
++                connection_pool_kw["retries"] = retries
+         self.connection_pool_kw = connection_pool_kw
+         self.pools = RecentlyUsedContainer(num_pools)
+ 
+@@ -389,7 +405,7 @@ class PoolManager(RequestMethods):
+             kw["body"] = None
+             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
+ 
+-        retries = kw.get("retries")
++        retries = kw.get("retries", response.retries)
+         if not isinstance(retries, Retry):
+             retries = Retry.from_int(retries, redirect=redirect)
+ 
+-- 
+2.34.1
+

--- a/SPECS/python-virtualenv/CVE-2025-50181v2.patch
+++ b/SPECS/python-virtualenv/CVE-2025-50181v2.patch
@@ -1,0 +1,48 @@
+From b9f02b9d46967b99beab18718c79e79e08304c89 Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Tue, 8 Jul 2025 22:33:17 -0400
+Subject: [PATCH] Address CVE-2025-50181v2
+Upstream Patch Reference: https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857
+---
+ pip/_vendor/urllib3/poolmanager.py | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/pip/_vendor/urllib3/poolmanager.py b/pip/_vendor/urllib3/poolmanager.py
+index fe5491c..d03b343 100644
+--- a/pip/_vendor/urllib3/poolmanager.py
++++ b/pip/_vendor/urllib3/poolmanager.py
+@@ -151,6 +151,22 @@ class PoolManager(RequestMethods):
+ 
+     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
+         RequestMethods.__init__(self, headers)
++        if "retries" in connection_pool_kw:
++            retries = connection_pool_kw["retries"]
++            if not isinstance(retries, Retry):
++                # When Retry is initialized, raise_on_redirect is based
++                # on a redirect boolean value.
++                # But requests made via a pool manager always set
++                # redirect to False, and raise_on_redirect always ends
++                # up being False consequently.
++                # Here we fix the issue by setting raise_on_redirect to
++                # a value needed by the pool manager without considering
++                # the redirect boolean.
++                raise_on_redirect = retries is not False
++                retries = Retry.from_int(retries, redirect=False)
++                retries.raise_on_redirect = raise_on_redirect
++                connection_pool_kw = connection_pool_kw.copy()
++                connection_pool_kw["retries"] = retries
+         self.connection_pool_kw = connection_pool_kw
+         self.pools = RecentlyUsedContainer(num_pools,
+                                            dispose_func=lambda p: p.close())
+@@ -333,7 +349,7 @@ class PoolManager(RequestMethods):
+         if response.status == 303:
+             method = 'GET'
+ 
+-        retries = kw.get('retries')
++        retries = kw.get("retries", response.retries)
+         if not isinstance(retries, Retry):
+             retries = Retry.from_int(retries, redirect=redirect)
+ 
+-- 
+2.34.1
+

--- a/SPECS/python-virtualenv/CVE-2025-50181v3.patch
+++ b/SPECS/python-virtualenv/CVE-2025-50181v3.patch
@@ -1,0 +1,48 @@
+From 3d5efc9facfee6c0136bbe14e02000de2cfcef23 Mon Sep 17 00:00:00 2001
+From: Aninda <v-anipradhan@microsoft.com>
+Date: Wed, 9 Jul 2025 07:33:05 -0400
+Subject: [PATCH] Address CVE-2025-50181v3
+Upstream Patch Reference: https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857
+---
+ pip/_vendor/urllib3/poolmanager.py | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/pip/_vendor/urllib3/poolmanager.py b/pip/_vendor/urllib3/poolmanager.py
+index 242a2f8..c542cea 100644
+--- a/pip/_vendor/urllib3/poolmanager.py
++++ b/pip/_vendor/urllib3/poolmanager.py
+@@ -158,6 +158,22 @@ class PoolManager(RequestMethods):
+ 
+     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
+         RequestMethods.__init__(self, headers)
++        if "retries" in connection_pool_kw:
++            retries = connection_pool_kw["retries"]
++            if not isinstance(retries, Retry):
++                # When Retry is initialized, raise_on_redirect is based
++                # on a redirect boolean value.
++                # But requests made via a pool manager always set
++                # redirect to False, and raise_on_redirect always ends
++                # up being False consequently.
++                # Here we fix the issue by setting raise_on_redirect to
++                # a value needed by the pool manager without considering
++                # the redirect boolean.
++                raise_on_redirect = retries is not False
++                retries = Retry.from_int(retries, redirect=False)
++                retries.raise_on_redirect = raise_on_redirect
++                connection_pool_kw = connection_pool_kw.copy()
++                connection_pool_kw["retries"] = retries
+         self.connection_pool_kw = connection_pool_kw
+         self.pools = RecentlyUsedContainer(num_pools, dispose_func=lambda p: p.close())
+ 
+@@ -340,7 +356,7 @@ class PoolManager(RequestMethods):
+         if response.status == 303:
+             method = "GET"
+ 
+-        retries = kw.get("retries")
++        retries = kw.get("retries", response.retries)
+         if not isinstance(retries, Retry):
+             retries = Retry.from_int(retries, redirect=redirect)
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Addresses python-virtualenv CVE-2025-50181

https://github.com/advisories/GHSA-pq67-6m6q-mj2v
-- Patch modified: Yes
-- Patch was backported for poolmanager.py, rest of the files [CHANGES.rst, docs/reference/contrib/emscripten.rst, dummyserver/app.py, test/contrib/emscripten/test_emscripten.py, test/test_poolmanager.py, test/with_dummyserver/test_poolmanager.py] are not available for the version of urllib3 being used along with this package.
-- Patch link found in Astrolabe: https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/python-virtualenv/python-virtualenv.spec
- added: SPECS/python-virtualenv/CVE-2025-50181v0.patch
- added: SPECS/python-virtualenv/CVE-2025-50181v1.patch
- added: SPECS/python-virtualenv/CVE-2025-50181v2.patch
- added: SPECS/python-virtualenv/CVE-2025-50181v3.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-50181

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build: 
- - build log: 
[python-virtualenv-20.26.6-2.cm2.src.rpm.log](https://github.com/user-attachments/files/21146099/python-virtualenv-20.26.6-2.cm2.src.rpm.log)
-- test log: 
[python-virtualenv-20.26.6-2.cm2.src.rpm.test.log](https://github.com/user-attachments/files/21146106/python-virtualenv-20.26.6-2.cm2.src.rpm.test.log)
-- Patch applied:
<img width="915" height="70" alt="image" src="https://github.com/user-attachments/assets/2c276ba7-afbb-4891-ade7-b772f7ced88f" />
<img width="913" height="57" alt="image" src="https://github.com/user-attachments/assets/79502233-e856-4693-8271-ac8432198b17" />
<img width="1005" height="46" alt="image" src="https://github.com/user-attachments/assets/520cd386-0b3d-4618-923a-b7f77ee20c52" />
<img width="805" height="50" alt="image" src="https://github.com/user-attachments/assets/8bb360cf-778c-47a6-bcee-53e87f9b1324" />


