### PR TITLE
[Medium] Patch nghttp2 for CVE-2025-23167

### DIFF
--- a/SPECS/nghttp2/CVE-2025-23167.patch
+++ b/SPECS/nghttp2/CVE-2025-23167.patch
@@ -1,0 +1,89 @@
+From 86489e604eab5f23eb6cfd6dd72ef6f04867ef23 Mon Sep 17 00:00:00 2001
+From: AkarshHCL <v-akarshc@microsoft.com>
+Date: Mon, 14 Jul 2025 13:03:50 +0000
+Subject: [PATCH] Address CVE-2025-23167
+
+Upstream Patch reference:https://github.com/nghttp2/nghttp2/pull/1941/commits/d5cb882e629d6fc5d0d7d9165cf6b2bb89b64c29
+
+---
+ third-party/llhttp/src/api.c | 64 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 64 insertions(+)
+
+diff --git a/third-party/llhttp/src/api.c b/third-party/llhttp/src/api.c
+index e0d0385..a1dd68b 100644
+--- a/third-party/llhttp/src/api.c
++++ b/third-party/llhttp/src/api.c
+@@ -315,6 +315,70 @@ void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled)
+   }
+ }
+ 
++void llhttp_set_lenient_version(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_VERSION;
++  } else {
++    parser->lenient_flags &= ~LENIENT_VERSION;
++  }
++}
++
++void llhttp_set_lenient_data_after_close(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_DATA_AFTER_CLOSE;
++  } else {
++    parser->lenient_flags &= ~LENIENT_DATA_AFTER_CLOSE;
++  }
++}
++
++void llhttp_set_lenient_optional_lf_after_cr(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_OPTIONAL_LF_AFTER_CR;
++  } else {
++    parser->lenient_flags &= ~LENIENT_OPTIONAL_LF_AFTER_CR;
++  }
++}
++
++void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
++  } else {
++    parser->lenient_flags &= ~LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
++  }
++}
++
++void llhttp_set_lenient_version(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_VERSION;
++  } else {
++    parser->lenient_flags &= ~LENIENT_VERSION;
++  }
++}
++
++void llhttp_set_lenient_data_after_close(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_DATA_AFTER_CLOSE;
++  } else {
++    parser->lenient_flags &= ~LENIENT_DATA_AFTER_CLOSE;
++  }
++}
++
++void llhttp_set_lenient_optional_lf_after_cr(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_OPTIONAL_LF_AFTER_CR;
++  } else {
++    parser->lenient_flags &= ~LENIENT_OPTIONAL_LF_AFTER_CR;
++  }
++}
++
++void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled) {
++  if (enabled) {
++    parser->lenient_flags |= LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
++  } else {
++    parser->lenient_flags &= ~LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
++  }
++}
++
+ /* Callbacks */
+ 
+ 
+-- 
+2.45.2
+

--- a/SPECS/nghttp2/nghttp2.spec
+++ b/SPECS/nghttp2/nghttp2.spec
@@ -1,7 +1,7 @@
 Summary:        nghttp2 is an implementation of HTTP/2 and its header compression algorithm, HPACK.
 Name:           nghttp2
 Version:        1.57.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          Applications/System
 URL:            https://nghttp2.org
 Source0:        https://github.com/nghttp2/nghttp2/releases/download/v%{version}/%{name}-%{version}.tar.xz
 Patch0:         CVE-2024-28182.patch
+Patch1:         CVE-2025-23167.patch
 BuildRequires:  gcc
 BuildRequires:  make
 %if %{with_check}
@@ -60,6 +61,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Mon Jul 14 2025 Akarsh Chaudhary <v-akarshc@microsoft.com>- 1.57.0-3
+- Patch CVE-2025-23167
+
 * Tue Oct 08 2024 Muhammad Falak <mwani@microsoft.com> - 1.57.0-2
 - Address CVE-2024-28182
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -189,7 +189,7 @@ libsolv-devel-0.7.24-1.cm2.aarch64.rpm
 libssh2-1.9.0-4.cm2.aarch64.rpm
 libssh2-devel-1.9.0-4.cm2.aarch64.rpm
 krb5-1.19.4-3.cm2.aarch64.rpm
