### PR TITLE
Fix git ptest with new git config syntax

### DIFF
--- a/SPECS/git/Ptest-fix-git-config-syntax.patch
+++ b/SPECS/git/Ptest-fix-git-config-syntax.patch
@@ -1,0 +1,46 @@
+From 5415cf267c1b5a4ef9591e11106085bc24b7131b Mon Sep 17 00:00:00 2001
+From: archana25-ms <v-shettigara@microsoft.com>
+Date: Thu, 17 Jul 2025 17:21:37 +0000
+Subject: [PATCH] Fix  git config syntax
+Upstream Patch reference: https://lkml.org/lkml/2025/7/8/1608
+
+---
+ t/t1300-config.sh           | 4 ++--
+ t/t7450-bad-git-dotfiles.sh | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/t/t1300-config.sh b/t/t1300-config.sh
+index 00f34c5..3ed4a0b 100755
+--- a/t/t1300-config.sh
++++ b/t/t1300-config.sh
+@@ -2743,8 +2743,8 @@ test_expect_success 'writing value with trailing CR not stripped on read' '
+ 
+ 	printf "bar\r\n" >expect &&
+ 	git init cr-test &&
+-	git -C cr-test config set core.foo $(printf "bar\r") &&
+-	git -C cr-test config get core.foo >actual &&
++	git -C cr-test config core.foo $(printf "bar\r") &&
++	git -C cr-test config --get core.foo >actual &&
+ 
+ 	test_cmp expect actual
+ '
+diff --git a/t/t7450-bad-git-dotfiles.sh b/t/t7450-bad-git-dotfiles.sh
+index ff63c05..38b9db8 100755
+--- a/t/t7450-bad-git-dotfiles.sh
++++ b/t/t7450-bad-git-dotfiles.sh
+@@ -388,10 +388,10 @@ test_expect_success SYMLINKS,!WINDOWS,!MINGW 'submodule must not checkout into d
+ 	git -C repo mv sub $(printf "sub\r") &&
+ 
+ 	# Ensure config values containing CR are wrapped in quotes.
+-	git config unset -f repo/.gitmodules submodule.sub.path &&
++	git config --unset -f repo/.gitmodules submodule.sub.path &&
+ 	printf "\tpath = \"sub\r\"\n" >>repo/.gitmodules &&
+ 
+-	git config unset -f repo/.git/modules/sub/config core.worktree &&
++	git config --unset -f repo/.git/modules/sub/config core.worktree &&
+ 	{
+ 		printf "[core]\n" &&
+ 		printf "\tworktree = \"../../../sub\r\"\n"
+-- 
+2.45.3
+

--- a/SPECS/git/git.spec
+++ b/SPECS/git/git.spec
@@ -14,6 +14,7 @@ Distribution:   Azure Linux
 Group:          System Environment/Programming
 URL:            https://git-scm.com/
 Source0:        https://github.com/git/git/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Below patch not needed for Git 2.46.0, already includes this fix.
 Patch0:         Ptest-fix-git-config-syntax.patch
 BuildRequires:  curl-devel
 BuildRequires:  python3-devel

--- a/SPECS/git/git.spec
+++ b/SPECS/git/git.spec
@@ -7,13 +7,14 @@
 Summary:        Fast distributed version control system
 Name:           git
 Version:        2.45.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System Environment/Programming
 URL:            https://git-scm.com/
 Source0:        https://github.com/git/git/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         Ptest-fix-git-config-syntax.patch
 BuildRequires:  curl-devel
 BuildRequires:  python3-devel
 Requires:       curl
@@ -106,7 +107,7 @@ BuildArch:      noarch
 %endif
 
 %prep
-%autosetup
+%autosetup -p1
 %{py3_shebang_fix} git-p4.py
 
 %build
@@ -173,6 +174,9 @@ fi
 %endif
 
 %changelog
+* Fri Jul 18 2025 Archana Shettigar <v-shettigara@microsoft.com> - 2.45.4-2
+- Fix ptest with new git config syntax in CVE-2025-48384
+
 * Fri Jul 11 2025 Archana Shettigar <v-shettigara@microsoft.com> - 2.45.4-1
 - Upgrade to 2.45.4 - CVE-2025-48384, CVE-2025-48385, CVE-2025-27613 & CVE-2025-27614
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Coordinated fix for CVE-2025-48384.
For 3.0 branch, inorder to fix CVE-2025-48384, we performed version upgrade from 2.45.3-> 2.45.4.
With the upgrade, following two files 
1. `t1300.237 - writing value with trailing CR not stripped on read`
2. `t7450.50  submodule must not checkout into different directory`
had used new git config syntax (get, set, unset) which is not available in the older releases.

Reference: https://git-scm.com/docs/git-config#_deprecated_modes
So following are the changes in git subcommands which are being transitioned
| Old subcommand | New subcommand style|
| ------- | ------- |
| git config --get <name> | git config get <name> |
| git config --unset <name> | git config unset <name> |
| git config --add <name> <value> | git config set --append <name> <value> |
| git config -e or --edit | git config edit |
| git config --remove-section <name> | git config remove-section <name> |

Patch reference: https://lkml.org/lkml/2025/7/8/1608

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/git/Ptest-fix-git-config-syntax.patch
- SPECS/git/git.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/58406858
Test Fails for the new test case added in CVE-2025-48384
<img width="675" height="239" alt="image" src="https://github.com/user-attachments/assets/8869a2e3-417f-47ac-ad12-2485ec9d9195" />



###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
<img width="340" height="408" alt="image" src="https://github.com/user-attachments/assets/e2dfa878-3af3-4fd5-bff0-9971744e6f70" />

- [x] Builds successfully - 
[git-2.45.4-1.azl3.src.rpm.log](https://github.com/user-attachments/files/21313422/git-2.45.4-1.azl3.src.rpm.log)

- [x] Tests successfully - 
[git-2.45.4-1.azl3.src.rpm.test.log](https://github.com/user-attachments/files/21313423/git-2.45.4-1.azl3.src.rpm.test.log)

<img width="592" height="74" alt="image" src="https://github.com/user-attachments/assets/8e0bbc79-ea9c-4ba8-8187-3743ce780ec5" />
