### PR TITLE
rubygem-webrick: Add %check section

### DIFF
--- a/SPECS/rubygem-webrick/CVE-2023-40225-content-length-validation.patch
+++ b/SPECS/rubygem-webrick/CVE-2023-40225-content-length-validation.patch
@@ -1,0 +1,69 @@
+From 96c29264519374ee41eaf27933d5049528264e98 Mon Sep 17 00:00:00 2001
+From: Jeremy Evans <code@jeremyevans.net>
+Date: Tue, 15 Aug 2023 14:37:59 -0700
+Subject: [PATCH] Raise HTTPStatus::BadRequest for requests with
+ invalid/duplicate content-length headers
+
+Addresses CVE-2023-40225.
+
+Fixes #119
+---
+ lib/webrick/httprequest.rb       |  8 ++++++++
+ test/webrick/test_httprequest.rb | 25 +++++++++++++++++++++++++
+ 2 files changed, 33 insertions(+)
+
+diff --git a/lib/webrick/httprequest.rb b/lib/webrick/httprequest.rb
+index 680ac65a..7a1686bc 100644
+--- a/lib/webrick/httprequest.rb
++++ b/lib/webrick/httprequest.rb
+@@ -479,6 +479,14 @@ def read_header(socket)
+         end
+       end
+       @header = HTTPUtils::parse_header(@raw_header.join)
++
++      if (content_length = @header['content-length']) && content_length.length != 0
++        if content_length.length > 1
++          raise HTTPStatus::BadRequest, "multiple content-length request headers"
++        elsif !/\A\d+\z/.match?(content_length[0])
++          raise HTTPStatus::BadRequest, "invalid content-length request header"
++        end
++      end
+     end
+ 
+     def parse_uri(str, scheme="http")
+diff --git a/test/webrick/test_httprequest.rb b/test/webrick/test_httprequest.rb
+index 2ff08d63..90332171 100644
+--- a/test/webrick/test_httprequest.rb
++++ b/test/webrick/test_httprequest.rb
+@@ -81,6 +81,31 @@ def test_request_uri_too_large
+     }
+   end
+ 
++  def test_invalid_content_length_header
++    ['', ' ', ' +1', ' -1', ' a'].each do |cl|
++      msg = <<-_end_of_message_
++        GET / HTTP/1.1
++        Content-Length:#{cl}
++      _end_of_message_
++      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++      assert_raise(WEBrick::HTTPStatus::BadRequest){
++        req.parse(StringIO.new(msg.gsub(/^ {8}/, "")))
++      }
++    end
++  end
++
++  def test_duplicate_content_length_header
++    msg = <<-_end_of_message_
++      GET / HTTP/1.1
++      Content-Length: 1
++      Content-Length: 2
++    _end_of_message_
++    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
++    assert_raise(WEBrick::HTTPStatus::BadRequest){
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
+   def test_parse_headers
+     msg = <<-_end_of_message_
+       GET /path HTTP/1.1

--- a/SPECS/rubygem-webrick/CVE-2025-6442.patch
+++ b/SPECS/rubygem-webrick/CVE-2025-6442.patch
@@ -1,18 +1,18 @@
-From c36cba7cf22aa6f2c0b24a40c0955e1735e0535f Mon Sep 17 00:00:00 2001
-From: archana25-ms <v-shettigara@microsoft.com>
-Date: Fri, 27 Jun 2025 08:17:33 +0000
-Subject: [PATCH] Address CVE-2025-6442
-Upstream Patch Reference: https://github.com/ruby/webrick/commit/ee60354bcb84ec33b9245e1d1aa6e1f7e8132101
+From a3d6b1b66f7daa71c0b2a023df6ad4f457710b7e Mon Sep 17 00:00:00 2001
+From: Kavya Sree Kaitepalli <kkaitepalli@microsoft.com>
+Date: Wed, 16 Jul 2025 05:43:48 +0000
+Subject: [PATCH] patch CVE-2025-6442
 
+patch Reference: https://github.com/ruby/webrick/commit/ee60354bcb84ec33b9245e1d1aa6e1f7e8132101
 ---
  lib/webrick/httprequest.rb       |   4 +-
- lib/webrick/httputils.rb         |   7 +-
+ lib/webrick/httputils.rb         |   8 +-
  test/webrick/test_filehandler.rb |   2 +-
- test/webrick/test_httprequest.rb | 202 +++++++++++++++++++++++++++----
- 4 files changed, 188 insertions(+), 27 deletions(-)
+ test/webrick/test_httprequest.rb | 149 +++++++++++++++++++++++++------
+ 4 files changed, 132 insertions(+), 31 deletions(-)
 
 diff --git a/lib/webrick/httprequest.rb b/lib/webrick/httprequest.rb
-index 680ac65..0256be7 100644
+index 7a1686b..7a5aed5 100644
 --- a/lib/webrick/httprequest.rb
 +++ b/lib/webrick/httprequest.rb
 @@ -458,7 +458,7 @@ module WEBrick
@@ -20,7 +20,7 @@ index 680ac65..0256be7 100644
  
        @request_time = Time.now
 -      if /^(\S+)\s+(\S++)(?:\s+HTTP\/(\d+\.\d+))?\r?\n/mo =~ @request_line
-+      if /^(\S+) (\S++)(?: +HTTP\/(\d+\.\d+))?\r\n/mo =~ @request_line
++      if /^(\S+) (\S++)(?: HTTP\/(\d+\.\d+))?\r\n/mo =~ @request_line
          @request_method = $1
          @unparsed_uri   = $2
          @http_version   = HTTPVersion.new($3 ? $3 : "0.9")
@@ -34,10 +34,10 @@ index 680ac65..0256be7 100644
              raise HTTPStatus::RequestEntityTooLarge, 'headers too large'
            end
 diff --git a/lib/webrick/httputils.rb b/lib/webrick/httputils.rb
-index 48aa137..7b82533 100644
+index 48aa137..3110646 100644
 --- a/lib/webrick/httputils.rb
 +++ b/lib/webrick/httputils.rb
-@@ -158,16 +158,19 @@ module WEBrick
+@@ -158,16 +158,18 @@ module WEBrick
        field = nil
        raw.each_line{|line|
          case line
@@ -48,12 +48,12 @@ index 48aa137..7b82533 100644
            header[field] = [] unless header.has_key?(field)
            header[field] << value
 -        when /^\s+(.*?)\s*\z/om
-+	when /^\s+([^\r\n\0]*?)\r\n/om
-           value = $1
+-          value = $1
++        when /^\s+([^\r\n\0]*?)\r\n/om
            unless field
              raise HTTPStatus::BadRequest, "bad header '#{line}'."
            end
-+          value = lineAdd commentMore actions
++          value = line
 +          value.lstrip!
 +          value.slice!(-2..-1)
            header[field][-1] << " " << value
@@ -73,7 +73,7 @@ index 881fb54..dad3fb0 100644
  
    def make_range_response(file, range_spec)
 diff --git a/test/webrick/test_httprequest.rb b/test/webrick/test_httprequest.rb
-index 2ff08d6..0704778 100644
+index 9033217..a3c0620 100644
 --- a/test/webrick/test_httprequest.rb
 +++ b/test/webrick/test_httprequest.rb
 @@ -11,7 +11,7 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
@@ -112,27 +112,25 @@ index 2ff08d6..0704778 100644
      assert_equal("GET", req.request_method)
      assert_equal("/path", req.unparsed_uri)
      assert_equal("", req.script_name)
-@@ -77,10 +77,125 @@ GET /
+@@ -77,7 +77,7 @@ GET /
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      assert_raise(WEBrick::HTTPStatus::RequestURITooLarge){
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
 +      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
-+    }
-+  end
-+
-+  def test_invalid_content_length_header
-+    ['', ' ', ' +1', ' -1', ' a'].each do |cl|
-+      msg = <<-_end_of_message_
-+        GET / HTTP/1.1
-+        Content-Length:#{cl}
-+      _end_of_message_
-+      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
-+      assert_raise(WEBrick::HTTPStatus::BadRequest){
+     }
+   end
+ 
+@@ -89,11 +89,101 @@ GET /
+       _end_of_message_
+       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+       assert_raise(WEBrick::HTTPStatus::BadRequest){
+-        req.parse(StringIO.new(msg.gsub(/^ {8}/, "")))
 +        req.parse(StringIO.new(msg.gsub(/^ {8}/, "").gsub("\n", "\r\n")))
-+      }
-+    end
-+  end
-+
+       }
+     end
+   end
+ 
 +  def test_bare_lf_request_line
 +    msg = <<-_end_of_message_
 +      GET / HTTP/1.1
@@ -177,10 +175,10 @@ index 2ff08d6..0704778 100644
 +    _end_of_message_
 +    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
 +    assert_raise(WEBrick::HTTPStatus::BadRequest){
-       req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
-     }
-   end
- 
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++    }
++  end
++
 +  def test_invalid_request_lines
 +    msg = <<-_end_of_message_
 +      GET  / HTTP/1.1\r
