### PR TITLE
[3.0] Change default AZ creds to AZ CLI creds.

### DIFF
--- a/toolkit/tools/internal/azureblobstorage/azureblobstorage.go
+++ b/toolkit/tools/internal/azureblobstorage/azureblobstorage.go
@@ -19,7 +19,7 @@ import (
 const (
 	AnonymousAccess        = 0
 	ServicePrincipalAccess = 1
-	ManagedIdentityAccess  = 2
+	AzureCLIAccess         = 2
 )
 
 type AzureBlobStorage struct {
@@ -36,13 +36,13 @@ func (abs *AzureBlobStorage) Upload(
 
 	localFile, err := os.OpenFile(localFileName, os.O_RDONLY, 0)
 	if err != nil {
-		return fmt.Errorf("Failed to open local file for upload:\n%w", err)
+		return fmt.Errorf("failed to open local file for upload:\n%w", err)
 	}
 	defer localFile.Close()
 
 	_, err = abs.theClient.UploadFile(ctx, containerName, blobName, localFile, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to upload local file to blob:\n%w", err)
+		return fmt.Errorf("failed to upload local file to blob:\n%w", err)
 	}
 
 	uploadEndTime := time.Now()
@@ -80,7 +80,7 @@ func (abs *AzureBlobStorage) Download(
 
 	_, err = abs.theClient.DownloadFile(ctx, containerName, blobName, localFile, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to download blob to local file:\n%w", err)
+		return fmt.Errorf("failed to download blob to local file:\n%w", err)
 	}
 
 	downloadEndTime := time.Now()
@@ -97,7 +97,7 @@ func (abs *AzureBlobStorage) Delete(
 	deleteStartTime := time.Now()
 	_, err = abs.theClient.DeleteBlob(ctx, containerName, blobName, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to delete blob:\n%w", err)
+		return fmt.Errorf("failed to delete blob:\n%w", err)
 	}
 	deleteEndTime := time.Now()
 	logger.Log.Infof("  delete time: %v", deleteEndTime.Sub(deleteStartTime))
@@ -106,49 +106,45 @@ func (abs *AzureBlobStorage) Delete(
 }
 
 func Create(tenantId string, userName string, password string, storageAccount string, authenticationType int) (abs *AzureBlobStorage, err error) {
-
 	url := "https://" + storageAccount + ".blob.core.windows.net/"
 
 	abs = &AzureBlobStorage{}
 
-	if authenticationType == AnonymousAccess {
-
+	switch authenticationType {
+	case AnonymousAccess:
 		abs.theClient, err = azblob.NewClientWithNoCredential(url, nil)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to init azure blob storage read-only client:\n%w", err)
+			return nil, fmt.Errorf("unable to init azure blob storage read-only client:\n%w", err)
 		}
 
 		return abs, nil
 
-	} else if authenticationType == ServicePrincipalAccess {
-
+	case ServicePrincipalAccess:
 		credential, err := azidentity.NewClientSecretCredential(tenantId, userName, password, nil)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to init azure service principal identity:\n%w", err)
+			return nil, fmt.Errorf("unable to init azure service principal identity:\n%w", err)
 		}
 
 		abs.theClient, err = azblob.NewClient(url, credential, nil)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to init azure blob storage read-write client:\n%w", err)
+			return nil, fmt.Errorf("unable to init azure blob storage read-write client:\n%w", err)
 		}
 
 		return abs, nil
 
-	} else if authenticationType == ManagedIdentityAccess {
-
-		credential, err := azidentity.NewDefaultAzureCredential(nil)
+	case AzureCLIAccess:
+		credential, err := azidentity.NewAzureCLICredential(nil)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to init azure managed identity:\n%w", err)
+			return nil, fmt.Errorf("unable to init azure managed identity:\n%w", err)
 		}
 
 		abs.theClient, err = azblob.NewClient(url, credential, nil)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to init azure blob storage read-write client:\n%w", err)
+			return nil, fmt.Errorf("unable to init azure blob storage read-write client:\n%w", err)
 		}
 
 		return abs, nil
-
 	}
 
-	return nil, errors.New("Unknown authentication type.")
+	return nil, errors.New("unknown authentication type")
 }

--- a/toolkit/tools/internal/ccachemanager/ccachemanager.go
+++ b/toolkit/tools/internal/ccachemanager/ccachemanager.go
@@ -454,7 +454,7 @@ func CreateManager(rootDir string, configFileName string) (m *CCacheManager, err
 	logger.Log.Infof("  creating blob storage client...")
 	accessType := azureblobstorage.AnonymousAccess
 	if configuration.RemoteStoreConfig.UploadEnabled {
-		accessType = azureblobstorage.ManagedIdentityAccess
+		accessType = azureblobstorage.AzureCLIAccess
 	}
 
 	azureBlobStorage, err := azureblobstorage.Create(configuration.RemoteStoreConfig.TenantId, configuration.RemoteStoreConfig.UserName, configuration.RemoteStoreConfig.Password, configuration.RemoteStoreConfig.StorageAccount, accessType)


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Internal Microsoft policy requires us to not use `NewDefaultAzureCredential` when logging into Azure. In all cases where we used the default method in our builds we relied on Azure CLI credentials, thus the switch to `NewAzureCLICredential`.

For more information see the [AzureCLICredential docs](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-authenticating-during-local-development).

The change also has minor Go linting clean-up.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Internal bug](https://microsoft.visualstudio.com/OS/_workitems/edit/58688069).

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR checks.
- Local runs of the code downloading blob contentents.