### PR TITLE
[High] patch git for CVE-2025-48384, CVE-2025-48385 and CVE-2025-27613

### DIFF
--- a/SPECS/git/CVE-2025-27613.patch
+++ b/SPECS/git/CVE-2025-27613.patch
@@ -1,0 +1,744 @@
+From b7a39ba7f56bde5e3b8af193c06b18f679426d9c Mon Sep 17 00:00:00 2001
+From: jykanase <v-jykanase@microsoft.com>
+Date: Mon, 14 Jul 2025 12:03:02 +0000
+Subject: [PATCH] CVE-2025-27613
+
+Upstream Patch Reference:https://github.com/j6t/gitk/compare/7dd272eca153058da2e8d5b9960bbbf0b4f0cbaa..67a128b91e25978a15f9f7e194d81b441d603652 
+---
+ gitk-git/gitk | 274 +++++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 182 insertions(+), 92 deletions(-)
+
+diff --git a/gitk-git/gitk b/gitk-git/gitk
+index 0ae7d68..0549e95 100755
+--- a/gitk-git/gitk
++++ b/gitk-git/gitk
+@@ -9,6 +9,92 @@ exec wish "$0" -- "$@"
+ 
+ package require Tk
+ 
++
++# Wrap exec/open to sanitize arguments
++
++# unsafe arguments begin with redirections or the pipe or background operators
++proc is_arg_unsafe {arg} {
++    regexp {^([<|>&]|2>)} $arg
++}
++
++proc make_arg_safe {arg} {
++    if {[is_arg_unsafe $arg]} {
++        set arg [file join . $arg]
++    }
++    return $arg
++}
++
++proc make_arglist_safe {arglist} {
++    set res {}
++    foreach arg $arglist {
++        lappend res [make_arg_safe $arg]
++    }
++    return $res
++}
++
++# executes one command
++# no redirections or pipelines are possible
++# cmd is a list that specifies the command and its arguments
++# calls `exec` and returns its value
++proc safe_exec {cmd} {
++    eval exec [make_arglist_safe $cmd]
++}
++
++# executes one command with redirections
++# no pipelines are possible
++# cmd is a list that specifies the command and its arguments
++# redir is a list that specifies redirections (output, background, constant(!) commands)
++# calls `exec` and returns its value
++proc safe_exec_redirect {cmd redir} {
++    eval exec [make_arglist_safe $cmd] $redir
++}
++
++proc safe_open_file {filename flags} {
++    # a file name starting with "|" would attempt to run a process
++    # but such a file name must be treated as a relative path
++    # hide the "|" behind "./"
++    if {[string index $filename 0] eq "|"} {
++        set filename [file join . $filename]
++    }
++    open $filename $flags
++}
++
++# opens a command pipeline for reading
++# cmd is a list that specifies the command and its arguments
++# calls `open` and returns the file id
++proc safe_open_command {cmd} {
++    open |[make_arglist_safe $cmd] r
++}
++
++# opens a command pipeline for reading and writing
++# cmd is a list that specifies the command and its arguments
++# calls `open` and returns the file id
++proc safe_open_command_rw {cmd} {
++    open |[make_arglist_safe $cmd] r+
++}
++
++# opens a command pipeline for reading with redirections
++# cmd is a list that specifies the command and its arguments
++# redir is a list that specifies redirections
++# calls `open` and returns the file id
++proc safe_open_command_redirect {cmd redir} {
++    set cmd [make_arglist_safe $cmd]
++    open |[concat $cmd $redir] r
++}
++
++# opens a pipeline with several commands for reading
++# cmds is a list of lists, each of which specifies a command and its arguments
++# calls `open` and returns the file id
++proc safe_open_pipeline {cmds} {
++    set cmd {}
++    foreach subcmd $cmds {
++        set cmd [concat $cmd | [make_arglist_safe $subcmd]]
++    }
++    open $cmd r
++}
++
++# End exec/open wrappers
++
+ proc hasworktree {} {
+     return [expr {[exec git rev-parse --is-bare-repository] == "false" &&
+                   [exec git rev-parse --is-inside-git-dir] == "false"}]
+@@ -134,7 +220,7 @@ proc unmerged_files {files} {
+     set mlist {}
+     set nr_unmerged 0
+     if {[catch {
+-        set fd [open "| git ls-files -u" r]
++        set fd [safe_open_command {git ls-files -u}]
+     } err]} {
+         show_error {} . "[mc "Couldn't get list of unmerged files:"] $err"
+         exit 1
+@@ -296,7 +382,7 @@ proc parseviewrevs {view revs} {
+     } elseif {[lsearch -exact $revs --all] >= 0} {
+         lappend revs HEAD
+     }
+-    if {[catch {set ids [eval exec git rev-parse $revs]} err]} {
++    if {[catch {set ids [safe_exec [concat git rev-parse $revs]]} err]} {
+         # we get stdout followed by stderr in $err
+         # for an unknown rev, git rev-parse echoes it and then errors out
+         set errlines [split $err "\n"]
+@@ -374,7 +460,7 @@ proc start_rev_list {view} {
+     set args $viewargs($view)
+     if {$viewargscmd($view) ne {}} {
+         if {[catch {
+-            set str [exec sh -c $viewargscmd($view)]
++            set str [safe_exec [list sh -c $viewargscmd($view)]]
+         } err]} {
+             error_popup "[mc "Error executing --argscmd command:"] $err"
+             return 0
+@@ -405,14 +491,15 @@ proc start_rev_list {view} {
+         if {$revs eq {}} {
+             return 0
+         }
+-        set args [concat $vflags($view) $revs]
++        set args $vflags($view)
+     } else {
++        set revs {}
+         set args $vorigargs($view)
+     }
+ 
+     if {[catch {
+-        set fd [open [concat | git log --no-color -z --pretty=raw $show_notes \
+-                        --parents --boundary $args "--" $files] r]
++        set fd [safe_open_command [concat git log --no-color -z --pretty=raw $show_notes \
++                        --parents --boundary $args "--" $files]]
+     } err]} {
+         error_popup "[mc "Error executing git log:"] $err"
+         return 0
+@@ -446,9 +533,9 @@ proc stop_instance {inst} {
+         set pid [pid $fd]
+ 
+         if {$::tcl_platform(platform) eq {windows}} {
+-            exec taskkill /pid $pid
++            safe_exec [list taskkill /pid $pid]
+         } else {
+-            exec kill $pid
++            safe_exec [list kill $pid]
+         }
+     }
+     catch {close $fd}
+@@ -554,13 +641,17 @@ proc updatecommits {} {
+             set revs $newrevs
+             set vposids($view) [lsort -unique [concat $oldpos $vposids($view)]]
+         }
+-        set args [concat $vflags($view) $revs --not $oldpos]
++        set args $vflags($view)
++        foreach r $oldpos {
++                lappend revs "^$r"
++        }
+     } else {
++        set revs {}
+         set args $vorigargs($view)
+     }
+     if {[catch {
+-        set fd [open [concat | git log --no-color -z --pretty=raw $show_notes \
+-                        --parents --boundary $args "--" $vfilelimit($view)] r]
++        set fd [safe_open_command [concat git log --no-color -z --pretty=raw $show_notes \
++                        --parents --boundary "--" $vfilelimit($view)]]
+     } err]} {
+         error_popup "[mc "Error executing git log:"] $err"
+         return
+@@ -1527,8 +1618,8 @@ proc getcommitlines {fd inst view updating}  {
+             # and if we already know about it, using the rewritten
+             # parent as a substitute parent for $id's children.
+             if {![catch {
+-                set rwid [exec git rev-list --first-parent --max-count=1 \
+-                              $id -- $vfilelimit($view)]
++                set rwid [safe_exec [list git rev-list --first-parent --max-count=1 \
++                              $id -- $vfilelimit($view)]]
+             }]} {
+                 if {$rwid ne {} && [info exists varcid($view,$rwid)]} {
+                     # use $rwid in place of $id
+@@ -1648,7 +1739,7 @@ proc do_readcommit {id} {
+     global tclencoding
+ 
+     # Invoke git-log to handle automatic encoding conversion
+-    set fd [open [concat | git log --no-color --pretty=raw -1 $id] r]
++    set fd [safe_open_command [concat git log --no-color --pretty=raw -1 $id]]
+     # Read the results using i18n.logoutputencoding
+     fconfigure $fd -translation lf -eofchar {}
+     if {$tclencoding != {}} {
+@@ -1784,7 +1875,7 @@ proc readrefs {} {
+     foreach v {tagids idtags headids idheads otherrefids idotherrefs} {
+         unset -nocomplain $v
+     }
+-    set refd [open [list | git show-ref -d] r]
++    set refd [safe_open_command [list git show-ref -d]]
+     if {$tclencoding != {}} {
+         fconfigure $refd -encoding $tclencoding
+     }
+@@ -1832,7 +1923,7 @@ proc readrefs {} {
+     set selectheadid {}
+     if {$selecthead ne {}} {
+         catch {
+-            set selectheadid [exec git rev-parse --verify $selecthead]
++            set selectheadid [safe_exec [list git rev-parse --verify $selecthead]]
+         }
+     }
+ }
+@@ -2092,7 +2183,7 @@ proc makewindow {} {
+             {mc "Reread re&ferences" command rereadrefs}
+             {mc "&List references" command showrefs -accelerator F2}
+             {xx "" separator}
+-            {mc "Start git &gui" command {exec git gui &}}
++            {mc "Start git &gui" command {safe_exec_redirect [list git gui] [list &]}}
+             {xx "" separator}
+             {mc "&Quit" command doquit -accelerator Meta1-Q}
+         }}
+@@ -2874,7 +2965,7 @@ proc savestuff {w} {
+     set remove_tmp 0
+     if {[catch {
+         set try_count 0
+-        while {[catch {set f [open $config_file_tmp {WRONLY CREAT EXCL}]}]} {
++        while {[catch {set f [safe_open_file $config_file_tmp {WRONLY CREAT EXCL}]}]} {
+             if {[incr try_count] > 50} {
+                 error "Unable to write config file: $config_file_tmp exists"
+             }
+@@ -3590,7 +3681,7 @@ proc gitknewtmpdir {} {
+             set tmpdir $gitdir
+         }
+         set gitktmpformat [file join $tmpdir ".gitk-tmp.XXXXXX"]
+-        if {[catch {set gitktmpdir [exec mktemp -d $gitktmpformat]}]} {
++        if {[catch {set gitktmpdir [safe_exec [list mktemp -d $gitktmpformat]]}]} {
+             set gitktmpdir [file join $gitdir [format ".gitk-tmp.%s" [pid]]]
+         }
+         if {[catch {file mkdir $gitktmpdir} err]} {
+@@ -3612,7 +3703,7 @@ proc gitknewtmpdir {} {
+ proc save_file_from_commit {filename output what} {
+     global nullfile
+ 
+-    if {[catch {exec git show $filename -- > $output} err]} {
++    if {[catch {safe_exec_redirect [list git show $filename --] [list > $output]} err]} {
+         if {[string match "fatal: bad revision *" $err]} {
+             return $nullfile
+         }
+@@ -3677,7 +3768,7 @@ proc external_diff {} {
+ 
+     if {$difffromfile ne {} && $difftofile ne {}} {
+         set cmd [list [shellsplit $extdifftool] $difffromfile $difftofile]
+-        if {[catch {set fl [open |$cmd r]} err]} {
++        if {[catch {set fl [safe_open_command $cmd]} err]} {
+             file delete -force $diffdir
+             error_popup "$extdifftool: [mc "command failed:"] $err"
+         } else {
+@@ -3781,7 +3872,7 @@ proc external_blame_diff {} {
+ # Find the SHA1 ID of the blob for file $fname in the index
+ # at stage 0 or 2
+ proc index_sha1 {fname} {
+-    set f [open [list | git ls-files -s $fname] r]
++    set f [safe_open_command [list git ls-files -s $fname]]
+     while {[gets $f line] >= 0} {
+         set info [lindex [split $line "\t"] 0]
+         set stage [lindex $info 2]
+@@ -3841,7 +3932,7 @@ proc external_blame {parent_idx {line {}}} {
+     # being given an absolute path...
+     set f [make_relative $f]
+     lappend cmdline $base_commit $f
+-    if {[catch {eval exec $cmdline &} err]} {
++    if {[catch {safe_exec_redirect $cmdline [list &]} err]} {
+         error_popup "[mc "git gui blame: command failed:"] $err"
+     }
+ }
+@@ -3869,7 +3960,7 @@ proc show_line_source {} {
+                 # must be a merge in progress...
+                 if {[catch {
+                     # get the last line from .git/MERGE_HEAD
+-                    set f [open [file join $gitdir MERGE_HEAD] r]
++                    set f [safe_open_file [file join $gitdir MERGE_HEAD] r]
+                     set id [lindex [split [read $f] "\n"] end-1]
+                     close $f
+                 } err]} {
+@@ -3892,19 +3983,17 @@ proc show_line_source {} {
+         }
+         set line [lindex $h 1]
+     }
+-    set blameargs {}
++    set blamefile [file join $cdup $flist_menu_file]
+     if {$from_index ne {}} {
+-        lappend blameargs | git cat-file blob $from_index
+-    }
+-    lappend blameargs | git blame -p -L$line,+1
+-    if {$from_index ne {}} {
+-        lappend blameargs --contents -
++        set blameargs [list \
++            [list git cat-file blob $from_index] \
++            [list git blame -p -L$line,+1 --contents - -- $blamefile]]
+     } else {
+-        lappend blameargs $id
++        set blameargs [list \
++            [list git blame -p -L$line,+1 $id -- $blamefile]]
+     }
+-    lappend blameargs -- [file join $cdup $flist_menu_file]
+     if {[catch {
+-        set f [open $blameargs r]
++        set f [safe_open_pipeline $blameargs]
+     } err]} {
+         error_popup [mc "Couldn't start git blame: %s" $err]
+         return
+@@ -4829,8 +4918,8 @@ proc do_file_hl {serial} {
+         # must be "containing:", i.e. we're searching commit info
+         return
+     }
+-    set cmd [concat | git diff-tree -r -s --stdin $gdtargs]
+-    set filehighlight [open $cmd r+]
++    set cmd [concat git diff-tree -r -s --stdin $gdtargs]
++    set filehighlight [safe_open_command_rw $cmd]
+     fconfigure $filehighlight -blocking 0
+     filerun $filehighlight readfhighlight
+     set fhl_list {}
+@@ -5259,8 +5348,8 @@ proc get_viewmainhead {view} {
+     global viewmainheadid vfilelimit viewinstances mainheadid
+ 
+     catch {
+-        set rfd [open [concat | git rev-list -1 $mainheadid \
+-                           -- $vfilelimit($view)] r]
++        set rfd [safe_open_command [concat git rev-list -1 $mainheadid \
++                           -- $vfilelimit($view)]]
+         set j [reg_instance $rfd]
+         lappend viewinstances($view) $j
+         fconfigure $rfd -blocking 0
+@@ -5325,14 +5414,14 @@ proc dodiffindex {} {
+     if {!$showlocalchanges || !$hasworktree} return
+     incr lserial
+     if {[package vcompare $git_version "1.7.2"] >= 0} {
+-        set cmd "|git diff-index --cached --ignore-submodules=dirty HEAD"
++        set cmd "git diff-index --cached --ignore-submodules=dirty HEAD"
+     } else {
+-        set cmd "|git diff-index --cached HEAD"
++        set cmd "git diff-index --cached HEAD"
+     }
+     if {$vfilelimit($curview) ne {}} {
+         set cmd [concat $cmd -- $vfilelimit($curview)]
+     }
+-    set fd [open $cmd r]
++    set fd [safe_open_command $cmd]
+     fconfigure $fd -blocking 0
+     set i [reg_instance $fd]
+     filerun $fd [list readdiffindex $fd $lserial $i]
+@@ -5357,11 +5446,11 @@ proc readdiffindex {fd serial inst} {
+     }
+ 
+     # now see if there are any local changes not checked in to the index
+-    set cmd "|git diff-files"
++    set cmd "git diff-files"
+     if {$vfilelimit($curview) ne {}} {
+         set cmd [concat $cmd -- $vfilelimit($curview)]
+     }
+-    set fd [open $cmd r]
++    set fd [safe_open_command $cmd]
+     fconfigure $fd -blocking 0
+     set i [reg_instance $fd]
+     filerun $fd [list readdifffiles $fd $serial $i]
+@@ -7150,8 +7239,8 @@ proc browseweb {url} {
+     global web_browser
+ 
+     if {$web_browser eq {}} return
+-    # Use eval here in case $web_browser is a command plus some arguments
+-    if {[catch {eval exec $web_browser [list $url] &} err]} {
++    # Use concat here in case $web_browser is a command plus some arguments
++    if {[catch {safe_exec_redirect [concat $web_browser [list $url]] [list &]} err]} {
+         error_popup "[mc "Error starting web browser:"] $err"
+     }
+ }
+@@ -7653,13 +7742,13 @@ proc gettree {id} {
+     if {![info exists treefilelist($id)]} {
+         if {![info exists treepending]} {
+             if {$id eq $nullid} {
+-                set cmd [list | git ls-files]
++                set cmd [list git ls-files]
+             } elseif {$id eq $nullid2} {
+-                set cmd [list | git ls-files --stage -t]
++                set cmd [list git ls-files --stage -t]
+             } else {
+-                set cmd [list | git ls-tree -r $id]
++                set cmd [list git ls-tree -r $id]
+             }
+-            if {[catch {set gtf [open $cmd r]}]} {
++            if {[catch {set gtf [safe_open_command $cmd]}]} {
+                 return
+             }
+             set treepending $id
+@@ -7723,13 +7812,13 @@ proc showfile {f} {
+         return
+     }
+     if {$diffids eq $nullid} {
+-        if {[catch {set bf [open $f r]} err]} {
++        if {[catch {set bf [safe_open_file $f r]} err]} {
+             puts "oops, can't read $f: $err"
+             return
+         }
+     } else {
+         set blob [lindex $treeidlist($diffids) $i]
+-        if {[catch {set bf [open [concat | git cat-file blob $blob] r]} err]} {
++        if {[catch {set bf [safe_open_command [concat git cat-file blob $blob]]} err]} {
+             puts "oops, error reading blob $blob: $err"
+             return
+         }
+@@ -7879,7 +7968,7 @@ proc diffcmd {ids flags} {
+     if {$i >= 0} {
+         if {[llength $ids] > 1 && $j < 0} {
+             # comparing working directory with some specific revision
+-            set cmd [concat | git diff-index $flags]
++            set cmd [concat git diff-index $flags]
+             if {$i == 0} {
+                 lappend cmd -R [lindex $ids 1]
+             } else {
+@@ -7887,7 +7976,7 @@ proc diffcmd {ids flags} {
+             }
+         } else {
+             # comparing working directory with index
+-            set cmd [concat | git diff-files $flags]
++            set cmd [concat git diff-files $flags]
+             if {$j == 1} {
+                 lappend cmd -R
+             }
+@@ -7896,7 +7985,7 @@ proc diffcmd {ids flags} {
+         if {[package vcompare $git_version "1.7.2"] >= 0} {
+             set flags "$flags --ignore-submodules=dirty"
+         }
+-        set cmd [concat | git diff-index --cached $flags]
++        set cmd [concat git diff-index --cached $flags]
+         if {[llength $ids] > 1} {
+             # comparing index with specific revision
+             if {$j == 0} {
+@@ -7912,7 +8001,7 @@ proc diffcmd {ids flags} {
+         if {$log_showroot} {
+             lappend flags --root
+         }
+-        set cmd [concat | git diff-tree -r $flags $ids]
++        set cmd [concat git diff-tree -r $flags $ids]
+     }
+     return $cmd
+ }
+@@ -7924,7 +8013,7 @@ proc gettreediffs {ids} {
+     if {$limitdiffs && $vfilelimit($curview) ne {}} {
+             set cmd [concat $cmd -- $vfilelimit($curview)]
+     }
+-    if {[catch {set gdtf [open $cmd r]}]} return
++    if {[catch {set gdtf [safe_open_command $cmd]}]} return
+ 
+     set treepending $ids
+     set treediff {}
+@@ -8044,7 +8133,7 @@ proc getblobdiffs {ids} {
+     if {$limitdiffs && $vfilelimit($curview) ne {}} {
+         set cmd [concat $cmd -- $vfilelimit($curview)]
+     }
+-    if {[catch {set bdf [open $cmd r]} err]} {
++    if {[catch {set bdf [safe_open_command $cmd]} err]} {
+         error_popup [mc "Error getting diffs: %s" $err]
+         return
+     }
+@@ -8761,7 +8850,7 @@ proc gotocommit {} {
+                 set id [lindex $matches 0]
+             }
+         } else {
+-            if {[catch {set id [exec git rev-parse --verify $sha1string]}]} {
++            if {[catch {set id [safe_exec [list git rev-parse --verify $sha1string]]}]} {
+                 error_popup [mc "Revision %s is not known" $sha1string]
+                 return
+             }
+@@ -9067,10 +9156,8 @@ proc getpatchid {id} {
+ 
+     if {![info exists patchids($id)]} {
+         set cmd [diffcmd [list $id] {-p --root}]
+-        # trim off the initial "|"
+-        set cmd [lrange $cmd 1 end]
+         if {[catch {
+-            set x [eval exec $cmd | git patch-id]
++            set x [safe_exec_redirect $cmd [list | git patch-id]]
+             set patchids($id) [lindex $x 0]
+         }]} {
+             set patchids($id) "error"
+@@ -9166,14 +9253,14 @@ proc diffcommits {a b} {
+     set fna [file join $tmpdir "commit-[string range $a 0 7]"]
+     set fnb [file join $tmpdir "commit-[string range $b 0 7]"]
+     if {[catch {
+-        exec git diff-tree -p --pretty $a >$fna
+-        exec git diff-tree -p --pretty $b >$fnb
++        safe_exec_redirect [list git diff-tree -p --pretty $a] [list >$fna]
++        safe_exec_redirect [list git diff-tree -p --pretty $b] [list >$fnb]
+     } err]} {
+         error_popup [mc "Error writing commit to file: %s" $err]
+         return
+     }
+     if {[catch {
+-        set fd [open "| diff -U$diffcontext $fna $fnb" r]
++        set fd [safe_open_command "diff -U$diffcontext $fna $fnb"]
+     } err]} {
+         error_popup [mc "Error diffing commits: %s" $err]
+         return
+@@ -9313,10 +9400,7 @@ proc mkpatchgo {} {
+     set newid [$patchtop.tosha1 get]
+     set fname [$patchtop.fname get]
+     set cmd [diffcmd [list $oldid $newid] -p]
+-    # trim off the initial "|"
+-    set cmd [lrange $cmd 1 end]
+-    lappend cmd >$fname &
+-    if {[catch {eval exec $cmd} err]} {
++    if {[catch {safe_exec_redirect $cmd [list >$fname &]} err]} {
+         error_popup "[mc "Error creating patch:"] $err" $patchtop
+     }
+     catch {destroy $patchtop}
+@@ -9385,9 +9469,9 @@ proc domktag {} {
+     }
+     if {[catch {
+         if {$msg != {}} {
+-            exec git tag -a -m $msg $tag $id
++            safe_exec [list git tag -a -m $msg $tag $id]
+         } else {
+-            exec git tag $tag $id
++            safe_exec [list git tag $tag $id]
+         }
+     } err]} {
+         error_popup "[mc "Error creating tag:"] $err" $mktagtop
+@@ -9455,7 +9539,7 @@ proc copyreference {} {
+     if {$autosellen < 40} {
+         lappend cmd --abbrev=$autosellen
+     }
+-    set reference [eval exec $cmd $rowmenuid]
++    set reference [safe_exec [concat $cmd $rowmenuid]]
+ 
+     clipboard clear
+     clipboard append $reference
+@@ -9505,7 +9589,7 @@ proc wrcomgo {} {
+     set id [$wrcomtop.sha1 get]
+     set cmd "echo $id | [$wrcomtop.cmd get]"
+     set fname [$wrcomtop.fname get]
+-    if {[catch {exec sh -c $cmd >$fname &} err]} {
++    if {[catch {safe_exec_redirect [list sh -c $cmd] [list >$fname &]} err]} {
+         error_popup "[mc "Error writing commit:"] $err" $wrcomtop
+     }
+     catch {destroy $wrcomtop}
+@@ -9609,7 +9693,7 @@ proc mkbrgo {top} {
+     nowbusy newbranch
+     update
+     if {[catch {
+-        eval exec git branch $cmdargs
++        safe_exec [concat git branch $cmdargs]
+     } err]} {
+         notbusy newbranch
+         error_popup $err
+@@ -9650,7 +9734,7 @@ proc mvbrgo {top prevname} {
+     nowbusy renamebranch
+     update
+     if {[catch {
+-        eval exec git branch $cmdargs
++        safe_exec [concat git branch $cmdargs]
+     } err]} {
+         notbusy renamebranch
+         error_popup $err
+@@ -9691,7 +9775,7 @@ proc exec_citool {tool_args {baseid {}}} {
+         }
+     }
+ 
+-    eval exec git citool $tool_args &
++    safe_exec_redirect [concat git citool $tool_args] [list &]
+ 
+     array unset env GIT_AUTHOR_*
+     array set env $save_env
+@@ -9714,7 +9798,7 @@ proc cherrypick {} {
+     update
+     # Unfortunately git-cherry-pick writes stuff to stderr even when
+     # no error occurs, and exec takes that as an indication of error...
+-    if {[catch {exec sh -c "git cherry-pick -r $rowmenuid 2>&1"} err]} {
++    if {[catch {safe_exec [list sh -c "git cherry-pick -r $rowmenuid 2>&1"]} err]} {
+         notbusy cherrypick
+         if {[regexp -line \
+                  {Entry '(.*)' (would be overwritten by merge|not uptodate)} \
+@@ -9776,7 +9860,7 @@ proc revert {} {
+     nowbusy revert [mc "Reverting"]
+     update
+ 
+-    if [catch {exec git revert --no-edit $rowmenuid} err] {
++    if [catch {safe_exec [list git revert --no-edit $rowmenuid]} err] {
+         notbusy revert
+         if [regexp {files would be overwritten by merge:(\n(( |\t)+[^\n]+\n)+)}\
+                 $err match files] {
+@@ -9852,8 +9936,8 @@ proc resethead {} {
+     bind $w <Visibility> "grab $w; focus $w"
+     tkwait window $w
+     if {!$confirm_ok} return
+-    if {[catch {set fd [open \
+-            [list | git reset --$resettype $rowmenuid 2>@1] r]} err]} {
++    if {[catch {set fd [safe_open_command_redirect \
++            [list git reset --$resettype $rowmenuid] [list 2>@1]]} err]} {
+         error_popup $err
+     } else {
+         dohidelocalchanges
+@@ -9924,7 +10008,7 @@ proc cobranch {} {
+ 
+     # check the tree is clean first??
+     set newhead $headmenuhead
+-    set command [list | git checkout]
++    set command [list git checkout]
+     if {[string match "remotes/*" $newhead]} {
+         set remote $newhead
+         set newhead [string range $newhead [expr [string last / $newhead] + 1] end]
+@@ -9938,12 +10022,11 @@ proc cobranch {} {
+     } else {
+         lappend command $newhead
+     }
+-    lappend command 2>@1
+     nowbusy checkout [mc "Checking out"]
+     update
+     dohidelocalchanges
+     if {[catch {
+-        set fd [open $command r]
++        set fd [safe_open_command_redirect $command [list 2>@1]]
+     } err]} {
+         notbusy checkout
+         error_popup $err
+@@ -10009,7 +10092,7 @@ proc rmbranch {} {
+     }
+     nowbusy rmbranch
+     update
+-    if {[catch {exec git branch -D $head} err]} {
++    if {[catch {safe_exec [list git branch -D $head]} err]} {
+         notbusy rmbranch
+         error_popup $err
+         return
+@@ -10200,7 +10283,7 @@ proc getallcommits {} {
+         set cachedarcs 0
+         set allccache [file join $gitdir "gitk.cache"]
+         if {![catch {
+-            set f [open $allccache r]
++            set f [safe_open_file $allccache r]
+             set allcwait 1
+             getcache $f
+         }]} return
+@@ -10209,7 +10292,7 @@ proc getallcommits {} {
+     if {$allcwait} {
+         return
+     }
+-    set cmd [list | git rev-list --parents]
++    set cmd [list git rev-list --parents]
+     set allcupdate [expr {$seeds ne {}}]
+     if {!$allcupdate} {
+         set ids "--all"
+@@ -10231,10 +10314,17 @@ proc getallcommits {} {
+             foreach id $seeds {
+                 lappend ids "^$id"
+             }
++            lappend ids "--"
+         }
+     }
+     if {$ids ne {}} {
+-        set fd [open [concat $cmd $ids] r]
++        if {$ids eq "--all"} {
++            set cmd [concat $cmd "--all"]
++            set fd [safe_open_command $cmd]
++        } else {
++            set cmd [concat $cmd --stdin]
++            set fd [safe_open_command_redirect $cmd [list "<<[join $ids "\n"]"]]
++        }
+         fconfigure $fd -blocking 0
+         incr allcommits
+         nowbusy allcommits
+@@ -10624,7 +10714,7 @@ proc savecache {} {
+     set cachearc 0
+     set cachedarcs $nextarc
+     catch {
+-        set f [open $allccache w]
++        set f [safe_open_file $allccache w]
+         puts $f [list 1 $cachedarcs]
+         run writecache $f
+     }
+@@ -11327,7 +11417,7 @@ proc add_tag_ctext {tag} {
+ 
+     if {![info exists cached_tagcontent($tag)]} {
+         catch {
+-            set cached_tagcontent($tag) [exec git cat-file -p $tag]
++            set cached_tagcontent($tag) [safe_exec [list git cat-file -p $tag]]
+         }
+     }
+     $ctext insert end "[mc "Tag"]: $tag\n" bold
+@@ -12213,7 +12303,7 @@ proc gitattr {path attr default} {
+         set r $path_attr_cache($attr,$path)
+     } else {
+         set r "unspecified"
+-        if {![catch {set line [exec git check-attr $attr -- $path]}]} {
++        if {![catch {set line [safe_exec [list git check-attr $attr -- $path]]}]} {
+             regexp "(.*): $attr: (.*)" $line m f r
+         }
+         set path_attr_cache($attr,$path) $r
+@@ -12240,7 +12330,7 @@ proc cache_gitattr {attr pathlist} {
+     while {$newlist ne {}} {
+         set head [lrange $newlist 0 [expr {$lim - 1}]]
+         set newlist [lrange $newlist $lim end]
+-        if {![catch {set rlist [eval exec git check-attr $attr -- $head]}]} {
++        if {![catch {set rlist [safe_exec [concat git check-attr $attr -- $head]]}]} {
+             foreach row [split $rlist "\n"] {
+                 if {[regexp "(.*): $attr: (.*)" $row m path value]} {
+                     if {[string index $path 0] eq "\""} {
+@@ -12293,11 +12383,11 @@ if {[catch {package require Tk 8.4} err]} {
+ 
+ # on OSX bring the current Wish process window to front
+ if {[tk windowingsystem] eq "aqua"} {
+-    exec osascript -e [format {
++    safe_exec [list osascript -e [format {
+         tell application "System Events"
+             set frontmost of processes whose unix id is %d to true
+         end tell
+-    } [pid] ]
++    } [pid] ]]
+ }
+ 
+ # Unset GIT_TRACE var if set
+@@ -12542,7 +12632,7 @@ if {$selecthead eq "HEAD"} {
+ if {$i >= [llength $argv] && $revtreeargs ne {}} {
+     # no -- on command line, but some arguments (other than --argscmd)
+     if {[catch {
+-        set f [eval exec git rev-parse --no-revs --no-flags $revtreeargs]
++        set f [safe_exec [concat git rev-parse --no-revs --no-flags $revtreeargs]]
+         set cmdline_files [split $f "\n"]
+         set n [llength $cmdline_files]
+         set revtreeargs [lrange $revtreeargs 0 end-$n]
+-- 
+2.45.2
+

--- a/SPECS/git/CVE-2025-48384.patch
+++ b/SPECS/git/CVE-2025-48384.patch
@@ -1,0 +1,90 @@
+From c69c97f01203eca25d010c34e7c08749693d2d53 Mon Sep 17 00:00:00 2001
+From: jykanase <v-jykanase@microsoft.com>
+Date: Fri, 11 Jul 2025 16:24:17 +0000
+Subject: [PATCH] CVE-2025-48384
+
+Upstream Patch Reference: https://github.com/git/git/commit/05e9cd64ee23bbadcea6bcffd6660ed02b8eab89
+---
+ config.c                    |  2 +-
+ t/t1300-config.sh           | 11 +++++++++++
+ t/t7450-bad-git-dotfiles.sh | 33 +++++++++++++++++++++++++++++++++
+ 3 files changed, 45 insertions(+), 1 deletion(-)
+
+diff --git a/config.c b/config.c
+index aa2888d..091d971 100644
+--- a/config.c
++++ b/config.c
+@@ -3023,7 +3023,7 @@ static ssize_t write_pair(int fd, const char *key, const char *value,
+ 	if (value[0] == ' ')
+ 		quote = "\"";
+ 	for (i = 0; value[i]; i++)
+-		if (value[i] == ';' || value[i] == '#')
++		if (value[i] == ';' || value[i] == '#' || value[i] == '\r')
+ 			quote = "\"";
+ 	if (i && value[i - 1] == ' ')
+ 		quote = "\"";
+diff --git a/t/t1300-config.sh b/t/t1300-config.sh
+index f1d42b6..8f1827f 100755
+--- a/t/t1300-config.sh
++++ b/t/t1300-config.sh
+@@ -2552,4 +2552,15 @@ test_expect_success 'includeIf.hasconfig:remote.*.url forbids remote url in such
+ 	grep "fatal: remote URLs cannot be configured in file directly or indirectly included by includeIf.hasconfig:remote.*.url" err
+ '
+ 
++test_expect_success 'writing value with trailing CR not stripped on read' '
++	test_when_finished "rm -rf cr-test" &&
++
++	printf "bar\r\n" >expect &&
++	git init cr-test &&
++	git -C cr-test config core.foo $(printf "bar\r") &&
++	git -C cr-test config --get core.foo >actual &&
++
++	test_cmp expect actual
++'
++
+ test_done
+diff --git a/t/t7450-bad-git-dotfiles.sh b/t/t7450-bad-git-dotfiles.sh
+index 60d6275..a8ae92b 100755
+--- a/t/t7450-bad-git-dotfiles.sh
++++ b/t/t7450-bad-git-dotfiles.sh
+@@ -347,4 +347,37 @@ test_expect_success 'checkout -f --recurse-submodules must not use a nested gitd
+ 	test_path_is_missing nested_checkout/thing2/.git
+ '
+ 
++test_expect_success SYMLINKS,!WINDOWS,!MINGW 'submodule must not checkout into different directory' '
++	test_when_finished "rm -rf sub repo bad-clone" &&
++
++	git init sub &&
++	write_script sub/post-checkout <<-\EOF &&
++	touch "$PWD/foo"
++	EOF
++	git -C sub add post-checkout &&
++	git -C sub commit -m hook &&
++
++	git init repo &&
++	git -C repo -c protocol.file.allow=always submodule add "$PWD/sub" sub &&
++	git -C repo mv sub $(printf "sub\r") &&
++
++	# Ensure config values containing CR are wrapped in quotes.
++	git config --unset -f repo/.gitmodules submodule.sub.path &&
++	printf "\tpath = \"sub\r\"\n" >>repo/.gitmodules &&
++
++	git config --unset -f repo/.git/modules/sub/config core.worktree &&
++	{
++		printf "[core]\n" &&
++		printf "\tworktree = \"../../../sub\r\"\n"
++	} >>repo/.git/modules/sub/config &&
++
++	ln -s .git/modules/sub/hooks repo/sub &&
++	git -C repo add -A &&
++	git -C repo commit -m submodule &&
++
++	git -c protocol.file.allow=always clone --recurse-submodules repo bad-clone &&
++	! test -f "$PWD/foo" &&
++	test -f $(printf "bad-clone/sub\r/post-checkout")
++'
++
+ test_done
+-- 
+2.45.2
+

--- a/SPECS/git/CVE-2025-48385.patch
+++ b/SPECS/git/CVE-2025-48385.patch
@@ -1,0 +1,79 @@
+From 91fc2a9cea39de3f0e268c188467251da0dc516a Mon Sep 17 00:00:00 2001
+From: jykanase <v-jykanase@microsoft.com>
+Date: Fri, 11 Jul 2025 09:56:13 +0000
+Subject: [PATCH] CVE-2025-48385
+
+Upsream Patch Reference: https://github.com/git/git/commit/35cb1bb0b92c132249d932c05bbd860d410e12d4
+---
+ bundle-uri.c                | 22 ++++++++++++++++++++++
+ t/t5558-clone-bundle-uri.sh | 21 +++++++++++++++++++++
+ 2 files changed, 43 insertions(+)
+
+diff --git a/bundle-uri.c b/bundle-uri.c
+index 8a3c39c..2e7938d 100644
+--- a/bundle-uri.c
++++ b/bundle-uri.c
+@@ -287,6 +287,28 @@ static int download_https_uri_to_file(const char *file, const char *uri)
+ 	struct strbuf line = STRBUF_INIT;
+ 	int found_get = 0;
+ 
++	/*
++	 * The protocol we speak with git-remote-https(1) uses a space to
++	 * separate between URI and file, so the URI itself must not contain a
++	 * space. If it did, an adversary could change the location where the
++	 * downloaded file is being written to.
++	 *
++	 * Similarly, we use newlines to separate commands from one another.
++	 * Consequently, neither the URI nor the file must contain a newline or
++	 * otherwise an adversary could inject arbitrary commands.
++	 *
++	 * TODO: Restricting newlines in the target paths may break valid
++	 *       usecases, even if those are a bit more on the esoteric side.
++	 *       If this ever becomes a problem we should probably think about
++	 *       alternatives. One alternative could be to use NUL-delimited
++	 *       requests in git-remote-http(1). Another alternative could be
++	 *       to use URL quoting.
++	 */
++	if (strpbrk(uri, " \n"))
++		return error("bundle-uri: URI is malformed: '%s'", file);
++	if (strchr(file, '\n'))
++		return error("bundle-uri: filename is malformed: '%s'", file);
++
+ 	strvec_pushl(&cp.args, "git-remote-https", uri, NULL);
+ 	cp.err = -1;
+ 	cp.in = -1;
+diff --git a/t/t5558-clone-bundle-uri.sh b/t/t5558-clone-bundle-uri.sh
+index afd5692..32927fe 100755
+--- a/t/t5558-clone-bundle-uri.sh
++++ b/t/t5558-clone-bundle-uri.sh
+@@ -1017,6 +1017,27 @@ test_expect_success 'creationToken heuristic with failed downloads (fetch)' '
+ 	EOF
+ 	test_cmp expect refs
+ '
++test_expect_success 'bundles with space in URI are rejected' '
++	test_when_finished "rm -rf busted repo" &&
++	mkdir -p "$HOME/busted/ /$HOME/repo/.git/objects/bundles" &&
++	git clone --bundle-uri="$HTTPD_URL/bogus $HOME/busted/" "$HTTPD_URL/smart/fetch.git" repo 2>err &&
++	test_grep "error: bundle-uri: URI is malformed: " err &&
++	find busted -type f >files &&
++	test_must_be_empty files
++'
++
++test_expect_success 'bundles with newline in URI are rejected' '
++	test_when_finished "rm -rf busted repo" &&
++	git clone --bundle-uri="$HTTPD_URL/bogus\nget $HTTPD_URL/bogus $HOME/busted" "$HTTPD_URL/smart/fetch.git" repo 2>err &&
++	test_grep "error: bundle-uri: URI is malformed: " err &&
++	test_path_is_missing "$HOME/busted"
++'
++
++test_expect_success 'bundles with newline in target path are rejected' '
++	git clone --bundle-uri="$HTTPD_URL/bogus" "$HTTPD_URL/smart/fetch.git" "$(printf "escape\nget $HTTPD_URL/bogus .")" 2>err &&
++	test_grep "error: bundle-uri: filename is malformed: " err &&
++	test_path_is_missing escape
++'
+ 
+ # Do not add tests here unless they use the HTTP server, as they will
+ # not run unless the HTTP dependencies exist.
+-- 
+2.45.2
+

--- a/SPECS/git/git.spec
+++ b/SPECS/git/git.spec
@@ -1,13 +1,17 @@
 Summary:        Fast distributed version control system
 Name:           git
 Version:        2.40.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Programming
 URL:            https://git-scm.com/
 Source0:        https://github.com/git/git/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2025-48384.patch
+Patch1:         CVE-2025-48385.patch
+Patch2:         CVE-2025-27613.patch
+
 BuildRequires:  curl-devel
 BuildRequires:  python3-devel
 Requires:       curl
@@ -102,7 +106,7 @@ BuildArch:      noarch
 %endif
 
 %prep
-%setup -q
+%autosetup -p1
 %{py3_shebang_fix} git-p4.py
 
 %build
@@ -169,6 +173,9 @@ fi
 %endif
 
 %changelog
+* Mon Jul 14 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 2.40.4-2
+- Add patch for CVE-2025-48384, CVE-2025-48385 and CVE-2025-27613
+
 * Thu Jan 16 2024 Suresh Thelkar <sthelkar@microsoft.com> - 2.40.4-1
 - Upgrade to 2.40.4 to address CVE-2024-50349 and CVE-2024-52006
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
patch git for CVE-2025-48384, CVE-2025-48385 and CVE-2025-27613

- CVE-2025-48384
  Patch Modified: No
  Astrolabe Patch Reference: https://github.com/git/git/commit/05e9cd64ee23bbadcea6bcffd6660ed02b8eab89

- CVE-2025-48385
  Patch Modified: No
  Astrolabe Patch Reference: https://github.com/git/git/commit/35cb1bb0b92c132249d932c05bbd860d410e12d4

- CVE-2025-27613
  Patch Modified: Yes
  https://nvd.nist.gov/vuln/detail/CVE-2025-27613https://nvd.nist.gov/vuln/detail/CVE-2025-27613 mentioned https://github.com/j6t/gitk/compare/7dd272eca153058da2e8d5b9960bbbf0b4f0cbaa..67a128b91e25978a15f9f7e194d81b441d603652 .
  
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- git.spec
- CVE-2025-27613.patch
- CVE-2025-48385.patch
- CVE-2025-48384.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-27613
-  https://nvd.nist.gov/vuln/detail/CVE-2025-48385
-  https://nvd.nist.gov/vuln/detail/CVE-2025-48384

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Verified patches are applied cleanly.
<img width="1218" height="199" alt="image" src="https://github.com/user-attachments/assets/6890995c-e394-4150-acc7-9b76bbb6045c" />
-  Verified build locally.

[git-2.40.4-2.cm2.src.rpm.log](https://github.com/user-attachments/files/21216569/git-2.40.4-2.cm2.src.rpm.log)
[git-2.40.4-2.cm2.src.rpm.test.log](https://github.com/user-attachments/files/21216518/git-2.40.4-2.cm2.src.rpm.test.log)
