### PR TITLE
[High] Patch nodejs18 for CVE-2025-7656

### DIFF
--- a/SPECS/nodejs/CVE-2025-7656.patch
+++ b/SPECS/nodejs/CVE-2025-7656.patch
@@ -1,0 +1,164 @@
+From 40f0c7577251cc5646d5216e493432e28c228cf3 Mon Sep 17 00:00:00 2001
+From: Victor Gomes <victorgomes@chromium.org>
+Date: Fri, 27 Jun 2025 12:40:10 +0200
+Subject: [PATCH] Ensure InstructionAccurateScope is called with correct count
+
+Upstream Patch Link: https://chromium.googlesource.com/v8/v8/+/c58fda1f0ec46429dd66c2cacf6a98fac001e4fd%5E%21/
+(Edited by <v-klockwood@microsoft.com> so it will apply correctly to our
+patched source)
+
+The scope prevents veneer pool generation. We need to pass the
+correct count of instructions to CheckVeneerPool inside the scope
+constructor, otherwise we might overflow the veneer distance
+margin in the next check (after the scope has ended).
+
+Fixed: 425583995
+Change-Id: Iebb81898c4f7999137fc784ce6704773614c2bb5
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6683635
+Auto-Submit: Victor Gomes <victorgomes@chromium.org>
+Commit-Queue: Victor Gomes <victorgomes@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#101089}
+---
+ .../codegen/arm64/macro-assembler-arm64.cc    | 20 ++++++++---
+ .../src/codegen/arm64/macro-assembler-arm64.h | 11 +++----
+ .../test/mjsunit/regress/regress-425583995.js | 33 +++++++++++++++++++
+ 3 files changed, 53 insertions(+), 11 deletions(-)
+ create mode 100644 deps/v8/test/mjsunit/regress/regress-425583995.js
+
+diff --git a/deps/v8/src/codegen/arm64/macro-assembler-arm64.cc b/deps/v8/src/codegen/arm64/macro-assembler-arm64.cc
+index 552425ed..e310fcd2 100644
+--- a/deps/v8/src/codegen/arm64/macro-assembler-arm64.cc
++++ b/deps/v8/src/codegen/arm64/macro-assembler-arm64.cc
+@@ -1178,7 +1178,7 @@ void TurboAssembler::PushHelper(int count, int size, const CPURegister& src0,
+                                 const CPURegister& src2,
+                                 const CPURegister& src3) {
+   // Ensure that we don't unintentially modify scratch or debug registers.
+-  InstructionAccurateScope scope(this);
++  InstructionAccurateScope scope(this, count <= 2 ? 1 : 2);
+ 
+   DCHECK(AreSameSizeAndType(src0, src1, src2, src3));
+   DCHECK(size == src0.SizeInBytes());
+@@ -1215,7 +1215,7 @@ void TurboAssembler::PopHelper(int count, int size, const CPURegister& dst0,
+                                const CPURegister& dst1, const CPURegister& dst2,
+                                const CPURegister& dst3) {
+   // Ensure that we don't unintentially modify scratch or debug registers.
+-  InstructionAccurateScope scope(this);
++  InstructionAccurateScope scope(this, count <= 2 ? 1 : 2);
+ 
+   DCHECK(AreSameSizeAndType(dst0, dst1, dst2, dst3));
+   DCHECK(size == dst0.SizeInBytes());
+@@ -1265,8 +1265,14 @@ void MacroAssembler::PeekPair(const CPURegister& dst1, const CPURegister& dst2,
+ 
+ void MacroAssembler::PushCalleeSavedRegisters() {
+   ASM_CODE_COMMENT(this);
++#ifdef V8_ENABLE_CONTROL_FLOW_INTEGRITY
++  constexpr int kInstrCount = 11;
++#else
++  constexpr int kInstrCount = 10;
++#endif
++
+   // Ensure that the macro-assembler doesn't use any scratch registers.
+-  InstructionAccurateScope scope(this);
++  InstructionAccurateScope scope(this, kInstrCount);
+ 
+   MemOperand tos(sp, -2 * static_cast<int>(kXRegSize), PreIndex);
+ 
+@@ -1299,8 +1305,14 @@ void MacroAssembler::PushCalleeSavedRegisters() {
+ 
+ void MacroAssembler::PopCalleeSavedRegisters() {
+   ASM_CODE_COMMENT(this);
++#ifdef V8_ENABLE_CONTROL_FLOW_INTEGRITY
++  constexpr int kInstrCount = 11;
++#else
++  constexpr int kInstrCount = 10;
++#endif
++
+   // Ensure that the macro-assembler doesn't use any scratch registers.
+-  InstructionAccurateScope scope(this);
++  InstructionAccurateScope scope(this, kInstrCount);
+ 
+   MemOperand tos(sp, 2 * kXRegSize, PostIndex);
+ 
+diff --git a/deps/v8/src/codegen/arm64/macro-assembler-arm64.h b/deps/v8/src/codegen/arm64/macro-assembler-arm64.h
+index ab56bba2..b232a4a9 100644
+--- a/deps/v8/src/codegen/arm64/macro-assembler-arm64.h
++++ b/deps/v8/src/codegen/arm64/macro-assembler-arm64.h
+@@ -2089,7 +2089,7 @@ class V8_EXPORT_PRIVATE MacroAssembler : public TurboAssembler {
+ // emitted is what you specified when creating the scope.
+ class V8_NODISCARD InstructionAccurateScope {
+  public:
+-  explicit InstructionAccurateScope(TurboAssembler* tasm, size_t count = 0)
++  explicit InstructionAccurateScope(TurboAssembler* tasm, size_t count)
+       : tasm_(tasm),
+         block_pool_(tasm, count * kInstrSize)
+ #ifdef DEBUG
+@@ -2097,12 +2097,11 @@ class V8_NODISCARD InstructionAccurateScope {
+         size_(count * kInstrSize)
+ #endif
+   {
++    DCHECK_GT(count, 0);
+     tasm_->CheckVeneerPool(false, true, count * kInstrSize);
+     tasm_->StartBlockVeneerPool();
+ #ifdef DEBUG
+-    if (count != 0) {
+-      tasm_->bind(&start_);
+-    }
++    masm_->bind(&start_);
+     previous_allow_macro_instructions_ = tasm_->allow_macro_instructions();
+     tasm_->set_allow_macro_instructions(false);
+ #endif
+@@ -2111,9 +2110,7 @@ class V8_NODISCARD InstructionAccurateScope {
+   ~InstructionAccurateScope() {
+     tasm_->EndBlockVeneerPool();
+ #ifdef DEBUG
+-    if (start_.is_bound()) {
+-      DCHECK(tasm_->SizeOfCodeGeneratedSince(&start_) == size_);
+-    }
++    DCHECK(masm_->SizeOfCodeGeneratedSince(&start_) == size_);
+     tasm_->set_allow_macro_instructions(previous_allow_macro_instructions_);
+ #endif
+   }
+diff --git a/deps/v8/test/mjsunit/regress/regress-425583995.js b/deps/v8/test/mjsunit/regress/regress-425583995.js
+new file mode 100644
+index 00000000..eaed312c
+--- /dev/null
++++ b/deps/v8/test/mjsunit/regress/regress-425583995.js
+@@ -0,0 +1,33 @@
++// Copyright 2025 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax
++
++const topLevel = %GetFunctionForCurrentFrame();
++%PrepareFunctionForOptimization(topLevel);
++
++function g(
++  // Too many arguments to fit here manually and overflow int32 calculation
++) {
++  return arguments.length + 1;
++}
++
++var num_args = 40000; // large number to cause overflow
++
++// Construct argument list string
++var argsList = "";
++for (var i = 0; i < num_args; i++) argsList += "a" + i + ",";
++argsList = argsList.slice(0, -1);
++
++// Construct function source to return sum of all args
++var body = "return arguments.length + 1;";
++
++// Create large argument function dynamically
++var bigArgFunc = new Function(argsList, body);
++
++// Call many times to trigger OSR in v8 maglev
++for (var i = 0; i < 2; i++) {
++  bigArgFunc(0);
++  %OptimizeOsr();
++}
+-- 
+2.34.1
+

--- a/SPECS/nodejs/nodejs18.spec
+++ b/SPECS/nodejs/nodejs18.spec
@@ -6,7 +6,7 @@ Name:           nodejs18
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
 Version:        18.20.3
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        BSD and MIT and Public Domain and NAIST-2003 and Artistic-2.0
 Group:          Applications/System
 Vendor:         Microsoft Corporation
@@ -26,6 +26,7 @@ Patch6:         CVE-2024-34064.patch
 Patch7:         CVE-2025-27516.patch
 Patch8:         CVE-2025-47279.patch
 Patch9:         CVE-2025-23166.patch
+Patch10:        CVE-2025-7656.patch
 
 BuildRequires:  brotli-devel
 BuildRequires:  coreutils >= 8.22
@@ -127,6 +128,9 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
+* Mon Jul 21 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 18.20.3-8
+- Patch CVE-2025-7656
+
 * Mon Jul 14 2025 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 18.20.3-7
 - Patch CVE-2025-23166
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch `nodejs18` for CVE-2025-7656

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add [patch](https://chromium.googlesource.com/v8/v8/+/c58fda1f0ec46429dd66c2cacf6a98fac001e4fd%5E%21/) for CVE-2025-7656 (edited slightly during the `git apply` process so that it applies cleanly
  <img width="1259" height="141" alt="image" src="https://github.com/user-attachments/assets/ada8fc7e-3852-458d-b106-1f0da557660d" />

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-7656

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
  <img width="397" height="380" alt="image" src="https://github.com/user-attachments/assets/d4561f8e-bdf5-4323-83a5-752c5afb470a" />
