### PR TITLE
feat: remove vm-base.kiwi package rsyslog

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -94,7 +94,6 @@
         <package name="openssh-clients" />
         <package name="openssh-server" />
         <package name="rsync" />
-        <package name="rsyslog" />
         <package name="selinux-policy-targeted" />
         <package name="setup" />
         <package name="shadow-utils" />


### PR DESCRIPTION
This isn't needed for logging, which uses systemd-journald; and this package pulls in:

- libestr
- libfastjson