### PR TITLE
[AUTO-CHERRYPICK] [AutoPR- Security] Patch libtiff for CVE-2025-9900 [HIGH] - branch aaruagrawal/autoPR2

### DIFF
--- a/SPECS/libtiff/CVE-2025-9900.patch
+++ b/SPECS/libtiff/CVE-2025-9900.patch
@@ -1,0 +1,53 @@
+From 14b8aed9744bb89a75e3fe481743c13c2cc536ac Mon Sep 17 00:00:00 2001
+From: Su Laus <sulau@freenet.de>
+Date: Wed, 11 Jun 2025 19:45:19 +0000
+Subject: [PATCH] tif_getimage.c: Fix buffer underflow crash for less raster
+ rows at TIFFReadRGBAImageOriented()
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://gitlab.com/libtiff/libtiff/-/commit/3e0dcf0ec651638b2bd849b2e6f3124b36890d99.patch
+---
+ libtiff/tif_getimage.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/libtiff/tif_getimage.c b/libtiff/tif_getimage.c
+index 6fee35d..08fdd5e 100644
+--- a/libtiff/tif_getimage.c
++++ b/libtiff/tif_getimage.c
+@@ -600,6 +600,22 @@ int TIFFRGBAImageGet(TIFFRGBAImage *img, uint32_t *raster, uint32_t w,
+             "No \"put\" routine setupl; probably can not handle image format");
+         return (0);
+     }
++    /* Verify raster width and height against image width and height. */
++    if (h > img->height)
++    {
++        /* Adapt parameters to read only available lines and put image at
++         * the bottom of the raster. */
++        raster += (size_t)(h - img->height) * w;
++        h = img->height;
++    }
++    if (w > img->width)
++    {
++        TIFFWarningExtR(img->tif, TIFFFileName(img->tif),
++                        "Raster width of %d shall not be larger than image "
++                        "width of %d -> raster width adapted for reading",
++                        w, img->width);
++        w = img->width;
++    }
+     return (*img->get)(img, raster, w, h);
+ }
+ 
+@@ -617,9 +633,7 @@ int TIFFReadRGBAImageOriented(TIFF *tif, uint32_t rwidth, uint32_t rheight,
+     if (TIFFRGBAImageOK(tif, emsg) && TIFFRGBAImageBegin(&img, tif, stop, emsg))
+     {
+         img.req_orientation = (uint16_t)orientation;
+-        /* XXX verify rwidth and rheight against width and height */
+-        ok = TIFFRGBAImageGet(&img, raster + (rheight - img.height) * rwidth,
+-                              rwidth, img.height);
++        ok = TIFFRGBAImageGet(&img, raster, rwidth, rheight);
+         TIFFRGBAImageEnd(&img);
+     }
+     else
+-- 
+2.45.4
+

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,7 +1,7 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.6.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        libtiff
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,6 +18,7 @@ Patch6:         CVE-2025-8177.patch
 Patch7:         CVE-2025-8534.patch
 Patch8:         CVE-2025-8851.patch
 Patch9:         CVE-2025-9165.patch
+Patch10:        CVE-2025-9900.patch
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libjpeg-turbo-devel
@@ -70,6 +71,9 @@ make %{?_smp_mflags} -k check
 %{_docdir}/*
 
 %changelog
+* Mon Sep 29 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 4.6.0-9
+- Patch for CVE-2025-9900
+
 * Thu Aug 21 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 4.6.0-8
 - Patch for CVE-2025-9165, CVE-2025-8851
 


### PR DESCRIPTION
This is an auto-generated pull request to cherry-pick commit f98f349ad669ec28dfe7311989d9b4607c23b4b2 to aaruagrawal/autoPR2. Original PR: #14736
 In case of no merge conflicts, the PR is merged without approval because it's an automated cherry-pick of an already approved PR.