### PR TITLE
Upgrade `rubygem-addressable` to 2.9.0 for CVE-2026-35611

### DIFF
--- a/SPECS/rubygem-addressable/rubygem-addressable.signatures.json
+++ b/SPECS/rubygem-addressable/rubygem-addressable.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "addressable-addressable-2.8.0.tar.gz": "ce5adc6636e9222897886fca3b07398c8a00c6604c3a9acba715761da201fe19"
- }
+  "Signatures": {
+    "addressable-addressable-2.9.0.tar.gz": "686ef39b4f4eee9078aa3bf61221a8465ae66e4cea3126fabdb8a1166351ca0d"
+  }
 }

--- a/SPECS/rubygem-addressable/rubygem-addressable.spec
+++ b/SPECS/rubygem-addressable/rubygem-addressable.spec
@@ -2,8 +2,8 @@
 %global gem_name addressable
 Summary:        an alternative implementation to the URI implementation that is part of Ruby's standard library
 Name:           rubygem-%{gem_name}
-Version:        2.8.0
-Release:        2%{?dist}
+Version:        2.9.0
+Release:        1%{?dist}
 License:        Apache 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -34,6 +34,9 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
+* Fri Apr 10 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.9.0-1
+- Auto-upgrade to 2.9.0 - for CVE-2026-35611
+
 * Wed Jun 22 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.8.0-2
 - Build from .tar.gz source.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -25885,8 +25885,8 @@
         "type": "other",
         "other": {
           "name": "rubygem-addressable",
-          "version": "2.8.0",
-          "downloadUrl": "https://github.com/sporkmonger/addressable/archive/refs/tags/addressable-2.8.0.tar.gz"
+          "version": "2.9.0",
+          "downloadUrl": "https://github.com/sporkmonger/addressable/archive/refs/tags/addressable-2.9.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Upgrade Pipeline - > https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1091034&view=results
Buddy Build - > https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1091039&view=results