### PR TITLE
fix(adding 40 components): dependencies pulled in to fix stage2 deped…

### DIFF
--- a/base/comps/GeoIP-GeoLite-data/GeoIP-GeoLite-data.comp.toml
+++ b/base/comps/GeoIP-GeoLite-data/GeoIP-GeoLite-data.comp.toml
@@ -1,0 +1,2 @@
+[components.GeoIP-GeoLite-data]
+spec = { type = "upstream", upstream-commit = "90cb11df7896b89afdb66d3517680751d4a5e79f" }

--- a/base/comps/GeoIP/GeoIP.comp.toml
+++ b/base/comps/GeoIP/GeoIP.comp.toml
@@ -1,0 +1,2 @@
+[components.GeoIP]
+spec = { type = "upstream", upstream-commit = "8fd8b7ef701a836354a8b36d30188e9e20c1fe8a" }

--- a/base/comps/batik/batik.comp.toml
+++ b/base/comps/batik/batik.comp.toml
@@ -1,0 +1,2 @@
+[components.batik]
+spec = { type = "upstream", upstream-commit = "f02721a33a60ac94f7954ef7e3ddf38a0e254c67" }

--- a/base/comps/caddy/caddy.comp.toml
+++ b/base/comps/caddy/caddy.comp.toml
@@ -1,0 +1,2 @@
+[components.caddy]
+spec = { type = "upstream", upstream-commit = "a28b0a7c7d0f53e350f31ce53226d3b9082d0b65" }

--- a/base/comps/coin-or-HiGHS/coin-or-HiGHS.comp.toml
+++ b/base/comps/coin-or-HiGHS/coin-or-HiGHS.comp.toml
@@ -1,0 +1,2 @@
+[components.coin-or-HiGHS]
+spec = { type = "upstream", upstream-commit = "30dafe31f9633ef8f84c24360c137ed66bf17cd0" }

--- a/base/comps/fop/fop.comp.toml
+++ b/base/comps/fop/fop.comp.toml
@@ -1,0 +1,2 @@
+[components.fop]
+spec = { type = "upstream", upstream-commit = "e640d3a33add6a171b428ab21a85552b1379f624" }

--- a/base/comps/ghc-lifted-base/ghc-lifted-base.comp.toml
+++ b/base/comps/ghc-lifted-base/ghc-lifted-base.comp.toml
@@ -1,0 +1,2 @@
+[components.ghc-lifted-base]
+spec = { type = "upstream", upstream-commit = "86470993c6a915eac679d6b2d69fe835f2c016be" }

--- a/base/comps/ghc-regex-posix/ghc-regex-posix.comp.toml
+++ b/base/comps/ghc-regex-posix/ghc-regex-posix.comp.toml
@@ -1,0 +1,2 @@
+[components.ghc-regex-posix]
+spec = { type = "upstream", upstream-commit = "4f09857c8252389089563f16e5246539b4634198" }

--- a/base/comps/ghc-snap-core/ghc-snap-core.comp.toml
+++ b/base/comps/ghc-snap-core/ghc-snap-core.comp.toml
@@ -1,0 +1,2 @@
+[components.ghc-snap-core]
+spec = { type = "upstream", upstream-commit = "f4d8ea302cbc64832e267967746d66593542cd84" }

--- a/base/comps/ghc-snap-server/ghc-snap-server.comp.toml
+++ b/base/comps/ghc-snap-server/ghc-snap-server.comp.toml
@@ -1,0 +1,2 @@
+[components.ghc-snap-server]
+spec = { type = "upstream", upstream-commit = "a676a84a7a2abf3c6a62e3bbcdebac9f78535983" }

--- a/base/comps/ghc-time-locale-compat/ghc-time-locale-compat.comp.toml
+++ b/base/comps/ghc-time-locale-compat/ghc-time-locale-compat.comp.toml
@@ -1,0 +1,2 @@
+[components.ghc-time-locale-compat]
+spec = { type = "upstream", upstream-commit = "a246b4ccbf6d7aa18ebc63ab1eae08be31b3a9d4" }

