### PR TITLE
fix: rootlesskit: pin to Fedora 43 build commit eb6bc70fe34c

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -4885,7 +4885,6 @@
 [components.rocthrust]
 [components.roctracer]
 [components.rocwmma]
-[components.rootlesskit]
 [components.rpcsvc-proto]
 [components.rpm-mpi-hooks]
 [components.rpm-ostree]

--- a/base/comps/rootlesskit/rootlesskit.comp.toml
+++ b/base/comps/rootlesskit/rootlesskit.comp.toml
@@ -1,0 +1,5 @@
+[components.rootlesskit]
+# Pin to the f43 commit used to build the current Fedora 43 package.
+# TODO: Drop this override once the default Fedora 43 snapshot
+# in distro/azurelinux.distro.toml advances past this commit.
+spec = { type = "upstream", upstream-name = "golang-github-rootless-containers-rootlesskit", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "eb6bc70fe34cb6947bb1fb1b61b23e34159273e7" }


### PR DESCRIPTION
Pin rootlesskit to upstream commit eb6bc70fe34cb6947bb1fb1b61b23e34159273e7 (Fedora dist-git: golang-github-rootless-containers-rootlesskit) to fetch sources from the commit used to build the current f43 package.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
