### PR TITLE
[TEST AUTO-CHERRYPICK] IGNORE 1 Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) - branch aaruagrawal/autoPRdummy3.0-dev

### DIFF
--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -21,7 +21,11 @@
 Summary:        A command line tool used for creating OCI Images
 Name:           buildah
 Version:        1.18.0
+<<<<<<< HEAD
 Release:        31%{?dist}
+=======
+Release:        33%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -32,7 +36,11 @@ BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  git
 BuildRequires:  glib2-devel
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  go-md2man
 BuildRequires:  go-rpm-macros
 BuildRequires:  golang
@@ -123,6 +131,15 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 %{_datadir}/%{name}/test
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.18.0-33
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 1.18.0-32
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.18.0-31
 - Bump to rebuild with updated glibc
 

--- a/SPECS-EXTENDED/catatonit/catatonit.spec
+++ b/SPECS-EXTENDED/catatonit/catatonit.spec
@@ -3,7 +3,11 @@ Distribution:   Azure Linux
 
 Name: catatonit
 Version: 0.1.7
+<<<<<<< HEAD
 Release: 19%{?dist}
+=======
+Release: 21%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 Summary: A signal-forwarding process manager for containers
 License: GPLv3+
 URL: https://github.com/openSUSE/catatonit
@@ -13,7 +17,11 @@ BuildRequires: automake
 BuildRequires: file
 BuildRequires: gcc
 BuildRequires: git
+<<<<<<< HEAD
 BuildRequires: glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires: glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires: libtool
 BuildRequires: make
 
@@ -61,6 +69,15 @@ ln -s %{_libexecdir}/%{name}/%{name} %{buildroot}%{_libexecdir}/podman/%{name}
 %{_libexecdir}/podman/%{name}
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 0.1.7-21
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 0.1.7-20
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 0.1.7-19
 - Bump to rebuild with updated glibc
 

--- a/SPECS-EXTENDED/dyninst/dyninst.spec
+++ b/SPECS-EXTENDED/dyninst/dyninst.spec
@@ -1,7 +1,11 @@
 Summary: An API for Run-time Code Generation
 License: LGPLv2+
 Name: dyninst
+<<<<<<< HEAD
 Release: 21%{?dist}
+=======
+Release: 23%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL: http://www.dyninst.org
@@ -31,7 +35,11 @@ BuildRequires: tbb tbb-devel
 
 # Extra requires just for the testsuite
 BuildRequires: gcc-gfortran libstdc++-static libxml2-devel
