### PR TITLE
[Medium] Patch erlang for CVE-2025-48039

### DIFF
--- a/SPECS/erlang/CVE-2025-48039.patch
+++ b/SPECS/erlang/CVE-2025-48039.patch
@@ -1,0 +1,230 @@
+From 043ee3c943e2977c1acdd740ad13992fd60b6bf0 Mon Sep 17 00:00:00 2001
+From: Jakub Witczak <kuba@erlang.org>
+Date: Fri, 11 Jul 2025 13:59:41 +0200
+Subject: [PATCH] ssh: ssh_sftpd verify path size for client data
+
+- reject max_path exceeding the 4096 limit or according to other option value
+
+Modified to apply to Azure Linux
+Modified by: Akhila Guruju <v-guakhila@microsoft.com>
+Date: Fri, 3 Oct 2025 11:07:55 +0000
+
+Upstream Patch Reference: https://github.com/erlang/otp/commit/043ee3c943e2977c1acdd740ad13992fd60b6bf0.patch
+---
+ lib/ssh/doc/src/ssh_sftpd.xml    |  8 ++++
+ lib/ssh/src/ssh_sftpd.erl        | 28 ++++++++++++
+ lib/ssh/test/ssh_sftpd_SUITE.erl | 78 ++++++++++++++++++++------------
+ 3 files changed, 85 insertions(+), 29 deletions(-)
+
+diff --git a/lib/ssh/doc/src/ssh_sftpd.xml b/lib/ssh/doc/src/ssh_sftpd.xml
+index 03e8dad..cbe015f 100644
+--- a/lib/ssh/doc/src/ssh_sftpd.xml
++++ b/lib/ssh/doc/src/ssh_sftpd.xml
+@@ -65,6 +65,14 @@
+ 	    If supplied, the number of filenames returned to the SFTP client per <c>READDIR</c>
+ 	    request is limited to at most the given value.</p>
+ 	  </item>
++          <tag><c>max_path</c></tag>
++	  <item>
++	    <p>The default value is <c>4096</c>. Positive integer
++	    value represents the maximum path length which cannot be
++	    exceeded in data provided by the SFTP client. (Note:
++	    limitations might be also enforced by underlying operating
++	    system)</p>
++	  </item>
+ 	  <tag><c>max_handles</c></tag>
+ 	  <item>
+             <p>The default value is <c>1000</c>. Positive integer value represents the maximum number of file handles allowed for a connection.</p>            
+diff --git a/lib/ssh/src/ssh_sftpd.erl b/lib/ssh/src/ssh_sftpd.erl
+index 0c64178..d02ece3 100644
+--- a/lib/ssh/src/ssh_sftpd.erl
++++ b/lib/ssh/src/ssh_sftpd.erl
+@@ -52,6 +52,7 @@
+ 	  file_handler,			% atom() - callback module 
+ 	  file_state,                   % state for the file callback module
+ 	  max_files,                    % integer >= 0 max no files sent during READDIR
++	  max_path,                     % integer > 0 - max length of path
+ 	  max_handles,                  % integer > 0  - max number of file handles
+ 	  options,			% from the subsystem declaration
+ 	  handles			% list of open handles
+@@ -66,6 +67,7 @@
+       Options :: [ {cwd, string()} |
+                    {file_handler, CbMod | {CbMod, FileState}} |
+                    {max_files, integer()} |
++                   {max_path, integer()} |
+                    {max_handles, integer()} |
+                    {root, string()} |
+                    {sftpd_vsn, integer()}
+@@ -117,11 +119,13 @@ init(Options) ->
+ 		{Root0, State0}
+ 	end,
+     MaxLength = proplists:get_value(max_files, Options, 0),
++    MaxPath = proplists:get_value(max_path, Options, 4096),
+     MaxHandles = proplists:get_value(max_handles, Options, 1000),
+     Vsn = proplists:get_value(sftpd_vsn, Options, 5),
+     {ok,  State#state{cwd = CWD,
+                       root = Root,
+                       max_files = MaxLength,
++                      max_path = MaxPath,
+                       max_handles = MaxHandles,
+ 		      options = Options,
+ 		      handles = [], pending = <<>>,
+@@ -239,6 +243,30 @@ handle_op(Request, ReqId, <<?UINT32(HLen), _/binary>>, State = #state{xf = XF})
+        HLen > 256 ->
+     ssh_xfer:xf_send_status(XF, ReqId, ?SSH_FX_INVALID_HANDLE, "Invalid handle"),
+     State;
++handle_op(Request, ReqId, <<?UINT32(PLen), _/binary>>,
++          State = #state{max_path = MaxPath, xf = XF})
++ when (Request == ?SSH_FXP_LSTAT orelse
++        Request == ?SSH_FXP_MKDIR orelse
++        Request == ?SSH_FXP_OPEN orelse
++        Request == ?SSH_FXP_OPENDIR orelse
++        Request == ?SSH_FXP_READLINK orelse
++        Request == ?SSH_FXP_REALPATH orelse
++        Request == ?SSH_FXP_REMOVE orelse
++        Request == ?SSH_FXP_RMDIR orelse
++        Request == ?SSH_FXP_SETSTAT orelse
++        Request == ?SSH_FXP_STAT),
++       PLen > MaxPath ->
++    ssh_xfer:xf_send_status(XF, ReqId, ?SSH_FX_NO_SUCH_PATH,
++                            "No such path"),
++    State;
++handle_op(Request, ReqId, <<?UINT32(PLen), _:PLen/binary, ?UINT32(PLen2), _/binary>>,
++          State = #state{max_path = MaxPath, xf = XF})
++  when (Request == ?SSH_FXP_RENAME orelse
++        Request == ?SSH_FXP_SYMLINK),
++       (PLen > MaxPath orelse PLen2 > MaxPath) ->
++    ssh_xfer:xf_send_status(XF, ReqId, ?SSH_FX_NO_SUCH_PATH,
++                            "No such path"),
++    State;
+ handle_op(?SSH_FXP_INIT, Version, B, State) when is_binary(B) ->
+     XF = State#state.xf,
+     Vsn = lists:min([XF#ssh_xfer.vsn, Version]),
+diff --git a/lib/ssh/test/ssh_sftpd_SUITE.erl b/lib/ssh/test/ssh_sftpd_SUITE.erl
+index 9da2e41..01321ed 100644
+--- a/lib/ssh/test/ssh_sftpd_SUITE.erl
++++ b/lib/ssh/test/ssh_sftpd_SUITE.erl
+@@ -43,6 +43,7 @@
+          open_file_dir_v6/1,
+          read_dir/1,
+          read_file/1,
++         max_path/1,
+          real_path/1,
+          relative_path/1,
+          relpath/1,
+@@ -71,6 +72,7 @@
+ -define(REG_ATTERS, <<0,0,0,0,1>>).
+ -define(UNIX_EPOCH,  62167219200).
+ -define(MAX_HANDLES, 10).
++-define(MAX_PATH, 200).
+ -define(is_set(F, Bits), ((F) band (Bits)) == (F)).
+ 
+ %%--------------------------------------------------------------------
+@@ -84,6 +86,7 @@ all() ->
+     [open_close_file, 
+      open_close_dir, 
+      read_file, 
++     max_path,
+      read_dir,
+      write_file, 
+      rename_file, 
+@@ -177,7 +180,9 @@ init_per_testcase(TestCase, Config) ->
+ 								  {sftpd_vsn, 6}])],
+ 			  ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+ 		      _ ->
+-			  SubSystems = [ssh_sftpd:subsystem_spec([{max_handles, ?MAX_HANDLES}])],
++			  SubSystems = [ssh_sftpd:subsystem_spec(
++                                          [{max_handles, ?MAX_HANDLES},
++                                           {max_path, ?MAX_PATH}])],
+ 			  ssh:daemon(0, [{subsystems, SubSystems}|Options])
+ 		  end,
+ 
+@@ -333,6 +338,23 @@ read_file(Config) when is_list(Config) ->
+     ct:log("Message: ~s", [Msg]),
+     ok.
+ 
++%%--------------------------------------------------------------------
++max_path(Config) when is_list(Config) ->
++    PrivDir =  proplists:get_value(priv_dir, Config),
++    FileName = filename:join(PrivDir, "test.txt"),
++    {Cm, Channel} = proplists:get_value(sftp, Config),
++    %% verify max_path limit
++    LongFileName =
++        filename:join(PrivDir,
++                      "t" ++ lists:flatten(lists:duplicate(?MAX_PATH, "e")) ++ "st.txt"),
++    {ok, _} = file:copy(FileName, LongFileName),
++    ReqId1 = req_id(),
++    {ok, <<?SSH_FXP_STATUS, ?UINT32(ReqId1), ?UINT32(?SSH_FX_NO_SUCH_PATH),
++	  _/binary>>, _} =
++	open_file(LongFileName, Cm, Channel, ReqId1,
++		  ?ACE4_READ_DATA  bor ?ACE4_READ_ATTRIBUTES,
++		  ?SSH_FXF_OPEN_EXISTING).
++
+ read_dir(Config) when is_list(Config) ->
+     PrivDir = proplists:get_value(priv_dir, Config),
+     {Cm, Channel} = proplists:get_value(sftp, Config),
+@@ -396,35 +418,33 @@ rename_file(Config) when is_list(Config) ->
+     PrivDir =  proplists:get_value(priv_dir, Config),
+     FileName = filename:join(PrivDir, "test.txt"),
+     NewFileName = filename:join(PrivDir, "test1.txt"),
+-    ReqId = 0,
++    LongFileName =
++        filename:join(PrivDir,
++                      "t" ++ lists:flatten(lists:duplicate(?MAX_PATH, "e")) ++ "st.txt"),
+     {Cm, Channel} = proplists:get_value(sftp, Config),
+-
+-    {ok, <<?SSH_FXP_STATUS, ?UINT32(ReqId),
+-	  ?UINT32(?SSH_FX_OK), _/binary>>, _} =
+-	rename(FileName, NewFileName, Cm, Channel, ReqId, 6, 0),
+-
+-    NewReqId = ReqId + 1,
+-
+-    {ok, <<?SSH_FXP_STATUS, ?UINT32(NewReqId),
+-	  ?UINT32(?SSH_FX_OK), _/binary>>, _} =
+-	rename(NewFileName, FileName, Cm, Channel, NewReqId, 6,
+-	       ?SSH_FXP_RENAME_OVERWRITE),
+-
+-    NewReqId1 = NewReqId + 1,
+-    file:copy(FileName, NewFileName),
+-
+-    %% No overwrite
+-    {ok, <<?SSH_FXP_STATUS, ?UINT32(NewReqId1),
+-	  ?UINT32(?SSH_FX_FILE_ALREADY_EXISTS), _/binary>>, _} =
+-	rename(FileName, NewFileName, Cm, Channel, NewReqId1, 6,
+-	       ?SSH_FXP_RENAME_NATIVE),
+-
+-    NewReqId2 = NewReqId1 + 1,
+-
+-    {ok, <<?SSH_FXP_STATUS, ?UINT32(NewReqId2),
+-	  ?UINT32(?SSH_FX_OP_UNSUPPORTED), _/binary>>, _} =
+-	rename(FileName, NewFileName, Cm, Channel, NewReqId2, 6,
+-	       ?SSH_FXP_RENAME_ATOMIC).
++    Version = 6,
++    [begin
++         case Action of
++             {Code, AFile, BFile, Flags} ->
++                 ReqId = req_id(),
++                 ct:log("ReqId = ~p,~nCode = ~p,~nAFile = ~p,~nBFile = ~p,~nFlags = ~p",
++                        [ReqId, Code, AFile, BFile, Flags]),
++                 {ok, <<?SSH_FXP_STATUS, ?UINT32(ReqId), ?UINT32(Code), _/binary>>, _} =
++                     rename(AFile, BFile, Cm, Channel, ReqId, Version, Flags);
++             {file_copy, AFile, BFile} ->
++                 {ok, _} = file:copy(AFile, BFile)
++         end
++     end ||
++        Action <-
++            [{?SSH_FX_OK, FileName, NewFileName, 0},
++             {?SSH_FX_OK, NewFileName, FileName, ?SSH_FXP_RENAME_OVERWRITE},
++             {file_copy, FileName, NewFileName},
++             %% no overwrite
++             {?SSH_FX_FILE_ALREADY_EXISTS, FileName, NewFileName, ?SSH_FXP_RENAME_NATIVE},
++             {?SSH_FX_OP_UNSUPPORTED, FileName, NewFileName, ?SSH_FXP_RENAME_ATOMIC},
++             %% max_path
++             {?SSH_FX_NO_SUCH_PATH, FileName, LongFileName, 0}]],
++    ok.
+ 
+ %%--------------------------------------------------------------------
+ mk_rm_dir(Config) when is_list(Config) ->
+-- 
+2.43.0
+

--- a/SPECS/erlang/erlang.spec
+++ b/SPECS/erlang/erlang.spec
@@ -2,7 +2,7 @@
 Summary:        erlang
 Name:           erlang
 Version:        25.3.2.21
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,6 +18,7 @@ Patch0:         CVE-2025-4748.patch
 Patch1:         CVE-2025-48038.patch
 Patch2:         CVE-2025-48040.patch
 Patch3:         CVE-2025-48041.patch
+Patch4:         CVE-2025-48039.patch
 
 %description
 erlang programming language
@@ -51,6 +52,9 @@ make
 %{_libdir}/erlang/*
 
 %changelog
+* Fri Oct 03 2025 Akhila Guruju <v-guakhila@microsoft.com> - 25.3.2.21-4
+- Patch for CVE-2025-48039
+
 * Sat Sep 13 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 25.3.2.21-3
 - Patch for CVE-2025-48041, CVE-2025-48040, CVE-2025-48038
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch erlang for CVE-2025-48039
Modified patch: YES
- Some of the changes in the upstream patch are already in the azl source, these were included in previous patches.
- last hunk in the file `lib/ssh/test/ssh_sftpd_SUITE.erl` of upstream patch is already introduced by one of the existing patches. So, excluded that change in this patch.

Taken patch https://github.com/erlang/otp/commit/043ee3c943e2977c1acdd740ad13992fd60b6bf0 from upstream. Debian mentions here https://security-tracker.debian.org/tracker/CVE-2025-48039 that it fixes this CVE.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/erlang/CVE-2025-48039.patch
- modified:   SPECS/erlang/erlang.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-48039

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- patch applies cleanly
<img width="400" height="207" alt="image" src="https://github.com/user-attachments/assets/7e3fd377-b4ce-49a9-a368-38c592fb2752" />

