### PR TITLE
workaround(WALinuxAgent): Provide /proc/version override 

### DIFF
--- a/base/comps/WALinuxAgent/10-proc-version.conf
+++ b/base/comps/WALinuxAgent/10-proc-version.conf
@@ -1,0 +1,10 @@
+# Expose a /proc/version override to waagent (and its child extensions) so that
+# tools like Guest-Configuration-Extension that grep for "Mariner" can identify
+# Azure Linux.  The bind mount is scoped to this service's mount namespace —
+# other processes see the real /proc/version.
+[Unit]
+Requires=proc-version-override.service
+After=proc-version-override.service
+
+[Service]
+BindReadOnlyPaths=/run/proc_version_override:/proc/version

--- a/base/comps/WALinuxAgent/WALinuxAgent.comp.toml
+++ b/base/comps/WALinuxAgent/WALinuxAgent.comp.toml
@@ -1,0 +1,104 @@
+# WALinuxAgent — Azure Linux Agent for Azure VMs.
+#
+# Overlays add a /proc/version override scoped to the waagent service namespace
+# so Guest-Configuration-Extension (and other tools that grep for "Mariner") can
+# identify Azure Linux 4.0.  System-wide /proc/version is unchanged.
+[components.WALinuxAgent]
+
+# Bump release so local RPM is preferred over the remote bootstrap repo.
+[[components.WALinuxAgent.overlays]]
+description = "Bump release to 2 so local build outranks bootstrap repo"
+type = "spec-set-tag"
+tag = "Release"
+value = "2%{?dist}"
+
+# --- Add source files for the proc-version override ---
+
+# Generator script: produces /run/proc_version_override with "CBL-Mariner" in
+# the user@host field.
+[[components.WALinuxAgent.overlays]]
+description = "Add proc-version-override generator script"
+type = "file-add"
+file = "proc-version-override.sh"
+source = "proc-version-override.sh"
+
+# Oneshot service that runs the generator at boot.
+[[components.WALinuxAgent.overlays]]
+description = "Add proc-version-override systemd service unit"
+type = "file-add"
+file = "proc-version-override.service"
+source = "proc-version-override.service"
+
+# Drop-in for waagent.service that bind-mounts the override into its namespace.
+[[components.WALinuxAgent.overlays]]
+description = "Add waagent.service drop-in to expose /proc/version override"
+type = "file-add"
+file = "10-proc-version.conf"
+source = "10-proc-version.conf"
+
+# --- Register sources in the spec ---
+
+[[components.WALinuxAgent.overlays]]
+description = "Register proc-version-override.sh as Source10"
+type = "spec-insert-tag"
+tag = "Source10"
+value = "proc-version-override.sh"
+
+[[components.WALinuxAgent.overlays]]
+description = "Register proc-version-override.service as Source11"
+type = "spec-insert-tag"
+tag = "Source11"
+value = "proc-version-override.service"
+
+[[components.WALinuxAgent.overlays]]
+description = "Register 10-proc-version.conf drop-in as Source12"
+type = "spec-insert-tag"
+tag = "Source12"
+value = "10-proc-version.conf"
+
+# --- Install the files ---
+
+[[components.WALinuxAgent.overlays]]
+description = "Install proc-version-override script, service, and drop-in"
+type = "spec-append-lines"
+section = "%install"
+lines = [
+    "",
+    "# Install proc-version-override (backward-compat for tools that grep /proc/version for \"Mariner\")",
+    "install -Dm0644 %{SOURCE11} -t %{buildroot}%{_unitdir}/",
+    "install -Dm0755 %{SOURCE10} %{buildroot}%{_libexecdir}/proc-version-override",
+    "install -Dm0644 %{SOURCE12} %{buildroot}%{_unitdir}/waagent.service.d/10-proc-version.conf",
+]
+
+# --- Add to %files ---
+
+[[components.WALinuxAgent.overlays]]
+description = "Ship proc-version-override files in main package"
+type = "spec-append-lines"
+section = "%files"
+lines = [
+    "%{_unitdir}/proc-version-override.service",
+    "%{_libexecdir}/proc-version-override",
+    "%{_unitdir}/waagent.service.d/10-proc-version.conf",
+]
+
+# --- Enable the generator service via preset ---
+
+[[components.WALinuxAgent.overlays]]
+description = "Add preset to auto-enable proc-version-override.service"
+type = "spec-append-lines"
+section = "%install"
+lines = [
+    "",
+    "# Enable proc-version-override.service by default",
+    "install -d %{buildroot}%{_prefix}/lib/systemd/system-preset/",
+    "echo 'enable proc-version-override.service' > %{buildroot}%{_prefix}/lib/systemd/system-preset/90-proc-version-override.preset",
+]
+
+[[components.WALinuxAgent.overlays]]
+description = "Ship the preset file"
+type = "spec-append-lines"
+section = "%files"
+lines = [
+    "%{_prefix}/lib/systemd/system-preset/90-proc-version-override.preset",
+]

--- a/base/comps/WALinuxAgent/WALinuxAgent.comp.toml
+++ b/base/comps/WALinuxAgent/WALinuxAgent.comp.toml
@@ -1,8 +1,7 @@
 # WALinuxAgent — Azure Linux Agent for Azure VMs.
 #
-# Overlays add a /proc/version override scoped to the waagent service namespace
-# so Guest-Configuration-Extension (and other tools that grep for "Mariner") can
-# identify Azure Linux 4.0.  System-wide /proc/version is unchanged.
+# Overlays add a system-wide /proc/version override so Guest-Configuration-Extension
+# (and other tools that grep for "Mariner") can identify Azure Linux 4.0.
 [components.WALinuxAgent]
 
 # Bump release so local RPM is preferred over the remote bootstrap repo.
