### PR TITLE
osguard: fix usr-a/b repart.d types to match image

### DIFF
--- a/toolkit/imageconfigs/files/osguard/repart.d/12-usr-a.conf
+++ b/toolkit/imageconfigs/files/osguard/repart.d/12-usr-a.conf
@@ -1,5 +1,5 @@
 [Partition]
-Type=usr
+Type=linux-generic
 Label=usr-a
 SizeMinBytes=1G
 SizeMaxBytes=1G

--- a/toolkit/imageconfigs/files/osguard/repart.d/16-usr-b.conf
+++ b/toolkit/imageconfigs/files/osguard/repart.d/16-usr-b.conf
@@ -1,5 +1,5 @@
 [Partition]
-Type=usr
+Type=linux-generic
 Label=usr-b
 SizeMinBytes=1G
 SizeMaxBytes=1G

--- a/toolkit/scripts/generate-repartd.sh
+++ b/toolkit/scripts/generate-repartd.sh
@@ -12,14 +12,7 @@ rm -f "$REPART_DIR"/*.conf
 
 emit_partition() {
     local num="$1" part="$2" type="$3" label="$4" size="$5"
-    # Set Type for root and root-hash partitions
-    if [[ "$part" =~ ^usr-(a|b)$ ]]; then
-        type_out="usr"
-    elif [[ "$part" =~ ^usr-hash-(a|b)$ ]]; then
-        type_out="usr-verity"
-    else
-        type_out="$type"
-    fi
+    type_out="$type"
     
     # Ensure label is never null
     if [[ -z "$label" || "$label" == "null" ]]; then


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
To avoid mismatch of partition type information between original
partitioning and repart.d configuration, this change updates the
repart.d generation script for osguard to use the type already present
rather than overwriting the partition type information.

The change also regenerates the osguard repart.d files so the usr-a/b
type information matches what is present in the osguard image, so
systemd-repartd is successful.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/mariner-org/mariner/_workitems/edit/14618

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [895311](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=895311&view=results)