--- a/base/comps/golang-github-tidwall-pretty/golang-github-tidwall-pretty.comp.toml
+++ b/base/comps/golang-github-tidwall-pretty/golang-github-tidwall-pretty.comp.toml
@@ -1,0 +1,2 @@
+[components.golang-github-tidwall-pretty]
+spec = { type = "upstream", upstream-commit = "d94f2af2d28a4eb109ef0348b73f09a7ab765635" }

--- a/base/comps/icc-profiles-openicc/icc-profiles-openicc.comp.toml
+++ b/base/comps/icc-profiles-openicc/icc-profiles-openicc.comp.toml
@@ -1,0 +1,2 @@
+[components.icc-profiles-openicc]
+spec = { type = "upstream", upstream-commit = "ad9bfd703e3c44c4d2acd0d8fce7de9b3aff32e2" }

--- a/base/comps/infinipath-psm/infinipath-psm.comp.toml
+++ b/base/comps/infinipath-psm/infinipath-psm.comp.toml
@@ -1,0 +1,2 @@
+[components.infinipath-psm]
+spec = { type = "upstream", upstream-commit = "dad9ceb68f162f85c42453de00cc1ce6b6cfbbfa" }

--- a/base/comps/memkind/memkind.comp.toml
+++ b/base/comps/memkind/memkind.comp.toml
@@ -1,0 +1,2 @@
+[components.memkind]
+spec = { type = "upstream", upstream-commit = "94e3deb1a1e7d5fcf56a07918f3c49ba4f0a526b" }

--- a/base/comps/openni-primesense/openni-primesense.comp.toml
+++ b/base/comps/openni-primesense/openni-primesense.comp.toml
@@ -1,0 +1,2 @@
+[components.openni-primesense]
+spec = { type = "upstream", upstream-commit = "9fc3b166a0220f48863855d5c994423a2a3bc9c1" }

--- a/base/comps/openni/openni.comp.toml
+++ b/base/comps/openni/openni.comp.toml
@@ -1,0 +1,2 @@
+[components.openni]
+spec = { type = "upstream", upstream-commit = "e8b560be234aaf9c628d5f7117feeb6168ad9850" }

--- a/base/comps/pdfbox/pdfbox.comp.toml
+++ b/base/comps/pdfbox/pdfbox.comp.toml
@@ -1,0 +1,2 @@
+[components.pdfbox]
+spec = { type = "upstream", upstream-commit = "369873ccb291059c7d364cd36f561535f3c44687" }

--- a/base/comps/perl-Switch/perl-Switch.comp.toml
+++ b/base/comps/perl-Switch/perl-Switch.comp.toml
@@ -1,0 +1,2 @@
+[components.perl-Switch]
+spec = { type = "upstream", upstream-commit = "b2f7123b188afd0bfde6858f7d586a2c5f9b8a5b" }

--- a/base/comps/rust-authenticode/rust-authenticode.comp.toml
+++ b/base/comps/rust-authenticode/rust-authenticode.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-authenticode]
+spec = { type = "upstream", upstream-commit = "c0580f70ba43a708fd134e23c4966b673f1229c7" }

--- a/base/comps/rust-cms/rust-cms.comp.toml
+++ b/base/comps/rust-cms/rust-cms.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-cms]
+spec = { type = "upstream", upstream-commit = "9e882cd7790c5eea49f63e323c36b7d21807c76a" }

--- a/base/comps/rust-convert_case/rust-convert_case.comp.toml
+++ b/base/comps/rust-convert_case/rust-convert_case.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-convert_case]
+spec = { type = "upstream", upstream-commit = "cdfa9545236b7c8ff0e311ccab27c8a364d8127a" }

--- a/base/comps/rust-igvm/rust-igvm.comp.toml
+++ b/base/comps/rust-igvm/rust-igvm.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-igvm]
+spec = { type = "upstream", upstream-commit = "2db95f12aebc6dfe50f1d7d42b4dd8f1775040ea" }

