### PR TITLE
feat(edk2): switch to RHEL 10 build path to remove Xen support

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -578,7 +578,6 @@
 [components.ecj]
 [components.ed25519-java]
 [components.editorconfig]
-[components.edk2]
 [components.efibootmgr]
 [components.efitools]
 [components.efl]

--- a/base/comps/edk2/edk2.comp.toml
+++ b/base/comps/edk2/edk2.comp.toml
@@ -1,0 +1,16 @@
+[components.edk2]
+
+# Build edk2 as RHEL 10 instead of Fedora to disable Xen OVMF and other
+# Fedora-only features not needed for Azure Linux (Hyper-V/KVM).
+# This also drops: experimental builds, riscv64, loongarch64, ext4 driver,
+# tools-python, IGVM, 4M qcow2 variants, microvm, stateless, pcrlock.
+# Cross-compilation is disabled (not needed for native-arch builds).
+[components.edk2.build]
+defines = { rhel = "10" }
+
+# build.defines can only set macros, not undefine them. Use a spec overlay
+# to undefine %fedora so that %{defined fedora} evaluates to false.
+[[components.edk2.overlays]]
+description = "Undefine %%fedora to switch edk2 from Fedora to RHEL build path"
+type = "spec-prepend-lines"
+lines = ["%undefine fedora"]


### PR DESCRIPTION
Azure Linux targets Hyper-V/KVM, not Xen. Switch edk2 from the Fedora build path to RHEL 10 by setting rhel=10 and undefining %%fedora.

This eliminates the edk2-ovmf-xen subpackage entirely and also drops Fedora-only features: experimental builds, riscv64/loongarch64 firmware, ext4 EFI driver, tools-python, IGVM, 4M qcow2 variants, microvm, stateless builds, and pcrlock measurements.

Core OVMF firmware (CODE, VARS, secboot, amdsev, inteltdx, qemuvars) and edk2-tools are preserved.