### PR TITLE
Fixed `coredns` random rebuilds bug.

### DIFF
--- a/SPECS/coredns/CVE-2025-47950.patch
+++ b/SPECS/coredns/CVE-2025-47950.patch
@@ -3,13 +3,22 @@ From: Aninda <v-anipradhan@microsoft.com>
 Date: Mon, 16 Jun 2025 15:03:49 -0400
 Subject: [PATCH] Address CVE-2025-47950
 Upstream Patch Reference: https://github.com/coredns/coredns/commit/efaed02c6a480ec147b1f799aab7cf815b17dfe1
+
+Modification from original patch by Pawel Winogrodzki <pawelwi@microsoft.com>:
+	Changed original file order. We want to modify plugin.cfg before
+	zdirectives.go and zplugin.go to guarantee their mtime is same or newer than
+	plugin.cfg. Makefile target for the two z*.go files depends on plugin.cfg,
+	so the original order was causing random runs of the z*.go target.
+	The target included calling 'go get', which in turn would fail builds with disabled
+	network access.
+
 ---
+ plugin.cfg                    |   1 +
  core/dnsserver/config.go      |   8 ++
  core/dnsserver/server_quic.go |  49 +++++--
  core/dnsserver/zdirectives.go |   1 +
  core/plugin/zplugin.go        |   1 +
  man/coredns-quic.7            |  69 ++++++++++
- plugin.cfg                    |   1 +
  plugin/quic/README.md         |  48 +++++++
  plugin/quic/setup.go          |  79 +++++++++++
  plugin/quic/setup_test.go     | 242 ++++++++++++++++++++++++++++++++++
@@ -20,6 +29,18 @@ Upstream Patch Reference: https://github.com/coredns/coredns/commit/efaed02c6a48
  create mode 100644 plugin/quic/setup.go
  create mode 100644 plugin/quic/setup_test.go
 
+diff --git a/plugin.cfg b/plugin.cfg
+index 532c3dd..a01852b 100644
+--- a/plugin.cfg
++++ b/plugin.cfg
+@@ -24,6 +24,7 @@ metadata:metadata
+ geoip:geoip
+ cancel:cancel
+ tls:tls
++quic:quic
+ timeouts:timeouts
+ reload:reload
+ nsid:nsid
 diff --git a/core/dnsserver/config.go b/core/dnsserver/config.go
 index 9e11166..cba5795 100644
 --- a/core/dnsserver/config.go
@@ -231,18 +252,6 @@ index 0000000..6301ec2
 +.fi
 +.RE
 +
-diff --git a/plugin.cfg b/plugin.cfg
-index 532c3dd..a01852b 100644
---- a/plugin.cfg
-+++ b/plugin.cfg
-@@ -24,6 +24,7 @@ metadata:metadata
- geoip:geoip
- cancel:cancel
- tls:tls
-+quic:quic
- timeouts:timeouts
- reload:reload
- nsid:nsid
 diff --git a/plugin/quic/README.md b/plugin/quic/README.md
 new file mode 100644
 index 0000000..63fe56d

--- a/SPECS/coredns/coredns.spec
+++ b/SPECS/coredns/coredns.spec
@@ -6,7 +6,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.11.4
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -83,6 +83,9 @@ go install github.com/fatih/faillint@latest && \
 %{_bindir}/%{name}
 
 %changelog
+* Thu Sep 18 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.11.4-10
+- Changed patch order to resolve 'make' race condition.
+
 * Thu Sep 11 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.11.4-9
 - Patch for CVE-2025-58063
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We were getting random failure for `coredns` and an investigation has revealed that it's due to `make` sometimes attempting to run this `coredns` target defined in `Makefile`:

```make
core/plugin/zplugin.go core/dnsserver/zdirectives.go: plugin.cfg
	go generate coredns.go
	go get
```

The two z*.go files along with `plugin.cfg` are present inside the repository but patch `CVE-2025-47950.patch` modifies all of them starting with the z*.go files. This made it possible for the mtime for `plugin.cfg` to sometimes be newer than for the z*.go files, causing `make` to believe the z*.go files are stale. Since the target for these files runs `go get`, this failed the builds when the network was disabled.

The fix makes it so, that we first patch the `plugin.cfg` file to guarantee the z*.go are never older.

The failure was mostly visible on ARM64 builds, where our builds machines were slower.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #14023

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local rebuild.
- PR check.