--- a/base/comps/rust-igvm_defs/rust-igvm_defs.comp.toml
+++ b/base/comps/rust-igvm_defs/rust-igvm_defs.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-igvm_defs]
+spec = { type = "upstream", upstream-commit = "f5a8d47fa2aae6e74f9a29e9a10e29c1e6a3e579" }

--- a/base/comps/rust-openssl-probe0.1/rust-openssl-probe0.1.comp.toml
+++ b/base/comps/rust-openssl-probe0.1/rust-openssl-probe0.1.comp.toml
@@ -1,0 +1,2 @@
+["components"."rust-openssl-probe0.1"]
+spec = { type = "upstream", upstream-commit = "991e04f4ef5833ed7488f21375815f3b2d040385" }

--- a/base/comps/rust-roff/rust-roff.comp.toml
+++ b/base/comps/rust-roff/rust-roff.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-roff]
+spec = { type = "upstream", upstream-commit = "6adbcc2ed953759a3dece428004074717910cd7c" }

--- a/base/comps/rust-socket2_0.4/rust-socket2_0.4.comp.toml
+++ b/base/comps/rust-socket2_0.4/rust-socket2_0.4.comp.toml
@@ -1,0 +1,2 @@
+["components"."rust-socket2_0.4"]
+spec = { type = "upstream", upstream-commit = "66e8ee6618a04bbdd2c3d4a291d34c72c1f59945" }

--- a/base/comps/rust-tower-test/rust-tower-test.comp.toml
+++ b/base/comps/rust-tower-test/rust-tower-test.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-tower-test]
+spec = { type = "upstream", upstream-commit = "b21207b56d9e07dbc6c12a4a497f0fa48a966d10" }

--- a/base/comps/rust-ucs2/rust-ucs2.comp.toml
+++ b/base/comps/rust-ucs2/rust-ucs2.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-ucs2]
+spec = { type = "upstream", upstream-commit = "34cea0bcf5cba5e56d7f1cd50f225129db7f9b80" }

--- a/base/comps/rust-udev/rust-udev.comp.toml
+++ b/base/comps/rust-udev/rust-udev.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-udev]
+spec = { type = "upstream", upstream-commit = "dbeb5dd6489ed2873621751551aec8c466601f2e" }

--- a/base/comps/rust-uefi-macros/rust-uefi-macros.comp.toml
+++ b/base/comps/rust-uefi-macros/rust-uefi-macros.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-uefi-macros]
+spec = { type = "upstream", upstream-commit = "1dda8d42cf00f280d099d29fa6482b1d4df06fe2" }

--- a/base/comps/rust-uefi-raw/rust-uefi-raw.comp.toml
+++ b/base/comps/rust-uefi-raw/rust-uefi-raw.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-uefi-raw]
+spec = { type = "upstream", upstream-commit = "ca4b7022fde9f76f29699b8d6ed60d5677746d98" }

--- a/base/comps/rust-uefi/rust-uefi.comp.toml
+++ b/base/comps/rust-uefi/rust-uefi.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-uefi]
+spec = { type = "upstream", upstream-commit = "0c1a132a7d52dc5f83e3c5ed8f917dd78fcbb7ff" }

--- a/base/comps/rust-uguid/rust-uguid.comp.toml
+++ b/base/comps/rust-uguid/rust-uguid.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-uguid]
+spec = { type = "upstream", upstream-commit = "ddaaa290c8746b775d8dc0c42699e8be164558a6" }

--- a/base/comps/rust-winnow0.7/rust-winnow0.7.comp.toml
+++ b/base/comps/rust-winnow0.7/rust-winnow0.7.comp.toml
@@ -1,0 +1,2 @@
+["components"."rust-winnow0.7"]
+spec = { type = "upstream", upstream-commit = "526c97c15b18ec9de7496fbfbc668de191ac37d7" }

--- a/base/comps/rust-x509-cert/rust-x509-cert.comp.toml
+++ b/base/comps/rust-x509-cert/rust-x509-cert.comp.toml
@@ -1,0 +1,2 @@
+[components.rust-x509-cert]
+spec = { type = "upstream", upstream-commit = "ec9634ace0550a0ff04688c0d3c8503ad0c668e8" }

