### PR TITLE
Additional cleanup for the OSGuard image definition

### DIFF
--- a/toolkit/imageconfigs/files/common/99-dhcp-eth0.network
+++ b/toolkit/imageconfigs/files/common/99-dhcp-eth0.network
@@ -1,6 +1,0 @@
-[Match]
-Name=eth0
-
-[Network]
-DHCP=yes
-IPv6AcceptRA=no

--- a/toolkit/imageconfigs/files/osguard/repart.d/14-root-a.conf
+++ b/toolkit/imageconfigs/files/osguard/repart.d/14-root-a.conf
@@ -1,6 +1,6 @@
 [Partition]
 Type=root
 Label=root-a
-SizeMinBytes=10G
+SizeMinBytes=12G
 Weight=1000
 GrowFileSystem=true

--- a/toolkit/imageconfigs/files/osguard/repart.d/18-root-b.conf
+++ b/toolkit/imageconfigs/files/osguard/repart.d/18-root-b.conf
@@ -1,6 +1,6 @@
 [Partition]
 Type=root
 Label=root-b
-SizeMinBytes=10G
+SizeMinBytes=12G
 Weight=1000
 GrowFileSystem=true

--- a/toolkit/imageconfigs/linuxguard-amd64.yaml
+++ b/toolkit/imageconfigs/linuxguard-amd64.yaml
@@ -189,6 +189,8 @@ scripts:
     - path: scripts/common/cleanup-machineid.sh
     # Move CNI binaries from /opt to /usr for IPE
     - path: scripts/common/prepare_trusted_cni_plugins.sh
+    # Move iptables scripts from /etc to /usr for IPE
+    - path: scripts/common/move-iptables-scripts-to-usr.sh
     # Disable exec and suid on /tmp
     - path: scripts/common/tmp-no-exec.sh
     # Remove ImportCredential from getty services to avoid boot log warnings

--- a/toolkit/imageconfigs/linuxguard-amd64.yaml
+++ b/toolkit/imageconfigs/linuxguard-amd64.yaml
@@ -66,14 +66,14 @@ storage:
       mountPoint:
         idType: part-label
         path: /boot/efi
-        options: umask=0077,noexec,nodev
+        options: nodev,noexec,umask=0077
 
     - deviceId: boot-a
       type: ext4
       mountPoint:
         idType: uuid
         path: /boot
-        options: noexec,nodev
+        options: nodev,noexec,nosuid
 
     - deviceId: root-a
       type: ext4
@@ -85,21 +85,21 @@ storage:
       type: ext4
       mountPoint:
         path: /usr
-        options: ro,nodev
+        options: nodev,ro
 
     - deviceId: trident
       type: ext4
       mountPoint:
         idType: part-label
         path: /var/lib/trident
-        options: noexec,nodev
+        options: nodev,noexec,nosuid
 
     - deviceId: home
       type: ext4
       mountPoint:
         idType: part-label
         path: /home
-        options: noexec,nodev
+        options: nodev,noexec,nosuid
 
 os:
   bootloader:
@@ -119,6 +119,7 @@ os:
       - rd.luks=0
       - rd.hostonly=0
       - ipe.enforce=0
+      - net.ifnames=1
 
   packages:
     remove:
@@ -177,15 +178,22 @@ os:
 
 scripts:
   postCustomization:
+    # Various performance tuning steps
     - path: scripts/common/performance-tuning.sh
-    # Config AzureLinuxagent
+    # Config AzureLinuxAgent
     - path: scripts/common/azlinuxagentconfig.sh
     # Disable unused SELinux policy modules and configure SELinux policy for CI
     - path: scripts/common/selinux-ci-config.py
       interpreter: /usr/bin/python3
+    # Ensure the /etc/machine-id is cleared before the first boot
     - path: scripts/common/cleanup-machineid.sh
+    # Move CNI binaries from /opt to /usr for IPE
     - path: scripts/common/prepare_trusted_cni_plugins.sh
+    # Disable exec and suid on /tmp
     - path: scripts/common/tmp-no-exec.sh
+    # Remove ImportCredential from getty services to avoid boot log warnings
+    - path: scripts/common/remove-getty-import-credential.sh
+    # Set OS release variant entries
     - path: scripts/set_os_release_variant_entries.sh
       arguments:
       - --variant-id

