### PR TITLE
Patch libxml2 for CVE-2025-49794, CVE-2025-49796[CRITICAL], CVE-2025-6021[MED], CVE-2025-6170[LOW]

### DIFF
--- a/SPECS/libxml2/CVE-2025-49794_CVE-2025-49796.patch
+++ b/SPECS/libxml2/CVE-2025-49794_CVE-2025-49796.patch
@@ -1,0 +1,182 @@
+From f0c3f2b962a5e82d665df81f0154d09df8097c1e Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Fri, 4 Jul 2025 14:28:26 +0200
+Subject: [PATCH] schematron: Fix memory safety issues in
+ xmlSchematronReportOutput
+
+Fix use-after-free (CVE-2025-49794) and type confusion (CVE-2025-49796)
+in xmlSchematronReportOutput.
+
+Fixes #931.
+Fixes #933.
+---
+ result/schematron/cve-2025-49794_0.err |  2 ++
+ result/schematron/cve-2025-49796_0.err |  2 ++
+ schematron.c                           | 49 ++++++++++++++------------
+ test/schematron/cve-2025-49794.sct     | 10 ++++++
+ test/schematron/cve-2025-49794_0.xml   |  6 ++++
+ test/schematron/cve-2025-49796.sct     |  9 +++++
+ test/schematron/cve-2025-49796_0.xml   |  3 ++
+ 7 files changed, 58 insertions(+), 23 deletions(-)
+ create mode 100644 result/schematron/cve-2025-49794_0.err
+ create mode 100644 result/schematron/cve-2025-49796_0.err
+ create mode 100644 test/schematron/cve-2025-49794.sct
+ create mode 100644 test/schematron/cve-2025-49794_0.xml
+ create mode 100644 test/schematron/cve-2025-49796.sct
+ create mode 100644 test/schematron/cve-2025-49796_0.xml
+
+diff --git a/result/schematron/cve-2025-49794_0.err b/result/schematron/cve-2025-49794_0.err
+new file mode 100644
+index 0000000..5775231
+--- /dev/null
++++ b/result/schematron/cve-2025-49794_0.err
+@@ -0,0 +1,2 @@
++./test/schematron/cve-2025-49794_0.xml:2: element boo0: schematron error : /librar0/boo0 line 2:  
++./test/schematron/cve-2025-49794_0.xml fails to validate
+diff --git a/result/schematron/cve-2025-49796_0.err b/result/schematron/cve-2025-49796_0.err
+new file mode 100644
+index 0000000..bf875ee
+--- /dev/null
++++ b/result/schematron/cve-2025-49796_0.err
+@@ -0,0 +1,2 @@
++./test/schematron/cve-2025-49796_0.xml:2: element boo0: schematron error : /librar0/boo0 line 2:  
++./test/schematron/cve-2025-49796_0.xml fails to validate
+diff --git a/schematron.c b/schematron.c
+index 68a4c62..673ef0a 100644
+--- a/schematron.c
++++ b/schematron.c
+@@ -1386,27 +1386,15 @@ exit:
+  *                                                                      *
+  ************************************************************************/
+ 
+-static xmlNodePtr
++static xmlXPathObjectPtr
+ xmlSchematronGetNode(xmlSchematronValidCtxtPtr ctxt,
+                      xmlNodePtr cur, const xmlChar *xpath) {
+-    xmlNodePtr node = NULL;
+-    xmlXPathObjectPtr ret;
+-
+     if ((ctxt == NULL) || (cur == NULL) || (xpath == NULL))
+         return(NULL);
+ 
+     ctxt->xctxt->doc = cur->doc;
+     ctxt->xctxt->node = cur;
+-    ret = xmlXPathEval(xpath, ctxt->xctxt);
+-    if (ret == NULL)
+-        return(NULL);
+-
+-    if ((ret->type == XPATH_NODESET) &&
+-        (ret->nodesetval != NULL) && (ret->nodesetval->nodeNr > 0))
+-        node = ret->nodesetval->nodeTab[0];
+-
+-    xmlXPathFreeObject(ret);
+-    return(node);
++    return(xmlXPathEval(xpath, ctxt->xctxt));
+ }
+ 
+ /**
+@@ -1452,25 +1440,40 @@ xmlSchematronFormatReport(xmlSchematronValidCtxtPtr ctxt,
+             (child->type == XML_CDATA_SECTION_NODE))
+             ret = xmlStrcat(ret, child->content);
+         else if (IS_SCHEMATRON(child, "name")) {
++            xmlXPathObject *obj = NULL;
+             xmlChar *path;
+ 
+             path = xmlGetNoNsProp(child, BAD_CAST "path");
+ 
+             node = cur;
+             if (path != NULL) {
+-                node = xmlSchematronGetNode(ctxt, cur, path);
+-                if (node == NULL)
+-                    node = cur;
++                obj = xmlSchematronGetNode(ctxt, cur, path);
++                if ((obj != NULL) &&
++                    (obj->type == XPATH_NODESET) &&
++                    (obj->nodesetval != NULL) &&
++                    (obj->nodesetval->nodeNr > 0))
++                    node = obj->nodesetval->nodeTab[0];
+                 xmlFree(path);
+             }
+ 
+-            if ((node->ns == NULL) || (node->ns->prefix == NULL))
+-                ret = xmlStrcat(ret, node->name);
+-            else {
+-                ret = xmlStrcat(ret, node->ns->prefix);
+-                ret = xmlStrcat(ret, BAD_CAST ":");
+-                ret = xmlStrcat(ret, node->name);
++            switch (node->type) {
++                case XML_ELEMENT_NODE:
++                case XML_ATTRIBUTE_NODE:
++                    if ((node->ns == NULL) || (node->ns->prefix == NULL))
++                        ret = xmlStrcat(ret, node->name);
++                    else {
++                        ret = xmlStrcat(ret, node->ns->prefix);
++                        ret = xmlStrcat(ret, BAD_CAST ":");
++                        ret = xmlStrcat(ret, node->name);
++                    }
++                    break;
++
++                /* TODO: handle other node types */
++                default:
++                    break;
+             }
++
++            xmlXPathFreeObject(obj);
+         } else if (IS_SCHEMATRON(child, "value-of")) {
+             xmlChar *select;
+             xmlXPathObjectPtr eval;
+diff --git a/test/schematron/cve-2025-49794.sct b/test/schematron/cve-2025-49794.sct
+new file mode 100644
+index 0000000..7fc9ee3
+--- /dev/null
++++ b/test/schematron/cve-2025-49794.sct
+@@ -0,0 +1,10 @@
++<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
++    <sch:pattern id="">
++        <sch:rule context="boo0">
++            <sch:report test="not(0)">
++                <sch:name path="&#9;e|namespace::*|e"/>
++            </sch:report>
++            <sch:report test="0"></sch:report>
++        </sch:rule>
++    </sch:pattern>
++</sch:schema>
+diff --git a/test/schematron/cve-2025-49794_0.xml b/test/schematron/cve-2025-49794_0.xml
+new file mode 100644
+index 0000000..debc64b
+--- /dev/null
++++ b/test/schematron/cve-2025-49794_0.xml
+@@ -0,0 +1,6 @@
++<librar0>
++    <boo0 t="">
++        <author></author>
++    </boo0>
++    <ins></ins>
++</librar0>
+diff --git a/test/schematron/cve-2025-49796.sct b/test/schematron/cve-2025-49796.sct
+new file mode 100644
+index 0000000..e9702d7
+--- /dev/null
++++ b/test/schematron/cve-2025-49796.sct
+@@ -0,0 +1,9 @@
++<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
++    <sch:pattern id="">
++        <sch:rule context="boo0">
++            <sch:report test="not(0)">
++                <sch:name path="/"/>
++            </sch:report>
++        </sch:rule>
++    </sch:pattern>
++</sch:schema>
+diff --git a/test/schematron/cve-2025-49796_0.xml b/test/schematron/cve-2025-49796_0.xml
+new file mode 100644
+index 0000000..be33c4e
+--- /dev/null
++++ b/test/schematron/cve-2025-49796_0.xml
+@@ -0,0 +1,3 @@
++<librar0>
++    <boo0/>
++</librar0>
+-- 
+2.45.4
+

--- a/SPECS/libxml2/CVE-2025-6021.patch
+++ b/SPECS/libxml2/CVE-2025-6021.patch
@@ -1,0 +1,50 @@
+From ff1a4c29bf7268826e3f24357eb191282b9dcc77 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 30 Jun 2025 11:36:24 -0500
+Subject: [PATCH] Address CVE-2025-6021
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781
+
+---
+ tree.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/tree.c b/tree.c
+index 03572ff..c0b0d70 100644
+--- a/tree.c
++++ b/tree.c
+@@ -47,6 +47,10 @@
+ #include "buf.h"
+ #include "save.h"
+ 
++#ifndef SIZE_MAX
++#define SIZE_MAX ((size_t) -1)
++#endif
++
+ int __xmlRegisterCallbacks = 0;
+ 
+ /************************************************************************
+@@ -219,16 +223,18 @@ xmlGetParameterEntityFromDtd(const xmlDtd *dtd, const xmlChar *name) {
+ xmlChar *
+ xmlBuildQName(const xmlChar *ncname, const xmlChar *prefix,
+ 	      xmlChar *memory, int len) {
+-    int lenn, lenp;
++    size_t lenn, lenp;
+     xmlChar *ret;
+ 
+-    if (ncname == NULL) return(NULL);
++    if ((ncname == NULL) || (len < 0)) return(NULL);
+     if (prefix == NULL) return((xmlChar *) ncname);
+ 
+     lenn = strlen((char *) ncname);
+     lenp = strlen((char *) prefix);
++    if (lenn >= SIZE_MAX - lenp - 1)
++        return(NULL);
+ 
+-    if ((memory == NULL) || (len < lenn + lenp + 2)) {
++    if ((memory == NULL) || ((size_t) len < lenn + lenp + 2)) {
+ 	ret = (xmlChar *) xmlMallocAtomic(lenn + lenp + 2);
+ 	if (ret == NULL) {
+ 	    xmlTreeErrMemory("building QName");
+-- 
+2.45.2
+

--- a/SPECS/libxml2/CVE-2025-6170.patch
+++ b/SPECS/libxml2/CVE-2025-6170.patch
@@ -1,0 +1,61 @@
+From af4d4fd3e12fc9553b532f66c3717fe5dedfae98 Mon Sep 17 00:00:00 2001
+From: BinduSri-6522866 <v-badabala@microsoft.com>
+Date: Fri, 4 Jul 2025 11:04:50 +0000
+Subject: [PATCH] Address CVE-2025-6170
+
+Upstream Patch reference: https://gitlab.gnome.org/GNOME/libxml2/-/issues/941
+---
+ debugXML.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/debugXML.c b/debugXML.c
+index 3bb1930..2d11213 100644
+--- a/debugXML.c
++++ b/debugXML.c
+@@ -2781,6 +2781,10 @@ xmlShellPwd(xmlShellCtxtPtr ctxt ATTRIBUTE_UNUSED, char *buffer,
+     return (0);
+ }
+ 
++#define MAX_PROMPT_SIZE     500
++#define MAX_ARG_SIZE        400
++#define MAX_COMMAND_SIZE    100
++
+ /**
+  * xmlShell:
+  * @doc:  the initial document
+@@ -2796,10 +2800,10 @@ void
+ xmlShell(xmlDocPtr doc, char *filename, xmlShellReadlineFunc input,
+          FILE * output)
+ {
+-    char prompt[500] = "/ > ";
++    char prompt[MAX_PROMPT_SIZE] = "/ > ";
+     char *cmdline = NULL, *cur;
+-    char command[100];
+-    char arg[400];
++    char command[MAX_COMMAND_SIZE];
++    char arg[MAX_ARG_SIZE];
+     int i;
+     xmlShellCtxtPtr ctxt;
+     xmlXPathObjectPtr list;
+@@ -2857,7 +2861,8 @@ xmlShell(xmlDocPtr doc, char *filename, xmlShellReadlineFunc input,
+             cur++;
+         i = 0;
+         while ((*cur != ' ') && (*cur != '\t') &&
+-               (*cur != '\n') && (*cur != '\r')) {
++               (*cur != '\n') && (*cur != '\r') &&
++               (i < (MAX_COMMAND_SIZE - 1))) {
+             if (*cur == 0)
+                 break;
+             command[i++] = *cur++;
+@@ -2872,7 +2877,7 @@ xmlShell(xmlDocPtr doc, char *filename, xmlShellReadlineFunc input,
+         while ((*cur == ' ') || (*cur == '\t'))
+             cur++;
+         i = 0;
+-        while ((*cur != '\n') && (*cur != '\r') && (*cur != 0)) {
++        while ((*cur != '\n') && (*cur != '\r') && (*cur != 0) && (i < (MAX_ARG_SIZE-1))) {
+             if (*cur == 0)
+                 break;
+             arg[i++] = *cur++;
+-- 
+2.45.3
+

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.10.4
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,9 @@ Patch5:         CVE-2025-24928.patch
 Patch6:         CVE-2025-27113.patch
 Patch7:         CVE-2025-32414.patch
 Patch8:         CVE-2025-32415.patch
+Patch9:         CVE-2025-6170.patch
+Patch10:        CVE-2025-6021.patch
+Patch11:        CVE-2025-49794_CVE-2025-49796.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -87,6 +90,10 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Sun Jul 20 2025 Kshitiz Godara <kgodara@microsoft.com> - 2.10.4-8
+- Patch CVE-2025-49794 and CVE-2025-49796
+- Also added patches for CVE-2025-6021 (PR#14310) and CVE-2025-6170 (PR#14228)
+
 * Mon May 05 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-7
 - Patch CVE-2025-32414 and CVE-2025-32415
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.aarch64.rpm
 curl-devel-8.8.0-6.cm2.aarch64.rpm
 curl-libs-8.8.0-6.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
-libxml2-2.10.4-7.cm2.aarch64.rpm
-libxml2-devel-2.10.4-7.cm2.aarch64.rpm
+libxml2-2.10.4-8.cm2.aarch64.rpm
+libxml2-devel-2.10.4-8.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.x86_64.rpm
 curl-devel-8.8.0-6.cm2.x86_64.rpm
 curl-libs-8.8.0-6.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
-libxml2-2.10.4-7.cm2.x86_64.rpm
-libxml2-devel-2.10.4-7.cm2.x86_64.rpm
+libxml2-2.10.4-8.cm2.x86_64.rpm
+libxml2-devel-2.10.4-8.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -209,9 +209,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.aarch64.rpm
 libtasn1-devel-4.19.0-2.cm2.aarch64.rpm
 libtool-2.4.6-8.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-8.cm2.aarch64.rpm
-libxml2-2.10.4-7.cm2.aarch64.rpm
-libxml2-debuginfo-2.10.4-7.cm2.aarch64.rpm
-libxml2-devel-2.10.4-7.cm2.aarch64.rpm
+libxml2-2.10.4-8.cm2.aarch64.rpm
+libxml2-debuginfo-2.10.4-8.cm2.aarch64.rpm
+libxml2-devel-2.10.4-8.cm2.aarch64.rpm
 libxslt-1.1.34-8.cm2.aarch64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.aarch64.rpm
 libxslt-devel-1.1.34-8.cm2.aarch64.rpm
@@ -521,7 +521,7 @@ python3-gpg-1.16.0-2.cm2.aarch64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.aarch64.rpm
 python3-libs-3.9.19-14.cm2.aarch64.rpm
-python3-libxml2-2.10.4-7.cm2.aarch64.rpm
+python3-libxml2-2.10.4-8.cm2.aarch64.rpm
 python3-lxml-4.9.1-1.cm2.aarch64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -215,9 +215,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.x86_64.rpm
 libtasn1-devel-4.19.0-2.cm2.x86_64.rpm
 libtool-2.4.6-8.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-8.cm2.x86_64.rpm
-libxml2-2.10.4-7.cm2.x86_64.rpm
-libxml2-debuginfo-2.10.4-7.cm2.x86_64.rpm
-libxml2-devel-2.10.4-7.cm2.x86_64.rpm
+libxml2-2.10.4-8.cm2.x86_64.rpm
+libxml2-debuginfo-2.10.4-8.cm2.x86_64.rpm
+libxml2-devel-2.10.4-8.cm2.x86_64.rpm
 libxslt-1.1.34-8.cm2.x86_64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.x86_64.rpm
 libxslt-devel-1.1.34-8.cm2.x86_64.rpm
@@ -527,7 +527,7 @@ python3-gpg-1.16.0-2.cm2.x86_64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.x86_64.rpm
 python3-libs-3.9.19-14.cm2.x86_64.rpm
-python3-libxml2-2.10.4-7.cm2.x86_64.rpm
+python3-libxml2-2.10.4-8.cm2.x86_64.rpm
 python3-lxml-4.9.1-1.cm2.x86_64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Added Patches for libxml2 for CVE-2025-49794, CVE-2025-49796[CRITICAL], CVE-2025-6021[MED], CVE-2025-6170[LOW]

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added Patches for libxml2 CVEs
- Updated toolchain version for the package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-49794
- https://nvd.nist.gov/vuln/detail/CVE-2025-49796
- https://nvd.nist.gov/vuln/detail/CVE-2025-6021
- https://nvd.nist.gov/vuln/detail/CVE-2025-6170

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [873678](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=873678&view=results)
