### PR TITLE
feat: Koji Tag Definitions 

### DIFF
--- a/distro/azurelinux.distro.tags.toml
+++ b/distro/azurelinux.distro.tags.toml
@@ -8,6 +8,7 @@ arches = ["x86_64", "aarch64"]
 
 # Mock build environment configuration (maps to Koji mock.* extras)
 [distros.azurelinux-staging.rpms-build-tag.mock]
+# parent = azl4-bootstrap-rpms-tag-20260307 (Will have to be injected by Control Tower)
 package-manager = "dnf5"
 new-chroot = false
 isolation = "simple"
@@ -15,7 +16,7 @@ releasever = '43'
 
 # RPM macros injected into the buildroot (maps to Koji rpm.macro.* extras)
 [distros.azurelinux-staging.rpms-build-tag.rpm-macros]
-# dist = '.azl4~bootstrap.20260307'
+# dist = '.azl4~bootstrap.20260307' (Will have to be injected by Control Tower).
 distribution = 'Azure Linux'
 vendor = 'Microsoft Corporation'
 

--- a/distro/azurelinux.distro.tags.toml
+++ b/distro/azurelinux.distro.tags.toml
@@ -6,6 +6,9 @@
 # Architectures this tag builds for
 arches = ["x86_64", "aarch64"]
 
+[distros.azurelinux-staging.rpms-build-tag.bootstrap]
+external-repositories = ["fedora-external", "fedora-external-updates"]
+
 # Mock build environment configuration (maps to Koji mock.* extras)
 [distros.azurelinux-staging.rpms-build-tag.mock]
 # parent = azl4-bootstrap-rpms-tag-20260307 (Will have to be injected by Control Tower)

--- a/distro/azurelinux.distro.tags.toml
+++ b/distro/azurelinux.distro.tags.toml
@@ -1,0 +1,80 @@
+# This file defines Koji tags for the Azure Linux distribution.
+# Tags are used to group packages and images for building and release management.
+
+# RPM build tag configuration (maps to Koji tag extras for RPM builds)
+[distros.azurelinux-staging.rpms-build-tag]
+# Architectures this tag builds for
+arches = ["x86_64", "aarch64"]
+
+# Mock build environment configuration (maps to Koji mock.* extras)
+[distros.azurelinux-staging.rpms-build-tag.mock]
+package-manager = "dnf5"
+new-chroot = false
+isolation = "simple"
+releasever = '43'
+
+# RPM macros injected into the buildroot (maps to Koji rpm.macro.* extras)
+[distros.azurelinux-staging.rpms-build-tag.rpm-macros]
+# dist = '.azl4~bootstrap.20260307'
+distribution = 'Azure Linux'
+vendor = 'Microsoft Corporation'
+
+# Build groups — packages installed in the mock chroot (maps to Koji tag groups)
+[distros.azurelinux-staging.rpms-build-tag.groups]
+# Packages installed when building RPMs
+build = [
+    "bash",
+    "bzip2",
+    "coreutils",
+    "cpio",
+    "diffutils",
+    "fedora-release",
+    "findutils",
+    "gawk",
+    "gcc",
+    "gcc-c++",
+    "grep",
+    "gzip",
+    "make",
+    "patch",
+    "python",
+    "redhat-rpm-config",
+    "rpm-build",
+    "sed",
+    "shadow-utils",
+    "tar",
+    "unzip",
+    "utils-linux",
+    "which",
+    "xz",
+]
+# Packages installed when generating SRPMs from spec files
+srpm-build = [
+    "bash",
+    "fedora-release",
+    "fedpkg-minimal",
+    "git",
+    "redhat-rpm-config",
+    "rhpkg-simple",
+    "rpm-build",
+    "shadow-utils",
+]
+
+# Generic extra options — catch-all for Koji tag extras with typed-value resolution
+# [distros.azurelinux-staging.rpms-build-tag.extra-options]
+# releasever = { type = "distro-version", distro = "azurelinux" }
+# snapshot = { type = "timestamp", value = "2026-02-24T00:00:00-08:00" }
+# tag2distrepo = { type = "template", template = "azl4-%{releasever}-%{snapshot}" }
+
+[distros.azurelinux-staging.rpms-dest-tag]
+arches = ["x86_64", "aarch64"]
+
+[distros.azurelinux-staging.container-build-tag]
+arches = ["x86_64", "aarch64"]
+
+# Mock build environment configuration (maps to Koji mock.* extras)
+[distros.azurelinux-staging.container-build-tag.mock]
+package-manager = "dnf5"
+new-chroot = false
+isolation = "simple"
+releasever = '43'

