### PR TITLE
feat(packages): add package publish annotation support

### DIFF
--- a/base/comps/wget2/wget2.comp.toml
+++ b/base/comps/wget2/wget2.comp.toml
@@ -3,3 +3,7 @@
 [components.wget2.build]
 # Supply the wget compatibility package.
 with = ["as_wget"]
+
+# Component level configuration
+[components.wget2.packages.wget2-wget.publish]
+channel = "rpm-base"

--- a/base/packages-demo.toml
+++ b/base/packages-demo.toml
@@ -1,0 +1,71 @@
+#
+# packages-demo.toml — Example of packages.toml with a small subset of packages.
+#
+# This file demonstrates how azldev splits binary packages across publish
+# repositories using package groups. Each [package-groups.<name>] section
+# assigns a set of packages to a publish channel.
+
+# The real packages.toml will be added in the future.
+#
+# Package publish configuration
+#
+
+# Project-wide baseline — unpublished unless overridden by a package group
+[default-package-config]
+publish = { channel = "none" }
+
+# Packages published to rpm-base
+[package-groups.base-packages]
+description = "base packages"
+packages = [
+    "kernel",
+    "kernel-core",
+    "kernel-cross-headers",
+    "kernel-debug",
+    "kernel-debug-core",
+    "kernel-debug-devel",
+    "kernel-debug-devel-matched",
+    "kernel-debug-modules",
+    "kernel-debug-modules-core",
+    "kernel-debug-modules-extra",
+    "kernel-debug-uki-virt",
+    "kernel-devel",
+    "kernel-devel-matched",
+    "kernel-doc",
+    "kernel-headers",
+    "kernel-modules",
+    "kernel-modules-core",
+    "kernel-modules-extra",
+    "kernel-modules-extra-matched",
+    "kernel-rpm-macros",
+    "kernel-srpm-macros",
+    "kernel-tools",
+    "kernel-tools-libs",
+    "kernel-tools-libs-devel",
+    "kernel-uki-virt",
+    "kernel-uki-virt-addons",
+    "libcurl",
+    "libcurl-devel",
+    "libcurl-minimal",
+    "wget2",
+    "wget2-libs",
+    "which",
+    "whois"
+]
+
+[package-groups.base-packages.default-package-config.publish]
+channel = "rpm-base"
+
+# Packages published to rpm-build-only
+[package-groups.build-only-packages]
+description = "build-only packages"
+packages = [
+    "kernel-debug-modules-internal",
+    "kernel-debug-uki-virt-addons",
+    "kernel-modules-internal",
+    "kernel-selftests-internal",
+    "wget2-devel"
+]
+
+[package-groups.build-only-packages.default-package-config.publish]
+channel = "rpm-build-only"

--- a/base/project.toml
+++ b/base/project.toml
@@ -2,7 +2,7 @@
 # Base project
 #
 
-includes = ["comps/components.toml", "images/images.toml"]
+includes = ["comps/components.toml", "images/images.toml", "packages-demo.toml"]
 
 [project]
 description = 'azurelinux-base'


### PR DESCRIPTION
This PR introduces a project-wide example configuration for package publishing channels and updates the project to include this configuration. It also adds an example of component-level configuration for `wget2-wget` package. These changes help clarify and demonstrate how packages are grouped and assigned to publishing channels in the project.

**Project-wide package publishing configuration:**

* Added `packages-demo.toml`, an example configuration file that demonstrates how packages are grouped and assigned to publish channels (`rpm-base` and `rpm-build-only`). This file includes sample package groupings and default publishing behaviors.
* Updated `project.toml` to include the new `packages-demo.toml` in the list of configuration includes, ensuring the example package publishing configuration is loaded by the project.

**Component-specific publishing configuration:**

* Added a `publish.channel` setting for the `wget2-wget` package in `wget2.comp.toml`, specifying that it should be published to the `rpm-base` channel.

`azldev package list <package-name>` can be used to view the package publish annotations before build, 
e.g.
<img width="907" height="169" alt="image" src="https://github.com/user-attachments/assets/baecf2c9-d325-4cfa-8ffc-3656dc85f462" />

The annotation will be available in the build output:
<img width="688" height="1057" alt="image" src="https://github.com/user-attachments/assets/2150264d-ba76-4ec3-bd47-4f89c610f5ee" />
