### PR TITLE
Updated schema and disabled origins for fedora override

### DIFF
--- a/external/schemas/azldev.schema.json
+++ b/external/schemas/azldev.schema.json
@@ -57,6 +57,43 @@
           "$ref": "#/$defs/CheckConfig",
           "title": "Check configuration",
           "description": "Configuration for the %check section"
+        },
+        "failure": {
+          "$ref": "#/$defs/ComponentBuildFailureConfig",
+          "title": "Build failure configuration",
+          "description": "Configuration and policy regarding build failures for this component."
+        },
+        "hints": {
+          "$ref": "#/$defs/ComponentBuildHints",
+          "title": "Build hints",
+          "description": "Non-essential hints for how or when to build the component."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ComponentBuildFailureConfig": {
+      "properties": {
+        "expected": {
+          "type": "boolean",
+          "title": "Expected failure",
+          "description": "Indicates that this component is expected to fail building."
+        },
+        "expected-reason": {
+          "type": "string",
+          "title": "Expected failure reason",
+          "description": "Required justification for why this component is expected to fail building."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ComponentBuildHints": {
+      "properties": {
+        "expensive": {
+          "type": "boolean",
+          "title": "Expensive to build",
+          "description": "Indicates that building this component is expensive and should be carefully considered when scheduling."
         }
       },
       "additionalProperties": false,
@@ -315,6 +352,11 @@
           "title": "Package Repositories",
           "description": "List of package repository definitions"
         },
+        "disable-origins": {
+          "type": "boolean",
+          "title": "Disable origins",
+          "description": "When true only allow source files from the lookaside cache and do not fall back to configured origins"
+        },
         "versions": {
           "additionalProperties": {
             "$ref": "#/$defs/DistroVersionDefinition"
@@ -550,8 +592,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "filename",
-        "origin"
+        "filename"
       ]
     },
     "SpecSource": {

--- a/overrides/fedora.distro.azl.sources.toml
+++ b/overrides/fedora.distro.azl.sources.toml
@@ -1,3 +1,4 @@
 [distros.fedora]
 dist-git-base-uri = "git://azl.src.kojiaks.internal/rpms/$pkg.git"
 lookaside-base-uri = "https://azltempstaginglookaside.blob.core.windows.net/repo/pkgs/$pkg/$filename/$hashtype/$hash/$filename"
+disable-origins = true


### PR DESCRIPTION
These changes introduce a feature added to `azldev` to explicitly disable preparing sources from outside the configured lookaside caches. You can disable origins by passing in this flag to a distro definition as shown below. This also requires that all components with `source-files` include a hash and hash-type in their definition. 

```toml
[distros.some-distro]
dist-git-base-uri = ...
lookaside-base-uri = ...
disable-origins = true
```