### PR TITLE
fix(kscreenlocker, plasma-login-manager): Pin libplasma-devel < 6.6.1 to avoid SONAME mismatch from bootstrap

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -3607,7 +3607,6 @@
 [components.plasma-desktop]
 [components.plasma-integration]
 [components.plasma-keyboard]
-[components.plasma-login-manager]
 [components.plasma-systemsettings]
 [components.plasma-wayland-protocols]
 [components.plasma-workspace]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1850,7 +1850,6 @@
 [components.kpipewire]
 [components.kronosnet]
 [components.ksc]
-[components.kscreenlocker]
 [components.ksh]
 [components.ksmtuned]
 [components.ksystemstats]

--- a/base/comps/kscreenlocker/kscreenlocker.comp.toml
+++ b/base/comps/kscreenlocker/kscreenlocker.comp.toml
@@ -3,7 +3,7 @@
 # the AZL snapshot selects 6.6.0 (provides .so.6). The bootstrap kscreenlocker
 # linked against .so.7 and its NVR (~bootstrap.20260405) sorts higher than the
 # non-bootstrap rebuild (~20260407), so the stale bootstrap version wins.
-# This overlay pins BuildRequires to libplasma-devel < 6.6.1 to force building
+# This overlay pins BuildRequires to libplasma-devel = 6.6.0 to force building
 # against libplasma 6.6.0 from Fedora. Remove this once bootstrap builds are
 # done.
 
@@ -13,4 +13,4 @@
 description = "Workaround: pin libplasma to 6.6.0 to avoid SONAME mismatch from bootstrap contamination. Remove once bootstrap builds are done ."
 type = "spec-search-replace"
 regex = "^BuildRequires:\\s+cmake\\(PlasmaQuick\\)$"
-replacement = "BuildRequires:  cmake(PlasmaQuick)\nBuildRequires:  libplasma-devel < 6.6.1"
+replacement = "BuildRequires:  cmake(PlasmaQuick)\nBuildRequires:  libplasma-devel = 6.6.0"

--- a/base/comps/kscreenlocker/kscreenlocker.comp.toml
+++ b/base/comps/kscreenlocker/kscreenlocker.comp.toml
@@ -1,0 +1,16 @@
+# WORKAROUND: Bootstrap tag contamination causes SONAME mismatch for libplasma.
+# The bootstrap tag was seeded with fc43's libplasma-6.6.3 (provides .so.7), but
+# the AZL snapshot selects 6.6.0 (provides .so.6). The bootstrap kscreenlocker
+# linked against .so.7 and its NVR (~bootstrap.20260405) sorts higher than the
+# non-bootstrap rebuild (~20260407), so the stale bootstrap version wins.
+# This overlay pins BuildRequires to libplasma-devel < 6.6.1 to force building
+# against libplasma 6.6.0 from Fedora. Remove this once bootstrap builds are
+# done.
+
+[components.kscreenlocker]
+
+[[components.kscreenlocker.overlays]]
+description = "Workaround: pin libplasma to 6.6.0 to avoid SONAME mismatch from bootstrap contamination. Remove once bootstrap builds are done ."
+type = "spec-search-replace"
+regex = "^BuildRequires:\\s+cmake\\(PlasmaQuick\\)$"
+replacement = "BuildRequires:  cmake(PlasmaQuick)\nBuildRequires:  libplasma-devel < 6.6.1"

--- a/base/comps/plasma-login-manager/plasma-login-manager.comp.toml
+++ b/base/comps/plasma-login-manager/plasma-login-manager.comp.toml
@@ -3,7 +3,7 @@
 # the AZL snapshot selects 6.6.0 (provides .so.6). The bootstrap plasma-workspace
 # linked against .so.7 and its NVR (~bootstrap.20260405) sorts higher than the
 # non-bootstrap rebuild (~20260407), so the stale bootstrap version wins.
-# This overlay pins BuildRequires to libplasma-devel < 6.6.1 to force building
+# This overlay pins BuildRequires to libplasma-devel = 6.6.0 to force building
 # against libplasma 6.6.0 from Fedora. Remove this once bootstrap builds are
 # done.
 
@@ -13,4 +13,4 @@
 description = "Workaround: pin libplasma to 6.6.0 to avoid SONAME mismatch from bootstrap contamination. Remove once bootstrap builds are done."
 type = "spec-search-replace"
 regex = "^BuildRequires:\\s+cmake\\(PlasmaQuick\\)$"
-replacement = "BuildRequires:  cmake(PlasmaQuick)\nBuildRequires:  libplasma-devel < 6.6.1"
+replacement = "BuildRequires:  cmake(PlasmaQuick)\nBuildRequires:  libplasma-devel = 6.6.0"

--- a/base/comps/plasma-login-manager/plasma-login-manager.comp.toml
+++ b/base/comps/plasma-login-manager/plasma-login-manager.comp.toml
@@ -1,0 +1,16 @@
+# WORKAROUND: Bootstrap tag contamination causes SONAME mismatch for libplasma.
+# The bootstrap tag was seeded with fc43's libplasma-6.6.3 (provides .so.7), but
+# the AZL snapshot selects 6.6.0 (provides .so.6). The bootstrap plasma-workspace
+# linked against .so.7 and its NVR (~bootstrap.20260405) sorts higher than the
+# non-bootstrap rebuild (~20260407), so the stale bootstrap version wins.
+# This overlay pins BuildRequires to libplasma-devel < 6.6.1 to force building
+# against libplasma 6.6.0 from Fedora. Remove this once bootstrap builds are
+# done.
+
+[components.plasma-login-manager]
+
+[[components.plasma-login-manager.overlays]]
+description = "Workaround: pin libplasma to 6.6.0 to avoid SONAME mismatch from bootstrap contamination. Remove once bootstrap builds are done."
+type = "spec-search-replace"
+regex = "^BuildRequires:\\s+cmake\\(PlasmaQuick\\)$"
+replacement = "BuildRequires:  cmake(PlasmaQuick)\nBuildRequires:  libplasma-devel < 6.6.1"


### PR DESCRIPTION
This pull request introduces workarounds to address a SONAME mismatch issue caused by bootstrap tag contamination for `libplasma`. Adds overlays to pin `libplasma` to version 6.6.0 for the affected components, and removes these components from the main `components-full.toml` list.

Validation: [koji build](https://52.249.25.247/koji/taskinfo?taskID=1199134) failed to pull and install `libplasma-6.6.0` in bootstrap chroot.