### PR TITLE
[Medium] Patch golang and golang-1.18 for CVE-2025-4673

### DIFF
--- a/SPECS/golang/CVE-2025-4673-1.18.patch
+++ b/SPECS/golang/CVE-2025-4673-1.18.patch
@@ -1,0 +1,111 @@
+From b897e97c36cb62629a458bc681723ca733404e32 Mon Sep 17 00:00:00 2001
+From: Neal Patel <nealpatel@google.com>
+Date: Wed, 21 May 2025 14:11:44 -0400
+Subject: [PATCH] [release-branch.go1.23] net/http: strip sensitive proxy
+ headers from redirect requests
+
+Similarly to Authentication entries, Proxy-Authentication entries should be stripped to ensure sensitive information is not leaked on redirects outside of the original domain.
+
+https://fetch.spec.whatwg.org/#authentication-entries
+
+Thanks to Takeshi Kaneko (GMO Cybersecurity by Ierae, Inc.) for reporting this issue.
+
+Updates golang/go#73816
+Fixes golang/go#73905
+Fixes CVE-2025-4673
+
+Change-Id: I1615f31977a2fd014fbc12aae43f82692315a6d0
+Reviewed-on: https://go-review.googlesource.com/c/go/+/679255
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Michael Knyszek <mknyszek@google.com>
+
+Modified patch to apply to AzureLinux
+Modified-by: Akhila Guruju <v-guakhila@microsoft.com>
+Date: Fri, 22 Aug 2025 05:02:08 +0000
+Subject: [PATCH] Address CVE-2025-4673
+
+Upstream patch Reference: https://github.com/golang/go/commit/b897e97c36cb62629a458bc681723ca733404e32.patch
+
+---
+ src/net/http/client.go      |  3 ++-
+ src/net/http/client_test.go | 50 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 52 insertions(+), 1 deletion(-)
+
+diff --git a/src/net/http/client.go b/src/net/http/client.go
+index 22db96b..4cfc293 100644
+--- a/src/net/http/client.go
++++ b/src/net/http/client.go
+@@ -985,7 +985,8 @@ func (b *cancelTimerBody) Close() error {
+ 
+ func shouldCopyHeaderOnRedirect(headerKey string, initial, dest *url.URL) bool {
+ 	switch CanonicalHeaderKey(headerKey) {
+-	case "Authorization", "Www-Authenticate", "Cookie", "Cookie2":
++	case "Authorization", "Www-Authenticate", "Cookie", "Cookie2",
++	    "Proxy-Authorization", "Proxy-Authenticate":
+ 		// Permit sending auth/cookie headers from "foo.com"
+ 		// to "sub.foo.com".
+ 
+diff --git a/src/net/http/client_test.go b/src/net/http/client_test.go
+index e91d526..6713143 100644
+--- a/src/net/http/client_test.go
++++ b/src/net/http/client_test.go
+@@ -1575,6 +1575,56 @@ func TestClientCopyHeadersOnRedirect(t *testing.T) {
+ 	}
+ }
+ 
++// Issue #70530: Once we strip a header on a redirect to a different host,
++// the header should stay stripped across any further redirects.
++
++func testClientStripHeadersOnRepeatedRedirect(t *testing.T) {
++	var proto string
++	ts := newClientServerTest(t, mode, HandlerFunc(func(w ResponseWriter, r *Request) {
++		if r.Host+r.URL.Path != "a.example.com/" {
++			if h := r.Header.Get("Authorization"); h != "" {
++				t.Errorf("on request to %v%v, Authorization=%q, want no header", r.Host, r.URL.Path, h)
++			} else if h := r.Header.Get("Proxy-Authorization"); h != "" {
++				t.Errorf("on request to %v%v, Proxy-Authorization=%q, want no header", r.Host, r.URL.Path, h)
++			}
++		}
++		// Follow a chain of redirects from a to b and back to a.
++		// The Authorization header is stripped on the first redirect to b,
++		// and stays stripped even if we're sent back to a.
++		switch r.Host + r.URL.Path {
++		case "a.example.com/":
++			Redirect(w, r, proto+"://b.example.com/", StatusFound)
++		case "b.example.com/":
++			Redirect(w, r, proto+"://b.example.com/redirect", StatusFound)
++		case "b.example.com/redirect":
++			Redirect(w, r, proto+"://a.example.com/redirect", StatusFound)
++		case "a.example.com/redirect":
++			w.Header().Set("X-Done", "true")
++		default:
++			t.Errorf("unexpected request to %v", r.URL)
++		}
++	})).ts
++	proto, _, _ = strings.Cut(ts.URL, ":")
++
++	c := ts.Client()
++	c.Transport.(*Transport).Dial = func(_ string, _ string) (net.Conn, error) {
++		return net.Dial("tcp", ts.Listener.Addr().String())
++	}
++
++	req, _ := NewRequest("GET", proto+"://a.example.com/", nil)
++	req.Header.Add("Cookie", "foo=bar")
++	req.Header.Add("Authorization", "secretpassword")
++	req.Header.Add("Proxy-Authorization", "secretpassword")
++	res, err := c.Do(req)
++	if err != nil {
++		t.Fatal(err)
++	}
++	defer res.Body.Close()
++	if res.Header.Get("X-Done") != "true" {
++		t.Fatalf("response missing expected header: X-Done=true")
++	}
++}
++
+ // Issue 22233: copy host when Client follows a relative redirect.
+ func TestClientCopyHostOnRedirect(t *testing.T) {
+ 	// Virtual hostname: should not receive any request.
+-- 
+2.45.2
+

--- a/SPECS/golang/CVE-2025-4673.patch
+++ b/SPECS/golang/CVE-2025-4673.patch
@@ -1,0 +1,66 @@
+From b897e97c36cb62629a458bc681723ca733404e32 Mon Sep 17 00:00:00 2001
+From: Neal Patel <nealpatel@google.com>
+Date: Wed, 21 May 2025 14:11:44 -0400
+Subject: [PATCH] [release-branch.go1.23] net/http: strip sensitive proxy
+ headers from redirect requests
+
+Similarly to Authentication entries, Proxy-Authentication entries should be stripped to ensure sensitive information is not leaked on redirects outside of the original domain.
+
+https://fetch.spec.whatwg.org/#authentication-entries
+
+Thanks to Takeshi Kaneko (GMO Cybersecurity by Ierae, Inc.) for reporting this issue.
+
+Updates golang/go#73816
+Fixes golang/go#73905
+Fixes CVE-2025-4673
+
+Change-Id: I1615f31977a2fd014fbc12aae43f82692315a6d0
+Reviewed-on: https://go-review.googlesource.com/c/go/+/679255
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Michael Knyszek <mknyszek@google.com>
+
+Upstream Patch Reference: https://github.com/golang/go/commit/b897e97c36cb62629a458bc681723ca733404e32.patch
+
+---
+ src/net/http/client.go      | 3 ++-
+ src/net/http/client_test.go | 3 +++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/net/http/client.go b/src/net/http/client.go
+index 23f4d81..e07616b 100644
+--- a/src/net/http/client.go
++++ b/src/net/http/client.go
+@@ -805,7 +805,8 @@ func (c *Client) makeHeadersCopier(ireq *Request) func(req *Request, stripSensit
+ 		for k, vv := range ireqhdr {
+ 			sensitive := false
+ 			switch CanonicalHeaderKey(k) {
+-			case "Authorization", "Www-Authenticate", "Cookie", "Cookie2":
++			case "Authorization", "Www-Authenticate", "Cookie", "Cookie2",
++				"Proxy-Authorization", "Proxy-Authenticate":
+ 				sensitive = true
+ 			}
+ 			if !(sensitive && stripSensitiveHeaders) {
+diff --git a/src/net/http/client_test.go b/src/net/http/client_test.go
+index 641d7ff..97150bd 100644
+--- a/src/net/http/client_test.go
++++ b/src/net/http/client_test.go
+@@ -1541,6 +1541,8 @@ func testClientStripHeadersOnRepeatedRedirect(t *testing.T, mode testMode) {
+ 		if r.Host+r.URL.Path != "a.example.com/" {
+ 			if h := r.Header.Get("Authorization"); h != "" {
+ 				t.Errorf("on request to %v%v, Authorization=%q, want no header", r.Host, r.URL.Path, h)
++			} else if h := r.Header.Get("Proxy-Authorization"); h != "" {
++				t.Errorf("on request to %v%v, Proxy-Authorization=%q, want no header", r.Host, r.URL.Path, h)
+ 			}
+ 		}
+ 		// Follow a chain of redirects from a to b and back to a.
+@@ -1569,6 +1571,7 @@ func testClientStripHeadersOnRepeatedRedirect(t *testing.T, mode testMode) {
+ 	req, _ := NewRequest("GET", proto+"://a.example.com/", nil)
+ 	req.Header.Add("Cookie", "foo=bar")
+ 	req.Header.Add("Authorization", "secretpassword")
++	req.Header.Add("Proxy-Authorization", "secretpassword")
+ 	res, err := c.Do(req)
+ 	if err != nil {
+ 		t.Fatal(err)
+-- 
+2.45.2
+

--- a/SPECS/golang/golang-1.18.spec
+++ b/SPECS/golang/golang-1.18.spec
@@ -13,7 +13,7 @@
 Summary:        Go
 Name:           golang
 Version:        1.18.8
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -32,6 +32,7 @@ Patch5:         CVE-2025-22871.patch
 Patch6:         CVE-2024-24789.patch
 Patch7:         CVE-2025-22870-1.18.patch
 Patch8:         CVE-2024-34155.patch
+Patch9:         CVE-2025-4673-1.18.patch
 Obsoletes:      %{name} < %{version}
 Provides:       %{name} = %{version}
 Provides:       go = %{version}-%{release}
@@ -56,6 +57,7 @@ patch -Np1 --ignore-whitespace < %{PATCH5}
 patch -Np1 --ignore-whitespace < %{PATCH6}
 patch -Np1 --ignore-whitespace < %{PATCH7}
 patch -Np1 --ignore-whitespace < %{PATCH8}
+patch -Np1 --ignore-whitespace < %{PATCH9}
 
 %build
 # Build go 1.4 bootstrap
@@ -136,6 +138,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Fri Aug 22 2025 Akhila Guruju <v-guakhila@microsoft.com> - 1.18.8-9
+- Patch CVE-2025-4673
+
 * Fri Apr 25 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.18.8-8
 - Patch CVE-2024-24789, CVE-2024-34155 & CVE-2025-22870
 

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -15,7 +15,7 @@
 Summary:        Go
 Name:           golang
 Version:        1.22.7
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -30,6 +30,7 @@ Patch1:         CVE-2024-45336.patch
 Patch2:         CVE-2024-45341.patch
 Patch3:         CVE-2025-22871.patch
 Patch4:         CVE-2025-22870.patch
+Patch5:         CVE-2025-4673.patch
 Obsoletes:      %{name} < %{version}
 Provides:       %{name} = %{version}
 Provides:       go = %{version}-%{release}
@@ -49,6 +50,7 @@ mv -v go go-bootstrap
 %patch 2 -p1
 %patch 3 -p1
 %patch 4 -p1
+%patch 5 -p1
 
 %build
 # Go 1.22 requires the final point release of Go 1.20 or later for bootstrap.
@@ -164,6 +166,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Fri Aug 22 2025 Akhila Guruju <v-guakhila@microsoft.com> - 1.22.7-5
+- Patch CVE-2025-4673
+
 * Thu May 08 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.22.7-4
 - Address CVE-2025-22870 using an upstream patch.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch golang and golang-1.18 for CVE-2025-4673
Astrolabe Patch Reference: [https://github.com/golang/go/commit/b897e97c36cb62629a458bc681723ca733404e32.patch](https://github.com/golang/go/commit/b897e97c36cb62629a458bc681723ca733404e32.patch)
For golang-1.22, patch applied directly. No modifications were done to patch.

For golan-1.18, Upstream patch has been modified.
- CVE is about adding stripping of `Proxy-Authentication` entries to ensure sensitive information is not leaked on redirects outside of the original domain.
- In upstream patch this was handled by 2 variables `sensitive && stripSensitiveHeaders`, but In older version this is handled in a single function `shouldCopyHeaderOnRedirect`
- There is switch case inside func `shouldCopyHeaderOnRedirect` which checks for `sensitive` entries. So, changes in upstream patch should be applied in this function.
- New test case was added as this test case is not present before in `golang-1.18`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   CVE-2025-4673-1.18.patch
- new file:   CVE-2025-4673.patch
- modified:   golang-1.18.spec
- modified:   golang.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-4673

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
[golang-1.18.8-9.cm2.src.rpm.log](https://github.com/user-attachments/files/21934825/golang-1.18.8-9.cm2.src.rpm.log)
[golang-1.22.7-5.cm2.src.rpm.log](https://github.com/user-attachments/files/21934828/golang-1.22.7-5.cm2.src.rpm.log)