@@ -223,22 +221,19 @@ index 2ff08d6..0704778 100644
 +    }
 +  end
 +
-+  def test_duplicate_content_length_header
-+    msg = <<-_end_of_message_
-+      GET / HTTP/1.1
-+      Content-Length: 1
-+      Content-Length: 2
-+    _end_of_message_
-+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
-+    assert_raise(WEBrick::HTTPStatus::BadRequest){
-+      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
-+    }
-+  end
-+
-   def test_parse_headers
+   def test_duplicate_content_length_header
      msg = <<-_end_of_message_
-       GET /path HTTP/1.1
-@@ -93,13 +208,13 @@ GET /
+       GET / HTTP/1.1
+@@ -102,7 +192,7 @@ GET /
+     _end_of_message_
+     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+     assert_raise(WEBrick::HTTPStatus::BadRequest){
+-      req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
++      req.parse(StringIO.new(msg.gsub(/^ {6}/, "").gsub("\n", "\r\n")))
+     }
+   end
+ 
+@@ -118,13 +208,13 @@ GET /
        Accept-Language: en;q=0.5, *; q=0
        Accept-Language: ja
        Content-Type: text/plain
@@ -254,7 +249,7 @@ index 2ff08d6..0704778 100644
      assert_equal(
        URI.parse("http://test.ruby-lang.org:8080/path"), req.request_uri)
      assert_equal("test.ruby-lang.org", req.host)