+<<<<<<< HEAD
 BuildRequires: glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires: glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 
 # Testsuite files should not provide/require anything
 %{?filter_setup:
@@ -194,6 +202,15 @@ echo "%{_libdir}/dyninst" > %{buildroot}/etc/ld.so.conf.d/%{name}-%{_arch}.conf
 %attr(644,root,root) %{_libdir}/dyninst/testsuite/*.a
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 10.1.0-23
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 10.1.0-22
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 10.1.0-21
 - Bump to rebuild with updated glibc
 

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -35,7 +35,11 @@
 
 Name:           podman
 Version:        4.1.1
+<<<<<<< HEAD
 Release:        29%{?dist}
+=======
+Release:        31%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        ASL 2.0 and BSD and ISC and MIT and MPLv2.0
 Summary:        Manage Pods, Containers and Container Images
 Vendor:         Microsoft Corporation
@@ -50,7 +54,11 @@ BuildRequires:  go-md2man
 BuildRequires:  golang
 BuildRequires:  gcc
 BuildRequires:  glib2-devel
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  git
 BuildRequires:  go-rpm-macros
 BuildRequires:  gpgme-devel
@@ -386,6 +394,15 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 4.1.1-31
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 4.1.1-30
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 4.1.1-29
 - Bump to rebuild with updated glibc
 

--- a/SPECS/busybox/busybox.spec
+++ b/SPECS/busybox/busybox.spec
@@ -1,7 +1,11 @@
 Summary:        Statically linked binary providing simplified versions of system commands
 Name:           busybox
 Version:        1.36.1
+<<<<<<< HEAD
 Release:        14%{?dist}
+=======
+Release:        16%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -19,7 +23,11 @@ Patch5:         CVE-2023-42366.patch
 Patch6:         CVE-2023-39810.patch
 Patch7:         CVE-2022-48174.patch
 BuildRequires:  gcc
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  libselinux-devel >= 1.27.7-2
 BuildRequires:  libsepol-devel
 %if 0%{?with_check}
@@ -106,6 +114,15 @@ SKIP_KNOWN_BUGS=1 ./runtest
 %{_mandir}/man1/busybox.petitboot.1.gz
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.36.1-16
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 1.36.1-15
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Mon Jul 07 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.36.1-14
 - Patch CVE-2022-48174
 

--- a/SPECS/flannel/flannel.spec
+++ b/SPECS/flannel/flannel.spec
@@ -3,7 +3,11 @@
 Summary:        Simple and easy way to configure a layer 3 network fabric designed for Kubernetes
 Name:           flannel
 Version:        0.24.2
+<<<<<<< HEAD
 Release:        15%{?dist}
+=======
+Release:        18%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -18,8 +22,13 @@ Patch3:         CVE-2025-30204.patch
 Patch4:         CVE-2024-51744.patch
 BuildRequires:  gcc
 BuildRequires:  glibc-devel
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
 BuildRequires:  golang >= 1.20
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+BuildRequires:  golang < 1.25
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  kernel-headers
 
 %description
@@ -52,6 +61,18 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./dist/flanneld
 %{_bindir}/flanneld
 
 %changelog
+<<<<<<< HEAD
+=======
+* Fri Sep 17 2025 Kanishk Bansal <kanbansal@microsoft.com> - 0.24.2-18
+- Bump to rebuild with updated glibc
+
+* Fri Sep 05 2025 Andrew Phelps <anphel@microsoft.com> - 0.24.2-17
+- Bump to rebuild with updated glibc
+
+* Sun Aug 31 2025 Andrew Phelps <anphel@microsoft.com> - 0.24.2-16
+- Set BR for golang to < 1.25
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 0.24.2-15
 - Bump to rebuild with updated glibc
 

--- a/SPECS/glibc/add_support_record_failure_barrier.patch
+++ b/SPECS/glibc/add_support_record_failure_barrier.patch
@@ -1,0 +1,49 @@
+From 4335cd9b58d1449abfba1bb5060970785940a399 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Mon, 23 Dec 2024 13:57:55 +0100
+Subject: [PATCH] support: Add support_record_failure_barrier
+
+This can be used to stop execution after a TEST_COMPARE_BLOB
+failure, for example.
+
+(cherry picked from commit d0b8aa6de4529231fadfe604ac2c434e559c2d9e)
+---
+ support/check.h                  |  3 +++
+ support/support_record_failure.c | 10 ++++++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/support/check.h b/support/check.h
+index 0a9fff484f..632fe5298a 100644
+--- a/support/check.h
++++ b/support/check.h
+@@ -207,6 +207,9 @@ void support_record_failure_reset (void);
+    failures or not.  */
+ int support_record_failure_is_failed (void);
+ 
++/* Terminate the process if any failures have been encountered so far.  */
++void support_record_failure_barrier (void);
++
+ __END_DECLS
+ 
+ #endif /* SUPPORT_CHECK_H */
+diff --git a/support/support_record_failure.c b/support/support_record_failure.c
+index 711f08801b..8466b895dc 100644
+--- a/support/support_record_failure.c
++++ b/support/support_record_failure.c
+@@ -112,3 +112,13 @@ support_record_failure_is_failed (void)
+      synchronization for reliable test error reporting anyway.  */
+   return __atomic_load_n (&state->failed, __ATOMIC_RELAXED);
+ }
++
++void
++support_record_failure_barrier (void)
++{
++  if (__atomic_load_n (&state->failed, __ATOMIC_RELAXED))
++    {
++      puts ("error: exiting due to previous errors");
++      exit (1);
++    }
++}
+-- 
+2.43.7
+

--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -10,7 +10,11 @@
 Summary:        Main C library
 Name:           glibc
 Version:        2.38
+<<<<<<< HEAD
 Release:        11%{?dist}
+=======
+Release:        13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        BSD AND GPLv2+ AND Inner-Net AND ISC AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -45,6 +49,10 @@ Patch16:        CVE-2024-33600.patch
 # Patch of CVE-2024-33601 fixes CVE-2024-33602 also
 Patch17:        CVE-2024-33601.patch
 Patch18:        CVE-2025-0395.patch
+Patch19:        CVE-2025-4802.patch
+# Add test for CVE-2025-4802. Requires additional patch for a support function
+Patch20:        add_support_record_failure_barrier.patch
+Patch21:        test-CVE-2025-4802.patch
 
 # Patches for testing
 Patch100:       0001-Remove-Wno-format-cflag-from-tests.patch