--- a/toolkit/imageconfigs/osguard-amd64.yaml
+++ b/toolkit/imageconfigs/osguard-amd64.yaml
@@ -3,7 +3,7 @@ storage:
 
   disks:
     - partitionTableType: gpt
-      maxSize: 24G
+      maxSize: 40G
       partitions:
         - id: esp
           type: esp
@@ -26,7 +26,7 @@ storage:
         - id: root-a
           type: root
           label: root-a
-          size: 4G
+          size: 12G
 
   verity:
     - id: usrverity

--- a/toolkit/imageconfigs/osguard-amd64.yaml
+++ b/toolkit/imageconfigs/osguard-amd64.yaml
@@ -222,6 +222,8 @@ scripts:
     - path: scripts/common/cleanup-machineid.sh
     # Move CNI binaries from /opt to /usr for IPE
     - path: scripts/common/prepare_trusted_cni_plugins.sh
+    # Move iptables scripts from /etc to /usr for IPE
+    - path: scripts/common/move-iptables-scripts-to-usr.sh
     # Disable exec and suid on /tmp
     - path: scripts/common/tmp-no-exec.sh
     # Remove ImportCredential from getty services to avoid boot log warnings

--- a/toolkit/imageconfigs/osguard-amd64.yaml
+++ b/toolkit/imageconfigs/osguard-amd64.yaml
@@ -42,26 +42,26 @@ storage:
       mountPoint:
         idType: part-label
         path: /boot/efi
-        options: umask=0077,noexec,nodev
+        options: nodev,noexec,umask=0077
 
     - deviceId: boot-a
       type: ext4
       mountPoint:
         idType: uuid
         path: /boot
-        options: noexec,nodev,nosuid
+        options: nodev,noexec,nosuid
 
     - deviceId: usrverity
       type: ext4
       mountPoint:
         path: /usr
-        options: ro,nodev
+        options: nodev,ro
 
     - deviceId: root-a
       type: ext4
       mountPoint:
         path: /
-        options: nodev,nosuid,x-initrd.mount,x-systemd.growfs
+        options: nodev,nosuid,x-systemd.growfs,x-initrd.mount
 
 os:
   bootloader:
@@ -83,14 +83,13 @@ os:
       - rd.hostonly=0
       - ipe.enforce=0
       - fips=1
+      - net.ifnames=1
 
   packages:
     remove:
-      - initramfs
       - dracut-hostonly # Not used for UKI images
       - grub2-efi-binary # Replaced by systemd-boot
       - kernel # Replaced by kernel-ipe
-
     install:
       - syslog
       - WALinuxAgent
@@ -121,10 +120,9 @@ os:
       - policycoreutils-python-utils
       - secilc
       - selinux-policy
-      # - selinux-policy-ci
+      - selinux-policy-ci
       - selinux-policy-modules
       - setools-console
-      - chrony
 
       # === System packages ===
       - systemd-ukify
@@ -139,7 +137,9 @@ os:
       - bind-utils
       - tar
       # =====AKS=====
+      - blobfuse2
       - ca-certificates
+      - chrony
       - cifs-utils
       - cloud-init-azure-kvp
       - conntrack-tools
@@ -152,11 +152,15 @@ os:
       - iproute
       - ipset
       - iptables
+      - iscsi-initiator-utils
       - jq
       - logrotate
       - lsof
+      - netplan
+      - nftables
       - nmap-ncat
       - nfs-utils
+      - oras
       - pam
       - psmisc
       - rsyslog
@@ -166,12 +170,6 @@ os:
       - util-linux
       - xz
       - zip
-      - blobfuse2
-      - nftables
-      - iscsi-initiator-utils
-      - netplan
-      - oras
-      - initramfs
 
   additionalDirs:
     - source: files/osguard/repart.d
@@ -182,8 +180,6 @@ os:
     # SELinux customizations
     - source: files/linuxguard/selinux-ci-uki.semanage
       destination: /etc/selinux/targeted/selinux-ci.semanage
