### PR TITLE
[MEDIUM] Patch apache-commons-lang3 for CVE-2025-48924

### DIFF
--- a/SPECS/apache-commons-lang3/CVE-2025-48924.patch
+++ b/SPECS/apache-commons-lang3/CVE-2025-48924.patch
@@ -77,7 +77,7 @@ index be9f0dd..a9ec195 100644
 -
 -            throw ex;
 -        }
-+         } while (lastDotIndex != -1);
++        } while (lastDotIndex != -1);
 +        throw new ClassNotFoundException(next);
      }
  

--- a/SPECS/apache-commons-lang3/CVE-2025-48924.patch
+++ b/SPECS/apache-commons-lang3/CVE-2025-48924.patch
@@ -1,0 +1,100 @@
+From b424803abdb2bec818e4fbcb251ce031c22aca53 Mon Sep 17 00:00:00 2001
+From: Gary Gregory <garydgregory@gmail.com>
+Date: Sat, 21 Sep 2024 17:23:08 -0400
+Subject: [PATCH] Rewrite ClassUtils.getClass() without recursion to avoid
+ StackOverflowError on very long inputs.
+
+- This was found fuzz testing Apache Commons Text which relies on
+ClassUtils.
+- OssFuzz Issue 42522972:
+apache-commons-text:StringSubstitutorInterpolatorFuzzer: Security
+exception in org.apache.commons.lang3.ClassUtils.getClass
+
+Upstream Patch Reference: https://github.com/apache/commons-lang/commit/b424803abdb2bec818e4fbcb251ce031c22aca53.patch
+---
+ src/changes/changes.xml                       |  1 +
+ .../org/apache/commons/lang3/ClassUtils.java  | 46 +++++++++----------
+ 2 files changed, 23 insertions(+), 24 deletions(-)
+
+diff --git a/src/changes/changes.xml b/src/changes/changes.xml
+index 5731324..dd2577b 100644
+--- a/src/changes/changes.xml
++++ b/src/changes/changes.xml
+@@ -47,6 +47,7 @@ The <action> type attribute can be add,update,fix,remove.
+ 
+   <release version="3.8.1" date="2018-09-19" description="This release is a bugfix for Restoring Bundle-SymbolicName in the MANIFEST.mf file.">
+     <action issue="LANG-1419" type="fix" dev="chtompki">Restore BundleSymbolicName for OSGi</action>
++    <action                   type="fix" dev="ggregory" due-to="OSS-Fuzz, Gary Gregory">Rewrite ClassUtils.getClass(...) without recursion to avoid StackOverflowError on very long inputs. OSS-Fuzz Issue 42522972: apache-commons-text:StringSubstitutorInterpolatorFuzzer: Security exception in org.apache.commons.lang3.ClassUtils.getClass.</action>
+   </release>
+ 
+   <release version="3.8" date="2018-08-15" description="New features and bug fixes. Requires Java 7, supports Java 8, 9, 10.">
+diff --git a/src/main/java/org/apache/commons/lang3/ClassUtils.java b/src/main/java/org/apache/commons/lang3/ClassUtils.java
+index be9f0dd..a9ec195 100644
+--- a/src/main/java/org/apache/commons/lang3/ClassUtils.java
++++ b/src/main/java/org/apache/commons/lang3/ClassUtils.java
+@@ -985,30 +985,27 @@ public class ClassUtils {
+      */
+     public static Class<?> getClass(
+             final ClassLoader classLoader, final String className, final boolean initialize) throws ClassNotFoundException {
+-        try {
+-            Class<?> clazz;
+-            if (namePrimitiveMap.containsKey(className)) {
+-                clazz = namePrimitiveMap.get(className);
+-            } else {
+-                clazz = Class.forName(toCanonicalName(className), initialize, classLoader);
+-            }
+-            return clazz;
+-        } catch (final ClassNotFoundException ex) {
+-            // allow path separators (.) as inner class name separators
+-            final int lastDotIndex = className.lastIndexOf(PACKAGE_SEPARATOR_CHAR);
+-
+-            if (lastDotIndex != -1) {
+-                try {
+-                    return getClass(classLoader, className.substring(0, lastDotIndex) +
+-                            INNER_CLASS_SEPARATOR_CHAR + className.substring(lastDotIndex + 1),
+-                            initialize);
+-                } catch (final ClassNotFoundException ex2) { // NOPMD
+-                    // ignore exception
++        // This method was re-written to avoid recursion and stack overflows found by fuzz testing.
++        String next = className;
++        int lastDotIndex = -1;
++        do {
++            try {
++                Class<?> clazz;
++                if (namePrimitiveMap.containsKey(next)) {
++                    clazz = namePrimitiveMap.get(next);
++                } else {
++                    clazz = Class.forName(toCanonicalName(next), initialize, classLoader);
++                }
++                return clazz;
++            } catch (final ClassNotFoundException ex) {
++                lastDotIndex = next.lastIndexOf(PACKAGE_SEPARATOR_CHAR);
++                if (lastDotIndex != -1) {
++                    next = next.substring(0, lastDotIndex) +
++                            INNER_CLASS_SEPARATOR_CHAR + next.substring(lastDotIndex + 1);
+                 }
+             }
+-
+-            throw ex;
+-        }
++         } while (lastDotIndex != -1);
++        throw new ClassNotFoundException(next);
+     }
+ 
+     /**
+@@ -1124,9 +1121,10 @@ public class ClassUtils {
+     private static String toCanonicalName(String className) {
+         className = StringUtils.deleteWhitespace(className);
+         Validate.notNull(className, "className must not be null.");
+-        if (className.endsWith("[]")) {
++        final String arrayMarker = "[]";
++        if (className.endsWith(arrayMarker)) {
+             final StringBuilder classNameBuffer = new StringBuilder();
+-            while (className.endsWith("[]")) {
++            while (className.endsWith(arrayMarker)) {
+                 className = className.substring(0, className.length() - 2);
+                 classNameBuffer.append("[");
+             }
+-- 
+2.34.1
+

--- a/SPECS/apache-commons-lang3/apache-commons-lang3.spec
+++ b/SPECS/apache-commons-lang3/apache-commons-lang3.spec
@@ -18,7 +18,7 @@
 Summary:        Apache Commons Lang Package
 Name:           apache-%{short_name}
 Version:        3.8.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -27,6 +27,7 @@ URL:            https://commons.apache.org/proper/commons-lang
 Source0:        https://archive.apache.org/dist/commons/lang/source/%{short_name}-%{version}-src.tar.gz
 Source1:        build.xml
 Source2:        default.properties
+Patch0:         CVE-2025-48924.patch
 BuildRequires:  ant
 BuildRequires:  ant-junit
 BuildRequires:  fdupes
@@ -57,7 +58,8 @@ Group:          Documentation/HTML
 Javadoc for %{name}.
 
 %prep
-%setup -q -n %{short_name}-%{version}-src
+
+%autosetup -n %{short_name}-%{version}-src -p1
 cp %{SOURCE1} .
 cp %{SOURCE2} .
 sed -i 's/\r//' *.txt
@@ -98,6 +100,9 @@ cp -pr target/apidocs/* %{buildroot}%{_javadocdir}/%{name}/
 %{_javadocdir}/%{name}
 
 %changelog
+* Wed Jul 16 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 3.8.1-6
+- Addressed CVE-2025-48924
+
 * Fri Mar 17 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 3.8.1-5
 - Moved from extended to core
 - License verified


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Addresses CVE-2025-48924

Patch backported : Yes
Excluded ClassUtilsOssFuzzTest.java file during backporting since its a binary test file
Patch reference from Astrolabe: https://github.com/apache/commons-lang/commit/b424803abdb2bec818e4fbcb251ce031c22aca53

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/apache-commons-lang3/apache-commons-lang3.spec
- added: SPECS/apache-commons-lang3/CVE-2025-48924.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-48924

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build:
- Patch applies cleanly: 
<img width="1008" height="195" alt="image" src="https://github.com/user-attachments/assets/61a5c218-9e28-43a3-83a8-cb5670b5bb93" />
- build log: 
[apache-commons-lang3-3.8.1-6.cm2.src.rpm.log](https://github.com/user-attachments/files/21264611/apache-commons-lang3-3.8.1-6.cm2.src.rpm.log)
<img width="1309" height="972" alt="image" src="https://github.com/user-attachments/assets/3b246f8d-4c4b-4dbc-9f7a-84b074448222" />



