### PR TITLE
[MEDIUM] Minor version of php upgraded to 8.3.23 - to fix CVE-2025-1735, CVE-2025-6491, CVE-2025-1220

### DIFF
--- a/SPECS/php/php-8.3.20-embed.patch
+++ b/SPECS/php/php-8.3.20-embed.patch
@@ -1,10 +1,10 @@
 diff -up ./sapi/embed/config.m4.embed ./sapi/embed/config.m4
---- ./sapi/embed/config.m4.embed	2020-07-07 13:51:05.879764972 +0200
-+++ ./sapi/embed/config.m4	2020-07-07 13:52:50.128412148 +0200
-@@ -12,7 +12,8 @@ if test "$PHP_EMBED" != "no"; then
-     yes|shared)
-       LIBPHP_CFLAGS="-shared"
-       PHP_EMBED_TYPE=shared
+--- ./sapi/embed/config.m4.embed	2025-03-26 08:07:06.692333414 +0100
++++ ./sapi/embed/config.m4	2025-03-26 08:07:42.872879994 +0100
+@@ -15,7 +15,8 @@ if test "$PHP_EMBED" != "no"; then
+         SAPI_SHARED="libs/libphp.dylib"
+         PHP_EMBED_TYPE=shared-dylib
+       ], [PHP_EMBED_TYPE=shared])
 -      INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(prefix)/lib; \$(INSTALL) -m 0755 $SAPI_SHARED \$(INSTALL_ROOT)\$(prefix)/lib"
 +      EXTRA_LDFLAGS="$EXTRA_LDFLAGS -release \$(PHP_MAJOR_VERSION).\$(PHP_MINOR_VERSION)"
 +      INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(libdir); \$(LIBTOOL) --mode=install \$(INSTALL) -m 0755 \$(OVERALL_TARGET) \$(INSTALL_ROOT)\$(libdir)"
@@ -12,8 +12,8 @@ diff -up ./sapi/embed/config.m4.embed ./sapi/embed/config.m4
      static)
        LIBPHP_CFLAGS="-static"
 diff -up ./scripts/php-config.in.embed ./scripts/php-config.in
---- ./scripts/php-config.in.embed	2020-07-07 12:54:42.000000000 +0200
-+++ ./scripts/php-config.in	2020-07-07 13:51:05.880764968 +0200
+--- ./scripts/php-config.in.embed	2025-03-25 22:00:06.000000000 +0100
++++ ./scripts/php-config.in	2025-03-26 08:07:06.692518461 +0100
 @@ -18,7 +18,7 @@ exe_extension="@EXEEXT@"
  php_cli_binary=NONE
  php_cgi_binary=NONE

--- a/SPECS/php/php.signatures.json
+++ b/SPECS/php/php.signatures.json
@@ -1,19 +1,19 @@
 {
-  "Signatures": {
-    "10-opcache.ini": "6065beb2ace54d6cb5a8cde751330ea358bd23692073c6e3d2c57f7c97bec869",
-    "20-ffi.ini": "f5e968fdd3eca54f3dab2399e243931cf16cd9da034f0364800aefab222271c0",
-    "macros.php": "917104496e8239e1ed1d4812871be772a5fa8b38cf80c4c59ec3e0c36d48310e",
-    "nginx-fpm.conf": "5a222ab2c3fc0145cb67a1c5125471bbf097de304e77c9858e7077a3b4fcad59",
-    "nginx-php.conf": "b3b3f744c4c122302fcb11f39cac78d01cef15ee6f8bd67e98b3438efcf8dc95",
-    "opcache-default.blacklist": "4eef0875e1a0c6a75b8a2bafd4ddc029b83be74dd336a6a99214b0c32808cb38",
-    "php-fpm-www.conf": "1cacdd4962c01a0a968933c38db503023940ad9105f021bdab85d6cdc46dcbb8",
-    "php-fpm.conf": "bb261d53b9b42bb163a7637bb373ffa18a20dddf27a3efe6cb5ed1b1cf5981a9",
-    "php-fpm.logrotate": "7d8279bebb9ffabc596a2699150e93d4ce4513245890b9b786d337288b19fa79",
-    "php-fpm.service": "574f50dec5a0edd60e60e44e7cc2d03575bc728bdc0b0cab021ce3c55abc0117",
-    "php-fpm.wants": "846297e91ba02bd0e29b6635eeddcca01a7ad4faf5a8f27113543804331d0328",
-    "php.conf": "e2388be032eccf7c0197d597ba72259a095bf8434438a184e6a640edb4b59de2",
-    "php.ini": "8fd5a4d891c19320c07010fbbbac982c886b422bc8d062acaeae49d70c136fc8",
-    "php.modconf": "dc7303ea584452d2f742d002a648abe74905025aabf240259c7e8bd01746d278",
-    "php-8.3.19.tar.xz": "976e4077dd25bec96b5dfe8938052d243bbd838f95368a204896eff12756545f"
-  }
+ "Signatures": {
+  "10-opcache.ini": "6065beb2ace54d6cb5a8cde751330ea358bd23692073c6e3d2c57f7c97bec869",
+  "20-ffi.ini": "f5e968fdd3eca54f3dab2399e243931cf16cd9da034f0364800aefab222271c0",
+  "macros.php": "917104496e8239e1ed1d4812871be772a5fa8b38cf80c4c59ec3e0c36d48310e",
+  "nginx-fpm.conf": "5a222ab2c3fc0145cb67a1c5125471bbf097de304e77c9858e7077a3b4fcad59",
+  "nginx-php.conf": "b3b3f744c4c122302fcb11f39cac78d01cef15ee6f8bd67e98b3438efcf8dc95",
+  "opcache-default.blacklist": "4eef0875e1a0c6a75b8a2bafd4ddc029b83be74dd336a6a99214b0c32808cb38",
+  "php-8.3.23.tar.xz": "08be64700f703bca6ff1284bf1fdaffa37ae1b9734b6559f8350248e8960a6db",
+  "php-fpm-www.conf": "1cacdd4962c01a0a968933c38db503023940ad9105f021bdab85d6cdc46dcbb8",
+  "php-fpm.conf": "bb261d53b9b42bb163a7637bb373ffa18a20dddf27a3efe6cb5ed1b1cf5981a9",
+  "php-fpm.logrotate": "7d8279bebb9ffabc596a2699150e93d4ce4513245890b9b786d337288b19fa79",
+  "php-fpm.service": "574f50dec5a0edd60e60e44e7cc2d03575bc728bdc0b0cab021ce3c55abc0117",
+  "php-fpm.wants": "846297e91ba02bd0e29b6635eeddcca01a7ad4faf5a8f27113543804331d0328",
+  "php.conf": "e2388be032eccf7c0197d597ba72259a095bf8434438a184e6a640edb4b59de2",
+  "php.ini": "8fd5a4d891c19320c07010fbbbac982c886b422bc8d062acaeae49d70c136fc8",
+  "php.modconf": "dc7303ea584452d2f742d002a648abe74905025aabf240259c7e8bd01746d278"
+ }
 }

