### PR TITLE
Prevent corruption from stale alias state on daemon-reload

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        30%{?dist}
+Release:        31%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Wed May 27 2026 Dan Streetman <ddstreet@ieee.org> - 255-31
+- Bump release to match systemd spec
+
 * Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-30
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/Prevent-corruption-from-stale-alias-state-on-daemon-reload.patch
+++ b/SPECS/systemd/Prevent-corruption-from-stale-alias-state-on-daemon-reload.patch
@@ -1,0 +1,43 @@
+From 4905c95118b3203f1117116cba8c8529763e8593 Mon Sep 17 00:00:00 2001
+From: Dan Streetman <ddstreet@ieee.org>
+Date: Fri, 13 Mar 2026 14:13:04 -0400
+Subject: [PATCH] Prevent corruption from stale alias state on daemon-reload
+
+Avoid incorrect systemd service unit state in certain conditions, to avoid pid1
+assert. Taken from unmerged upstream PR.
+
+Upstream PR: #39703
+https://github.com/systemd/systemd/pull/39703
+
+Fixes: #38817
+https://github.com/systemd/systemd/issues/38817
+
+All credit for identifying and debugging this problem goes to
+Balakumaran Kannan <balakumaran.kannan@microsoft.com>
+
+---
+ src/core/manager-serialize.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/core/manager-serialize.c b/src/core/manager-serialize.c
+index e9d567a97b..4f7c315b4b 100644
+--- a/src/core/manager-serialize.c
++++ b/src/core/manager-serialize.c
+@@ -204,6 +204,14 @@ static int manager_deserialize_one_unit(Manager *m, const char *name, FILE *f, F
+                 return log_notice_errno(r, "Failed to load unit \"%s\", skipping deserialization: %m", name);
+         }
+ 
++        if (!streq(u->id, name)) {
++                log_warning("Unit file for '%s' was overridden by a symlink to '%s'. Skipping stale state of old unit. Any processes from the overridden unit are now abandoned!",
++                            name,
++                            u->id);
++
++                return unit_deserialize_state_skip(f);
++        }
++
+         r = unit_deserialize_state(u, f, fds);
+         if (r < 0) {
+                 if (r == -ENOMEM)
+-- 
+2.51.0
+

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        30%{?dist}
+Release:        31%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -154,6 +154,7 @@ Patch0910:      CVE-2026-40226.patch
 Patch0911:      CVE-2026-40225.patch
 Patch0912:      networkd-address-skip-firewall-init.patch
 Patch0913:      network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch
+Patch0914:      Prevent-corruption-from-stale-alias-state-on-daemon-reload.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1239,6 +1240,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Wed May 27 2026 Dan Streetman <ddstreet@ieee.org> - 255-31
+- Prevent corruption from stale alias state on daemon-reload
+
 * Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-30
 - Backport upstream commit 78f8d5e: network: also check ID_NET_MANAGED_BY
   property on reconfigure.


### PR DESCRIPTION
Avoid incorrect systemd service unit state in certain conditions, to avoid pid1 assert. Taken from upstream PR.

Upstream PR: #39703
https://github.com/systemd/systemd/pull/39703

Fixes: #38817
https://github.com/systemd/systemd/issues/38817

All credit for identifying and debugging this problem goes to                                                                                                                                 
Balakumaran Kannan <balakumaran.kannan@microsoft.com>                                                                                                                                         

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix systemd pid1 crash in certain situations, with one example being rsyslog service.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Avoid deserializing unit state into wrong service.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
https://github.com/systemd/systemd/issues/38817
https://github.com/systemd/systemd/pull/39703