-nghttp2-1.57.0-2.cm2.aarch64.rpm
+nghttp2-1.57.0-3.cm2.aarch64.rpm
 curl-8.8.0-6.cm2.aarch64.rpm
 curl-devel-8.8.0-6.cm2.aarch64.rpm
 curl-libs-8.8.0-6.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -189,7 +189,7 @@ libsolv-devel-0.7.24-1.cm2.x86_64.rpm
 libssh2-1.9.0-4.cm2.x86_64.rpm
 libssh2-devel-1.9.0-4.cm2.x86_64.rpm
 krb5-1.19.4-3.cm2.x86_64.rpm
-nghttp2-1.57.0-2.cm2.x86_64.rpm
+nghttp2-1.57.0-3.cm2.x86_64.rpm
 curl-8.8.0-6.cm2.x86_64.rpm
 curl-devel-8.8.0-6.cm2.x86_64.rpm
 curl-libs-8.8.0-6.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -261,9 +261,9 @@ newt-0.52.21-5.cm2.aarch64.rpm
 newt-debuginfo-0.52.21-5.cm2.aarch64.rpm
 newt-devel-0.52.21-5.cm2.aarch64.rpm
 newt-lang-0.52.21-5.cm2.aarch64.rpm
-nghttp2-1.57.0-2.cm2.aarch64.rpm
-nghttp2-debuginfo-1.57.0-2.cm2.aarch64.rpm
-nghttp2-devel-1.57.0-2.cm2.aarch64.rpm
+nghttp2-1.57.0-3.cm2.aarch64.rpm
+nghttp2-debuginfo-1.57.0-3.cm2.aarch64.rpm
+nghttp2-devel-1.57.0-3.cm2.aarch64.rpm
 ninja-build-1.10.2-2.cm2.aarch64.rpm
 ninja-build-debuginfo-1.10.2-2.cm2.aarch64.rpm
 npth-1.6-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -267,9 +267,9 @@ newt-0.52.21-5.cm2.x86_64.rpm
 newt-debuginfo-0.52.21-5.cm2.x86_64.rpm
 newt-devel-0.52.21-5.cm2.x86_64.rpm
 newt-lang-0.52.21-5.cm2.x86_64.rpm
-nghttp2-1.57.0-2.cm2.x86_64.rpm
-nghttp2-debuginfo-1.57.0-2.cm2.x86_64.rpm
-nghttp2-devel-1.57.0-2.cm2.x86_64.rpm
+nghttp2-1.57.0-3.cm2.x86_64.rpm
+nghttp2-debuginfo-1.57.0-3.cm2.x86_64.rpm
+nghttp2-devel-1.57.0-3.cm2.x86_64.rpm
 ninja-build-1.10.2-2.cm2.x86_64.rpm
 ninja-build-debuginfo-1.10.2-2.cm2.x86_64.rpm
 npth-1.6-4.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
[Medium] Patch nghttp2 for CVE-2025-23167
Astrolabe patch reference: https://github.com/nghttp2/nghttp2/pull/1941/commits/d5cb882e629d6fc5d0d7d9165cf6b2bb89b64c29
Patch Modified: Yes
Some changes in the upstream patch were already present in the source code of the package so only changes not present in source code are their in this pr.
Changes already present in files-IIhttp.h and IIhttp.c
File changed-api.c

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/nghttp2/CVE-2025-23167.patch
- SPECS/nghttp2/nghttp2.spec
 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Patch applies cleanly
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a6cc1d4a-b163-4535-af86-c3ed601f82aa" />
- Build is successful
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/21679311-b342-4d1c-82bc-f7cb0f13f8f9" />

