### PR TITLE
[High] patch helm for CVE-2025-53547

### DIFF
--- a/SPECS/helm/CVE-2025-53547.patch
+++ b/SPECS/helm/CVE-2025-53547.patch
@@ -1,0 +1,148 @@
+From 4740f58fb36257e4a9c8ae18a3d050b4462e360c Mon Sep 17 00:00:00 2001
+From: jykanase <v-jykanase@microsoft.com>
+Date: Thu, 10 Jul 2025 13:18:01 +0000
+Subject: [PATCH] CVE-2025-53547
+
+Upstream patch reference: https://github.com/helm/helm/commit/4b8e61093d8f579f1165cdc6bd4b43fa5455f571 
+---
+ pkg/downloader/manager.go      | 14 +++++
+ pkg/downloader/manager_test.go | 94 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 108 insertions(+)
+
+diff --git a/pkg/downloader/manager.go b/pkg/downloader/manager.go
+index 68c9c6e..4f24609 100644
+--- a/pkg/downloader/manager.go
++++ b/pkg/downloader/manager.go
+@@ -852,6 +852,20 @@ func writeLock(chartpath string, lock *chart.Lock, legacyLockfile bool) error {
+ 		lockfileName = "requirements.lock"
+ 	}
+ 	dest := filepath.Join(chartpath, lockfileName)
++
++	info, err := os.Lstat(dest)
++	if err != nil && !os.IsNotExist(err) {
++		return fmt.Errorf("error getting info for %q: %w", dest, err)
++	} else if err == nil {
++		if info.Mode()&os.ModeSymlink != 0 {
++			link, err := os.Readlink(dest)
++			if err != nil {
++				return fmt.Errorf("error reading symlink for %q: %w", dest, err)
++			}
++			return fmt.Errorf("the %s file is a symlink to %q", lockfileName, link)
++		}
++	}
++
+ 	return os.WriteFile(dest, data, 0644)
+ }
+ 
+diff --git a/pkg/downloader/manager_test.go b/pkg/downloader/manager_test.go
+index db2487d..77c3ee9 100644
+--- a/pkg/downloader/manager_test.go
++++ b/pkg/downloader/manager_test.go
+@@ -21,6 +21,9 @@ import (
+ 	"path/filepath"
+ 	"reflect"
+ 	"testing"
++        "time"
++        
++	"sigs.k8s.io/yaml"
+ 
+ 	"helm.sh/helm/v3/pkg/chart"
+ 	"helm.sh/helm/v3/pkg/chart/loader"
+@@ -598,3 +601,94 @@ func TestKey(t *testing.T) {
+ 		}
+ 	}
+ }
++
++func TestWriteLock(t *testing.T) {
++	fixedTime, err := time.Parse(time.RFC3339, "2025-07-04T00:00:00Z")
++	assert.NoError(t, err)
++	lock := &chart.Lock{
++		Generated: fixedTime,
++		Digest:    "sha256:12345",
++		Dependencies: []*chart.Dependency{
++			{
++				Name:       "fantastic-chart",
++				Version:    "1.2.3",
++				Repository: "https://example.com/charts",
++			},
++		},
++	}
++	expectedContent, err := yaml.Marshal(lock)
++	assert.NoError(t, err)
++
++	t.Run("v2 lock file", func(t *testing.T) {
++		dir := t.TempDir()
++		err := writeLock(dir, lock, false)
++		assert.NoError(t, err)
++
++		lockfilePath := filepath.Join(dir, "Chart.lock")
++		_, err = os.Stat(lockfilePath)
++		assert.NoError(t, err, "Chart.lock should exist")
++
++		content, err := os.ReadFile(lockfilePath)
++		assert.NoError(t, err)
++		assert.Equal(t, expectedContent, content)
++
++		// Check that requirements.lock does not exist
++		_, err = os.Stat(filepath.Join(dir, "requirements.lock"))
++		assert.Error(t, err)
++		assert.True(t, os.IsNotExist(err))
++	})
++
++	t.Run("v1 lock file", func(t *testing.T) {
++		dir := t.TempDir()
++		err := writeLock(dir, lock, true)
++		assert.NoError(t, err)
++
++		lockfilePath := filepath.Join(dir, "requirements.lock")
++		_, err = os.Stat(lockfilePath)
++		assert.NoError(t, err, "requirements.lock should exist")
++
++		content, err := os.ReadFile(lockfilePath)
++		assert.NoError(t, err)
++		assert.Equal(t, expectedContent, content)
++
++		// Check that Chart.lock does not exist
++		_, err = os.Stat(filepath.Join(dir, "Chart.lock"))
++		assert.Error(t, err)
++		assert.True(t, os.IsNotExist(err))
++	})
++
++	t.Run("overwrite existing lock file", func(t *testing.T) {
++		dir := t.TempDir()
++		lockfilePath := filepath.Join(dir, "Chart.lock")
++		assert.NoError(t, os.WriteFile(lockfilePath, []byte("old content"), 0644))
++
++		err = writeLock(dir, lock, false)
++		assert.NoError(t, err)
++
++		content, err := os.ReadFile(lockfilePath)
++		assert.NoError(t, err)
++		assert.Equal(t, expectedContent, content)
++	})
++
++	t.Run("lock file is a symlink", func(t *testing.T) {
++		dir := t.TempDir()
++		dummyFile := filepath.Join(dir, "dummy.txt")
++		assert.NoError(t, os.WriteFile(dummyFile, []byte("dummy"), 0644))
++
++		lockfilePath := filepath.Join(dir, "Chart.lock")
++		assert.NoError(t, os.Symlink(dummyFile, lockfilePath))
++
++		err = writeLock(dir, lock, false)
++		assert.Error(t, err)
++		assert.Contains(t, err.Error(), "the Chart.lock file is a symlink to")
++	})
++
++	t.Run("chart path is not a directory", func(t *testing.T) {
++		dir := t.TempDir()
++		filePath := filepath.Join(dir, "not-a-dir")
++		assert.NoError(t, os.WriteFile(filePath, []byte("file"), 0644))
++
++		err = writeLock(filePath, lock, false)
++		assert.Error(t, err)
++	})
++}
+-- 
+2.45.2
+

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -2,7 +2,7 @@
 
 Name:          helm
 Version:       3.14.2
