### PR TITLE
fix(mesa): re-enable VA-API drivers for rocdecode/rocjpeg

### DIFF
--- a/base/comps/mesa/mesa.comp.toml
+++ b/base/comps/mesa/mesa.comp.toml
@@ -4,8 +4,9 @@
 # for a cloud/server distro (teflon, opencl, asahi, d3d12, embedded ARM GPUs,
 # old AMD/Intel drivers, etc.). Keeps llvmpipe (SW raster), virgl (virtio-gpu),
 # radeonsi, iris/crocus, vmware (svga), and basic Vulkan.
+# Re-enable with_va (disabled by RHEL profile) for rocdecode/rocjpeg.
 [components.mesa.build]
-defines = { rhel = "10" }
+defines = { rhel = "10", with_va = "1" }
 
 # RHEL uses rust-toolset (a meta-package) instead of cargo-rpm-macros for Rust
 # builds. AZL doesn't have rust-toolset — use cargo-rpm-macros like Fedora.


### PR DESCRIPTION
The RHEL build profile (rhel=10) disables with_va, which prevents the mesa-va-drivers subpackage from being built. Both rocdecode and rocjpeg have BuildRequires and Requires on mesa-va-drivers for AMD GPU video decode support.

Add with_va=1 to the build defines to re-enable VA-API drivers while keeping the rest of the RHEL feature profile.

Fixes: [AB#18918](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/18918)