### PR TITLE
qemu: Enable user_static builds for providing user mode emulation.

### DIFF
--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -1170,10 +1170,6 @@ Requires: %{name}-user = %{version}-%{release}
 Requires(post): systemd-units
 Requires(postun): systemd-units
 # qemu-user-binfmt + qemu-user-static both provide binfmt rules
-# Temporarily disable to get fedora CI working. Re-enable
-# once this CI issue let's us deal with subpackage conflicts:
-# https://pagure.io/fedora-ci/general/issue/184
-#
 # introduce conflicts to not install both binfmt rules.
 Conflicts: qemu-user-static
 %description user-binfmt

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -66,9 +66,6 @@ Distribution:   Azure Linux
 
 
 %global user_static 1
-%if 0%{?azl}
-%global user_static 0
-%endif
 
 %global have_kvm 0
 %if 0%{?kvm_package:1}
@@ -435,7 +432,7 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 9.1.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -677,7 +674,7 @@ BuildRequires: rutabaga-gfx-ffi-devel
 %if %{user_static}
 BuildRequires: glibc-static >= 2.38-19%{?dist}
 BuildRequires: glib2-static zlib-static
-BuildRequires: pcre2-static
+BuildRequires: pcre2-devel-static
 %endif
 
 # Requires for the Fedora 'qemu' metapackage
@@ -1176,7 +1173,9 @@ Requires(postun): systemd-units
 # Temporarily disable to get fedora CI working. Re-enable
 # once this CI issue let's us deal with subpackage conflicts:
 # https://pagure.io/fedora-ci/general/issue/184
-#Conflicts: qemu-user-static
+#
+# introduce conflicts to not install both binfmt rules.
+Conflicts: qemu-user-static
 %description user-binfmt
 This package provides the user mode emulation of qemu targets
 
@@ -1197,8 +1196,10 @@ Requires(postun): systemd-units
 # Temporarily disable to get fedora CI working. Re-enable
 # once this CI issue let's us deal with subpackage conflicts:
 # https://pagure.io/fedora-ci/general/issue/184
-#Conflicts: qemu-user-binfmt
-#Provides: qemu-user-binfmt
+#
+# introduce conflicts to not install both binfmt rules.
+Conflicts: qemu-user-binfmt
+Provides: qemu-user-binfmt
 Requires: qemu-user-static-aarch64
 Requires: qemu-user-static-alpha
 Requires: qemu-user-static-arm
@@ -1311,7 +1312,6 @@ Summary: QEMU user mode emulation of sh4 qemu targets static build
 %description user-static-sh4
 This package provides the sh4 user mode emulation of qemu targets built as
 static binaries
-%endif
 
 %package user-static-sparc
 Summary: QEMU user mode emulation of sparc qemu targets static build
@@ -1331,6 +1331,7 @@ Summary: QEMU user mode emulation of xtensa qemu targets static build
 This package provides the xtensa user mode emulation of qemu targets built as
 static binaries
 
+%endif
 
 %package system-aarch64
 Summary: QEMU system emulator for AArch64
@@ -2045,6 +2046,7 @@ pushd %{static_builddir}
 run_configure \
   --enable-attr \
   --enable-linux-user \
+  --enable-pie \
   --enable-tcg \
   --disable-install-blobs \
   --static
@@ -2384,96 +2386,190 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 /bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
 
 %if %{user_static}
+# marker to run systemd-binfmt service only once when installing the meta package qemu-user-static
+%define setbinfmtonce %{_localstatedir}/lib/rpm-state/qemu-user-static-binfmt
+
+%define try_run_systemd_binfmt() \
+if ! /bin/systemctl is-active --quiet systemd-binfmt.service; then \
+    /bin/systemctl --system restart systemd-binfmt.service &>/dev/null || : \
+else \
+    /bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || : \
+fi \
+%{nil}
+
+%pretrans user-static
+touch %{setbinfmtonce}
+exit 0
+
+%posttrans user-static
+%try_run_systemd_binfmt
+rm -f %{setbinfmtonce}
+exit 0
+
 %post user-static-aarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-aarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-alpha
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-alpha
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-arm
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-arm
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-cris
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-cris
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-hexagon
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-hexagon
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-hppa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-hppa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-loongarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-loongarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-m68k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-m68k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-microblaze
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-microblaze
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-mips
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-mips
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-or1k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-or1k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-ppc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-ppc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-riscv
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-riscv
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-s390x
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-s390x
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-sh4
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-sh4
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
-%endif
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-sparc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-sparc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-x86
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-x86
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-xtensa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-xtensa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
+
+# endif user-static
+%endif
 
 # endif !tools_only
 %endif