--- a/distro/azurelinux.distro.toml
+++ b/distro/azurelinux.distro.toml
@@ -1,6 +1,47 @@
 [distros.azurelinux]
 description = "Azure Linux"
 default-version = "4.0-stage1"
+branch = "toml/base/main"
+
+[distros.azurelinux-staging]
+description = "Azure Linux Staging Repo"
+default-version = "4.0-stage1"
+branch = "toml/overrides/azurelinux-staging/main"
+
+[distros.azurelinux-staging.inputs]
+# Upstream package repositories to pull SPECs at buildtime.
+upstream-git-repos = ["azl4-fedora-mirror"]
+# Where we will be retrieving source code for packages at buildtime.
+source-stores = ["main"]
+# Where we will be retrieving package dependencies at buildtime, configured in Koji as tag "external-repositories".
+package-repositories = ["fedora-external", "fedora-external-updates"]
+
+[distros.azurelinux-staging.outputs]
+# Upstream package repositories to pull SPECs at buildtime.
+package-repositories = ["azurelinux-staging-rpms"]
+source-stores = ["main"]
+# Where we will be retrieving source code for packages at buildtime.
+image-repositories = ["azurelinux-staging-images"]
+
+# [[resources.source-stores.main]]
+# type = "fedora-lookaside-cache"
+# uri = "https://azltempstaginglookaside.blob.core.windows.net/repo/pkgs/$pkg/$filename/$hashtype/$hash/$filename"
+
+# [[resources.package-repositories.fedora-external]]
+# name = "fedora-external"
+# type = "rpm-repository"
+# uri = "https://dl.fedoraproject.org/pub/fedora/linux/releases/43/Everything/$arch/os/"
+
+# [[resources.package-repositories.fedora-external-updates]]
+# name = "fedora-external-updates"
+# type = "rpm-repository"
+# uri = "https://dl.fedoraproject.org/pub/fedora/linux/updates/43/Everything/$arch/os/"
+
+# [[resources.upstream-git-repos.azl4-fedora-mirror]]
+# name = "azl4-fedora-mirror"
+# uri = "git://azl.src.kojiaks.internal/rpms/$pkg.git"
+
+# NOTE: The above resources are examples of how to define source stores and package repositories.
 
 #
 # Azure Linux 4.0 Stage1

--- a/distro/azurelinux.distro.toml
+++ b/distro/azurelinux.distro.toml
@@ -8,6 +8,15 @@ description = "Azure Linux Staging Repo"
 default-version = "4.0-stage1"
 branch = "toml/overrides/azurelinux-staging/main"
 
+[[distros.azurelinux-staging.projects]]
+name = "base"
+type = "git"
+uri = "?"
+path = "projects/azurelinux/base"
+branch = "main"
+auth = false
+
+
 [distros.azurelinux-staging.inputs]
 # Upstream package repositories to pull SPECs at buildtime.
 upstream-git-repos = ["azl4-fedora-mirror"]


### PR DESCRIPTION
This pull request introduces configuration changes to support the Azure Linux Staging repository and its build infrastructure. The updates add new TOML sections for staging, define build and output sources, and specify Koji tag settings for RPM and container builds. These changes are foundational for enabling package builds and release management for the Azure Linux Staging environment.

Configuration for Azure Linux Staging repository:

* Added `[distros.azurelinux-staging]` section in `azurelinux.distro.toml` to define the staging repo, including description, default version, branch, and input/output sources for upstream repositories, source stores, and package repositories.

Build infrastructure for staging:

* Created `azurelinux.distro.tags.toml` with Koji tag configurations for RPM and container builds, including architecture support, mock build environment settings, RPM macros, and build groups for both RPM and SRPM builds.

Resource definitions and examples:

* Included commented examples in `azurelinux.distro.toml` for source stores, package repositories, and upstream git repos, illustrating how to define external resources for the build process.