-@@ -110,9 +225,9 @@ GET /
+@@ -135,9 +225,9 @@ GET /
        req.accept)
      assert_equal(%w(gzip compress identity *), req.accept_encoding)
      assert_equal(%w(ja en *), req.accept_language)
@@ -266,7 +261,7 @@ index 2ff08d6..0704778 100644
      assert_equal("", req["x-empty-header"])
      assert_equal(nil, req["x-no-header"])
      assert(req.query.empty?)
-@@ -121,7 +236,7 @@ GET /
+@@ -146,7 +236,7 @@ GET /
    def test_parse_header2()
      msg = <<-_end_of_message_
        POST /foo/bar/../baz?q=a HTTP/1.0
@@ -275,7 +270,7 @@ index 2ff08d6..0704778 100644
        User-Agent:
          FOO   BAR
          BAZ
-@@ -129,14 +244,14 @@ GET /
+@@ -154,14 +244,14 @@ GET /
        hogehoge
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -293,7 +288,7 @@ index 2ff08d6..0704778 100644
    end
  
    def test_parse_headers3
-@@ -146,7 +261,7 @@ GET /
+@@ -171,7 +261,7 @@ GET /
  
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -302,7 +297,7 @@ index 2ff08d6..0704778 100644
      assert_equal(URI.parse("http://test.ruby-lang.org/path"), req.request_uri)
      assert_equal("test.ruby-lang.org", req.host)
      assert_equal(80, req.port)
-@@ -157,7 +272,7 @@ GET /
+@@ -182,7 +272,7 @@ GET /
  
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -311,7 +306,7 @@ index 2ff08d6..0704778 100644
      assert_equal(URI.parse("http://192.168.1.1/path"), req.request_uri)
      assert_equal("192.168.1.1", req.host)
      assert_equal(80, req.port)
-@@ -168,7 +283,7 @@ GET /
+@@ -193,7 +283,7 @@ GET /
  
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -320,7 +315,7 @@ index 2ff08d6..0704778 100644
      assert_equal(URI.parse("http://[fe80::208:dff:feef:98c7]/path"),
                   req.request_uri)
      assert_equal("[fe80::208:dff:feef:98c7]", req.host)