@@ -3432,6 +3528,13 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
+* Tue Apr 14 2026 Sumedh Sharma <sumsharma@microsoft.com> - 9.1.0-6
+- Enable user_static builds for qemu
+- configure user_static with 'enable-pie'
+- manage systemd-binfmt restarts post install/uninstall to avoid start-limit-hit
+- add conflicts between qemu-user-static and qemu-user-binfmt as both
+  provide binfmt rules
+
 * Sun Apr 05 2026 Woojoong Kim <woojoongkim@microsoft.com> - 9.1.0-5
 - Add 23 QEMU patches from RHEL qemu-kvm 9.1.0-20 for KubeVirt live migration
 - Post-migration networking: fix announce_self ARP/GARP (RHEL-73891),

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -2390,6 +2390,7 @@ fi \
 %{nil}
 
 %pretrans user-static
+mkdir -p %{_localstatedir}/lib/rpm-state/
 touch %{setbinfmtonce}
 exit 0
 

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -1189,10 +1189,6 @@ Summary: QEMU user mode emulation of qemu targets static build
 Requires(post): systemd-units
 Requires(postun): systemd-units
 # qemu-user-binfmt + qemu-user-static both provide binfmt rules
-# Temporarily disable to get fedora CI working. Re-enable
-# once this CI issue let's us deal with subpackage conflicts:
-# https://pagure.io/fedora-ci/general/issue/184
-#
 # introduce conflicts to not install both binfmt rules.
 Conflicts: qemu-user-binfmt
 Provides: qemu-user-binfmt

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -66,9 +66,6 @@ Distribution:   Azure Linux
 
 
 %global user_static 1
-%if 0%{?azl}
-%global user_static 0
-%endif
 
 %global have_kvm 0
 %if 0%{?kvm_package:1}
@@ -435,7 +432,7 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 9.1.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -654,7 +651,7 @@ BuildRequires: rutabaga-gfx-ffi-devel
 %if %{user_static}
 BuildRequires: glibc-static >= 2.38-19%{?dist}
 BuildRequires: glib2-static zlib-static
-BuildRequires: pcre2-static
+BuildRequires: pcre2-devel-static
 %endif
 
 # Requires for the Fedora 'qemu' metapackage
@@ -1153,7 +1150,9 @@ Requires(postun): systemd-units
 # Temporarily disable to get fedora CI working. Re-enable
 # once this CI issue let's us deal with subpackage conflicts:
 # https://pagure.io/fedora-ci/general/issue/184
-#Conflicts: qemu-user-static
+#
+# introduce conflicts to not install both binfmt rules.
+Conflicts: qemu-user-static
 %description user-binfmt
 This package provides the user mode emulation of qemu targets
 
@@ -1174,8 +1173,10 @@ Requires(postun): systemd-units
 # Temporarily disable to get fedora CI working. Re-enable
 # once this CI issue let's us deal with subpackage conflicts:
 # https://pagure.io/fedora-ci/general/issue/184
-#Conflicts: qemu-user-binfmt
-#Provides: qemu-user-binfmt
+#
+# introduce conflicts to not install both binfmt rules.
+Conflicts: qemu-user-binfmt
+Provides: qemu-user-binfmt
 Requires: qemu-user-static-aarch64
 Requires: qemu-user-static-alpha
 Requires: qemu-user-static-arm
@@ -1288,7 +1289,6 @@ Summary: QEMU user mode emulation of sh4 qemu targets static build
 %description user-static-sh4
 This package provides the sh4 user mode emulation of qemu targets built as
 static binaries
