### PR TITLE
[AUTO-CHERRYPICK] Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) - branch 3.0-dev

### DIFF
--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -6,6 +6,7 @@
 %else
 %global debug_package   %{nil}
 %endif
+<<<<<<< HEAD
 
 %global gomodulesmode GO111MODULE=on
 
@@ -60,6 +61,49 @@ Requires: libcontainers-common
 BuildRequires: libseccomp-devel
 Requires: libseccomp >= 2.4.1-0
 Suggests: cpp
+=======
+%global provider github
+%global provider_tld com
+%global project containers
+%global repo buildah
+# https://github.com/containers/buildah
+%global import_path %{provider}.%{provider_tld}/%{project}/%{repo}
+%global git0 https://%{import_path}
+# Used for comparing with latest upstream tag
+# to decide whether to autobuild (non-rawhide only)
+%define built_tag v1.18.0
+%define built_tag_strip %(b=%{built_tag}; echo ${b:1})
+%define download_url https://%{import_path}/archive/%{built_tag}.tar.gz
+Summary:        A command line tool used for creating OCI Images
+Name:           buildah
+Version:        1.18.0
+Release:        33%{?dist}
+License:        ASL 2.0
+Vendor:         Microsoft Corporation
+Distribution:   Azure Linux
+URL:            https://%{name}.io
+Source:         %{download_url}#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2022-2990.patch
+BuildRequires:  btrfs-progs-devel
+BuildRequires:  device-mapper-devel
+BuildRequires:  git
+BuildRequires:  glib2-devel
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+BuildRequires:  go-md2man
+BuildRequires:  go-rpm-macros
+BuildRequires:  golang
+BuildRequires:  gpgme-devel
+BuildRequires:  libassuan-devel
+BuildRequires:  libseccomp-static
+BuildRequires:  make
+BuildRequires:  ostree-devel
+Requires:       libcontainers-common
+Requires:       libseccomp >= 2.4.1-0
+Requires:       moby-runc
+Recommends:     container-selinux
+Recommends:     fuse-overlayfs
+Recommends:     slirp4netns >= 0.3-0
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 
 %description
 The %{name} package provides a command line tool which can be used to
@@ -173,11 +217,14 @@ make test-unit
 %{_datadir}/%{name}/test
 
 %changelog
+<<<<<<< HEAD
 * Fri Sep 12 2025 Akarsh Chaudhary <v-akarshc@microsoft.com> - 1.41.4-1
 - Initial Azure Linux import from Fedora 41 (license: MIT).
 - Added Check section
 - License verified
 
+=======
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 1.18.0-33
 - Bump to rebuild with updated glibc
 

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -19,6 +19,7 @@
 # %%{name}
 %global git0 %{container_base_url}/%{name}
 
+<<<<<<< HEAD
 %define build_origin %{?packager}
 
 Name: podman
@@ -51,6 +52,51 @@ BuildRequires: glibc-devel
 BuildRequires: glibc-static >= 2.38-13%{?dist}
 BuildRequires: golang
 BuildRequires: git-core
+=======
+Name:           podman
+Version:        4.1.1
+Release:        31%{?dist}
+License:        ASL 2.0 and BSD and ISC and MIT and MPLv2.0
+Summary:        Manage Pods, Containers and Container Images
+Vendor:         Microsoft Corporation
+Distribution:   Azure Linux
+URL:            https://%{name}.io/
+Source0:        %{git0}/archive/%{built_tag}.tar.gz#/%{name}-%{version}.tar.gz
+Source1:        %{git_plugins}/archive/%{commit_plugins}/%{repo_plugins}-%{commit_plugins}.tar.gz#/%{repo_plugins}-%{shortcommit_plugins}.tar.gz
+Source2:        %{git_gvproxy}/archive/%{commit_gvproxy}/%{repo_gvproxy}-%{commit_gvproxy}.tar.gz#/%{repo_gvproxy}-%{shortcommit_gvproxy}.tar.gz
+Patch0:         CVE-2022-2989.patch
+Provides:       %{name}-manpages = %{version}-%{release}
+BuildRequires:  go-md2man
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  glib2-devel
+BuildRequires:  glibc-static >= 2.38-13%{?dist}
+BuildRequires:  git
+BuildRequires:  go-rpm-macros
+BuildRequires:  gpgme-devel
+BuildRequires:  libassuan-devel
+BuildRequires:  libgpg-error-devel
+BuildRequires:  libseccomp-devel
+BuildRequires:  libselinux-devel
+BuildRequires:  shadow-utils
+BuildRequires:  pkgconfig
+BuildRequires:  make
+BuildRequires:  ostree-devel
+BuildRequires:  systemd
+BuildRequires:  systemd-devel
+BuildRequires:  libcontainers-common
+Requires:       catatonit
+Requires:       iptables
+Requires:       nftables
+Requires:       conmon >= 2.0.30
+Requires:       libcontainers-common
+Requires:       netavark >= 1.0.3
+Requires:       shadow-utils-subid
+Requires:       moby-runc
+Requires:       slirp4netns
+Requires:       containernetworking-plugins >= 0.9.1
+Suggests:       qemu-user-static
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 
 BuildRequires: go-rpm-macros
 
