### PR TITLE
systemd-boot-signed: add aarch64 package

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -1,6 +1,12 @@
 %global debug_package %{nil}
 %ifarch x86_64
 %global buildarch x86_64
+%global grubefiname grubx64.efi
+%global sdbootefiname systemd-bootx64.efi
+%elifarch aarch64
+%global buildarch aarch64
+%global grubefiname grubaa64.efi
+%global sdbootefiname systemd-bootaa64.efi
 %endif
 
 # Support for quick builds with rpmbuild --build-in-place.
@@ -14,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -32,8 +38,7 @@ URL:            https://systemd.io
 #   3. Place the unsigned package and signed binary in this spec's folder
 #   4. Build this spec
 Source0:        systemd-boot-%{version}-%{release}.%{buildarch}.rpm
-Source1:        systemd-bootx64.efi
-ExclusiveArch:  x86_64
+Source1:        %{sdbootefiname}
 
 %description
 This package contains the systemd-boot EFI binary signed for secure boot. The package is
@@ -71,8 +76,8 @@ pushd rpm_contents
 
 # This spec's whole purpose is to inject the signed systemd-boot binary
 rpm2cpio %{SOURCE0} | cpio -idmv
-cp %{SOURCE1} ./usr/lib/systemd/boot/efi/systemd-bootx64.efi
 
+cp %{SOURCE1} ./usr/lib/systemd/boot/efi/%{sdbootefiname}
 popd
 
 %install
@@ -81,7 +86,7 @@ pushd rpm_contents
 # Don't use * wildcard. It does not copy over hidden files in the root folder...
 cp -rp ./. %{buildroot}/
 
-cp %{buildroot}/usr/lib/systemd/boot/efi/systemd-bootx64.efi %{buildroot}/boot/efi/EFI/BOOT/grubx64.efi
+cp %{buildroot}/usr/lib/systemd/boot/efi/%{sdbootefiname} %{buildroot}/boot/efi/EFI/BOOT/%{grubefiname}
 
 popd
 
@@ -90,9 +95,12 @@ popd
 /usr/share/man/man5/loader.conf.5.gz
 /usr/share/man/man7/sd-boot.7.gz
 /usr/share/man/man7/systemd-boot.7.gz
-/boot/efi/EFI/BOOT/grubx64.efi
+/boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Mon Aug 18 2025 Sean Dougherty <sdougherty@microsoft.com> - 255-23
+- Add aarch64 package
+
 * Wed Aug 06 2025 Sean Dougherty <sdougherty@microsoft.com> - 255-22
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        22%{?dist}
+Release:        23%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -1228,6 +1228,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Mon Aug 18 2025 Sean Dougherty <sdougherty@microsoft.com> - 255-23
+- Bump release to match systemd-boot-signed spec
+
 * Tue Aug 05 2025 Chris Co <chrco@microsoft.com> - 255-22 
 - enable building ukify and sd-boot on arm64
 - enable pyflakes buildrequires which is needed for ukify testing


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Following along the addition of the unsigned aarch64 systemd-boot package in PR #14449 , this adds the signed systemd-boot package for aarch64 architecture.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update systemd-boot-signed SPEC to include building the aarch64 package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- pipeline BuildID: 911568
  - Verified a signed systemd-boot.aarch64.rpm was built, contents were signed, and booted an image with sdboot
- pipeline BuildID: 912594
  - Verified a signed systemd-boot.x86_64.rpm was built and contents were signed