-Release:       6%{?dist}
+Release:       7%{?dist}
 Summary:       The Kubernetes Package Manager
 Group:         Applications/Networking
 License:       Apache 2.0
@@ -28,6 +28,7 @@ Patch0:        CVE-2023-45288.patch
 Patch1:        CVE-2024-45338.patch
 Patch2:        CVE-2025-32386.patch
 Patch3:        CVE-2025-22872.patch
+Patch4:        CVE-2025-53547.patch
 BuildRequires: golang
 
 %description
@@ -57,6 +58,9 @@ install -m 755 ./helm %{buildroot}%{_bindir}
 go test -v ./cmd/helm
 
 %changelog
+* Fri Jul 11 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 3.14.2-7
+- Add patch for CVE-2025-53547
+
 * Thu Apr 17 2025 Archana Shettigar <v-shettigara@microsoft.com> - 3.14.2-6
 - Patch CVE-2025-32386 & CVE-2025-22872
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
patch helm for CVE-2025-53547
Patch Modified: No
Astrolabe Patch Reference: https://github.com/helm/helm/commit/4b8e61093d8f579f1165cdc6bd4b43fa5455f571

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- helm.spec
- CVE-2025-53547.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-53547

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Verified patch is applied.
<img width="1112" height="252" alt="Screenshot 2025-07-11 134929" src="https://github.com/user-attachments/assets/e7bf215f-6018-400c-ac21-7e875f170119" />

-  Verified build locally.

[helm-3.14.2-7.cm2.src.rpm.test.log](https://github.com/user-attachments/files/21179061/helm-3.14.2-7.cm2.src.rpm.test.log)
[helm-3.14.2-7.cm2.src.rpm.log](https://github.com/user-attachments/files/21179065/helm-3.14.2-7.cm2.src.rpm.log)
