### PR TITLE
dbus: enable user sessions

### DIFF
--- a/SPECS/dbus/dbus.spec
+++ b/SPECS/dbus/dbus.spec
@@ -2,7 +2,7 @@
 Summary:        DBus for systemd
 Name:           dbus
 Version:        1.15.8
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+ OR AFL
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -51,6 +51,7 @@ autoreconf -i
     --docdir=%{_versioneddocdir}  \
     --enable-libaudit=yes \
     --enable-selinux=yes \
+    --enable-user-session=yes \
     --runstatedir=/run \
     --with-console-auth-dir=/run/console
 
@@ -78,6 +79,7 @@ make %{?_smp_mflags} check
 %{_libdir}/tmpfiles.d/dbus.conf
 %{_sysconfdir}/dbus-1
 %{_unitdir}/*
+%{_userunitdir}/*
 %exclude %{_libdir}/sysusers.d
 
 #%%{_sharedstatedir}/*
@@ -94,6 +96,9 @@ make %{?_smp_mflags} check
 %dir %{_libdir}/dbus-1.0
 
 %changelog
+* Mon Mar 16 2026 Dan Streetman <ddstreet@ieee.org> - 1.15.8-4
+- Enable user sessions
+
 * Tue Mar 20 2024 Sam Meluch <sammeluch@microsfot.com> - 1.15.8-3
 - fix attributes on dbus-daemon-launch-helper
 - sort files list


### PR DESCRIPTION
While most distros have migrated over to dbus-broker, we still provide dbus-daemon, and we do not enable user sessions, so each user login does not have any dbus that can be used to communicate with the user session's systemd manager. This leads to frequent error messages while upgrading packages, and at other times, similar to:

Failed to connect to bus: No medium found
Reload daemon failed: Transport endpoint is not connected

Those errors also mean that while the systemd system manager (pid1) can be reloaded or reexeced, systemd user managers will not be reexeced on a package upgrade, nor can any other package that provides user session services cause their user services to reload/reexec on upgrade. This may leave user processes running old code after some package updates.

Note that the user can still communicate with the user session systemd manager, via systemctl, because it will use the private systemd bus. However, the root user (including scripts run during package updates) cannot connect to any user's private systemd bus and so must use the public user dbus, which is not provided by our dbus package currently.

This changes the dbus build to include support for user sessions.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
enable user dbus support

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
enables user dbus support

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
n

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