@@ -29,12 +28,7 @@ type = "file-add"
 file = "proc-version-override.service"
 source = "proc-version-override.service"
 
-# Drop-in for waagent.service that bind-mounts the override into its namespace.
-[[components.WALinuxAgent.overlays]]
-description = "Add waagent.service drop-in to expose /proc/version override"
-type = "file-add"
-file = "10-proc-version.conf"
-source = "10-proc-version.conf"
+
 
 # --- Register sources in the spec ---
 
@@ -50,11 +44,7 @@ type = "spec-insert-tag"
 tag = "Source11"
 value = "proc-version-override.service"
 
-[[components.WALinuxAgent.overlays]]
-description = "Register 10-proc-version.conf drop-in as Source12"
-type = "spec-insert-tag"
-tag = "Source12"
-value = "10-proc-version.conf"
+
 
 # --- Install the files ---
 
@@ -67,7 +57,7 @@ lines = [
     "# Install proc-version-override (backward-compat for tools that grep /proc/version for \"Mariner\")",
     "install -Dm0644 %{SOURCE11} -t %{buildroot}%{_unitdir}/",
     "install -Dm0755 %{SOURCE10} %{buildroot}%{_libexecdir}/proc-version-override",
-    "install -Dm0644 %{SOURCE12} %{buildroot}%{_unitdir}/waagent.service.d/10-proc-version.conf",
+
 ]
 
 # --- Add to %files ---
@@ -79,7 +69,7 @@ section = "%files"
 lines = [
     "%{_unitdir}/proc-version-override.service",
     "%{_libexecdir}/proc-version-override",
-    "%{_unitdir}/waagent.service.d/10-proc-version.conf",
+
 ]
 
 # --- Enable the generator service via preset ---

--- a/base/comps/WALinuxAgent/proc-version-override.service
+++ b/base/comps/WALinuxAgent/proc-version-override.service
@@ -2,12 +2,15 @@
 Description=Generate /proc/version override for legacy OS detection (CBL-Mariner compat)
 DefaultDependencies=no
 After=systemd-tmpfiles-setup.service local-fs.target
+Before=waagent.service
 ConditionVirtualization=vm
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/libexec/proc-version-override
+ExecStartPost=/usr/bin/mount --bind /run/proc_version_override /proc/version
+ExecStop=/usr/bin/umount /proc/version
 
 [Install]
 WantedBy=multi-user.target

--- a/base/comps/WALinuxAgent/proc-version-override.service
+++ b/base/comps/WALinuxAgent/proc-version-override.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Generate /proc/version override for legacy OS detection (CBL-Mariner compat)
+DefaultDependencies=no
+After=systemd-tmpfiles-setup.service local-fs.target
+ConditionVirtualization=vm
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/proc-version-override
+
+[Install]
+WantedBy=multi-user.target

--- a/base/comps/WALinuxAgent/proc-version-override.sh
+++ b/base/comps/WALinuxAgent/proc-version-override.sh
@@ -12,7 +12,10 @@ OVERRIDE="/run/proc_version_override"
 KVER=$(uname -r)
 
 # Strip the first parenthesised group (user@host) and keep everything after it.
-TAIL=$(sed 's/^[^)]*)[[:space:]]*//' /proc/version)
+# Also replace "Red Hat" in the GCC version string so tools that pattern-match
+# /proc/version (e.g. GCE's guest-configuration-shim) don't misidentify AZL as
+# RHEL based on the compiler tag.
+TAIL=$(sed 's/^[^)]*)[[:space:]]*//' /proc/version | sed 's/Red Hat/Azure Linux/g')
 
 printf 'Linux version %s (root@CBL-Mariner-azurelinux) %s\n' \
     "${KVER}" "${TAIL}" > "${OVERRIDE}"

--- a/base/comps/WALinuxAgent/proc-version-override.sh
+++ b/base/comps/WALinuxAgent/proc-version-override.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+# Generate a /proc/version override file that includes "CBL-Mariner" in the
+# user@host field so legacy tools (e.g. Guest-Configuration-Extension) that
+# grep for "Mariner" can identify this OS.
+#
+# The real kernel version, compiler string, and build timestamp are preserved.
+# Only the "(user@host)" group is replaced with "(root@CBL-Mariner-azurelinux)".
+
+set -euo pipefail
+
+OVERRIDE="/run/proc_version_override"
+KVER=$(uname -r)
+
+# Strip the first parenthesised group (user@host) and keep everything after it.
+TAIL=$(sed 's/^[^)]*)[[:space:]]*//' /proc/version)
+
+printf 'Linux version %s (root@CBL-Mariner-azurelinux) %s\n' \
+    "${KVER}" "${TAIL}" > "${OVERRIDE}"

--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -321,7 +321,6 @@ includes = ["**/*.comp.toml", "components-full.toml", "component-check-disableme
 [components.userspace-rcu]
 [components.util-linux]
 [components.vim]
-[components.WALinuxAgent]
 [components.which]
 [components.words]
 [components.xfsdump]


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Guest-Configuration-Extension greps /proc/version for "Mariner" to detect the OS. AZL no longer includes that string since it builds with Fedora's kernel toolchain.

Add a systemd oneshot service that generates a /proc/version override at boot, replacing the user@host field with "root@CBL-Mariner-azurelinux". A drop-in on waagent.service uses BindReadOnlyPaths to expose the override only within waagent's mount namespace — system-wide /proc/version is unchanged.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- workaround(WALinuxAgent): scope /proc/version override to waagent namespace

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/mariner-org/mariner/_workitems/edit/18482?src=WorkItemMention&src-action=artifact_link


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- TaskID: 971043
