### PR TITLE
Upgrade irqbalance to 1.9.5

### DIFF
--- a/SPECS/irqbalance/irqbalance.signatures.json
+++ b/SPECS/irqbalance/irqbalance.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "irqbalance-1.9.3.tar.gz": "8d698799251ea8518f342f36be26f2f092df51189f6777db33116d40cf0dae6c"
+  "irqbalance-1.9.5.tar.gz": "c5fc3b1880136437d297afe9a7833781e7849939e104d0780888ffcafc37e339"
  }
 }

--- a/SPECS/irqbalance/irqbalance.spec
+++ b/SPECS/irqbalance/irqbalance.spec
@@ -1,14 +1,13 @@
 Summary:        Irqbalance daemon
 Name:           irqbalance
-Version:        1.9.3
-Release:        2%{?dist}
+Version:        1.9.5
+Release:        1%{?dist}
 License:        GPLv2
 URL:            https://github.com/Irqbalance/irqbalance
 Group:          System Environment/Services
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Source0:        https://github.com/Irqbalance/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Patch0:         0001-define-IRQBALANCE_ARGS-as-empty-string.patch
 BuildRequires:  systemd-devel
 BuildRequires:  glib-devel
 Requires:       systemd
@@ -33,8 +32,14 @@ make %{?_smp_mflags}
 
 %install
 make DESTDIR=%{buildroot} install
+# Remove upstream-installed default env to avoid unpackaged duplicate
+rm -f %{buildroot}%{_prefix}/etc/default/irqbalance.env || true
 install -D -m 0644 misc/irqbalance.env %{buildroot}/etc/sysconfig/irqbalance
-sed -i 's#/path/to/irqbalance.env#/etc/sysconfig/irqbalance#' misc/irqbalance.service
+# Normalize unit EnvironmentFile entries
+sed -i \
+  -e 's#^EnvironmentFile=/usr/etc/default/irqbalance\.env#EnvironmentFile=/etc/sysconfig/irqbalance#' \
+  -e '/^EnvironmentFile=-\${prefix}\/etc\/default\/irqbalance/d' \
+  misc/irqbalance.service
 install -D -m 0644 misc/irqbalance.service %{buildroot}%{_prefix}/lib/systemd/system/irqbalance.service
 
 %check
@@ -57,6 +62,10 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_datadir}/*
 
 %changelog
+* Tue Dec 23 2025 Suresh Thelkar <sthelkar@microsoft.com> - 1.9.5-1
+- Bump to v1.9.5 to include upstream ENOSPC mitigation (PR #312)
+- Drop Patch0 (IRQBALANCE_ARGS) since v1.9.5 defines IRQBALANCE_ARGS="" in irqbalance.env
+
 * Mon Jul 01 2024 Cameron Baird <cameronbaird@microsoft.com> - 1.9.3-2
 - Define IRQBALANCE_ARGS variable in EnvironmentFile for irqbalance.service
     to squelch systemd warning. 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7551,8 +7551,8 @@
         "type": "other",
         "other": {
           "name": "irqbalance",
-          "version": "1.9.3",
-          "downloadUrl": "https://github.com/Irqbalance/irqbalance/archive/v1.9.3.tar.gz"
+          "version": "1.9.5",
+          "downloadUrl": "https://github.com/Irqbalance/irqbalance/archive/v1.9.5.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Summary
- Bump irqbalance 1.9.3 → 1.9.5; reset Release to 1
- Drop Patch0 (IRQBALANCE_ARGS) as upstream defines IRQBALANCE_ARGS="" in irqbalance.env
- Normalize systemd unit EnvironmentFile to /etc/sysconfig/irqbalance; remove upstream-prefixed entries
- Remove upstream-installed default env file from %{_prefix}/etc/default/irqbalance.env during install to avoid duplicate/unpackaged file
- Update signatures (irqbalance-1.9.5.tar.gz SHA256) and cgmanifest to v1.9.5
- Includes upstream ENOSPC mitigation (PR #312)
- Commit: 8e5f09f26

Changed files
- SPECS/irqbalance/irqbalance.spec
- SPECS/irqbalance/irqbalance.signatures.json
- cgmanifest.json
