### PR TITLE
[Medium] Upgrade vim version to 9.1.1552 for CVE-2025-53905 and CVE-2025-53906

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "vim-9.1.1198.tar.gz": "ce85c04b1b1dc1258635d4887d84681aa6b637b0ca15364898d9b27e2a747057"
+    "vim-9.1.1552.tar.gz": "66400ef982ba96496a4c02c5861bf5ecb317fdfccc750342111a4548f714721d"
   }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        9.1.1198
+Version:        9.1.1552
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -136,7 +136,6 @@ fi
 %{_datarootdir}/vim/vim*/lang/*.vim
 %doc %{_datarootdir}/vim/vim*/lang/*.txt
 %lang(af) %{_datarootdir}/vim/vim*/lang/af/LC_MESSAGES/vim.mo
-%lang(am) %{_datarootdir}/vim/vim*/lang/am/LC_MESSAGES/vim.mo
 %lang(ca) %{_datarootdir}/vim/vim*/lang/ca/LC_MESSAGES/vim.mo
 %lang(cs) %{_datarootdir}/vim/vim*/lang/cs/LC_MESSAGES/vim.mo
 %lang(de) %{_datarootdir}/vim/vim*/lang/de/LC_MESSAGES/vim.mo
@@ -147,6 +146,7 @@ fi
 %lang(fr) %{_datarootdir}/vim/vim*/lang/fr/LC_MESSAGES/vim.mo
 %lang(ga) %{_datarootdir}/vim/vim*/lang/ga/LC_MESSAGES/vim.mo
 %lang(hu) %{_datarootdir}/vim/vim*/lang/hu/LC_MESSAGES/vim.mo
+%lang(hy) %{_datarootdir}/vim/vim*/lang/hy/LC_MESSAGES/vim.mo
 %lang(it) %{_datarootdir}/vim/vim*/lang/it/LC_MESSAGES/vim.mo
 %lang(ja) %{_datarootdir}/vim/vim*/lang/ja/LC_MESSAGES/vim.mo
 %lang(ko.UTF-8) %{_datarootdir}/vim/vim*/lang/ko.UTF-8/LC_MESSAGES/vim.mo
@@ -201,6 +201,9 @@ fi
 %{_datarootdir}/vim/vim91/README.txt
 
 %changelog
+* Fri Jul 18 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 9.1.1552-1
+- Upgrade to 9.1.1552 - for CVE-2025-53905 and CVE-2025-53906
+
 * Mon Mar 17 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.1.1198-1
 - Auto-upgrade to 9.1.1198 - for CVE-2025-29768
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29467,8 +29467,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "9.1.1198",
-          "downloadUrl": "https://github.com/vim/vim/archive/v9.1.1198.tar.gz"
+          "version": "9.1.1552",
+          "downloadUrl": "https://github.com/vim/vim/archive/v9.1.1552.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade vim version to 9.1.1552 for CVE-2025-53905 and CVE-2025-53906
Performed minor version upgrade of vim from 9.1.1198 -> 9.1.1552 to fix the CVEs.
- The code changes from https://github.com/vim/vim/commit/87757c6b0a4b2c1f71c72ea8e1438b8fb116b239 and https://github.com/vim/vim/commit/586294a04179d855c3d1d4ee5ea83931963680b8 mentioned by astrolabe are included in the vim-9.1.1552 source code.

Removed /usr/share/vim/vim*/lang/am/LC_MESSAGES/vim.mo since it is not generated now in the 9.1.1552 source code, and added /usr/share/vim/vim*/lang/hy/LC_MESSAGES/vim.mo to the files section.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- vim.spec
- vim.signatures.json
- cgmanifest.json

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-53905
- https://nvd.nist.gov/vuln/detail/CVE-2025-53906

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Verified build locally.
[vim-9.1.1552-1.cm2.src.rpm.test.log](https://github.com/user-attachments/files/21313723/vim-9.1.1552-1.cm2.src.rpm.test.log)
[vim-9.1.1552-1.cm2.src.rpm.log](https://github.com/user-attachments/files/21313726/vim-9.1.1552-1.cm2.src.rpm.log)