@@ -367,6 +375,16 @@ grep "^FAIL: nptl/tst-mutex10" tests.sum >/dev/null && n=$((n+1)) ||:
 %exclude %{_libdir}/locale/C.utf8
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.38-13
+- Fix Patch application of CVE-2025-4802
+- Add test for CVE-2025-4802
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 2.38-12
+- Bump to rebuild with build-id fix from toolchain gcc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.38-11
 - Patch CVE-2023-4527, CVE-2023-4806, CVE-2024-33599, CVE-2024-33600, CVE-2024-33601, CVE-2025-0395, CVE-2025-4802
 - Fix CVE-2023-5156

--- a/SPECS/glibc/test-CVE-2025-4802.patch
+++ b/SPECS/glibc/test-CVE-2025-4802.patch
@@ -1,0 +1,167 @@
+From 31fa0f73e2fba5c3451d7e763eace3d669961c1c Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Tue, 20 May 2025 19:45:06 +0200
+Subject: [PATCH] elf: Test case for bug 32976 (CVE-2025-4802)
+
+NOTE change for Azure Linux:
+This patch has been slightly modified to fit into the Azure Linux
+version of glibc. The original commit message is below:
+
+Check that LD_LIBRARY_PATH is ignored for AT_SECURE statically
+linked binaries, using support_capture_subprogram_self_sgid.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit d8f7a79335b0d861c12c42aec94c04cd5bb181e2)
+---
+ elf/Makefile              |   4 ++
+ elf/tst-dlopen-sgid-mod.c |   1 +
+ elf/tst-dlopen-sgid.c     | 104 ++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 109 insertions(+)
+ create mode 100644 elf/tst-dlopen-sgid-mod.c
+ create mode 100644 elf/tst-dlopen-sgid.c
+
+diff --git a/elf/Makefile b/elf/Makefile
+index 9d60f46087..ff14e80900 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -261,6 +261,7 @@ tests-static-normal := \
+   tst-array1-static \
+   tst-array5-static \
+   tst-dl-iter-static \
++  tst-dlopen-sgid \
+   tst-dst-static \
+   tst-env-setuid \
+   tst-env-setuid-tunables \
+@@ -824,6 +825,7 @@ modules-names += \
+   tst-dlmopen-twice-mod1 \
+   tst-dlmopen-twice-mod2 \
+   tst-dlmopen1mod \
++  tst-dlopen-sgid-mod \
+   tst-dlopenfaillinkmod \
+   tst-dlopenfailmod1 \
+   tst-dlopenfailmod2 \
+@@ -3009,3 +3011,5 @@ LDFLAGS-tst-dlclose-lazy-mod1.so = -Wl,-z,lazy,--no-as-needed
+ $(objpfx)tst-dlclose-lazy-mod1.so: $(objpfx)tst-dlclose-lazy-mod2.so
+ $(objpfx)tst-dlclose-lazy.out: \
+   $(objpfx)tst-dlclose-lazy-mod1.so $(objpfx)tst-dlclose-lazy-mod2.so
++
++$(objpfx)tst-dlopen-sgid.out: $(objpfx)tst-dlopen-sgid-mod.so
+diff --git a/elf/tst-dlopen-sgid-mod.c b/elf/tst-dlopen-sgid-mod.c
+new file mode 100644
+index 0000000000..5eb79eef48
+--- /dev/null
++++ b/elf/tst-dlopen-sgid-mod.c
+@@ -0,0 +1 @@
++/* Opening this object should not succeed.  */
+diff --git a/elf/tst-dlopen-sgid.c b/elf/tst-dlopen-sgid.c
+new file mode 100644
+index 0000000000..47829a405e
+--- /dev/null
++++ b/elf/tst-dlopen-sgid.c
+@@ -0,0 +1,104 @@
++/* Test case for ignored LD_LIBRARY_PATH in static startug (bug 32976).
++   Copyright (C) 2025 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <dlfcn.h>
++#include <gnu/lib-names.h>
++#include <stddef.h>
++#include <stdint.h>
++#include <stdlib.h>
++#include <string.h>
++#include <support/capture_subprocess.h>
++#include <support/check.h>
++#include <support/support.h>
++#include <support/temp_file.h>
++#include <unistd.h>
++
++/* This is the name of our test object.  Use a custom module for
++   testing, so that this object does not get picked up from the system
++   path.  */
++static const char dso_name[] = "tst-dlopen-sgid-mod.so";
++
++/* Used to mark the recursive invocation.  */
++static const char magic_argument[] = "run-actual-test";
++
++static int
++do_test (void)
++{
++/* Pathname of the directory that receives the shared objects this
++   test attempts to load.  */
++  char *libdir = support_create_temp_directory ("tst-dlopen-sgid-");
++
++  /* This is supposed to be ignored and stripped.  */
++  TEST_COMPARE (setenv ("LD_LIBRARY_PATH", libdir, 1), 0);
++
++  /* Copy of libc.so.6.  */
++  {
++    char *from = xasprintf ("%s/%s", support_objdir_root, LIBC_SO);
++    char *to = xasprintf ("%s/%s", libdir, LIBC_SO);
++    add_temp_file (to);
++    support_copy_file (from, to);
++    free (to);
++    free (from);
++  }
++
++  /* Copy of the test object.   */
++  {
++    char *from = xasprintf ("%s/elf/%s", support_objdir_root, dso_name);
++    char *to = xasprintf ("%s/%s", libdir, dso_name);
++    add_temp_file (to);
++    support_copy_file (from, to);
++    free (to);
++    free (from);
++  }
++
++  TEST_COMPARE (support_capture_subprogram_self_sgid (magic_argument), 0);
++
++  free (libdir);
++
++  return 0;
++}
++
++static void
++alternative_main (int argc, char **argv)
++{
++  if (argc == 2 && strcmp (argv[1], magic_argument) == 0)
++    {
++      if (getgid () == getegid ())
++        /* This can happen if the file system is mounted nosuid.  */
++        FAIL_UNSUPPORTED ("SGID failed: GID and EGID match (%jd)\n",
++                          (intmax_t) getgid ());
++
++      /* Should be removed due to SGID.  */
++      TEST_COMPARE_STRING (getenv ("LD_LIBRARY_PATH"), NULL);
++
++      TEST_VERIFY (dlopen (dso_name, RTLD_NOW) == NULL);
++      {
++        const char *message = dlerror ();
++        TEST_COMPARE_STRING (message,
++                             "tst-dlopen-sgid-mod.so:"
++                             " cannot open shared object file:"
++                             " No such file or directory");
++      }
++
++      support_record_failure_barrier ();
++      exit (EXIT_SUCCESS);
++    }
++}
++
++#define PREPARE alternative_main
++#include <support/test-driver.c>
+-- 
+2.43.7

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,11 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.30.10
+<<<<<<< HEAD
 Release:        8%{?dist}
