### PR TITLE
fix: remove fedora-release and fedora-repos components

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -246,8 +246,6 @@
 [components.fdk-aac-free]
 [components.fdupes]
 [components.fedora-logos]
-[components.fedora-release]
-[components.fedora-repos]
 [components.felix-parent]
 [components.felix-utils]
 [components.ffcall]


### PR DESCRIPTION
Both of these are replaced with azurelinux packages, and should no longer get built.