-@@ -180,7 +295,7 @@ GET /
+@@ -205,7 +295,7 @@ GET /
  
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -329,7 +324,7 @@ index 2ff08d6..0704778 100644
      assert_equal(URI.parse("http://192.168.1.1:8080/path"), req.request_uri)
      assert_equal("192.168.1.1", req.host)
      assert_equal(8080, req.port)
-@@ -191,7 +306,7 @@ GET /
+@@ -216,7 +306,7 @@ GET /
  
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -338,7 +333,7 @@ index 2ff08d6..0704778 100644
      assert_equal(URI.parse("http://[fe80::208:dff:feef:98c7]:8080/path"),
                   req.request_uri)
      assert_equal("[fe80::208:dff:feef:98c7]", req.host)
-@@ -206,7 +321,7 @@ GET /
+@@ -231,7 +321,7 @@ GET /
  
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -347,7 +342,7 @@ index 2ff08d6..0704778 100644
      query = req.query
      assert_equal("1", query["foo"])
      assert_equal(["1", "2", "3"], query["foo"].to_ary)
-@@ -226,7 +341,7 @@ GET /
+@@ -251,7 +341,7 @@ GET /
        #{param}
      _end_of_message_
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -356,7 +351,7 @@ index 2ff08d6..0704778 100644
      query = req.query
      assert_equal("1", query["foo"])
      assert_equal(["1", "2", "3"], query["foo"].to_ary)
