### PR TITLE
feat: disable kernel lockdown mode by default

### DIFF
--- a/toolkit/tools/internal/resources/assets/grub2/grub
+++ b/toolkit/tools/internal/resources/assets/grub2/grub
@@ -2,7 +2,7 @@ GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR="AzureLinux"
 GRUB_DISABLE_SUBMENU=y
 GRUB_TERMINAL_OUTPUT="console"
-GRUB_CMDLINE_LINUX="{{.LuksUUID}} {{.LVM}} {{.IMAPolicy}} {{.SELinux}} {{.FIPS}} rd.auto=1 net.ifnames=0 lockdown=integrity {{.CGroup}}"
+GRUB_CMDLINE_LINUX="{{.LuksUUID}} {{.LVM}} {{.IMAPolicy}} {{.SELinux}} {{.FIPS}} rd.auto=1 net.ifnames=0 {{.CGroup}}"
 GRUB_CMDLINE_LINUX_DEFAULT="{{.ExtraCommandLine}} \$kernelopts"
 
 # =============================notice===============================


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Disable kernel lockdown mode by default through GRUB config change. With this update, kernel lockdown mode is disabled by default and is only enabled when Trusted Launch is active. In the Trusted Launch flow, the kernel includes an OOT patch that automatically enables lockdown in integrity mode when Trusted Launch is on.
This is to support customer scenario where they want to install custom GPU drivers when using AzureLinux in AKS

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disable kernel lockdown mode by default through GRUB config.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- aks-image-build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1057877&view=results&j=8f79342b-f097-58f8-e10f-02bdcdcbe9d8
- manually validated in both Azure VM and AKS that kernel lockdown mode gets disabled by default and gets enabled when Trusted Launch setting is on.