-    - source: files/common/99-dhcp-eth0.network
-      destination: /etc/systemd/network/99-dhcp-eth0.network
     # Cloud-init configuration
     - source: files/osguard/cloud.cfg
       destination: /etc/cloud/cloud.cfg
@@ -202,8 +198,9 @@ os:
       permissions: "600"
 
   services:
-    enable:
+    disable:
       - sshd
+    enable:
       - systemd-networkd
       - systemd-resolved
 
@@ -214,14 +211,22 @@ os:
 
 scripts:
   postCustomization:
+    # Various performance tuning steps
     - path: scripts/common/performance-tuning.sh
-    # Config AzureLinuxagent
+    # Config AzureLinuxAgent
     - path: scripts/common/azlinuxagentconfig.sh
     # Disable unused SELinux policy modules and configure SELinux policy for CI
-    #- path: scripts/linuxguard/selinux-ci-config.sh
+    - path: scripts/common/selinux-ci-config.py
+      interpreter: /usr/bin/python3
+    # Ensure the /etc/machine-id is cleared before the first boot
     - path: scripts/common/cleanup-machineid.sh
+    # Move CNI binaries from /opt to /usr for IPE
     - path: scripts/common/prepare_trusted_cni_plugins.sh
+    # Disable exec and suid on /tmp
     - path: scripts/common/tmp-no-exec.sh
+    # Remove ImportCredential from getty services to avoid boot log warnings
+    - path: scripts/common/remove-getty-import-credential.sh
+    # Set OS release variant entries
     - path: scripts/set_os_release_variant_entries.sh
       arguments:
       - --variant-id

--- a/toolkit/imageconfigs/scripts/common/move-iptables-scripts-to-usr.sh
+++ b/toolkit/imageconfigs/scripts/common/move-iptables-scripts-to-usr.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Move iptables scripts to /usr/libexec/iptables, as /etc will be locked down by
+# IPE and also is mounted with noexec.
+
+START_SOURCE="/etc/systemd/scripts/iptables"
+STOP_SOURCE="/etc/systemd/scripts/iptables.stop"
+
+START_TARGET="/usr/libexec/iptables/iptables"
+STOP_TARGET="/usr/libexec/iptables/iptables.stop"
+
+mkdir -p /usr/libexec/iptables
+
+mv "$START_SOURCE" "$START_TARGET"
+mv "$STOP_SOURCE" "$STOP_TARGET"
+
+# Create symlinks for compatibility
+ln -s "$START_TARGET" "$START_SOURCE"
+ln -s "$STOP_TARGET" "$STOP_SOURCE"

--- a/toolkit/imageconfigs/scripts/common/remove-getty-import-credential.sh
+++ b/toolkit/imageconfigs/scripts/common/remove-getty-import-credential.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Reported upstream as https://github.com/util-linux/util-linux/issues/2896,
+# requires systemd updated to v256. The workaround is to remove the ImportCredential lines.
+sed -i /ImportCredential=/d /usr/lib/systemd/system/getty@.service
+sed -i /ImportCredential=/d /usr/lib/systemd/system/serial-getty@.service

--- a/toolkit/imageconfigs/scripts/common/tmp-no-exec.sh
+++ b/toolkit/imageconfigs/scripts/common/tmp-no-exec.sh
@@ -5,4 +5,4 @@
 
 set -euxo pipefail
 
-sed -i 's/^Options=/Options=noexec,/' /usr/lib/systemd/system/tmp.mount
+sed -i 's/^Options=/Options=noexec,nosuid,/' /usr/lib/systemd/system/tmp.mount

--- a/toolkit/scripts/generate-repartd.sh
+++ b/toolkit/scripts/generate-repartd.sh
@@ -31,7 +31,7 @@ emit_partition() {
 [Partition]
 Type=$type_out
 Label=$label
-SizeMinBytes=10G
+SizeMinBytes=12G
 Weight=1000
 GrowFileSystem=true
 EOF


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Enables stable interface names
- Works around missing credentials directory
- Stops reinstalling initramfs
- Reenables selinux-policy-ci
- Reorders AKS packages for cleanliness
- Removes custom eth0 configuration
- Disables SSHD (though it gets reenabled in runtime anyway)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Image built using BuildVariants dev pipelines and validated by creating custom BYOI AKS cluster
