### PR TITLE
fix: update azurelinux-rpm-config and rpm tomls

### DIFF
--- a/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
+++ b/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
@@ -9,12 +9,12 @@ overlays = [
     { type = "spec-set-tag", tag = "URL", value = "https://aka.ms/azurelinux" },
     # Set our version.
     { type = "spec-update-tag", tag = "Version", value = "1004" },
+    # Global search-and-replace in spec file: {fedora,redhat}->azurelinux
+    { type = "spec-search-replace", regex = "(fedora|redhat)", replacement = "azurelinux" },
     # Provide compatibility with Fedora's upstream version.
     { type = "spec-add-tag", tag = "Provides", value = "redhat-rpm-config = %{version}-%{release}" },
     # Make sure this package takes precedence over any Fedora variant.
     { type = "spec-add-tag", tag = "Obsoletes", value = "redhat-rpm-config < 1000" },
-    # Global search-and-replace in spec file: {fedora,redhat}->azurelinux
-    { type = "spec-search-replace", regex = "(fedora|redhat)", replacement = "azurelinux" },
     # Remove symlink; replace it with a dynamically constructed one in the spec.
     # We need to change how we generate a symlink and the tag referencing the checked-in one.
     { type = "spec-search-replace", regex = '^.*:\s*azurelinux-annobin-cc1\s*$', replacement = "" },

--- a/base/comps/rpm/rpm.comp.toml
+++ b/base/comps/rpm/rpm.comp.toml
@@ -1,9 +1,11 @@
 [components.rpm]
-
-# Update vendor macro.
-[[components.rpm.overlays]]
-description = "Customize RPM vendor"
-type = "spec-search-replace"
-regex = "RPM_VENDOR=redhat"
-replacement = "RPM_VENDOR=azurelinux"
-
+overlays = [
+    # Update vendor macro.
+    { type = "spec-search-replace", regex = "RPM_VENDOR=redhat", replacement = "RPM_VENDOR=azurelinux" },
+    # Remove __pycache__ from python3-rpm files section - it's not generated during build with Python 3.14
+    { type = "spec-search-replace", regex = "%artifact %\\{python3_sitearch\\}/rpm/__pycache__/", replacement = "" },
+    # Remove doc line that copies from BUILD dir - cmake already installs to BUILDROOT
+    { type = "spec-search-replace", regex = "%doc CREDITS docs/manual/\\[a-z\\]\\*", replacement = "" },
+    # Add wildcard to capture all cmake-installed docs
+    { type = "spec-search-replace", regex = "%doc %\\{_defaultdocdir\\}/rpm/README", replacement = "%doc %{_defaultdocdir}/rpm/*" },
+]


### PR DESCRIPTION
This PR fixes a few issues in azurelinux-rpm-config and rpm tomls:

**Azure Linux branding and compatibility:**

- Ensured the `{fedora,redhat} -> azurelinux` global search-and-replace operation is positioned appropriately in the overlay list for clarity and correct application order in `azurelinux-rpm-config.comp.toml`. This fixes the issue that redhat-rpm-config was found in image packages file and incorrectly added in components.toml.

With the above change, I found 2 errors while building rpm package: 
* Following error is found in `./base/build/work/rpm/2026-02-06.181213/rpm-build-*/build.log`:
```
Processing files: python3-rpm-6.0.1-1.azl4.x86_64
error: Directory not found: /builddir/build/BUILD/rpm-6.0.1-build/BUILDROOT/usr/lib64/python3.14/site-packages/rpm/__pycache__
```
 `__pycache__` folder is not found which should be generated with Python 3.14. I had to remove the reference to `__pycache__` in the Python 3 RPM files section.
* Then I got another error reporting file duplicates. 
```
Processing files: rpm-debuginfo-6.0.1-1.azl4.x86_64
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILD/rpm-6.0.1-build/BUILDROOT
error: Installed (but unpackaged) file(s) found:
   /usr/share/doc/rpm/CREDITS
   /usr/share/doc/rpm/about.md
   /usr/share/doc/rpm/arch_dependencies.md
   /usr/share/doc/rpm/autosetup.md
   /usr/share/doc/rpm/boolean_dependencies.md
   /usr/share/doc/rpm/buildprocess.md
   /usr/share/doc/rpm/buildsystem.md
   /usr/share/doc/rpm/conditionalbuilds.md
   /usr/share/doc/rpm/dependencies.md
   /usr/share/doc/rpm/dependency_generators.md
   /usr/share/doc/rpm/devel_documentation.md
   /usr/share/doc/rpm/dynamic_specs.md
   /usr/share/doc/rpm/file_triggers.md
   /usr/share/doc/rpm/format_header.md
   /usr/share/doc/rpm/format_lead.md
   /usr/share/doc/rpm/format_v3.md
   /usr/share/doc/rpm/format_v4.md
   /usr/share/doc/rpm/format_v6.md
   /usr/share/doc/rpm/index.md
   /usr/share/doc/rpm/large_files.md
   /usr/share/doc/rpm/lua.md
   /usr/share/doc/rpm/macros.md
   /usr/share/doc/rpm/more_dependencies.md
   /usr/share/doc/rpm/philosophy.md
   /usr/share/doc/rpm/plugins.md
   /usr/share/doc/rpm/queryformat.md
   /usr/share/doc/rpm/relocatable.md
   /usr/share/doc/rpm/scriptlet_expansion.md
   /usr/share/doc/rpm/signatures_digests.md
   /usr/share/doc/rpm/spec.md
   /usr/share/doc/rpm/tags.md
   /usr/share/doc/rpm/triggers.md
   /usr/share/doc/rpm/tsort.md
   /usr/share/doc/rpm/users_and_groups.md
    Installed (but unpackaged) file(s) found:
   /usr/share/doc/rpm/CREDITS
   /usr/share/doc/rpm/about.md
   /usr/share/doc/rpm/arch_dependencies.md
   /usr/share/doc/rpm/autosetup.md
   /usr/share/doc/rpm/boolean_dependencies.md
   /usr/share/doc/rpm/buildprocess.md
   /usr/share/doc/rpm/buildsystem.md
   /usr/share/doc/rpm/conditionalbuilds.md
   /usr/share/doc/rpm/dependencies.md
   /usr/share/doc/rpm/dependency_generators.md
   /usr/share/doc/rpm/devel_documentation.md
   /usr/share/doc/rpm/dynamic_specs.md
   /usr/share/doc/rpm/file_triggers.md
   /usr/share/doc/rpm/format_header.md
   /usr/share/doc/rpm/format_lead.md
   /usr/share/doc/rpm/format_v3.md
   /usr/share/doc/rpm/format_v4.md
   /usr/share/doc/rpm/format_v6.md
   /usr/share/doc/rpm/index.md
   /usr/share/doc/rpm/large_files.md
   /usr/share/doc/rpm/lua.md
   /usr/share/doc/rpm/macros.md
   /usr/share/doc/rpm/more_dependencies.md
   /usr/share/doc/rpm/philosophy.md
   /usr/share/doc/rpm/plugins.md
   /usr/share/doc/rpm/queryformat.md
   /usr/share/doc/rpm/relocatable.md
   /usr/share/doc/rpm/scriptlet_expansion.md
   /usr/share/doc/rpm/signatures_digests.md
   /usr/share/doc/rpm/spec.md
   /usr/share/doc/rpm/tags.md
   /usr/share/doc/rpm/triggers.md
   /usr/share/doc/rpm/tsort.md
   /usr/share/doc/rpm/users_and_groups.md
RPM build errors:
Child return code was: 1
EXCEPTION: [Error('Command failed: \n # /usr/bin/systemd-nspawn -q -M 672eb4c43ac34c20ada6da9124b3aa22 -D /var/lib/mock/azl-4.0-x86_64/root -a -u mockbuild --capability=cap_ipc_lock --bind=/tmp/mock-resolv.sckf9i15:/etc/resolv.conf --bind=/dev/loop-control --bind=/dev/loop0 --bind=/dev/loop1 --bind=/dev/loop2 --bind=/dev/loop3 --bind=/dev/loop4 --bind=/dev/loop5 --bind=/dev/loop6 --bind=/dev/loop7 --bind=/dev/loop8 --bind=/dev/loop9 --bind=/dev/loop10 --bind=/dev/loop11 --console=pipe --setenv=TERM=vt100 --setenv=SHELL=/bin/bash --setenv=HOME=/builddir --setenv=HOSTNAME=mock --setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin \'--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"\' \'--setenv=PS1=<mock-chroot> \\s-\\v\\$ \' --setenv=LANG=C.UTF-8 --setenv=CCACHE_DIR=/var/tmp/ccache --setenv=CCACHE_UMASK=002 --setenv=CCACHE_HASHDIR=1 --setenv=CCACHE_NODEBUG=1 --resolv-conf=off bash --login -c \'/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps --define \'"\'"\'__spec_check_template exit 0; \'"\'"\' /builddir/build/SPECS/rpm.spec\'\n', 1)]
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.14/site-packages/mockbuild/util.py", line 610, in do_with_status
    raise exception.Error("Command failed: \n # %s\n%s" % (cmd_pretty(command, env), output), child.returncode)
mockbuild.exception.Error: Command failed: 
 # /usr/bin/systemd-nspawn -q -M 672eb4c43ac34c20ada6da9124b3aa22 -D /var/lib/mock/azl-4.0-x86_64/root -a -u mockbuild --capability=cap_ipc_lock --bind=/tmp/mock-resolv.sckf9i15:/etc/resolv.conf --bind=/dev/loop-control --bind=/dev/loop0 --bind=/dev/loop1 --bind=/dev/loop2 --bind=/dev/loop3 --bind=/dev/loop4 --bind=/dev/loop5 --bind=/dev/loop6 --bind=/dev/loop7 --bind=/dev/loop8 --bind=/dev/loop9 --bind=/dev/loop10 --bind=/dev/loop11 --console=pipe --setenv=TERM=vt100 --setenv=SHELL=/bin/bash --setenv=HOME=/builddir --setenv=HOSTNAME=mock --setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin '--setenv=PROMPT_COMMAND=printf "\033]0;<mock-chroot>\007"' '--setenv=PS1=<mock-chroot> \s-\v\$ ' --setenv=LANG=C.UTF-8 --setenv=CCACHE_DIR=/var/tmp/ccache --setenv=CCACHE_UMASK=002 --setenv=CCACHE_HASHDIR=1 --setenv=CCACHE_NODEBUG=1 --resolv-conf=off bash --login -c '/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps --define '"'"'__spec_check_template exit 0; '"'"' /builddir/build/SPECS/rpm.spec'

```
In [rpm.spec](https://[src.fedoraproject.org/rpms/rpm/raw/f43/f/rpm.spec](https://src.fedoraproject.org/rpms/rpm/raw/f43/f/rpm.spec)), The `%install` section installs the doc files to `/usr/share/doc/rpm`, but the `%doc` directive tries to copy them again from source, creating duplicates. So I removed a doc line to fix it.

Repro of rpm build issue:
Build packages locally only with commit: 27d17423f8cb1cb5b7fc630d2ae0ffd52e8f088f