### PR TITLE
[LOW] Patch gnupg2 for CVE-2025-30258

### DIFF
--- a/SPECS/gnupg2/CVE-2025-30258.patch
+++ b/SPECS/gnupg2/CVE-2025-30258.patch
@@ -1,0 +1,630 @@
+From 48978ccb4e20866472ef18436a32744350a65158 Mon Sep 17 00:00:00 2001
+From: Werner Koch <wk@gnupg.org>
+Date: Fri, 21 Feb 2025 12:16:17 +0100
+Subject: [PATCH] gpg: Fix a verification DoS due to a malicious subkey in the
+ keyring.
+
+* g10/getkey.c (get_pubkey): Factor code out to ...
+(get_pubkey_bykid): new.  Add feature to return the keyblock.
+(get_pubkey_for_sig): Add arg r_keyblock to return the used keyblock.
+Request a signing usage.
+(get_pubkeyblock_for_sig): Remove.
+(finish_lookup): Improve debug output.
+* g10/sig-check.c (check_signature): Add arg r_keyblock and pass it
+down.
+* g10/mainproc.c (do_check_sig): Ditto.
+(check_sig_and_print): Use the keyblock returned by do_check_sig to
+show further information instead of looking it up again with
+get_pubkeyblock_for_sig.  Also re-check the signature after the import
+of an included keyblock.
+--
+
+The problem here is that it is possible to import a key from someone
+who added a signature subkey from another public key and thus inhibits
+that a good signature good be verified.
+
+Such a malicious key signature subkey must have been created w/o the
+mandatory backsig which bind a signature subkey to its primary key.
+For encryption subkeys this is not an issue because the existence of a
+decryption private key is all you need to decrypt something and then
+it does not matter if the public subkey or its binding signature has
+been put below another primary key; in fact we do the latter for
+ADSKs.
+
+GnuPG-bug-id: 7527
+
+Upstream Patch Reference: https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=48978ccb4e20866472ef18436a32744350a65158
+---
+ g10/getkey.c    | 106 ++++++++++++++++++++++++++++++------------------
+ g10/gpg.h       |   3 +-
+ g10/keydb.h     |  10 ++++-
+ g10/mainproc.c  |  93 ++++++++++++++++++++++++++----------------
+ g10/packet.h    |   2 +-
+ g10/sig-check.c |  24 +++++++----
+ 6 files changed, 153 insertions(+), 85 deletions(-)
+
+diff --git a/g10/getkey.c b/g10/getkey.c
+index 6363fea..47ee126 100644
+--- a/g10/getkey.c
++++ b/g10/getkey.c
+@@ -310,27 +310,50 @@ pk_from_block (PKT_public_key *pk, kbnode_t keyblock, kbnode_t found_key)
+ 
+ /* Specialized version of get_pubkey which retrieves the key based on
+  * information in SIG.  In contrast to get_pubkey PK is required.  IF
+- * FORCED_PK is not NULL, this public key is used and copied to PK. */
++ * FORCED_PK is not NULL, this public key is used and copied to PK.
++ * If R_KEYBLOCK is not NULL the entire keyblock is stored there if
++ * found and FORCED_PK is not used; if not used or on error NULL is
++ * stored there. */
+ gpg_error_t
+ get_pubkey_for_sig (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig,
+-                    PKT_public_key *forced_pk)
++                    PKT_public_key *forced_pk, kbnode_t *r_keyblock)
+ {
++  gpg_error_t err;
+   const byte *fpr;
+   size_t fprlen;
+ 
++  if (r_keyblock)
++    *r_keyblock = NULL;
++
+   if (forced_pk)
+     {
+       copy_public_key (pk, forced_pk);
+       return 0;
+     }
+ 
++  /* Make sure to request only keys cabable of signing.  This makes
++   * sure that a subkey w/o a valid backsig or with bad usage flags
++   * will be skipped.  */
++  pk->req_usage = PUBKEY_USAGE_SIG;
++
+   /* First try the ISSUER_FPR info.  */
+   fpr = issuer_fpr_raw (sig, &fprlen);
+-  if (fpr && !get_pubkey_byfprint (ctrl, pk, NULL, fpr, fprlen))
++  if (fpr && !get_pubkey_byfprint (ctrl, pk, r_keyblock, fpr, fprlen))
+     return 0;
++  if (r_keyblock)
++    {
++      release_kbnode (*r_keyblock);
++      *r_keyblock = NULL;
++    }
+ 
+   /* Fallback to use the ISSUER_KEYID.  */
+-  return get_pubkey (ctrl, pk, sig->keyid);
++  err = get_pubkey_bykid (ctrl, pk, r_keyblock, sig->keyid);
++  if (err && r_keyblock)
++    {
++      release_kbnode (*r_keyblock);
++      *r_keyblock = NULL;
++    }
++  return err;
+ }
+ 
+ 
+@@ -348,6 +371,10 @@ get_pubkey_for_sig (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig,
+  * usage will be returned.  As such, it is essential that
+  * PK->REQ_USAGE be correctly initialized!
+  *
++ * If R_KEYBLOCK is not NULL, then the first result's keyblock is
++ * returned in *R_KEYBLOCK.  This should be freed using
++ * release_kbnode().
++ *
+  * Returns 0 on success, GPG_ERR_NO_PUBKEY if there is no public key
+  * with the specified key id, or another error code if an error
+  * occurs.
+@@ -355,24 +382,30 @@ get_pubkey_for_sig (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig,
+  * If the data was not read from the cache, then the self-signed data
+  * has definitely been merged into the public key using
+  * merge_selfsigs.  */
+-int
+-get_pubkey (ctrl_t ctrl, PKT_public_key * pk, u32 * keyid)
++gpg_error_t
++get_pubkey_bykid (ctrl_t ctrl, PKT_public_key *pk, kbnode_t *r_keyblock,
++                  u32 *keyid)
+ {
+   int internal = 0;
+-  int rc = 0;
++  gpg_error_t rc = 0;
++
++  if (r_keyblock)
++    *r_keyblock = NULL;
+ 
+ #if MAX_PK_CACHE_ENTRIES
+-  if (pk)
++  if (pk && !r_keyblock)
+     {
+       /* Try to get it from the cache.  We don't do this when pk is
+-         NULL as it does not guarantee that the user IDs are
+-         cached. */
++       * NULL as it does not guarantee that the user IDs are cached.
++       * The old get_pubkey_function did not check PK->REQ_USAGE when
++       * reading form the caceh.  This is probably a bug.  Note that
++       * the cache is not used when the caller asked to return the
++       * entire keyblock.  This is because the cache does not
++       * associate the public key wit its primary key.  */
+       pk_cache_entry_t ce;
+       for (ce = pk_cache; ce; ce = ce->next)
+ 	{
+ 	  if (ce->keyid[0] == keyid[0] && ce->keyid[1] == keyid[1])
+-	    /* XXX: We don't check PK->REQ_USAGE here, but if we don't
+-	       read from the cache, we do check it!  */
+ 	    {
+ 	      copy_public_key (pk, ce->pk);
+ 	      return 0;
+@@ -380,6 +413,7 @@ get_pubkey (ctrl_t ctrl, PKT_public_key * pk, u32 * keyid)
+ 	}
+     }
+ #endif
++
+   /* More init stuff.  */
+   if (!pk)
+     {
+@@ -425,16 +459,18 @@ get_pubkey (ctrl_t ctrl, PKT_public_key * pk, u32 * keyid)
+     ctx.req_usage = pk->req_usage;
+     rc = lookup (ctrl, &ctx, 0, &kb, &found_key);
+     if (!rc)
++      pk_from_block (pk, kb, found_key);
++    getkey_end (ctrl, &ctx);
++    if (!rc && r_keyblock)
+       {
+-	pk_from_block (pk, kb, found_key);
++        *r_keyblock = kb;
++        kb = NULL;
+       }
+-    getkey_end (ctrl, &ctx);
+     release_kbnode (kb);
+   }
+-  if (!rc)
+-    goto leave;
+ 
+-  rc = GPG_ERR_NO_PUBKEY;
++  if (rc)  /* Return a more useful error code.  */
++    rc = gpg_error (GPG_ERR_NO_PUBKEY);
+ 
+ leave:
+   if (!rc)
+@@ -444,6 +480,14 @@ leave:
+   return rc;
+ }
+ 
++/* Wrapper for get_pubkey_bykid w/o keyblock return feature.  */
++int
++get_pubkey (ctrl_t ctrl, PKT_public_key *pk, u32 *keyid)
++{
++  return get_pubkey_bykid (ctrl, pk, NULL, keyid);
++}
++
++
+ 
+ /* Same as get_pubkey but if the key was not found the function tries
+  * to import it from LDAP.  FIXME: We should not need this but swicth
+@@ -557,28 +601,6 @@ get_pubkey_fast (ctrl_t ctrl, PKT_public_key * pk, u32 * keyid)
+ }
+ 
+ 
+-/* Return the entire keyblock used to create SIG.  This is a
+- * specialized version of get_pubkeyblock.
+- *
+- * FIXME: This is a hack because get_pubkey_for_sig was already called
+- * and it could have used a cache to hold the key.  */
+-kbnode_t
+-get_pubkeyblock_for_sig (ctrl_t ctrl, PKT_signature *sig)
+-{
+-  const byte *fpr;
+-  size_t fprlen;
+-  kbnode_t keyblock;
+-
+-  /* First try the ISSUER_FPR info.  */
+-  fpr = issuer_fpr_raw (sig, &fprlen);
+-  if (fpr && !get_pubkey_byfprint (ctrl, NULL, &keyblock, fpr, fprlen))
+-    return keyblock;
+-
+-  /* Fallback to use the ISSUER_KEYID.  */
+-  return get_pubkeyblock (ctrl, sig->keyid);
+-}
+-
+-
+ /* Return the key block for the key with key id KEYID or NULL, if an
+  * error occurs.  Use release_kbnode() to release the key block.
+  *
+@@ -3612,6 +3634,7 @@ finish_lookup (kbnode_t keyblock, unsigned int req_usage, int want_exact,
+   kbnode_t latest_key;
+   PKT_public_key *pk;
+   int req_prim;
++  int diag_exactfound = 0;
+   u32 curtime = make_timestamp ();
+ 
+   if (r_flags)
+@@ -3642,6 +3665,7 @@ finish_lookup (kbnode_t keyblock, unsigned int req_usage, int want_exact,
+ 	      foundk = k;
+               pk = k->pkt->pkt.public_key;
+               pk->flags.exact = 1;
++              diag_exactfound = 1;
+ 	      break;
+ 	    }
+ 	}
+@@ -3662,10 +3686,14 @@ finish_lookup (kbnode_t keyblock, unsigned int req_usage, int want_exact,
+     log_debug ("finish_lookup: checking key %08lX (%s)(req_usage=%x)\n",
+ 	       (ulong) keyid_from_pk (keyblock->pkt->pkt.public_key, NULL),
+ 	       foundk ? "one" : "all", req_usage);
++  if (diag_exactfound && DBG_LOOKUP)
++    log_debug ("\texact search requested and found\n");
+ 
+   if (!req_usage)
+     {
+       latest_key = foundk ? foundk : keyblock;
++      if (DBG_LOOKUP)
++        log_debug ("\tno usage requested - accepting key\n");
+       goto found;
+     }
+ 
+diff --git a/g10/gpg.h b/g10/gpg.h
+index c51bbbb..0cdcb8b 100644
+--- a/g10/gpg.h
++++ b/g10/gpg.h
+@@ -69,7 +69,8 @@ struct dirmngr_local_s;
+ typedef struct dirmngr_local_s *dirmngr_local_t;
+ 
+ /* Object used to describe a keyblock node.  */
+-typedef struct kbnode_struct *KBNODE;   /* Deprecated use kbnode_t. */typedef struct kbnode_struct *kbnode_t;
++typedef struct kbnode_struct *KBNODE;   /* Deprecated use kbnode_t. */
++typedef struct kbnode_struct *kbnode_t;
+ 
+ /* The handle for keydb operations.  */
+ typedef struct keydb_handle_s *KEYDB_HANDLE;
+diff --git a/g10/keydb.h b/g10/keydb.h
+index 771bc8e..4a62e4c 100644
+--- a/g10/keydb.h
++++ b/g10/keydb.h
+@@ -332,9 +332,15 @@ void getkey_disable_caches(void);
+ /* Return the public key used for signature SIG and store it at PK.  */
+ gpg_error_t get_pubkey_for_sig (ctrl_t ctrl,
+                                 PKT_public_key *pk, PKT_signature *sig,
+-                                PKT_public_key *forced_pk);
++                                PKT_public_key *forced_pk,
++                                kbnode_t *r_keyblock);
+ 
+-/* Return the public key with the key id KEYID and store it at PK.  */
++/* Return the public key with the key id KEYID and store it at PK.
++ * Optionally return the entire keyblock.  */
++gpg_error_t get_pubkey_bykid (ctrl_t ctrl, PKT_public_key *pk,
++                              kbnode_t *r_keyblock, u32 *keyid);
++
++/* Same as get_pubkey_bykid but w/o r_keyblock.  */
+ int get_pubkey (ctrl_t ctrl, PKT_public_key *pk, u32 *keyid);
+ 
+ /* Same as get_pubkey but with auto LDAP fetch.  */
+diff --git a/g10/mainproc.c b/g10/mainproc.c
+index 330ad10..1d86e71 100644
+--- a/g10/mainproc.c
++++ b/g10/mainproc.c
+@@ -1150,12 +1150,15 @@ proc_compressed (CTX c, PACKET *pkt)
+  * used to verify the signature will be stored there, or NULL if not
+  * found.  If FORCED_PK is not NULL, this public key is used to verify
+  * _data signatures_ and no key lookup is done.  Returns: 0 = valid
+- * signature or an error code
++ * signature or an error code.  If R_KEYBLOCK is not NULL the keyblock
++ * carries the used PK is stored there.  The caller should always free
++ * the return value using release_kbnode.
+  */
+ static int
+ do_check_sig (CTX c, kbnode_t node, const void *extrahash, size_t extrahashlen,
+               PKT_public_key *forced_pk, int *is_selfsig,
+-	      int *is_expkey, int *is_revkey, PKT_public_key **r_pk)
++	      int *is_expkey, int *is_revkey,
++              PKT_public_key **r_pk, kbnode_t *r_keyblock)
+ {
+   PKT_signature *sig;
+   gcry_md_hd_t md = NULL;
+@@ -1165,6 +1168,8 @@ do_check_sig (CTX c, kbnode_t node, const void *extrahash, size_t extrahashlen,
+ 
+   if (r_pk)
+     *r_pk = NULL;
++  if (r_keyblock)
++    *r_keyblock = NULL;
+ 
+   log_assert (node->pkt->pkttype == PKT_SIGNATURE);
+   if (is_selfsig)
+@@ -1241,18 +1246,20 @@ do_check_sig (CTX c, kbnode_t node, const void *extrahash, size_t extrahashlen,
+   /* We only get here if we are checking the signature of a binary
+      (0x00) or text document (0x01).  */
+   rc = check_signature2 (c->ctrl, sig, md, extrahash, extrahashlen,
+-                         forced_pk,
+-                         NULL, is_expkey, is_revkey, r_pk);
++                         forced_pk, NULL, is_expkey, is_revkey,
++                         r_pk, r_keyblock);
+   if (! rc)
+     md_good = md;
+   else if (gpg_err_code (rc) == GPG_ERR_BAD_SIGNATURE && md2)
+     {
+       PKT_public_key *pk2;
+ 
++      if (r_keyblock)
++        release_kbnode (*r_keyblock);
+       rc = check_signature2 (c->ctrl, sig, md2, extrahash, extrahashlen,
+                              forced_pk,
+                              NULL, is_expkey, is_revkey,
+-                             r_pk? &pk2 : NULL);
++                             r_pk? &pk2 : NULL, r_keyblock);
+       if (!rc)
+         {
+           md_good = md2;
+@@ -1415,7 +1422,7 @@ list_node (CTX c, kbnode_t node)
+         {
+           fflush (stdout);
+           rc2 = do_check_sig (c, node, NULL, 0, NULL,
+-                              &is_selfsig, NULL, NULL, NULL);
++                              &is_selfsig, NULL, NULL, NULL, NULL);
+           switch (gpg_err_code (rc2))
+             {
+             case 0:		          sigrc = '!'; break;
+@@ -1875,7 +1882,7 @@ check_sig_and_print (CTX c, kbnode_t node)
+   PKT_public_key *pk = NULL;  /* The public key for the signature or NULL. */
+   const void *extrahash = NULL;
+   size_t extrahashlen = 0;
+-  kbnode_t included_keyblock = NULL;
++  kbnode_t keyblock = NULL;
+ 
+   if (opt.skip_verify)
+     {
+@@ -1994,7 +2001,8 @@ check_sig_and_print (CTX c, kbnode_t node)
+       {
+       ambiguous:
+         log_error(_("can't handle this ambiguous signature data\n"));
+-        return 0;
++        rc = 0;
++        goto leave;
+       }
+   } /* End checking signature packet composition.  */
+ 
+@@ -2030,7 +2038,7 @@ check_sig_and_print (CTX c, kbnode_t node)
+     log_info (_("               issuer \"%s\"\n"), sig->signers_uid);
+ 
+   rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
+-                     NULL, &is_expkey, &is_revkey, &pk);
++                     NULL, &is_expkey, &is_revkey, &pk, &keyblock);
+ 
+   /* If the key is not found but the signature includes a key block we
+    * use that key block for verification and on success import it.  */
+@@ -2038,6 +2046,7 @@ check_sig_and_print (CTX c, kbnode_t node)
+       && sig->flags.key_block
+       && opt.flags.auto_key_import)
+     {
++      kbnode_t included_keyblock = NULL;
+       PKT_public_key *included_pk;
+       const byte *kblock;
+       size_t kblock_len;
+@@ -2049,10 +2058,12 @@ check_sig_and_print (CTX c, kbnode_t node)
+                                       kblock+1, kblock_len-1,
+                                       sig->keyid, &included_keyblock))
+         {
++          /* Note: This is the only place where we use the forced_pk
++           *       arg (ie. included_pk) with do_check_sig.  */
+           rc = do_check_sig (c, node, extrahash, extrahashlen, included_pk,
+-                             NULL, &is_expkey, &is_revkey, &pk);
++                             NULL, &is_expkey, &is_revkey, &pk, NULL);
+           if (opt.verbose)
+-            log_debug ("checked signature using included key block: %s\n",
++            log_info ("checked signature using included key block: %s\n",
+                        gpg_strerror (rc));
+           if (!rc)
+             {
+@@ -2062,6 +2073,18 @@ check_sig_and_print (CTX c, kbnode_t node)
+ 
+         }
+       free_public_key (included_pk);
++      release_kbnode (included_keyblock);
++
++      /* To make sure that nothing strange happened we check the
++       * signature again now using our own key store. This also
++       * returns the keyblock which we use later on.  */
++      if (!rc)
++        {
++          release_kbnode (keyblock);
++          keyblock = NULL;
++          rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
++                             NULL, &is_expkey, &is_revkey, &pk, &keyblock);
++        }
+     }
+ 
+   /* If the key isn't found, check for a preferred keyserver.  Note
+@@ -2108,8 +2131,13 @@ check_sig_and_print (CTX c, kbnode_t node)
+                                                 KEYSERVER_IMPORT_FLAG_QUICK);
+                   glo_ctrl.in_auto_key_retrieve--;
+                   if (!res)
+-                    rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
+-                                       NULL, &is_expkey, &is_revkey, &pk);
++                    {
++                      release_kbnode (keyblock);
++                      keyblock = NULL;
++                      rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
++                                         NULL, &is_expkey, &is_revkey, &pk,
++                                         &keyblock);
++                    }
+                   else if (DBG_LOOKUP)
+                     log_debug ("lookup via %s failed: %s\n", "Pref-KS",
+                                gpg_strerror (res));
+@@ -2150,8 +2178,12 @@ check_sig_and_print (CTX c, kbnode_t node)
+       /* Fixme: If the fingerprint is embedded in the signature,
+        * compare it to the fingerprint of the returned key.  */
+       if (!res)
+-        rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
+-                           NULL, &is_expkey, &is_revkey, &pk);
++        {
++          release_kbnode (keyblock);
++          keyblock = NULL;
++          rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
++                             NULL, &is_expkey, &is_revkey, &pk, &keyblock);
++        }
+       else if (DBG_LOOKUP)
+         log_debug ("lookup via %s failed: %s\n", "WKD", gpg_strerror (res));
+     }
+@@ -2181,8 +2213,13 @@ check_sig_and_print (CTX c, kbnode_t node)
+                                          KEYSERVER_IMPORT_FLAG_QUICK);
+           glo_ctrl.in_auto_key_retrieve--;
+           if (!res)
+-            rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
+-                               NULL, &is_expkey, &is_revkey, &pk);
++            {
++              release_kbnode (keyblock);
++              keyblock = NULL;
++              rc = do_check_sig (c, node, extrahash, extrahashlen, NULL,
++                                 NULL, &is_expkey, &is_revkey, &pk,
++                                 &keyblock);
++            }
+           else if (DBG_LOOKUP)
+             log_debug ("lookup via %s failed: %s\n", "KS", gpg_strerror (res));
+         }
+@@ -2193,7 +2230,7 @@ check_sig_and_print (CTX c, kbnode_t node)
+     {
+       /* We have checked the signature and the result is either a good
+        * signature or a bad signature.  Further examination follows.  */
+-      kbnode_t un, keyblock;
++      kbnode_t un;
+       int count = 0;
+       int keyblock_has_pk = 0;  /* For failsafe check.  */
+       int statno;
+@@ -2211,18 +2248,6 @@ check_sig_and_print (CTX c, kbnode_t node)
+       else
+         statno = STATUS_GOODSIG;
+ 
+-      /* FIXME: We should have the public key in PK and thus the
+-       * keyblock has already been fetched.  Thus we could use the
+-       * fingerprint or PK itself to lookup the entire keyblock.  That
+-       * would best be done with a cache.  */
+-      if (included_keyblock)
+-        {
+-          keyblock = included_keyblock;
+-          included_keyblock = NULL;
+-        }
+-      else
+-        keyblock = get_pubkeyblock_for_sig (c->ctrl, sig);
+-
+       snprintf (keyid_str, sizeof keyid_str, "%08lX%08lX [uncertain] ",
+                 (ulong)sig->keyid[0], (ulong)sig->keyid[1]);
+ 
+@@ -2288,10 +2313,10 @@ check_sig_and_print (CTX c, kbnode_t node)
+            * contained in the keyring.*/
+ 	}
+ 
+-      log_assert (mainpk);
+-      if (!keyblock_has_pk)
++      if (!mainpk || !keyblock_has_pk)
+         {
+-          log_error ("signature key lost from keyblock\n");
++          log_error ("signature key lost from keyblock (%p,%p,%d)\n",
++                     keyblock, mainpk, keyblock_has_pk);
+           rc = gpg_error (GPG_ERR_INTERNAL);
+         }
+ 
+@@ -2559,8 +2584,8 @@ check_sig_and_print (CTX c, kbnode_t node)
+         log_error (_("Can't check signature: %s\n"), gpg_strerror (rc));
+     }
+ 
++ leave:
+   free_public_key (pk);
+-  release_kbnode (included_keyblock);
+   xfree (issuer_fpr);
+   return rc;
+ }
+diff --git a/g10/packet.h b/g10/packet.h
+index eeea9b4..05ff573 100644
+--- a/g10/packet.h
++++ b/g10/packet.h
+@@ -906,7 +906,7 @@ gpg_error_t check_signature2 (ctrl_t ctrl,
+                               const void *extrahash, size_t extrahashlen,
+                               PKT_public_key *forced_pk,
+                               u32 *r_expiredate, int *r_expired, int *r_revoked,
+-                              PKT_public_key **r_pk);
++                             PKT_public_key **r_pk, kbnode_t *r_keyblock);
+ 
+ 
+ /*-- pubkey-enc.c --*/
+diff --git a/g10/sig-check.c b/g10/sig-check.c
+index 7c48c06..8dfc6b0 100644
+--- a/g10/sig-check.c
++++ b/g10/sig-check.c
+@@ -102,7 +102,7 @@ int
+ check_signature (ctrl_t ctrl, PKT_signature *sig, gcry_md_hd_t digest)
+ {
+   return check_signature2 (ctrl, sig, digest, NULL, 0, NULL,
+-                           NULL, NULL, NULL, NULL);
++                           NULL, NULL, NULL, NULL, NULL);
+ }
+ 
+ 
+@@ -149,6 +149,11 @@ check_signature (ctrl_t ctrl, PKT_signature *sig, gcry_md_hd_t digest)
+  * If R_PK is not NULL, the public key is stored at that address if it
+  * was found; other wise NULL is stored.
+  *
++ * If R_KEYBLOCK is not NULL, the entire keyblock used to verify the
++ * signature is stored at that address.  If no key was found or on
++ * some other errors NULL is stored there.  The callers needs to
++ * release the keyblock using release_kbnode (kb).
++ *
+  * Returns 0 on success.  An error code otherwise.  */
+ gpg_error_t
+ check_signature2 (ctrl_t ctrl,
+@@ -156,7 +161,8 @@ check_signature2 (ctrl_t ctrl,
+                   const void *extrahash, size_t extrahashlen,
+                   PKT_public_key *forced_pk,
+                   u32 *r_expiredate,
+-		  int *r_expired, int *r_revoked, PKT_public_key **r_pk)
++		  int *r_expired, int *r_revoked,
++		  PKT_public_key **r_pk, kbnode_t *r_keyblock)
+ {
+   int rc=0;
+   PKT_public_key *pk;
+@@ -169,6 +175,8 @@ check_signature2 (ctrl_t ctrl,
+     *r_revoked = 0;
+   if (r_pk)
+     *r_pk = NULL;
++  if (r_keyblock)
++    *r_keyblock = NULL;
+ 
+   pk = xtrycalloc (1, sizeof *pk);
+   if (!pk)
+@@ -199,7 +207,7 @@ check_signature2 (ctrl_t ctrl,
+       log_info(_("WARNING: signature digest conflict in message\n"));
+       rc = gpg_error (GPG_ERR_GENERAL);
+     }
+-  else if (get_pubkey_for_sig (ctrl, pk, sig, forced_pk))
++  else if (get_pubkey_for_sig (ctrl, pk, sig, forced_pk, r_keyblock))
+     rc = gpg_error (GPG_ERR_NO_PUBKEY);
+   else if ((rc = check_key_verify_compliance (pk)))
+     ;/* Compliance failure.  */
+@@ -797,9 +805,9 @@ check_revocation_keys (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig)
+           keyid_from_fingerprint (ctrl, pk->revkey[i].fpr, pk->revkey[i].fprlen,
+                                   keyid);
+ 
+-          if(keyid[0]==sig->keyid[0] && keyid[1]==sig->keyid[1])
+-	    /* The signature was generated by a designated revoker.
+-	       Verify the signature.  */
++          /* If the signature was generated by a designated revoker
++           * verify the signature.  */
++          if (keyid[0] == sig->keyid[0] && keyid[1] == sig->keyid[1])
+ 	    {
+               gcry_md_hd_t md;
+ 
+@@ -807,7 +815,7 @@ check_revocation_keys (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig)
+                 BUG ();
+               hash_public_key(md,pk);
+ 	      /* Note: check_signature only checks that the signature
+-		 is good.  It does not fail if the key is revoked.  */
++              * is good.  It does not fail if the key is revoked.  */
+               rc = check_signature (ctrl, sig, md);
+ 	      cache_sig_result(sig,rc);
+               gcry_md_close (md);
+@@ -1013,7 +1021,7 @@ check_signature_over_key_or_uid (ctrl_t ctrl, PKT_public_key *signer,
+               if (IS_CERT (sig))
+                 signer->req_usage = PUBKEY_USAGE_CERT;
+ 
+-              rc = get_pubkey_for_sig (ctrl, signer, sig, NULL);
++              rc = get_pubkey_for_sig (ctrl, signer, sig, NULL, NULL);
+               if (rc)
+                 {
+                   xfree (signer);
+-- 
+2.45.4
+

--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -1,7 +1,7 @@
 Summary:        OpenPGP standard implementation used for encrypted communication and data storage.
 Name:           gnupg2
 Version:        2.4.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD and CC0 and GPLv2+ and LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ URL:            https://gnupg.org/index.html
 Source0:        https://gnupg.org/ftp/gcrypt/gnupg/gnupg-%{version}.tar.bz2
 Patch0:         CVE-2025-68973.patch
 Patch1:         CVE-2026-24882.patch
+Patch2:         CVE-2025-30258.patch
 BuildRequires:  zlib-devel
 BuildRequires:  bzip2-devel
 BuildRequires:  readline-devel
@@ -91,6 +92,9 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %defattr(-,root,root)
 
 %changelog
+* Wed Nov 05 2025 Ratiranjan Behera <v-ratbehera@microsoft.com> - 2.4.0-4
+- Add patch for CVE-2025-30258
+
 * Tue Feb 24 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.4.0-3
 - Patch for CVE-2026-24882, CVE-2025-68973
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -221,8 +221,8 @@ libksba-devel-1.6.3-1.cm2.aarch64.rpm
 libxslt-1.1.34-10.cm2.aarch64.rpm
 npth-1.6-4.cm2.aarch64.rpm
 pinentry-1.2.0-1.cm2.aarch64.rpm
-gnupg2-2.4.0-3.cm2.aarch64.rpm
-gnupg2-lang-2.4.0-3.cm2.aarch64.rpm
+gnupg2-2.4.0-4.cm2.aarch64.rpm
+gnupg2-lang-2.4.0-4.cm2.aarch64.rpm
 gpgme-1.16.0-2.cm2.aarch64.rpm
 mariner-repos-shared-2.0-9.cm2.noarch.rpm
 mariner-repos-2.0-9.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -221,8 +221,8 @@ libksba-devel-1.6.3-1.cm2.x86_64.rpm
 libxslt-1.1.34-10.cm2.x86_64.rpm
 npth-1.6-4.cm2.x86_64.rpm
 pinentry-1.2.0-1.cm2.x86_64.rpm
-gnupg2-2.4.0-3.cm2.x86_64.rpm
-gnupg2-lang-2.4.0-3.cm2.x86_64.rpm
+gnupg2-2.4.0-4.cm2.x86_64.rpm
+gnupg2-lang-2.4.0-4.cm2.x86_64.rpm
 gpgme-1.16.0-2.cm2.x86_64.rpm
 mariner-repos-shared-2.0-9.cm2.noarch.rpm
 mariner-repos-2.0-9.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -118,9 +118,9 @@ glibc-tools-2.35-10.cm2.aarch64.rpm
 gmp-6.2.1-4.cm2.aarch64.rpm
 gmp-debuginfo-6.2.1-4.cm2.aarch64.rpm
 gmp-devel-6.2.1-4.cm2.aarch64.rpm
-gnupg2-2.4.0-3.cm2.aarch64.rpm
-gnupg2-debuginfo-2.4.0-3.cm2.aarch64.rpm
-gnupg2-lang-2.4.0-3.cm2.aarch64.rpm
+gnupg2-2.4.0-4.cm2.aarch64.rpm
+gnupg2-debuginfo-2.4.0-4.cm2.aarch64.rpm
+gnupg2-lang-2.4.0-4.cm2.aarch64.rpm
 gperf-3.1-5.cm2.aarch64.rpm
 gperf-debuginfo-3.1-5.cm2.aarch64.rpm
 gpgme-1.16.0-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -123,9 +123,9 @@ glibc-tools-2.35-10.cm2.x86_64.rpm
 gmp-6.2.1-4.cm2.x86_64.rpm
 gmp-debuginfo-6.2.1-4.cm2.x86_64.rpm
 gmp-devel-6.2.1-4.cm2.x86_64.rpm
-gnupg2-2.4.0-3.cm2.x86_64.rpm
-gnupg2-debuginfo-2.4.0-3.cm2.x86_64.rpm
-gnupg2-lang-2.4.0-3.cm2.x86_64.rpm
+gnupg2-2.4.0-4.cm2.x86_64.rpm
+gnupg2-debuginfo-2.4.0-4.cm2.x86_64.rpm
+gnupg2-lang-2.4.0-4.cm2.x86_64.rpm
 gperf-3.1-5.cm2.x86_64.rpm
 gperf-debuginfo-3.1-5.cm2.x86_64.rpm
 gpgme-1.16.0-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch gnupg2 for CVE-2025-30258
Patch modified: Yes
- Upstream patch is applied manually as hunk failed.
   i. Upstream uses `get_pubkey_byfpr()` and  `check_signature()`, while our code base uses `get_pubkey_byfprint()` and 
      `check_signature2()` respectively.
   ii. check_signature2() now has 11 parameters (the last one is  kbnode_t *r_keyblock introduced by upstream
       changes). Adding an extra NULL ensures proper alignment with the function definition and prevents compilation errors.  
   iii. Adjustments were made to align with our existing function names and argument structure.

Upstream Patch reference:
https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=48978ccb4e20866472ef18436a32744350a65158

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/gnupg2/CVE-2025-30258.patch
- modified:   SPECS/gnupg2/gnupg2.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-30258

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful. Failed SRPMs tests not due to regression from the created patch.
<img width="993" height="226" alt="Screenshot 2025-11-07 143748" src="https://github.com/user-attachments/assets/669936c4-c409-4e1b-9ff7-55fb285f3357" />

[gnupg2-2.4.0-2.cm2.src.rpm.log](https://github.com/user-attachments/files/23416550/gnupg2-2.4.0-2.cm2.src.rpm.log)

-Patch applies cleanly.
<img width="480" height="101" alt="gnupg2-2 0-CVE-2025-30258" src="https://github.com/user-attachments/assets/946033d6-419b-4631-884d-1941025dcd41" />

-Check Installation
<img width="857" height="178" alt="image" src="https://github.com/user-attachments/assets/3eef159a-ef9b-4efa-9e36-0284b0140424" />

-Check Uninstallation
<img width="746" height="331" alt="image" src="https://github.com/user-attachments/assets/34836b15-c34c-4c19-a48f-e18acbbce99c" />