-%endif
 
 %package user-static-sparc
 Summary: QEMU user mode emulation of sparc qemu targets static build
@@ -1308,6 +1308,7 @@ Summary: QEMU user mode emulation of xtensa qemu targets static build
 This package provides the xtensa user mode emulation of qemu targets built as
 static binaries
 
+%endif
 
 %package system-aarch64
 Summary: QEMU system emulator for AArch64
@@ -2022,6 +2023,7 @@ pushd %{static_builddir}
 run_configure \
   --enable-attr \
   --enable-linux-user \
+  --enable-pie \
   --enable-tcg \
   --disable-install-blobs \
   --static
@@ -2361,96 +2363,190 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 /bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
 
 %if %{user_static}
+# marker to run systemd-binfmt service only once when installing the meta package qemu-user-static
+%define setbinfmtonce %{_localstatedir}/lib/rpm-state/qemu-user-static-binfmt
+
+%define try_run_systemd_binfmt() \
+if ! /bin/systemctl is-active --quiet systemd-binfmt.service; then \
+    /bin/systemctl --system restart systemd-binfmt.service &>/dev/null || : \
+else \
+    /bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || : \
+fi \
+%{nil}
+
+%pretrans user-static
+touch %{setbinfmtonce}
+exit 0
+
+%posttrans user-static
+%try_run_systemd_binfmt
+rm -f %{setbinfmtonce}
+exit 0
+
 %post user-static-aarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-aarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-alpha
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-alpha
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-arm
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-arm
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-cris
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-cris
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-hexagon
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-hexagon
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-hppa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-hppa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-loongarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-loongarch64
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-m68k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-m68k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-microblaze
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-microblaze
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-mips
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-mips
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-or1k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-or1k
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-ppc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-ppc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-riscv
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-riscv
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-s390x
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-s390x
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-sh4
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-sh4
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
-%endif
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-sparc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-sparc
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-x86
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-x86
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 
 %post user-static-xtensa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
 %postun user-static-xtensa
-/bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
+if [ ! -f %{setbinfmtonce} ];then
+    %try_run_systemd_binfmt
+fi
+
+# endif user-static
+%endif
 
 # endif !tools_only
 %endif
@@ -3409,6 +3505,13 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
+* Tue Apr 14 2026 Sumedh Sharma <sumsharma@microsoft.com> - 9.1.0-4
+- Enable user_static builds for qemu
+- configure user_static with 'enable-pie'
+- manage systemd-binfmt restarts post install/uninstall to avoid start-limit-hit
+- add conflicts between qemu-user-static and qemu-user-binfmt as both
+  provide binfmt rules
+
 * Wed Mar 25 2026 Aditya Singh <v-aditysing@microsoft.com> - 9.1.0-3
 - Bump to rebuild with updated glibc
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR introduces changes to enable user_static builds in qemu to build qemu-user-static* arch specific packages for providing user mode emulation. This enables support to run for ex aarch64 bins using qemu-user-static-aarch64 sub-package via binfmt-misc on x86_64 host. By default, the binfmt config is set with 'F = fix binary' flag to preload the interpreter binary to allow running non-native instructions inside the container environment.

The sub-package `qemu-user-binfmt` also provides binfmt config but they are dynamic interpreter configurations.
For ex qemu-aarch64, the interpreter registered is "/usr/bin/qemu-aarch64" which is a dynamically linked shared object.
Also, the interpreter is registered without the F = fix binary flag.
We cannot use this package for container-based builds because:
- there are no entries inside the /proc/sys/fs/binfmt_misc IN the containers mount ns
- when installing arm64 packages, the pre/post scriptlets start to fail when trying to run without the 'F' flag
    - because there is no binfmt_misc registered inside container ns
    - in host, the interpreter is not loaded since without F indicates lazy loading by kernel
    - tries to execute arm64 instructions natively and fails

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enable user_static global compile flag
- configure user_static with 'enable_pie'
- manage systemd-binfmt restarts post install/uninstall to avoid start-limit-hit
- add conflicts between qemu-user-static and qemu-user-binfmt as both
  provide binfmt rules

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1094245&view=results)