--- a/SPECS/php/php.spec
+++ b/SPECS/php/php.spec
@@ -32,7 +32,7 @@
 %global with_qdbm     0
 Summary:        PHP scripting language for creating dynamic web sites
 Name:           php
-Version:        8.3.19
+Version:        8.3.23
 Release:        1%{?dist}
 # All files licensed under PHP version 3.01, except
 # Zend is licensed under Zend
@@ -64,7 +64,7 @@ Source53:       20-ffi.ini
 # Build fixes
 Patch1:         php-7.4.0-httpd.patch
 Patch5:         php-7.2.0-includedir.patch
-Patch6:         php-8.0.0-embed.patch
+Patch6:         php-8.3.20-embed.patch
 Patch8:         php-8.1.0-libdb.patch
 # Functional changes
 # Use system nikic/php-parser
@@ -1514,6 +1514,10 @@ systemctl try-restart php-fpm.service >/dev/null 2>&1 || :
 %dir %{_datadir}/php/preload
 
 %changelog
+* Tue Jul 15 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 8.3.23-1
+- Upgrade to 8.3.23 to fix CVE-2025-1735, CVE-2025-6491, CVE-2025-1220
+- Fixed build issue by replacing php-8.0.0-embed.patch with php-8.3.20-embed.patch
+
 * Sun Mar 30 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.3.19-1
 - Auto-upgrade to 8.3.19 - for CVE-2025-1217 CVE-2025-1219, CVE-2025-1736, CVE-2025-1861
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21083,8 +21083,8 @@
         "type": "other",
         "other": {
           "name": "php",
-          "version": "8.3.19",
-          "downloadUrl": "https://www.php.net/distributions/php-8.3.19.tar.xz"
+          "version": "8.3.23",
+          "downloadUrl": "https://www.php.net/distributions/php-8.3.23.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Minor version of php bumped to 8.3.23 - to fix CVE-2025-1735, CVE-2025-6491, CVE-2025-1220

<img width="1131" height="741" alt="image" src="https://github.com/user-attachments/assets/ae4e107f-a924-496a-ab94-8d8c592b341f" />

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/php/php.signatures.json
- modified: SPECS/php/php.spec
- modified: cgmanifest.json
- deleted: SPECS/php/php-8.0.0-embed.patch
- added: SPECS/php/php-8.3.20-embed.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-1735
- https://nvd.nist.gov/vuln/detail/CVE-2025-6491
- https://nvd.nist.gov/vuln/detail/CVE-2025-1220

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
- build log: 
[php-8.3.23-1.azl3.src.rpm.log](https://github.com/user-attachments/files/21239845/php-8.3.23-1.azl3.src.rpm.log)
[php-8.3.23-1.azl3.src.rpm.test.log](https://github.com/user-attachments/files/21239848/php-8.3.23-1.azl3.src.rpm.test.log)
