### PR TITLE
[toolkit] Optimized processing time of prebuilt specs

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -37,23 +37,26 @@ func InjectMissingImplicitProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph
 			return
 		}
 
+		didInjectAny = didInjectAny || len(provideToNodes) > 0
+
 		for provide, nodes := range provideToNodes {
-			err = replaceNodesWithProvides(res, pkgGraph, provide, nodes, rpmFile)
+			err = replaceNodesWithProvides(pkgGraph, provide, nodes, rpmFile)
 			if err != nil {
 				return
 			}
-
-			didInjectAny = true
 		}
 	}
 
-	// Make sure the graph is still a directed acyclic graph (DAG) after manipulating it.
-	err = pkgGraph.MakeDAG()
+	if didInjectAny {
+		// Make sure the graph is still a directed acyclic graph (DAG) after manipulating it.
+		err = pkgGraph.MakeDAG()
+	}
+
 	return
 }
 
 // replaceNodesWithProvides will replace a slice of nodes with a new node with the given provides in the graph.
-func replaceNodesWithProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph, provides *pkgjson.PackageVer, nodes []*pkggraph.PkgNode, rpmFileProviding string) (err error) {
+func replaceNodesWithProvides(pkgGraph *pkggraph.PkgGraph, provides *pkgjson.PackageVer, nodes []*pkggraph.PkgNode, rpmFileProviding string) (err error) {
 	var parentNode *pkggraph.PkgNode
 
 	// Find a local run node that is backed by the same rpm as the one providing the implicit provide.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

### What changes

Skipping the step removing cycles from the build graph after a package build, if the built spec did not indicate any built RPM files. This is the case for all prebuilt packages.

### Details

Capabilities provided by prebuilt packages are resolved by the graph package fetcher **before** the scheduler runs the builds. This allows the tooling to treat prebuilt packages as a special case and leave the `BuiltFiles` slice populated in `buildworker.go::BuildNodeWorker()` empty. Thanks to that, when the scheduler updates the graph with new provides coming from a freshly-built package inside `implicitprovides.go::InjectMissingImplicitProvides()`, it skips updating the graph if the analyzed package is a prebuilt package. In such cases it is unnecessary to attempt to remove cycles from the build graph `pkggraph.go::MageDAG()`, because the graph has not been modified.

### Impact

In case of delta builds (prime examples: production builds and GitHub PR checks), most packages are prebuilt. In an extreme case, if there are no updates packages, the time for the scheduler to run and AMD64 build drops from ~40 minutes to ~2.5 minutes (93+% improvement):
- [Build with all packages prebuilt before the change](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=933643&view=logs&j=f4e482b8-ded8-5b64-2c75-d45f566f3bf2&t=1341f982-a501-53d8-ac7e-1c6370df1744&l=26320).
- [Build with all packages prebuilt after the change](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=933770&view=logs&j=f4e482b8-ded8-5b64-2c75-d45f566f3bf2&t=1341f982-a501-53d8-ac7e-1c6370df1744&l=26318).

ARM64 builds show a drop from ~[56 minutes](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=933643&view=logs&j=ce1e97fe-3d22-53c5-0891-0e3f46e7da49&t=1355e80b-a7f1-5866-3dbe-f57c37bb723d&l=25806) to ~[4 minutes](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=933770&view=logs&j=ce1e97fe-3d22-53c5-0891-0e3f46e7da49&t=1355e80b-a7f1-5866-3dbe-f57c37bb723d&l=25802) (93+% improvement as well).

End-to-end PR check build dropped from ~86 minutes to ~34 minutes (60+% improvement).

**NOTE**: the above is the best-case scenario. Usually, we end up actually building some packages. However, many have single-digit build and test times and can run in parallel, so the time improvements remain impactful.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR check for this change.