### PR TITLE
fix: check  before copying `cfg.SrpmsDir`

### DIFF
--- a/toolkit/tools/pkg/specreaderutils/specreaderutil.go
+++ b/toolkit/tools/pkg/specreaderutils/specreaderutil.go
@@ -188,14 +188,18 @@ func CreateChroot(chrootName, workerTar, buildDir, specsDir string, opts ...Chro
 
 	// If this is not a regular build then copy in all of the SPECs since there are no bind mounts.
 	if !buildpipeline.IsRegularBuild() {
-		dirsToCopy := []string{specsDir, cfg.SrpmsDir}
+		dirsToCopy := []string{specsDir}
+		if cfg.SrpmsDir != "" {
+			dirsToCopy = append(dirsToCopy, cfg.SrpmsDir)
+		}
 		for _, dir := range dirsToCopy {
 			dirInChroot := filepath.Join(chroot.RootDir(), dir)
 			err = directory.CopyContents(dir, dirInChroot)
 			if err != nil {
+				logger.Log.Errorf("Failed to copy directory (%s) into chroot at (%s): %s", dir, dirInChroot, err)
 				closeErr := chroot.Close(leaveFilesOnDisk)
 				if closeErr != nil {
-					logger.Log.Errorf("Failed to close chroot, err: %s", err)
+					logger.Log.Errorf("Failed to close chroot, err: %s", closeErr)
 				}
 				return
 			}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Adding a check for an empty `cfg.SrpmsDir`. Without the check, the `CreateChroot` logic would crash trying to copy the non-existent directory when ran inside a container.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #15578

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Sanity toolkit check build running in a container](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1085789&view=results).