-@@ -245,6 +360,7 @@ GET /
+@@ -270,6 +360,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -364,48 +359,7 @@ index 2ff08d6..0704778 100644
      File.open(__FILE__){|io|
        while chunk = io.read(100)
          msg << chunk.size.to_s(16) << crlf
-@@ -264,6 +380,40 @@ GET /
-     assert_equal(expect, dst.string)
-   end
- 
-+  def test_bad_chunked
-+    msg = <<-_end_of_message_
-+      POST /path HTTP/1.1\r
-+      Transfer-Encoding: chunked\r
-+      \r
-+      01x1\r
-+      \r
-+      1
-+    _end_of_message_
-+    msg.gsub!(/^ {6}/, "")
-+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
-+    req.parse(StringIO.new(msg))
-+    assert_raise(WEBrick::HTTPStatus::BadRequest){ req.body }
-+
-+    # chunked req.body_reader
-+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
-+    req.parse(StringIO.new(msg))
-+    dst = StringIO.new
-+    assert_raise(WEBrick::HTTPStatus::BadRequest) do
-+      IO.copy_stream(req.body_reader, dst)
-+    end
-+  end
-+
-+  def test_null_byte_in_header
-+    msg = <<-_end_of_message_
-+      POST /path HTTP/1.1\r
-+      Evil: evil\x00\r
-+      \r
-+    _end_of_message_
-+    msg.gsub!(/^ {6}/, "")
-+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
-+    assert_raise(WEBrick::HTTPStatus::BadRequest){ req.parse(StringIO.new(msg)) }
-+  end
-+
-   def test_forwarded
-     msg = <<-_end_of_message_
-       GET /foo HTTP/1.1
-@@ -276,6 +426,7 @@ GET /
+@@ -301,6 +392,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -413,7 +367,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert_equal("server.example.com", req.server_name)
-@@ -296,6 +447,7 @@ GET /
+@@ -321,6 +413,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -421,7 +375,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert_equal("server.example.com", req.server_name)
-@@ -318,6 +470,7 @@ GET /
+@@ -343,6 +436,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -429,7 +383,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert_equal("server.example.com", req.server_name)
-@@ -340,6 +493,7 @@ GET /
+@@ -365,6 +459,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -437,7 +391,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert_equal("server1.example.com", req.server_name)
-@@ -362,6 +516,7 @@ GET /
+@@ -387,6 +482,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -445,7 +399,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert_equal("server1.example.com", req.server_name)
-@@ -384,6 +539,7 @@ GET /
+@@ -409,6 +505,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -453,7 +407,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert_equal("server1.example.com", req.server_name)
-@@ -401,6 +557,7 @@ GET /
+@@ -426,6 +523,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -461,7 +415,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert req['expect']
-@@ -417,6 +574,7 @@ GET /
+@@ -442,6 +540,7 @@ GET /
  
      _end_of_message_
      msg.gsub!(/^ {6}/, "")
@@ -469,7 +423,7 @@ index 2ff08d6..0704778 100644
      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
      req.parse(StringIO.new(msg))
      assert !req['expect']
-@@ -436,7 +594,7 @@ GET /
+@@ -461,7 +560,7 @@ GET /
      _end_of_message_
      assert_raise(WEBrick::HTTPStatus::LengthRequired){
        req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -478,7 +432,7 @@ index 2ff08d6..0704778 100644
        req.body
      }
  
-@@ -449,7 +607,7 @@ GET /
+@@ -474,7 +573,7 @@ GET /
      _end_of_message_
      assert_raise(WEBrick::HTTPStatus::BadRequest){
        req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
@@ -487,7 +441,7 @@ index 2ff08d6..0704778 100644
        req.body
      }
  
-@@ -462,7 +620,7 @@ GET /
+@@ -487,7 +586,7 @@ GET /
      _end_of_message_
      assert_raise(WEBrick::HTTPStatus::NotImplemented){
        req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)

--- a/SPECS/rubygem-webrick/rubygem-webrick.spec
+++ b/SPECS/rubygem-webrick/rubygem-webrick.spec
@@ -50,7 +50,7 @@ popd
 
 %files
 %defattr(-,root,root,-)
-%doc %{gemdir}/gems/%{gem_name}-%{version}/LICENSE.txt
+%license LICENSE.txt
 %{gemdir}
 
 %changelog

--- a/SPECS/rubygem-webrick/rubygem-webrick.spec
+++ b/SPECS/rubygem-webrick/rubygem-webrick.spec
@@ -3,15 +3,18 @@
 Summary:        HTTP server toolkit
 Name:           rubygem-%{gem_name}
 Version:        1.8.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD
 Vendor:	        Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://github.com/ruby/webrick
 Source0:        https://github.com/ruby/webrick/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
-Patch0:         CVE-2025-6442.patch
+Patch0:         CVE-2023-40225-content-length-validation.patch
+Patch1:         CVE-2025-6442.patch
 BuildRequires:  git
 BuildRequires:  ruby
+BuildRequires:  rubygem-test-unit
+BuildRequires:  rubygems-devel
 Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 %description
@@ -30,12 +33,31 @@ gem build %{gem_name}
 %install
 gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-%{version}.gem
 
+%check
+pushd %{buildroot}%{gem_instdir}
+# Symlink the test suite from source directory
+ln -sf %{_builddir}/%{gem_name}-%{version}/test .
+ 
+# Use --verbose to set $VERBOSE to true. `test_sni` in test/webrick/test_https.rb
+# relies on output in $stderr from lib/webrick/ssl.rb that is only written there
+# if $VERBOSE is true.
+# https://github.com/ruby/webrick/pull/158
+ruby --verbose           \
+     -Ilib:test:test/lib \
+     -rhelper            \
+     -e 'Dir.glob "./test/**/test_*.rb", &method(:require)'
+popd
+
 %files
 %defattr(-,root,root,-)
 %doc %{gemdir}/gems/%{gem_name}-%{version}/LICENSE.txt
 %{gemdir}
 
 %changelog
+* Wed Jul 16 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 1.8.1-3
+- Add %check section
+- Add patch to fix failing tests
+
 * Fri Jun 27 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.8.1-2
 - Patch for CVE-2025-6442
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- The  patch CVE-2025-6442.patch adds some tests, but it doesn't include the actual code those tests are meant to check. Because of this, the tests fail when this patch is applied.(These patches can be removed when upgraded to 1.8.2)
- Added an extra patch that brings in the missing code.  (Although it is patch version upgrade, starting from version 1.8.2, Webrick depends on a new gem called test-unit-ruby-core. Before that, it used some test helper files that were part of the same repo.But since test-unit-ruby-core is not available in Azure Linux, we're staying on version 1.8.1 for now and using patches.)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add %check section
- Add patch to fix failing tests

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/58146364

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-6442

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Patch application successful
<img width="1177" height="203" alt="image" src="https://github.com/user-attachments/assets/8f36a37d-4b67-41ca-a94a-860f7f32bcbe" />

- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=869558&view=results
