### PR TITLE
[High] Patch redis for CVE-2025-48367

### DIFF
--- a/SPECS/redis/CVE-2025-48367.patch
+++ b/SPECS/redis/CVE-2025-48367.patch
@@ -1,0 +1,104 @@
+From 0fe67435935cc5724ff6eb9c4ca4120c58a15765 Mon Sep 17 00:00:00 2001
+From: Ozan Tezcan <ozantezcan@gmail.com>
+Date: Wed, 14 May 2025 11:02:30 +0300
+Subject: [PATCH] Retry accept() even if accepted connection reports an error
+ (CVE-2025-48367)
+
+Upstream Patch Link: https://github.com/redis/redis/commit/0fe67435935cc5724ff6eb9c4ca4120c58a15765.patch
+
+In case of accept4() returns an error, we should check errno value and
+decide if we should retry accept4() without waiting next event loop iteration.
+---
+ src/anet.c       | 24 ++++++++++++++++++++++++
+ src/anet.h       |  2 +-
+ src/cluster.c    |  2 ++
+ src/networking.c |  6 ++++++
+ 4 files changed, 33 insertions(+), 1 deletion(-)
+
+diff --git a/src/anet.c b/src/anet.c
+index 91f61718ef3..2e42fc572c3 100644
+--- a/src/anet.c
++++ b/src/anet.c
+@@ -594,3 +594,27 @@ int anetFormatFdAddr(int fd, char *buf, size_t buf_len, int fd_to_str_type) {
+     anetFdToString(fd,ip,sizeof(ip),&port,fd_to_str_type);
+     return anetFormatAddr(buf, buf_len, ip, port);
+ }
++
++/* This function must be called after accept4() fails. It returns 1 if 'err'
++ * indicates accepted connection faced an error, and it's okay to continue
++ * accepting next connection by calling accept4() again. Other errors either
++ * indicate programming errors, e.g. calling accept() on a closed fd or indicate
++ * a resource limit has been reached, e.g. -EMFILE, open fd limit has been
++ * reached. In the latter case, caller might wait until resources are available.
++ * See accept4() documentation for details. */
++int anetAcceptFailureNeedsRetry(int err) {
++    if (err == ECONNABORTED)
++        return 1;
++
++#if defined(__linux__)
++    /* For details, see 'Error Handling' section on
++     * https://man7.org/linux/man-pages/man2/accept.2.html */
++    if (err == ENETDOWN || err == EPROTO || err == ENOPROTOOPT ||
++        err == EHOSTDOWN || err == ENONET || err == EHOSTUNREACH ||
++        err == EOPNOTSUPP || err == ENETUNREACH)
++    {
++        return 1;
++    }
++#endif
++    return 0;
++}
+diff --git a/src/anet.h b/src/anet.h
+index 2a685cc0169..adedaf3e1a8 100644
+--- a/src/anet.h
++++ b/src/anet.h
+@@ -72,5 +72,5 @@ int anetFdToString(int fd, char *ip, size_t ip_len, int *port, int fd_to_str_typ
+ int anetKeepAlive(char *err, int fd, int interval);
+ int anetFormatAddr(char *fmt, size_t fmt_len, char *ip, int port);
+ int anetFormatFdAddr(int fd, char *buf, size_t buf_len, int fd_to_str_type);
+-
++int anetAcceptFailureNeedsRetry(int err);
+ #endif
+diff --git a/src/cluster.c b/src/cluster.c
+index 8807fe2c8c3..030897c6ab1 100644
+--- a/src/cluster.c
++++ b/src/cluster.c
+@@ -691,6 +691,8 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
+     while(max--) {
+         cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
+         if (cfd == ANET_ERR) {
++            if (anetAcceptFailureNeedsRetry(errno))
++                continue;
+             if (errno != EWOULDBLOCK)
+                 serverLog(LL_VERBOSE,
+                     "Error accepting cluster node: %s", server.neterr);
+diff --git a/src/networking.c b/src/networking.c
+index 11891d3e970..2598a58baa8 100644
+--- a/src/networking.c
++++ b/src/networking.c
+@@ -1190,6 +1190,8 @@ void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
+     while(max--) {
+         cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
+         if (cfd == ANET_ERR) {
++            if (anetAcceptFailureNeedsRetry(errno))
++                continue;
+             if (errno != EWOULDBLOCK)
+                 serverLog(LL_WARNING,
+                     "Accepting client connection: %s", server.neterr);
+@@ -1211,6 +1213,8 @@ void acceptTLSHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
+     while(max--) {
+         cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
+         if (cfd == ANET_ERR) {
++            if (anetAcceptFailureNeedsRetry(errno))
++                continue;
+             if (errno != EWOULDBLOCK)
+                 serverLog(LL_WARNING,
+                     "Accepting client connection: %s", server.neterr);
+@@ -1231,6 +1235,8 @@ void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
+     while(max--) {
+         cfd = anetUnixAccept(server.neterr, fd);
+         if (cfd == ANET_ERR) {
++            if (anetAcceptFailureNeedsRetry(errno))
++                continue;
+             if (errno != EWOULDBLOCK)
+                 serverLog(LL_WARNING,
+                     "Accepting client connection: %s", server.neterr);

--- a/SPECS/redis/redis.spec
+++ b/SPECS/redis/redis.spec
@@ -1,7 +1,7 @@
 Summary:        advanced key-value store
 Name:           redis
 Version:        6.2.18
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Source0:        https://download.redis.io/releases/%{name}-%{version}.tar.gz
 Patch0:         redis-conf.patch
 Patch1:         disable_active_defrag_big_keys.patch
 Patch2:         CVE-2025-32023.patch
+Patch3:         CVE-2025-48367.patch
 BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  openssl-devel
@@ -85,6 +86,9 @@ exit 0
 %config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/redis.conf
 
 %changelog
+* Wed Jul 09 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 6.2.18-3
+- Patch for CVE-2025-48367
+
 * Wed Jul 09 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 6.2.18-2
 - Patch for CVE-2025-32023
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patches `redis` for CVE-2025-48367

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for CVE-2025-48367.patch
	- Patch needed no modification besides adding upstream link (https://github.com/redis/redis/commit/0fe67435935cc5724ff6eb9c4ca4120c58a15765.patch)
	- Patch applies cleanly:
	  <img width="1146" height="102" alt="image" src="https://github.com/user-attachments/assets/4c2a62b7-f323-42dd-a122-828ac23c86c1" />

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-48367

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build (some tests timed out twice in a row, I don't think I introduced any failures, I want to see if it passes the pipeline)
  <img width="1085" height="290" alt="image" src="https://github.com/user-attachments/assets/cd770454-635b-4fda-b8c2-4aa5171de71d" />