@@ -295,11 +341,14 @@ make localunit
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
+<<<<<<< HEAD
 * Fri Sep 19 2025 Sumit Jena <v-sumitjena@microsof.com>
 - Update to version 5.6.1
 - added check section
 - License verified
 
+=======
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 * Thu Aug 28 2025 Kanishk Bansal <kanbansal@microsoft.com> - 4.1.1-31
 - Bump to rebuild with updated glibc
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,9 @@
 filesystem-1.1-21.azl3.aarch64.rpm
+<<<<<<< HEAD
 kernel-headers-6.6.104.2-2.azl3.noarch.rpm
+=======
+kernel-headers-6.6.96.2-2.azl3.noarch.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 glibc-2.38-13.azl3.aarch64.rpm
 glibc-devel-2.38-13.azl3.aarch64.rpm
 glibc-i18n-2.38-13.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,9 @@
 filesystem-1.1-21.azl3.x86_64.rpm
+<<<<<<< HEAD
 kernel-headers-6.6.104.2-2.azl3.noarch.rpm
+=======
+kernel-headers-6.6.96.2-2.azl3.noarch.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 glibc-2.38-13.azl3.x86_64.rpm
 glibc-devel-2.38-13.azl3.x86_64.rpm
 glibc-i18n-2.38-13.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -122,11 +122,19 @@ gdbm-lang-1.23-1.azl3.aarch64.rpm
 gettext-0.22-1.azl3.aarch64.rpm
 gettext-debuginfo-0.22-1.azl3.aarch64.rpm
 gfortran-13.2.0-7.azl3.aarch64.rpm
+<<<<<<< HEAD
 glib-2.78.6-4.azl3.aarch64.rpm
 glib-debuginfo-2.78.6-4.azl3.aarch64.rpm
 glib-devel-2.78.6-4.azl3.aarch64.rpm
 glib-doc-2.78.6-4.azl3.noarch.rpm
 glib-schemas-2.78.6-4.azl3.aarch64.rpm
+=======
+glib-2.78.6-3.azl3.aarch64.rpm
+glib-debuginfo-2.78.6-3.azl3.aarch64.rpm
+glib-devel-2.78.6-3.azl3.aarch64.rpm
+glib-doc-2.78.6-3.azl3.noarch.rpm
+glib-schemas-2.78.6-3.azl3.aarch64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 glibc-2.38-13.azl3.aarch64.rpm
 glibc-debuginfo-2.38-13.azl3.aarch64.rpm
 glibc-devel-2.38-13.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -129,11 +129,19 @@ gdbm-lang-1.23-1.azl3.x86_64.rpm
 gettext-0.22-1.azl3.x86_64.rpm
 gettext-debuginfo-0.22-1.azl3.x86_64.rpm
 gfortran-13.2.0-7.azl3.x86_64.rpm
+<<<<<<< HEAD
 glib-2.78.6-4.azl3.x86_64.rpm
 glib-debuginfo-2.78.6-4.azl3.x86_64.rpm
 glib-devel-2.78.6-4.azl3.x86_64.rpm
 glib-doc-2.78.6-4.azl3.noarch.rpm
 glib-schemas-2.78.6-4.azl3.x86_64.rpm
+=======
+glib-2.78.6-3.azl3.x86_64.rpm
+glib-debuginfo-2.78.6-3.azl3.x86_64.rpm
+glib-devel-2.78.6-3.azl3.x86_64.rpm
+glib-doc-2.78.6-3.azl3.noarch.rpm
+glib-schemas-2.78.6-3.azl3.x86_64.rpm
+>>>>>>> d3975f800 (Fix : patch application of CVE-2025-4802 in `glibc` (re-apply: #14582) (#14669))
 glibc-2.38-13.azl3.x86_64.rpm
 glibc-debuginfo-2.38-13.azl3.x86_64.rpm
 glibc-devel-2.38-13.azl3.x86_64.rpm


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit d3975f800fe5adb73aa8d99ed3e82788ebfd8eb9 to 3.0-dev. Original PR: #14669