### PR TITLE
feat: remove vm-base.kiwi package azurelinux-rpm-config

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -41,7 +41,6 @@
     <packages type="image">
         <!-- Core group -->
         <package name="azurelinux-release-cloud" />
-        <package name="azurelinux-rpm-config" />
         <package name="azurelinux-repos" />
         <package name="bash" />
         <package name="ca-certificates" />


### PR DESCRIPTION
This is only needed for building rpms, and shouldn't be installed by default.

This also removes many `*-[s]rpm-macros` packages from the image, as well as:

- add-determinism
- dwz
- glibc-gconv-extra
- gpgverify
- zip