### PR TITLE
[High] Patch qt5-qtbase for CVE-2025-6558

### DIFF
--- a/SPECS/qt5-qtbase/CVE-2025-6558.patch
+++ b/SPECS/qt5-qtbase/CVE-2025-6558.patch
@@ -1,0 +1,97 @@
+From 33defc607f50e3f47442c716df697290a5380d4c Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Wed, 25 Jun 2025 13:17:47 -0400
+Subject: [PATCH] Validate buffers bound for transform feedback are not
+ modified.
+
+Upstream Patch Link: https://chromium.googlesource.com/angle/angle/+/2f8193ecfe1ed464374ae56235cfdc112343f9c3
+
+(Edited/backported by <v-klockwood@microsoft.com> for clean application)
+
+The ES spec says it is undefined to write to a buffer that is currently
+being used for transform feedback output but recommends generating an
+error. Generate INVALID_OPERATION in this case.
+
+Bug: chromium:427162086
+Change-Id: I727d18c2035509fe2e5d60680eb5198e40a60e33
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/6673310
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: Vasiliy Telezhnikov <vasilyt@chromium.org>
+---
+ .../angle/src/libANGLE/TransformFeedback.cpp  | 12 +++++++++++
+ .../angle/src/libANGLE/TransformFeedback.h    |  4 ++++
+ .../angle/src/libANGLE/validationES2.cpp      | 20 +++++++++++++++++++
+ 3 files changed, 36 insertions(+)
+
+diff --git a/src/3rdparty/angle/src/libANGLE/TransformFeedback.cpp b/src/3rdparty/angle/src/libANGLE/TransformFeedback.cpp
+index 99235deb..4f9b3110 100644
+--- a/src/3rdparty/angle/src/libANGLE/TransformFeedback.cpp
++++ b/src/3rdparty/angle/src/libANGLE/TransformFeedback.cpp
+@@ -197,6 +197,18 @@ void TransformFeedback::bindIndexedBuffer(const Context *context,
+     mImplementation->bindIndexedBuffer(index, mState.mIndexedBuffers[index]);
+ }
+ 
++bool TransformFeedback::isBufferBound(BufferID bufferID) const
++{
++    for (const auto &buffer : mState.mIndexedBuffers)
++    {
++        if (buffer.id() == bufferID)
++        {
++            return true;
++        }
++    }
++    return false;
++}
++
+ const OffsetBindingPointer<Buffer> &TransformFeedback::getIndexedBuffer(size_t index) const
+ {
+     ASSERT(index < mState.mIndexedBuffers.size());
+diff --git a/src/3rdparty/angle/src/libANGLE/TransformFeedback.h b/src/3rdparty/angle/src/libANGLE/TransformFeedback.h
+index 2b35d43f..e1fd53ce 100644
+--- a/src/3rdparty/angle/src/libANGLE/TransformFeedback.h
++++ b/src/3rdparty/angle/src/libANGLE/TransformFeedback.h
+@@ -84,6 +84,10 @@ class TransformFeedback final : public RefCountObject, public LabeledObject
+     const OffsetBindingPointer<Buffer> &getIndexedBuffer(size_t index) const;
+     size_t getIndexedBufferCount() const;
+ 
++    // Returns true if the buffer is bound to any of the indexed binding points in this transform
++    // feedback.
++    bool isBufferBound(BufferID bufferID) const;
++
+     void detachBuffer(const Context *context, GLuint bufferName);
+ 
+     rx::TransformFeedbackImpl *getImplementation();
+diff --git a/src/3rdparty/angle/src/libANGLE/validationES2.cpp b/src/3rdparty/angle/src/libANGLE/validationES2.cpp
+index 5e505aa6..0469728c 100644
+--- a/src/3rdparty/angle/src/libANGLE/validationES2.cpp
++++ b/src/3rdparty/angle/src/libANGLE/validationES2.cpp
+@@ -4220,6 +4220,26 @@ bool ValidateBufferData(ValidationContext *context,
+         return false;
+     }
+ 
++    // Do some additional WebGL-specific validation
++    if (ANGLE_UNLIKELY(context->isWebGL()))
++    {
++        if (buffer->hasWebGLXFBBindingConflict(true))
++        {
++            ANGLE_VALIDATION_ERR(context, InvalidOperation(), BufferBoundForTransformFeedback);
++            return false;
++        }
++
++        const TransformFeedback *transformFeedbackObject =
++            context->getState().getCurrentTransformFeedback();
++        if (transformFeedbackObject && transformFeedbackObject->isActive() &&
++            !transformFeedbackObject->isPaused() &&
++            transformFeedbackObject->isBufferBound(buffer->id()))
++        {
++            ANGLE_VALIDATION_ERR(context, InvalidOperation(), BufferBoundForTransformFeedback);
++            return false;
++        }
++    }
++
+     return true;
+ }
+ 
+-- 
+2.34.1
+

--- a/SPECS/qt5-qtbase/qt5-qtbase.spec
+++ b/SPECS/qt5-qtbase/qt5-qtbase.spec
@@ -33,7 +33,7 @@
 Name:         qt5-qtbase
 Summary:      Qt5 - QtBase components
 Version:      5.12.11
-Release:      16%{?dist}
+Release:      17%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:      GFDL AND LGPLv3 AND GPLv2 AND GPLv3 with exceptions AND QT License Agreement 4.0
 Vendor:       Microsoft Corporation
@@ -168,6 +168,7 @@ Patch93: CVE-2022-25255.patch
 Patch94: CVE-2024-25580.patch
 Patch95: CVE-2023-34410.patch
 Patch96: CVE-2025-30348.patch
+Patch97: CVE-2025-6558.patch
 
 # Do not check any files in %%{_qt5_plugindir}/platformthemes/ for requires.
 # Those themes are there for platform integration. If the required libraries are
@@ -777,6 +778,9 @@ fi
 %{_qt5_libdir}/cmake/Qt5Gui/Qt5Gui_QXdgDesktopPortalThemePlugin.cmake
 
 %changelog
+* Mon Jul 21 2025 Kevin Lockwood <v-klockwood@microsoft.com> - 5.12.11-17
+- Fix CVE-2025-6558
+
 * Fri Jun 13 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 5.12.11-16
 - Fix CVE-2025-30348
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch `qt5-qtbase` for CVE-2025-6558

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch originates from astrolabe triage notes (https://chromium.googlesource.com/angle/angle/+/2f8193ecfe1ed464374ae56235cfdc112343f9c3)
- Apply changes to `TransformFeedback.[cpp|h]` basically unchanged (patch had different surrounding context, but the content was still valid)
- Apply changes to `WebGLCompatibilityTest.cpp` unchanged
- Backport changes to `validationES2.cpp` as our version of `libANGLE` is much older than what the upstream patch targets. Mostly this consisted of changing the call from `ANGLE_VALIDATION_ERROR` to the older `ANGLE_VALIDATION_ERR`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-6558

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
  <insert screenshot>
