### PR TITLE
systemd: fix pcrlock failure on Hyper-V VMs with vTPM

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        26%{?dist}
+Release:        27%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Thu Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
+- Bump release to match systemd spec
+
 * Tue Mar 03 2026 Dan Streetman <ddstreet@ieee.org> - 255-26
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/fix-pcrlock-hyperv-hash-algorithm-ordering.patch
+++ b/SPECS/systemd/fix-pcrlock-hyperv-hash-algorithm-ordering.patch
@@ -1,0 +1,58 @@
+From e90a255e55e3af0effac927ccaa10c2662501e1a Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Wed, 21 Feb 2024 14:43:42 +0100
+Subject: [PATCH] pcrlock: handle measurement logs where hash algs in header
+ are announced in different order than in records
+
+Apparently on HyperV the measurement logs announce the hash algs in a
+different order in the header than the records have them. Let's handle
+this gracefully
+---
+ src/pcrlock/pcrlock.c | 21 ++++++++++++++-------
+ 1 file changed, 14 insertions(+), 7 deletions(-)
+
+diff --git a/src/pcrlock/pcrlock.c b/src/pcrlock/pcrlock.c
+index e70c44c6..1fb9d692 100644
+--- a/src/pcrlock/pcrlock.c
++++ b/src/pcrlock/pcrlock.c
+@@ -936,23 +936,30 @@ static int event_log_load_firmware(EventLog *el) {
+                 assert(event->digests.count == n_algorithms);
+ 
+                 for (size_t i = 0; i < n_algorithms; i++, ha = ha_next) {
+-                        ha_next = (const uint8_t*) ha + offsetof(TPMT_HA, digest) + algorithms[i].digestSize;
+-
+                         /* The TPMT_HA is not aligned in the record, hence read the hashAlg field via an unaligned read */
+                         assert_cc(__builtin_types_compatible_p(uint16_t, typeof(TPMI_ALG_HASH)));
+                         uint16_t hash_alg = unaligned_read_ne16((const uint8_t*) ha + offsetof(TPMT_HA, hashAlg));
+ 
+-                        if (hash_alg != algorithms[i].algorithmId)
+-                                return log_error_errno(SYNTHETIC_ERRNO(EBADMSG), "Hash algorithms in event log record don't match log.");
++                        /* On some systems (some HyperV?) the order of hash algorithms announced in the
++                         * header does not match the order in the records. Let's hence search for the right
++                         * mapping */
++                        size_t j;
++                        for (j = 0; j < n_algorithms; j++)
++                                if (hash_alg == algorithms[j].algorithmId)
++                                        break;
++                        if (j >= n_algorithms)
++                                return log_error_errno(SYNTHETIC_ERRNO(EBADMSG), "Hash algorithms in event log record not among those advertised by log header.");
++
++                        ha_next = (const uint8_t*) ha + offsetof(TPMT_HA, digest) + algorithms[j].digestSize;
+ 
+-                        if (!tpm2_hash_alg_to_string(algorithms[i].algorithmId))
++                        if (!tpm2_hash_alg_to_string(hash_alg))
+                                 continue;
+ 
+                         r = event_log_record_add_bank(
+                                         record,
+-                                        algorithms[i].algorithmId,
++                                        hash_alg,
+                                         (const uint8_t*) ha + offsetof(TPMT_HA, digest),
+-                                        algorithms[i].digestSize,
++                                        algorithms[j].digestSize,
+                                         /* ret= */ NULL);
+                         if (r < 0)
+                                 return log_error_errno(r, "Failed to add bank to event log record: %m");
+-- 
+2.45.4
+

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        26%{?dist}
+Release:        27%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -149,6 +149,7 @@ Patch0905:      ipc-call-0001-path-util-add-flavour-of-path_startswith-that-leav
 Patch0906:      ipc-call-0003-core-cgroup-avoid-one-unnecessary-strjoina.patch
 Patch0907:      ipc-call-0002-path-util-invert-PATH_STARTSWITH_ACCEPT_DOT_DOT-flag.patch
 Patch0908:      ipc-call-0004-core-validate-input-cgroup-path-more-prudently.patch
+Patch0909:      fix-pcrlock-hyperv-hash-algorithm-ordering.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1234,6 +1235,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Wed Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
+- Fix pcrlock failure on Hyper-V/Azure VMs with vTPM by backporting upstream
+  commit e90a255 from systemd v256 (PR #31429).
+
 * Mon Mar 02 2026 Dan Streetman <ddstreet@ieee.org> - 255-26
 - Apply patches for ipc issue.
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1235,7 +1235,7 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
-* Wed Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
+* Thu Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
 - Fix pcrlock failure on Hyper-V/Azure VMs with vTPM by backporting upstream
   commit e90a255 from systemd v256 (PR #31429).
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Backport upstream systemd fix for `systemd-pcrlock` failures on Hyper-V/Azure VMs with vTPM.

On Hyper-V, the vTPM event log lists hash algorithms in a different order in the records than declared in the header. systemd v255 uses strict positional index matching which fails with "Hash algorithms in event log record don't match log", causing `systemd-pcrlock-firmware-code`, `systemd-pcrlock-firmware-config`, `systemd-pcrlock-make-policy`, and `systemd-pcrlock-secureboot-authority` services to fail on boot.

The upstream fix (commit e90a255 from systemd v256, [PR](https://github.com/systemd/systemd/pull/31429) systemd/systemd#31429) replaces the positional index lookup with a search loop so the algorithm is matched by ID regardless of ordering.

###### Change Log  <!-- REQUIRED -->
- Add `fix-pcrlock-hyperv-hash-algorithm-ordering.patch` backported from upstream systemd v256 (commit e90a255)
- Bump Release from 26 to 27

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- upstream fix: systemd/systemd#31429

###### Links to CVEs  <!-- optional -->
N/A

###### Test Methodology
- Built custom systemd RPM (255-27) with the patch using Azure Linux toolkit
- Deployed to Azure Trusted Launch VM with Secure Boot and vTPM enabled
- Verified systemd health check passes with 0 failed units and system state `running`
- All pcrlock services complete successfully without any bypass workaround
- Pipeline build for verifications listed above
