### PR TITLE
pam: set config files in /etc as noreplace

### DIFF
--- a/SPECS/pam/pam.spec
+++ b/SPECS/pam/pam.spec
@@ -1,7 +1,7 @@
 Summary:        Linux Pluggable Authentication Modules
 Name:           pam
 Version:        1.5.1
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        BSD and GPLv2+
 URL:            https://github.com/linux-pam/linux-pam
 Source0:        https://github.com/linux-pam/linux-pam/releases/download/v%{version}/Linux-PAM-%{version}.tar.xz
@@ -84,7 +84,9 @@ EOF
 %files
 %defattr(-,root,root)
 %license COPYING
-%{_sysconfdir}/*
+%config(noreplace) %{_sysconfdir}/environment
+%dir %{_sysconfdir}/security
+%{_sysconfdir}/security/*
 /sbin/*
 %{_libdir}/security/*
 %{_libdir}/systemd/system/pam_namespace.service
@@ -102,6 +104,9 @@ EOF
 %{_docdir}/%{name}-%{version}/*
 
 %changelog
+* Thu Jul 24 2025 Chris Co <chrco@microsoft.com> - 1.5.1-9
+- Set /etc/environment as config(noreplace)
+
 * Wed Jul 02 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 1.5.1-8
 - Add patch for CVE-2025-6020
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -281,10 +281,10 @@ p11-kit-debuginfo-0.24.1-1.cm2.aarch64.rpm
 p11-kit-devel-0.24.1-1.cm2.aarch64.rpm
 p11-kit-server-0.24.1-1.cm2.aarch64.rpm
 p11-kit-trust-0.24.1-1.cm2.aarch64.rpm
-pam-1.5.1-8.cm2.aarch64.rpm
-pam-debuginfo-1.5.1-8.cm2.aarch64.rpm
-pam-devel-1.5.1-8.cm2.aarch64.rpm
-pam-lang-1.5.1-8.cm2.aarch64.rpm
+pam-1.5.1-9.cm2.aarch64.rpm
+pam-debuginfo-1.5.1-9.cm2.aarch64.rpm
+pam-devel-1.5.1-9.cm2.aarch64.rpm
+pam-lang-1.5.1-9.cm2.aarch64.rpm
 patch-2.7.6-8.cm2.aarch64.rpm
 patch-debuginfo-2.7.6-8.cm2.aarch64.rpm
 pcre-8.45-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -287,10 +287,10 @@ p11-kit-debuginfo-0.24.1-1.cm2.x86_64.rpm
 p11-kit-devel-0.24.1-1.cm2.x86_64.rpm
 p11-kit-server-0.24.1-1.cm2.x86_64.rpm
 p11-kit-trust-0.24.1-1.cm2.x86_64.rpm
-pam-1.5.1-8.cm2.x86_64.rpm
-pam-debuginfo-1.5.1-8.cm2.x86_64.rpm
-pam-devel-1.5.1-8.cm2.x86_64.rpm
-pam-lang-1.5.1-8.cm2.x86_64.rpm
+pam-1.5.1-9.cm2.x86_64.rpm
+pam-debuginfo-1.5.1-9.cm2.x86_64.rpm
+pam-devel-1.5.1-9.cm2.x86_64.rpm
+pam-lang-1.5.1-9.cm2.x86_64.rpm
 patch-2.7.6-8.cm2.x86_64.rpm
 patch-debuginfo-2.7.6-8.cm2.x86_64.rpm
 pcre-8.45-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When pam package is updated on a system, the package upgrade will
replace the config files found in /etc as well as the /etc/environment
file, even if the user has made edits to the file. As a result, those
edits will be lost after package upgrade.

To solve this, use rpm's %config(noreplace) macro to indicate these
files hold configuration data and will not replace the file if the file
has been altered.

These config macro settings match Fedora's settings.

As part of this change, the %files section was altered to expand the
files present in the /etc directory (via the %{_sysconfdir} macro). The
original pam rpm was packaging the following files in /etc:
```
$ rpm -qlp pam-1.5.1-8.cm2.x86_64.rpm
warning: pam-1.5.1-8.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
/etc/environment
/etc/security
/etc/security/access.conf
/etc/security/faillock.conf
/etc/security/group.conf
/etc/security/limits.conf
/etc/security/limits.d
/etc/security/namespace.conf
/etc/security/namespace.d
/etc/security/namespace.init
/etc/security/pam_env.conf
/etc/security/sepermit.conf
/etc/security/time.conf
```

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/58478724

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [878374](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=878374&view=results)