--- a/base/comps/tinyxml/tinyxml.comp.toml
+++ b/base/comps/tinyxml/tinyxml.comp.toml
@@ -1,0 +1,2 @@
+[components.tinyxml]
+spec = { type = "upstream", upstream-commit = "ea777b3f06e58d4ca78ba1eb41d228ed1db96e80" }

--- a/base/comps/virt-firmware-rs/virt-firmware-rs.comp.toml
+++ b/base/comps/virt-firmware-rs/virt-firmware-rs.comp.toml
@@ -1,0 +1,2 @@
+[components.virt-firmware-rs]
+spec = { type = "upstream", upstream-commit = "11939f3731b04b646bf72fb824ca7c9732dc148e" }

--- a/base/comps/xml-maven-plugin/xml-maven-plugin.comp.toml
+++ b/base/comps/xml-maven-plugin/xml-maven-plugin.comp.toml
@@ -1,0 +1,2 @@
+[components.xml-maven-plugin]
+spec = { type = "upstream", upstream-commit = "a9776225b87e38c1502a99f27352e4e210fc3147" }

--- a/base/comps/xmlgraphics-commons/xmlgraphics-commons.comp.toml
+++ b/base/comps/xmlgraphics-commons/xmlgraphics-commons.comp.toml
@@ -1,0 +1,2 @@
+[components.xmlgraphics-commons]
+spec = { type = "upstream", upstream-commit = "a25361ce60201aa50e74996b6a83f7c67e0f4a05" }


### PR DESCRIPTION
…ency failures

The 40 components corresponding to the rpms below were identified as the closure required to satisfy dependency failures for:
-- stage2 failures ---
coin-or-HiGHS
fop
memkind
ghc-lifted-base
ghc-snap-core
ghc-snap-server
infinipath-psm
xtensor
openni
openni-primesense
virt-firmware-rs
golang-github-tidwall-pretty-devel
-- --

Each of the components below are pinned to the version identified as required to satisfy the dependency. This should increase the chances of further stage2 dependency failures.

-- 40 package list --
GeoIP-1.6.12-21.fc43
GeoIP-GeoLite-data-2018.06-19.fc43
batik-1.14-17.fc43
caddy-2.10.2-1.fc43
coin-or-HiGHS-1.13.1-1.fc43
fop-2.9-9.fc41
ghc-lifted-base-0.2.3.12-32.fc43
ghc-regex-posix-0.96.0.2-3.fc43
ghc-snap-core-1.0.5.1-32.fc43
ghc-snap-server-1.1.2.1-30.fc43
ghc-time-locale-compat-0.1.1.5-31.fc43
golang-github-tidwall-pretty-1.0.2-14.fc43
icc-profiles-openicc-1.3.1-30.fc43
infinipath-psm-3.3-26_g604758e_open.6.fc43.15
memkind-1.14.0-11.fc43
openni-1.5.7.10-38.fc43
openni-primesense-5.1.6.6-31.fc43
pdfbox-2.0.30-6.fc43
perl-Switch-2.17-34.fc43
rust-authenticode-0.5.0-2.fc43
rust-cms-0.2.3-1.fc43
rust-convert_case-0.10.0-1.fc43
rust-igvm-0.4.0-2.fc43
rust-igvm_defs-0.4.0-2.fc43
rust-openssl-probe0.1-0.1.6-1.fc43
rust-roff-1.1.0-1.fc43
rust-socket2_0.4-0.4.10-5.fc43
rust-tower-test-0.4.0-12.fc43
rust-ucs2-0.3.3-3.fc43
rust-udev-0.9.3-2.fc43
rust-uefi-0.37.0-2.fc43
rust-uefi-macros-0.19.0-2.fc43
rust-uefi-raw-0.14.0-2.fc43
rust-uguid-2.2.1-5.fc43
rust-winnow0.7-0.7.15-1.fc43
rust-x509-cert-0.2.5-4.fc43
tinyxml-2.6.2-32.fc43
virt-firmware-rs-26.4-3.fc43
xml-maven-plugin-1.1.0-7.fc43
xmlgraphics-commons-2.11-5.fc43
-- --

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