+=======
+Release:        12%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -27,8 +31,13 @@ Patch5:         CVE-2024-51744.patch
 Patch6:         CVE-2025-30204.patch
 Patch7:         CVE-2025-22872.patch
 BuildRequires:  flex-devel
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
 BuildRequires:  golang
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+BuildRequires:  golang < 1.25
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  rsync
 BuildRequires:  systemd-devel
 BuildRequires:  which
@@ -277,6 +286,21 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+<<<<<<< HEAD
+=======
+* Fri Sep 17 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.30.10-12
+- Bump to rebuild with updated glibc
+
+* Fri Sep 05 2025 Andrew Phelps <anphel@microsoft.com> - 1.30.10-11
+- Bump to rebuild with updated glibc
+
+* Sun Aug 31 2025 Andrew Phelps <anphel@microsoft.com> - 1.30.10-10
+- Set BR for golang to < 1.25
+
+* Mon Jun 30 2025 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 1.30.10-9
+- Patch CVE-2025-4563
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.30.10-8
 - Bump to rebuild with updated glibc
 

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -19,8 +19,13 @@
 
 Summary:        Container native virtualization
 Name:           kubevirt
+<<<<<<< HEAD
 Version:        1.2.0
 Release:        18%{?dist}
+=======
+Version:        1.5.0
+Release:        3%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -43,7 +48,11 @@ Patch8:         CVE-2025-22872.patch
 %global debug_package %{nil}
 BuildRequires:  swtpm-tools
 BuildRequires:  glibc-devel
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  golang >= 1.21
 BuildRequires:  golang-packaging
 BuildRequires:  pkgconfig
@@ -280,6 +289,23 @@ install -p -m 0644 cmd/virt-launcher/qemu.conf %{buildroot}%{_datadir}/kube-virt
 %{_bindir}/virt-tests
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.5.0-3
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 1.5.0-2
+- Bump to rebuild with updated glibc
+
+* Thu Jul 03 2025 Harshit Gupta <guptaharshit@microsoft.com> - 1.5.0-1
+- Upgrade to 1.5.0
+- Removed old patches
+- Remove virt_launcher.cil SELinux policy
+
+* Thu Jul 10 2025 BinduSri Adabala <v-badabala@microsoft.com> - 1.2.0-19
+- Patch CVE-2024-33394
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.2.0-18
 - Bump to rebuild with updated glibc
 

--- a/SPECS/libcap/libcap.spec
+++ b/SPECS/libcap/libcap.spec
@@ -1,7 +1,11 @@
 Summary:        Libcap
 Name:           libcap
 Version:        2.69
