### PR TITLE
[Medium] Patch systemd for CVE-2026-40226, CVE-2026-40225

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Tue Apr 21 2026 Akhila Guruju <v-guakhila@microsoft.com> - 255-28
+- Bump release to match systemd spec
+
 * Thu Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/CVE-2026-40225.patch
+++ b/SPECS/systemd/CVE-2026-40225.patch
@@ -1,0 +1,139 @@
+From 03bb697b8df0339c37f4b845025320b261aeb7cc Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@gmail.com>
+Date: Fri, 6 Mar 2026 19:32:35 +0000
+Subject: [PATCH] udev: check for invalid chars in various fields received from
+ the kernel
+
+(cherry picked from commit 16325b35fa6ecb25f66534a562583ce3b96d52f3)
+(cherry picked from commit 3513862eabe9ec4a6a095d7266e98f998f289ed2)
+(cherry picked from commit c20d21e0da293e715db468f9f4a15a5c8fbf8273)
+
+From 5887e72ff87d3a66a4c3fa91897fbec1545f4d3d Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@gmail.com>
+Date: Fri, 13 Mar 2026 11:10:47 +0000
+Subject: [PATCH] udev: fix review mixup
+
+The previous version in the PR changed variable and sanitized it
+in place. The second version switched to skip if CCs are in the
+string instead, but didn't move back to the original variable.
+Because it's an existing variable, no CI caught it.
+
+Upstream Patch reference:
+1. https://github.com/systemd/systemd/commit/03bb697b8df0339c37f4b845025320b261aeb7cc.patch
+2. https://github.com/systemd/systemd/commit/5887e72ff87d3a66a4c3fa91897fbec1545f4d3d.patch
+---
+ src/udev/dmi_memory_id/dmi_memory_id.c | 3 ++-
+ src/udev/scsi_id/scsi_id.c             | 3 ++-
+ src/udev/udev-builtin-net_id.c         | 9 +++++++++
+ src/udev/v4l_id/v4l_id.c               | 5 ++++-
+ 4 files changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/src/udev/dmi_memory_id/dmi_memory_id.c b/src/udev/dmi_memory_id/dmi_memory_id.c
+index 37c098a..c965f4a 100644
+--- a/src/udev/dmi_memory_id/dmi_memory_id.c
++++ b/src/udev/dmi_memory_id/dmi_memory_id.c
+@@ -51,6 +51,7 @@
+ #include "string-util.h"
+ #include "udev-util.h"
+ #include "unaligned.h"
++#include "utf8.h"
+ 
+ #define SUPPORTED_SMBIOS_VER 0x030300
+ 
+@@ -185,7 +186,7 @@ static void dmi_memory_device_string(
+ 
+         str = strdupa_safe(dmi_string(h, s));
+         str = strstrip(str);
+-        if (!isempty(str))
++        if (!isempty(str) && utf8_is_valid(str) && !string_has_cc(str, /* ok= */ NULL))
+                 printf("MEMORY_DEVICE_%u_%s=%s\n", slot_num, attr_suffix, str);
+ }
+ 
+diff --git a/src/udev/scsi_id/scsi_id.c b/src/udev/scsi_id/scsi_id.c
+index 6308c52..b2df8d9 100644
+--- a/src/udev/scsi_id/scsi_id.c
++++ b/src/udev/scsi_id/scsi_id.c
+@@ -27,6 +27,7 @@
+ #include "strv.h"
+ #include "strxcpyx.h"
+ #include "udev-util.h"
++#include "utf8.h"
+ 
+ static const struct option options[] = {
+         { "device",             required_argument, NULL, 'd' },
+@@ -443,7 +444,7 @@ static int scsi_id(char *maj_min_dev) {
+                 }
+                 if (dev_scsi.tgpt_group[0] != '\0')
+                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
+-                if (dev_scsi.unit_serial_number[0] != '\0')
++                if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
+                         printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
+                 goto out;
+         }
+diff --git a/src/udev/udev-builtin-net_id.c b/src/udev/udev-builtin-net_id.c
+index 91b4008..715184e 100644
+--- a/src/udev/udev-builtin-net_id.c
++++ b/src/udev/udev-builtin-net_id.c
+@@ -39,6 +39,7 @@
+ #include "strv.h"
+ #include "strxcpyx.h"
+ #include "udev-builtin.h"
++#include "utf8.h"
+ 
+ #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
+ #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
+@@ -247,6 +248,9 @@ static int get_port_specifier(sd_device *dev, bool fallback_to_dev_id, char **re
+                         }
+                 }
+ 
++                if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
++                        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
++
+                 /* Otherwise, use phys_port_name as is. */
+                 buf = strjoin("n", phys_port_name);
+                 if (!buf)
+@@ -351,6 +355,9 @@ static int names_pci_onboard_label(sd_device *dev, sd_device *pci_dev, const cha
+         if (r < 0)
+                 return log_device_debug_errno(pci_dev, r, "Failed to get PCI onboard label: %m");
+ 
++        if (!utf8_is_valid(label) || string_has_cc(label, /* ok= */ NULL))
++                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid label");
++
+         char str[ALTIFNAMSIZ];
+         if (snprintf_ok(str, sizeof str, "%s%s",
+                         naming_scheme_has(NAMING_LABEL_NOPREFIX) ? "" : prefix,
+@@ -1209,6 +1216,8 @@ static int names_netdevsim(sd_device *dev, const char *prefix, bool test) {
+         if (isempty(phys_port_name))
+                 return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                               "The 'phys_port_name' attribute is empty.");
++        if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
++                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
+ 
+         char str[ALTIFNAMSIZ];
+         if (snprintf_ok(str, sizeof str, "%si%un%s", prefix, addr, phys_port_name))
+diff --git a/src/udev/v4l_id/v4l_id.c b/src/udev/v4l_id/v4l_id.c
+index 30527e9..2ec96d8 100644
+--- a/src/udev/v4l_id/v4l_id.c
++++ b/src/udev/v4l_id/v4l_id.c
+@@ -29,6 +29,8 @@
+ #include "build.h"
+ #include "fd-util.h"
+ #include "main-func.h"
++#include "string-util.h"
++#include "utf8.h"
+ 
+ static const char *arg_device = NULL;
+ 
+@@ -82,7 +84,8 @@ static int run(int argc, char *argv[]) {
+                 int capabilities;
+ 
+                 printf("ID_V4L_VERSION=2\n");
+-                printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
++                if (utf8_is_valid((char *)v2cap.card) && !string_has_cc((char *)v2cap.card, /* ok= */ NULL))
++                        printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
+                 printf("ID_V4L_CAPABILITIES=:");
+ 
+                 if (v2cap.capabilities & V4L2_CAP_DEVICE_CAPS)
+-- 
+2.43.0
+

--- a/SPECS/systemd/CVE-2026-40225.patch
+++ b/SPECS/systemd/CVE-2026-40225.patch
@@ -8,16 +8,6 @@ Subject: [PATCH] udev: check for invalid chars in various fields received from
 (cherry picked from commit 3513862eabe9ec4a6a095d7266e98f998f289ed2)
 (cherry picked from commit c20d21e0da293e715db468f9f4a15a5c8fbf8273)
 
-From 5887e72ff87d3a66a4c3fa91897fbec1545f4d3d Mon Sep 17 00:00:00 2001
-From: Luca Boccassi <luca.boccassi@gmail.com>
-Date: Fri, 13 Mar 2026 11:10:47 +0000
-Subject: [PATCH] udev: fix review mixup
-
-The previous version in the PR changed variable and sanitized it
-in place. The second version switched to skip if CCs are in the
-string instead, but didn't move back to the original variable.
-Because it's an existing variable, no CI caught it.
-
 Upstream Patch reference:
 1. https://github.com/systemd/systemd/commit/03bb697b8df0339c37f4b845025320b261aeb7cc.patch
 2. https://github.com/systemd/systemd/commit/5887e72ff87d3a66a4c3fa91897fbec1545f4d3d.patch

--- a/SPECS/systemd/CVE-2026-40226.patch
+++ b/SPECS/systemd/CVE-2026-40226.patch
@@ -1,0 +1,91 @@
+From 773fd3b6e72e6c83cbb1cfc1cb20f3793db8649a Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@gmail.com>
+Date: Wed, 11 Mar 2026 12:15:26 +0000
+Subject: [PATCH] nspawn: apply BindUser/Ephemeral from settings file only if
+ trusted
+
+Originally reported on yeswehack.com as:
+YWH-PGM9780-116
+
+Follow-up for 2f8930449079403b26c9164b8eeac78d5af2c8df
+Follow-up for a2f577fca0be79b23f61f033229b64884e7d840a
+
+(cherry picked from commit 61bceb1bff4b1f9c126b18dc971ca3e6d8c71c40)
+(cherry picked from commit 718711ed876c870a72149eea279b819cdab14e91)
+(cherry picked from commit e4db9c12957d315c0ed22c6ca87a816d0927d6dc)
+
+From bfa0a842822c4f79da9d47f8a773fd128d8f8a0a Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@gmail.com>
+Date: Wed, 11 Mar 2026 13:27:14 +0000
+Subject: [PATCH] nspawn: normalize pivot_root paths
+
+Originally reported on yeswehack.com as:
+YWH-PGM9780-116
+
+Follow-up for b53ede699cdc5233041a22591f18863fb3fe2672
+
+(cherry picked from commit 7b85f5498a958e5bb660c703b8f4a71cceed3373)
+(cherry picked from commit 6566dc1451089e07090f5a114ae2eb43ed39188d)
+(cherry picked from commit 1c55a0a5e26a07df828f72092ad1203e221b60db)
+
+Upstream Patch references:
+1. https://github.com/systemd/systemd/commit/773fd3b6e72e6c83cbb1cfc1cb20f3793db8649a.patch
+2. https://github.com/systemd/systemd/commit/bfa0a842822c4f79da9d47f8a773fd128d8f8a0a.patch
+---
+ src/nspawn/nspawn-mount.c |  4 +++-
+ src/nspawn/nspawn.c       | 18 ++++++++++++++----
+ 2 files changed, 17 insertions(+), 5 deletions(-)
+
+diff --git a/src/nspawn/nspawn-mount.c b/src/nspawn/nspawn-mount.c
+index 470f477..09c442a 100644
+--- a/src/nspawn/nspawn-mount.c
++++ b/src/nspawn/nspawn-mount.c
+@@ -1255,7 +1255,9 @@ int pivot_root_parse(char **pivot_root_new, char **pivot_root_old, const char *s
+ 
+         if (!path_is_absolute(root_new))
+                 return -EINVAL;
+-        if (root_old && !path_is_absolute(root_old))
++        if (!path_is_normalized(root_new))
++                return -EINVAL;
++        if (root_old && (!path_is_absolute(root_old) || !path_is_normalized(root_old)))
+                 return -EINVAL;
+ 
+         free_and_replace(*pivot_root_new, root_new);
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 8ac86ee..dee343b 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -4263,8 +4263,13 @@ static int merge_settings(Settings *settings, const char *path) {
+         }
+ 
+         if ((arg_settings_mask & SETTING_EPHEMERAL) == 0 &&
+-            settings->ephemeral >= 0)
+-                arg_ephemeral = settings->ephemeral;
++            settings->ephemeral >= 0) {
++
++                if (!arg_settings_trusted)
++                        log_warning("Ignoring ephemeral setting, file %s is not trusted.", path);
++                else
++                        arg_ephemeral = settings->ephemeral;
++        }
+ 
+         if ((arg_settings_mask & SETTING_DIRECTORY) == 0 &&
+             settings->root) {
+@@ -4432,8 +4437,13 @@ static int merge_settings(Settings *settings, const char *path) {
+         }
+ 
+         if ((arg_settings_mask & SETTING_BIND_USER) == 0 &&
+-            !strv_isempty(settings->bind_user))
+-                strv_free_and_replace(arg_bind_user, settings->bind_user);
++            !strv_isempty(settings->bind_user)) {
++
++                if (!arg_settings_trusted)
++                        log_warning("Ignoring bind user setting, file %s is not trusted.", path);
++                else
++                        strv_free_and_replace(arg_bind_user, settings->bind_user);
++        }
+ 
+         if ((arg_settings_mask & SETTING_NOTIFY_READY) == 0 &&
+             settings->notify_ready >= 0)
+-- 
+2.43.0

--- a/SPECS/systemd/CVE-2026-40226.patch
+++ b/SPECS/systemd/CVE-2026-40226.patch
@@ -14,20 +14,6 @@ Follow-up for a2f577fca0be79b23f61f033229b64884e7d840a
 (cherry picked from commit 718711ed876c870a72149eea279b819cdab14e91)
 (cherry picked from commit e4db9c12957d315c0ed22c6ca87a816d0927d6dc)
 
-From bfa0a842822c4f79da9d47f8a773fd128d8f8a0a Mon Sep 17 00:00:00 2001
-From: Luca Boccassi <luca.boccassi@gmail.com>
-Date: Wed, 11 Mar 2026 13:27:14 +0000
-Subject: [PATCH] nspawn: normalize pivot_root paths
-
-Originally reported on yeswehack.com as:
-YWH-PGM9780-116
-
-Follow-up for b53ede699cdc5233041a22591f18863fb3fe2672
-
-(cherry picked from commit 7b85f5498a958e5bb660c703b8f4a71cceed3373)
-(cherry picked from commit 6566dc1451089e07090f5a114ae2eb43ed39188d)
-(cherry picked from commit 1c55a0a5e26a07df828f72092ad1203e221b60db)
-
 Upstream Patch references:
 1. https://github.com/systemd/systemd/commit/773fd3b6e72e6c83cbb1cfc1cb20f3793db8649a.patch
 2. https://github.com/systemd/systemd/commit/bfa0a842822c4f79da9d47f8a773fd128d8f8a0a.patch

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        27%{?dist}
+Release:        28%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -150,6 +150,8 @@ Patch0906:      ipc-call-0003-core-cgroup-avoid-one-unnecessary-strjoina.patch
 Patch0907:      ipc-call-0002-path-util-invert-PATH_STARTSWITH_ACCEPT_DOT_DOT-flag.patch
 Patch0908:      ipc-call-0004-core-validate-input-cgroup-path-more-prudently.patch
 Patch0909:      fix-pcrlock-hyperv-hash-algorithm-ordering.patch
+Patch0910:      CVE-2026-40226.patch
+Patch0911:      CVE-2026-40225.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1235,6 +1237,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Tue Apr 21 2026 Akhila Guruju <v-guakhila@microsoft.com> - 255-28
+- Patch CVE-2026-40226, CVE-2026-40225
+
 * Thu Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
 - Fix pcrlock failure on Hyper-V/Azure VMs with vTPM by backporting upstream
   commit e90a255 from systemd v256 (PR #31429).

--- a/toolkit/resources/manifests/package/license_file_exceptions.json
+++ b/toolkit/resources/manifests/package/license_file_exceptions.json
@@ -52,6 +52,14 @@
             "IgnoredFilesRegexList": [
                 "^/usr/share/doc/libvirt-docs/html/fonts/LICENSE\\.rst$"
             ]
+        },
+        {
+            "_comment1": "SD_NOTICE is a logging-priority macro defined in <systemd/sd-daemon.h> (one of SD_EMERG..SD_DEBUG).",
+            "_comment2": "The man page documents the API macro and is not an actual license/notice file.",
+            "PackageName": "systemd-devel",
+            "IgnoredFilesRegexList": [
+                "^/usr/share/man/man3/SD_NOTICE\\.3\\.gz$"
+            ]
         }
     ],
     "GlobalExceptionsRegexList": [


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch systemd for CVE-2026-40226
GH advisories (https://github.com/systemd/systemd/security/advisories/GHSA-9mj4-rrc3-gjcx) mentioned that these 2 commits will fix the CVE.
Patch reference:
1. [https://github.com/systemd/systemd/commit/773fd3b6e72e6c83cbb1cfc1cb20f3793db8649a.patch](https://github.com/systemd/systemd/commit/773fd3b6e72e6c83cbb1cfc1cb20f3793db8649a.patch)
2. [https://github.com/systemd/systemd/commit/bfa0a842822c4f79da9d47f8a773fd128d8f8a0a.patch](https://github.com/systemd/systemd/commit/bfa0a842822c4f79da9d47f8a773fd128d8f8a0a.patch)

Patch applies cleanly. No backporting is done.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/systemd/CVE-2026-40226.patch
- modified:   SPECS/systemd/systemd.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-40226

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build.
- Patch applies cleanly.
<img width="578" height="93" alt="image" src="https://github.com/user-attachments/assets/c1d10303-53b6-4b17-a988-98744fd5f87a" />

