### PR TITLE
[Medium] Patch ruby for CVE-2025-24294

### DIFF
--- a/SPECS/ruby/CVE-2025-24294.patch
+++ b/SPECS/ruby/CVE-2025-24294.patch
@@ -1,0 +1,56 @@
+From 0402b9455a79af510e18bbd60f83427fe30fea86 Mon Sep 17 00:00:00 2001
+From: BinduSri-6522866 <v-badabala@microsoft.com>
+Date: Tue, 15 Jul 2025 07:41:43 +0000
+Subject: [PATCH] Address CVE-2025-24294
+
+Upstream Patch reference: https://github.com/ruby/resolv/commit/4c2f71b5e80826506f78417d85b38481c058fb25
+---
+ lib/resolv.rb           | 6 +++++-
+ test/resolv/test_dns.rb | 7 +++++++
+ 2 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/lib/resolv.rb b/lib/resolv.rb
+index 57fd173..778891c 100644
+--- a/lib/resolv.rb
++++ b/lib/resolv.rb
+@@ -1655,6 +1655,7 @@ class Resolv
+           prev_index = @index
+           save_index = nil
+           d = []
++          size = -1
+           while true
+             raise DecodeError.new("limit exceeded") if @limit <= @index
+             case @data.getbyte(@index)
+@@ -1675,7 +1676,10 @@ class Resolv
+               end
+               @index = idx
+             else
+-              d << self.get_label
++              l = self.get_label
++              d << l
++              size += 1 + l.string.bytesize
++              raise DecodeError.new("name label data exceed 255 octets") if size > 255
+             end
+           end
+         end
+diff --git a/test/resolv/test_dns.rb b/test/resolv/test_dns.rb
+index 20c3408..c25026e 100644
+--- a/test/resolv/test_dns.rb
++++ b/test/resolv/test_dns.rb
+@@ -589,6 +589,13 @@ class TestResolvDNS < Test::Unit::TestCase
+     assert_operator(2**14, :<, m.to_s.length)
+   end
+ 
++  def test_too_long_address
++    too_long_address_message = [0, 0, 1, 0, 0, 0].pack("n*") + "\x01x" * 129 + [0, 0, 0].pack("cnn")
++    assert_raise_with_message(Resolv::DNS::DecodeError, /name label data exceed 255 octets/) do
++      Resolv::DNS::Message.decode too_long_address_message
++    end
++  end
++
+   def assert_no_fd_leak
+     socket = assert_throw(self) do |tag|
+       Resolv::DNS.stub(:bind_random_port, ->(s, *) {throw(tag, s)}) do
+-- 
+2.45.3
+

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -83,7 +83,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        3.1.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -100,6 +100,7 @@ Source7:        macros.rubygems
 # Updates default ruby-uri to 0.12.2 and vendored one to 0.10.3. Remove once ruby gets updated to a version that comes with both lib/uri/version.rb and lib/bundler/vendor/uri/lib/uri/version.rb versions >= 0.12.2 or == 0.10.3
 Patch0:         CVE-2023-36617.patch
 Patch1:         CVE-2025-6442.patch
+Patch2:         CVE-2025-24294.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline
 BuildRequires:  readline-devel
@@ -402,6 +403,9 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
+* Tue Jul 15 2025 BinduSri Adabala <v-badabala@microsoft.com> - 3.1.7-3
+- Patch CVE-2025-24294
+
 * Mon Jun 30 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 3.1.7-2
 - Patch CVE-2025-6442
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch ruby for [CVE-2025-24294](https://nvd.nist.gov/vuln/detail/CVE-2025-24294)
Patch Modified: No
Upstream Patch Reference: https://ubuntu.com/security/CVE-2025-24294 navigates to https://github.com/ruby/resolv/commit/4c2f71b5e80826506f78417d85b38481c058fb25

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/ruby/CVE-2025-24294.patch
- modified:   SPECS/ruby/ruby.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-24294

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Patch applies cleanly
<img width="1213" height="423" alt="image" src="https://github.com/user-attachments/assets/3557d814-e28b-4344-a0a1-bba102ec5aa1" />

- Build is successful -
[ruby-3.1.7-3.cm2.src.rpm.log](https://github.com/user-attachments/files/21230740/ruby-3.1.7-3.cm2.src.rpm.log)

- Test is successful -
[ruby-3.1.7-3.cm2.src.rpm.test.log](https://github.com/user-attachments/files/21230762/ruby-3.1.7-3.cm2.src.rpm.test.log)