+<<<<<<< HEAD
 Release:        5%{?dist}
+=======
+Release:        7%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        GPLv2+
 Group:          System Environment/Security
 URL:            https://www.gnu.org/software/hurd/community/gsoc/project_ideas/libcap.html
@@ -9,7 +13,11 @@ Source0:        https://www.kernel.org/pub/linux/libs/security/linux-privs/libca
 Patch0:         CVE-2025-1390.patch
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 
 %description
 The libcap package implements the user-space interfaces to the POSIX 1003.1e capabilities available
@@ -62,6 +70,15 @@ sed -i '/echo "attempt to exploit kernel bug"/,/^fi$/d' quicktest.sh
 %{_mandir}/man3/*
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.69-7
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 2.69-6
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 2.69-5
 - Bump to rebuild with updated glibc
 

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -25,7 +25,11 @@
 Summary:        Access and modify virtual machine disk images
 Name:           libguestfs
 Version:        1.52.0
+<<<<<<< HEAD
 Release:        13%{?dist}
+=======
+Release:        15%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -82,7 +86,11 @@ BuildRequires:  gcc-c++
 BuildRequires:  gdisk
 BuildRequires:  genisoimage
 BuildRequires:  gfs2-utils
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  gobject-introspection-devel
 BuildRequires:  gperf
 BuildRequires:  grep
@@ -1147,6 +1155,15 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.52.0-15
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 1.52.0-14
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.52.0-13
 - Bump to rebuild with updated glibc
 

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -428,7 +428,11 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 8.2.0
+<<<<<<< HEAD
 Release: 17%{?dist}
+=======
+Release: 20%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -651,7 +655,11 @@ BuildRequires: rutabaga-gfx-ffi-devel
 %endif
 
 %if %{user_static}
+<<<<<<< HEAD
 BuildRequires: glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires: glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires: glib2-static zlib-static
 BuildRequires: pcre2-static
 %endif
@@ -3432,6 +3440,18 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 8.2.0-20
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 8.2.0-19
+- Bump to rebuild with updated glibc
+
+* Thu Aug 14 2025 Kshitiz Godara <kgodara@microsoft.com> - 8.2.0-18
+- Added Patch for CVE-2024-7409
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 8.2.0-17
 - Bump to rebuild with updated glibc
 

--- a/SPECS/rust/rust-1.75.spec
+++ b/SPECS/rust/rust-1.75.spec
@@ -9,7 +9,11 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.75.0
+<<<<<<< HEAD
 Release:        16%{?dist}
+=======
+Release:        19%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -63,7 +67,11 @@ BuildRequires:  python3
 # make sure rust depends on system zlib
 BuildRequires:  zlib-devel
 %if 0%{?with_check}
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  sudo
 %endif
 # rustc uses a C compiler to invoke the linker, and links to glibc in most cases
@@ -179,6 +187,18 @@ rm %{buildroot}%{_bindir}/*.old
 %{_mandir}/man1/*
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.75.0-19
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 1.75.0-18
+- Bump to rebuild with updated glibc
+
+* Mon Jul 21 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 1.75.0-17
+- Add patch for CVE-2025-53605
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Tue Jun 10 2025 Kavya Sree Kaitepalli kkaitepalli@microsoft.com - 1.75.0-16
 - Run %check as non root user to fix ptests
 - Patch CVE-2025-4574

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -9,7 +9,11 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.86.0
+<<<<<<< HEAD
 Release:        3%{?dist}
+=======
+Release:        7%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -59,7 +63,11 @@ BuildRequires:  python3
 # make sure rust depends on system zlib
 BuildRequires:  zlib-devel
 %if 0%{?with_check}
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:	sudo
 %endif
 # rustc uses a C compiler to invoke the linker, and links to glibc in most cases
@@ -179,6 +187,21 @@ rm %{buildroot}%{_docdir}/docs/html/.lock
 %{_mandir}/man1/*
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.86.0-7
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 1.86.0-6
+- Bump to rebuild with updated glibc
+
+* Fri Aug 08 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.86.0-5
+- Patch for CVE-2024-11738
+ 
+* Mon Jul 21 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 1.86.0-4
+- patch for CVE-2025-53605
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Fri Jun 13 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 1.86.0-3
 - Patch CVE-2025-4574
 

--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -21,7 +21,11 @@
 Summary:        Tool for creating supermin appliances
 Name:           supermin
 Version:        5.3.4
+<<<<<<< HEAD
 Release:        6%{?dist}
+=======
+Release:        8%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -54,7 +58,11 @@ BuildRequires:  systemd-udev
 %if %{with dietlibc}
 BuildRequires:  dietlibc-devel
 %else
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 %endif
 
 %if 0%{?with_check}
@@ -129,6 +137,15 @@ make check || {
 %{_rpmconfigdir}/supermin-find-requires
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 5.3.4-8
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 5.3.4-7
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 5.3.4-6
 - Bump to rebuild with updated glibc
 

--- a/SPECS/tini/tini.spec
+++ b/SPECS/tini/tini.spec
@@ -1,7 +1,11 @@
 Summary:        A tiny but valid init for containers
 Name:           tini
 Version:        0.19.0
+<<<<<<< HEAD
 Release:        21%{?dist}
+=======
+Release:        23%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -13,7 +17,11 @@ BuildRequires:  diffutils
 BuildRequires:  file
 BuildRequires:  gcc
 BuildRequires:  glibc-devel
+<<<<<<< HEAD
 BuildRequires:  glibc-static >= 2.38-11%{?dist}
+=======
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 BuildRequires:  kernel-headers
 BuildRequires:  make
 BuildRequires:  sed
@@ -66,6 +74,15 @@ ln -s %{_bindir}/tini-static %{buildroot}%{_bindir}/docker-init
 %{_bindir}/docker-init
 
 %changelog
+<<<<<<< HEAD
+=======
+* Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 0.19.0-23
+- Bump to rebuild with updated glibc
+
+* Mon Aug 25 2025 Andrew Phelps <anphel@microsoft.com> - 0.19.0-22
+- Bump to rebuild with updated glibc
+
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu May 22 2025 Kanishk Bansal <kanbansal@microsoft.com> - 0.19.0-21
 - Bump to rebuild with updated glibc
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,4 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
+<<<<<<< HEAD
 kernel-headers-6.6.96.1-1.azl3.noarch.rpm
 glibc-2.38-11.azl3.aarch64.rpm
 glibc-devel-2.38-11.azl3.aarch64.rpm
@@ -8,6 +9,17 @@ glibc-lang-2.38-11.azl3.aarch64.rpm
 glibc-locales-all-2.38-11.azl3.aarch64.rpm
 glibc-nscd-2.38-11.azl3.aarch64.rpm
 glibc-tools-2.38-11.azl3.aarch64.rpm
+=======
+kernel-headers-6.6.96.2-2.azl3.noarch.rpm
+glibc-2.38-13.azl3.aarch64.rpm
+glibc-devel-2.38-13.azl3.aarch64.rpm
+glibc-i18n-2.38-13.azl3.aarch64.rpm
+glibc-iconv-2.38-13.azl3.aarch64.rpm
+glibc-lang-2.38-13.azl3.aarch64.rpm
+glibc-locales-all-2.38-13.azl3.aarch64.rpm
+glibc-nscd-2.38-13.azl3.aarch64.rpm
+glibc-tools-2.38-13.azl3.aarch64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 zlib-1.3.1-1.azl3.aarch64.rpm
 zlib-devel-1.3.1-1.azl3.aarch64.rpm
 file-5.45-1.azl3.aarch64.rpm
@@ -170,6 +182,7 @@ gtk-doc-1.33.2-1.azl3.noarch.rpm
 autoconf-2.72-2.azl3.noarch.rpm
 automake-1.16.5-2.azl3.noarch.rpm
 ocaml-srpm-macros-9-4.azl3.noarch.rpm
+<<<<<<< HEAD
 openssl-3.3.3-2.azl3.aarch64.rpm
 openssl-devel-3.3.3-2.azl3.aarch64.rpm
 openssl-libs-3.3.3-2.azl3.aarch64.rpm
@@ -177,6 +190,15 @@ openssl-perl-3.3.3-2.azl3.aarch64.rpm
 openssl-static-3.3.3-2.azl3.aarch64.rpm
 libcap-2.69-5.azl3.aarch64.rpm
 libcap-devel-2.69-5.azl3.aarch64.rpm
+=======
+openssl-3.3.3-3.azl3.aarch64.rpm
+openssl-devel-3.3.3-3.azl3.aarch64.rpm
+openssl-libs-3.3.3-3.azl3.aarch64.rpm
+openssl-perl-3.3.3-3.azl3.aarch64.rpm
+openssl-static-3.3.3-3.azl3.aarch64.rpm
+libcap-2.69-7.azl3.aarch64.rpm
+libcap-devel-2.69-7.azl3.aarch64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 debugedit-5.0-2.azl3.aarch64.rpm
 libarchive-3.7.7-2.azl3.aarch64.rpm
 libarchive-devel-3.7.7-2.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,4 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
+<<<<<<< HEAD
 kernel-headers-6.6.96.1-1.azl3.noarch.rpm
 glibc-2.38-11.azl3.x86_64.rpm
 glibc-devel-2.38-11.azl3.x86_64.rpm
@@ -8,6 +9,17 @@ glibc-lang-2.38-11.azl3.x86_64.rpm
 glibc-locales-all-2.38-11.azl3.x86_64.rpm
 glibc-nscd-2.38-11.azl3.x86_64.rpm
 glibc-tools-2.38-11.azl3.x86_64.rpm
+=======
+kernel-headers-6.6.96.2-2.azl3.noarch.rpm
+glibc-2.38-13.azl3.x86_64.rpm
+glibc-devel-2.38-13.azl3.x86_64.rpm
+glibc-i18n-2.38-13.azl3.x86_64.rpm
+glibc-iconv-2.38-13.azl3.x86_64.rpm
+glibc-lang-2.38-13.azl3.x86_64.rpm
+glibc-locales-all-2.38-13.azl3.x86_64.rpm
+glibc-nscd-2.38-13.azl3.x86_64.rpm
+glibc-tools-2.38-13.azl3.x86_64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 zlib-1.3.1-1.azl3.x86_64.rpm
 zlib-devel-1.3.1-1.azl3.x86_64.rpm
 file-5.45-1.azl3.x86_64.rpm
@@ -170,6 +182,7 @@ gtk-doc-1.33.2-1.azl3.noarch.rpm
 autoconf-2.72-2.azl3.noarch.rpm
 automake-1.16.5-2.azl3.noarch.rpm
 ocaml-srpm-macros-9-4.azl3.noarch.rpm
+<<<<<<< HEAD
 openssl-3.3.3-2.azl3.x86_64.rpm
 openssl-devel-3.3.3-2.azl3.x86_64.rpm
 openssl-libs-3.3.3-2.azl3.x86_64.rpm
@@ -177,6 +190,15 @@ openssl-perl-3.3.3-2.azl3.x86_64.rpm
 openssl-static-3.3.3-2.azl3.x86_64.rpm
 libcap-2.69-5.azl3.x86_64.rpm
 libcap-devel-2.69-5.azl3.x86_64.rpm
+=======
+openssl-3.3.3-3.azl3.x86_64.rpm
+openssl-devel-3.3.3-3.azl3.x86_64.rpm
+openssl-libs-3.3.3-3.azl3.x86_64.rpm
+openssl-perl-3.3.3-3.azl3.x86_64.rpm
+openssl-static-3.3.3-3.azl3.x86_64.rpm
+libcap-2.69-7.azl3.x86_64.rpm
+libcap-devel-2.69-7.azl3.x86_64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 debugedit-5.0-2.azl3.x86_64.rpm
 libarchive-3.7.7-2.azl3.x86_64.rpm
 libarchive-devel-3.7.7-2.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -122,6 +122,7 @@ gdbm-lang-1.23-1.azl3.aarch64.rpm
 gettext-0.22-1.azl3.aarch64.rpm
 gettext-debuginfo-0.22-1.azl3.aarch64.rpm
 gfortran-13.2.0-7.azl3.aarch64.rpm
+<<<<<<< HEAD
 glib-2.78.6-2.azl3.aarch64.rpm
 glib-debuginfo-2.78.6-2.azl3.aarch64.rpm
 glib-devel-2.78.6-2.azl3.aarch64.rpm
@@ -137,6 +138,23 @@ glibc-locales-all-2.38-11.azl3.aarch64.rpm
 glibc-nscd-2.38-11.azl3.aarch64.rpm
 glibc-static-2.38-11.azl3.aarch64.rpm
 glibc-tools-2.38-11.azl3.aarch64.rpm
+=======
+glib-2.78.6-3.azl3.aarch64.rpm
+glib-debuginfo-2.78.6-3.azl3.aarch64.rpm
+glib-devel-2.78.6-3.azl3.aarch64.rpm
+glib-doc-2.78.6-3.azl3.noarch.rpm
+glib-schemas-2.78.6-3.azl3.aarch64.rpm
+glibc-2.38-13.azl3.aarch64.rpm
+glibc-debuginfo-2.38-13.azl3.aarch64.rpm
+glibc-devel-2.38-13.azl3.aarch64.rpm
+glibc-i18n-2.38-13.azl3.aarch64.rpm
+glibc-iconv-2.38-13.azl3.aarch64.rpm
+glibc-lang-2.38-13.azl3.aarch64.rpm
+glibc-locales-all-2.38-13.azl3.aarch64.rpm
+glibc-nscd-2.38-13.azl3.aarch64.rpm
+glibc-static-2.38-13.azl3.aarch64.rpm
+glibc-tools-2.38-13.azl3.aarch64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 gmp-6.3.0-1.azl3.aarch64.rpm
 gmp-debuginfo-6.3.0-1.azl3.aarch64.rpm
 gmp-devel-6.3.0-1.azl3.aarch64.rpm
@@ -177,9 +195,15 @@ libassuan-devel-2.5.6-1.azl3.aarch64.rpm
 libattr-2.5.2-1.azl3.aarch64.rpm
 libattr-devel-2.5.2-1.azl3.aarch64.rpm
 libbacktrace-static-13.2.0-7.azl3.aarch64.rpm
+<<<<<<< HEAD
 libcap-2.69-5.azl3.aarch64.rpm
 libcap-debuginfo-2.69-5.azl3.aarch64.rpm
 libcap-devel-2.69-5.azl3.aarch64.rpm
+=======
+libcap-2.69-7.azl3.aarch64.rpm
+libcap-debuginfo-2.69-7.azl3.aarch64.rpm
+libcap-devel-2.69-7.azl3.aarch64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 libcap-ng-0.8.4-1.azl3.aarch64.rpm
 libcap-ng-debuginfo-0.8.4-1.azl3.aarch64.rpm
 libcap-ng-devel-0.8.4-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -129,6 +129,7 @@ gdbm-lang-1.23-1.azl3.x86_64.rpm
 gettext-0.22-1.azl3.x86_64.rpm
 gettext-debuginfo-0.22-1.azl3.x86_64.rpm
 gfortran-13.2.0-7.azl3.x86_64.rpm
+<<<<<<< HEAD
 glib-2.78.6-2.azl3.x86_64.rpm
 glib-debuginfo-2.78.6-2.azl3.x86_64.rpm
 glib-devel-2.78.6-2.azl3.x86_64.rpm
@@ -144,6 +145,23 @@ glibc-locales-all-2.38-11.azl3.x86_64.rpm
 glibc-nscd-2.38-11.azl3.x86_64.rpm
 glibc-static-2.38-11.azl3.x86_64.rpm
 glibc-tools-2.38-11.azl3.x86_64.rpm
+=======
+glib-2.78.6-3.azl3.x86_64.rpm
+glib-debuginfo-2.78.6-3.azl3.x86_64.rpm
+glib-devel-2.78.6-3.azl3.x86_64.rpm
+glib-doc-2.78.6-3.azl3.noarch.rpm
+glib-schemas-2.78.6-3.azl3.x86_64.rpm
+glibc-2.38-13.azl3.x86_64.rpm
+glibc-debuginfo-2.38-13.azl3.x86_64.rpm
+glibc-devel-2.38-13.azl3.x86_64.rpm
+glibc-i18n-2.38-13.azl3.x86_64.rpm
+glibc-iconv-2.38-13.azl3.x86_64.rpm
+glibc-lang-2.38-13.azl3.x86_64.rpm
+glibc-locales-all-2.38-13.azl3.x86_64.rpm
+glibc-nscd-2.38-13.azl3.x86_64.rpm
+glibc-static-2.38-13.azl3.x86_64.rpm
+glibc-tools-2.38-13.azl3.x86_64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 gmp-6.3.0-1.azl3.x86_64.rpm
 gmp-debuginfo-6.3.0-1.azl3.x86_64.rpm
 gmp-devel-6.3.0-1.azl3.x86_64.rpm
@@ -185,9 +203,15 @@ libassuan-devel-2.5.6-1.azl3.x86_64.rpm
 libattr-2.5.2-1.azl3.x86_64.rpm
 libattr-devel-2.5.2-1.azl3.x86_64.rpm
 libbacktrace-static-13.2.0-7.azl3.x86_64.rpm
+<<<<<<< HEAD
 libcap-2.69-5.azl3.x86_64.rpm
 libcap-debuginfo-2.69-5.azl3.x86_64.rpm
 libcap-devel-2.69-5.azl3.x86_64.rpm
+=======
+libcap-2.69-7.azl3.x86_64.rpm
+libcap-debuginfo-2.69-7.azl3.x86_64.rpm
+libcap-devel-2.69-7.azl3.x86_64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 libcap-ng-0.8.4-1.azl3.x86_64.rpm
 libcap-ng-debuginfo-0.8.4-1.azl3.x86_64.rpm
 libcap-ng-devel-0.8.4-1.azl3.x86_64.rpm


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit d3975f800fe5adb73aa8d99ed3e82788ebfd8eb9 to aaruagrawal/autoPRdummy3.0-dev. Original PR: #14669