### PR TITLE
azurelinux-repos: add split/unified repo templates for Alpha2

### DIFF
--- a/base/comps/azurelinux-repos/azurelinux-repos.comp.toml
+++ b/base/comps/azurelinux-repos/azurelinux-repos.comp.toml
@@ -2,4 +2,7 @@
 spec = { type = "local", path = "azurelinux-repos.spec" }
 
 [components.azurelinux-repos.build]
+# Alpha2: use split repo layout with Alpha2 blob prefix.
+with = ["split_repos"]
+defines = { repo_uri_prefix = "https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod" }
 check = { skip = true, skip_reason = "Tests fail due to evergreen repos and any repo from this package is currently unavailable anyway." }

--- a/base/comps/azurelinux-repos/azurelinux-repos.spec
+++ b/base/comps/azurelinux-repos/azurelinux-repos.spec
@@ -1,10 +1,16 @@
 %global evergreen_major 5
 %global evergreen_release %{evergreen_major}.0
 
+# Select between split and unified repo URL layouts.
+# Split: repos are under .../base/{$basearch,debuginfo,srpms} (e.g. release builds).
+# Unified: repos are directly under .../{$basearch,debuginfo,srpms} (e.g. daily builds).
+# Enable with: --with split_repos   (or build.with in comp.toml)
+%bcond split_repos 0
+
 Summary:        Azure Linux package repositories
 Name:           azurelinux-repos
 Version:        4.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -19,8 +25,9 @@ BuildArch:      noarch
 BuildRequires:  gnupg sed rpm
 
 Source1:        archmap
-Source2:        azurelinux.repo
+Source2:        azurelinux-unified.repo.in
 Source3:        azurelinux-evergreen.repo
+Source4:        azurelinux-split.repo.in
 
 Source10:       RPM-GPG-KEY-azurelinux-4.0-primary
 
@@ -94,9 +101,13 @@ popd
 
 # Install repo files
 install -d -m 755 $RPM_BUILD_ROOT/etc/yum.repos.d
-for file in %{_sourcedir}/azurelinux*repo ; do
-  install -m 644 $file $RPM_BUILD_ROOT/etc/yum.repos.d
-done
+install -m 644 %{_sourcedir}/azurelinux-evergreen.repo $RPM_BUILD_ROOT/etc/yum.repos.d/azurelinux-evergreen.repo
+# Select stable repo template based on the split_repos knob.
+%if %{with split_repos}
+install -m 644 %{_sourcedir}/azurelinux-split.repo.in $RPM_BUILD_ROOT/etc/yum.repos.d/azurelinux.repo
+%else
+install -m 644 %{_sourcedir}/azurelinux-unified.repo.in $RPM_BUILD_ROOT/etc/yum.repos.d/azurelinux.repo
+%endif
 
 # Enable or disable repos based on current release cycle state.
 %if "%{evergreen_release}" == "%{version}"
@@ -113,17 +124,20 @@ for repo in $RPM_BUILD_ROOT/etc/yum.repos.d/azurelinux.repo; do
     sed -i "s/^enabled=AUTO_VALUE$/enabled=${stable_enabled}/" $repo || exit 1
 done
 
-# Update BASE_REPO_URI in azurelinux.repo; compute based on dist tag.
-# Extract an 8-digit date stamp from %%dist.
-# Handles both dotted forms (e.g. ".azl4~bootstrap.20260303") and tilde-only forms (e.g. ".azl4~20260412").
-# If no 8-digit date is found, fall back to a hard-coded URI.
-date_segment=$(echo '%{dist}' | grep -oE '[0-9]{8}')
+# Compute REPO_URI_PREFIX for the stable repo file.
+# If repo_uri_prefix macro is explicitly set, use it directly.
+# Otherwise, auto-compute from %%dist date stamp (daily-build default).
+%if 0%{?repo_uri_prefix:1}
+repo_uri_prefix='%{repo_uri_prefix}'
+%else
+date_segment=$(echo '%{dist}' | grep -oE '[0-9]{8}' || true)
 if [ -n "$date_segment" ]; then
-    base_repo_uri="https://stcontroltowerdevjwisitg.blob.core.windows.net/daily-repo-dev/${date_segment}"
+    repo_uri_prefix="https://stcontroltowerdevjwisitg.blob.core.windows.net/daily-repo-dev/${date_segment}"
 else
-    base_repo_uri='https://packages.microsoft.com/azurelinux/$releasever/prod/base'
+    repo_uri_prefix='https://packages.microsoft.com/azurelinux/$releasever/prod/base'
 fi
-sed -i "s|BASE_REPO_URI|${base_repo_uri}|" $RPM_BUILD_ROOT/etc/yum.repos.d/azurelinux.repo
+%endif
+sed -i "s|REPO_URI_PREFIX|${repo_uri_prefix}|" $RPM_BUILD_ROOT/etc/yum.repos.d/azurelinux.repo
 
 # Adjust Evergreen repo files to include Evergreen+1 GPG key.
 # This is necessary for the period when Evergreen gets bumped to N+1 and packages
@@ -150,7 +164,7 @@ done
 %check
 # Make sure all repo variables were substituted
 for repo in $RPM_BUILD_ROOT/etc/yum.repos.d/*.repo; do
-    if grep -q AUTO_VALUE $repo; then
+    if grep -qE 'AUTO_VALUE|REPO_URI_PREFIX' $repo; then
         echo "ERROR: Repo $repo contains an unsubstituted placeholder value"
         exit 1
     fi
@@ -259,6 +273,13 @@ rm -f "$TMPRING"
 
 
 %changelog
+* Tue Apr 21 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-6
+- Consolidate repo templates: azurelinux-unified.repo.in and azurelinux-split.repo.in.
+- Add split_repos bcond to select between unified and split URL layouts.
+- Add repo_uri_prefix macro to override the auto-computed repo URI prefix.
+- Only one azurelinux.repo file ships, selected by split_repos at build time.
+- Fix dist tag date extraction to tolerate missing date (grep || true).
+
 * Mon Apr 13 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-5
 - Fix dist tag date extraction to handle tilde-only forms (e.g. ".azl4~20260412").
 

--- a/base/comps/azurelinux-repos/azurelinux-split.repo.in
+++ b/base/comps/azurelinux-repos/azurelinux-split.repo.in
@@ -1,6 +1,6 @@
-[azurelinux]
+[azurelinux-base]
 name=Azure Linux $releasever - $basearch
-baseurl=BASE_REPO_URI/$basearch
+baseurl=REPO_URI_PREFIX/base/$basearch
 enabled=AUTO_VALUE
 countme=1
 metadata_expire=AUTO_VALUE
@@ -10,9 +10,9 @@ gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
 skip_if_unavailable=True
 
-[azurelinux-debuginfo]
+[azurelinux-base-debuginfo]
 name=Azure Linux $releasever - $basearch - Debug
-baseurl=BASE_REPO_URI/debuginfo/$basearch
+baseurl=REPO_URI_PREFIX/base/debuginfo/$basearch
 enabled=0
 metadata_expire=AUTO_VALUE
 repo_gpgcheck=0
@@ -21,9 +21,9 @@ gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
 skip_if_unavailable=True
 
-[azurelinux-source]
+[azurelinux-base-source]
 name=Azure Linux $releasever - Source
-baseurl=BASE_REPO_URI/srpms
+baseurl=REPO_URI_PREFIX/base/srpms
 enabled=0
 metadata_expire=AUTO_VALUE
 repo_gpgcheck=0

--- a/base/comps/azurelinux-repos/azurelinux-unified.repo.in
+++ b/base/comps/azurelinux-repos/azurelinux-unified.repo.in
@@ -1,0 +1,33 @@
+[azurelinux]
+name=Azure Linux $releasever - $basearch
+baseurl=REPO_URI_PREFIX/$basearch
+enabled=AUTO_VALUE
+countme=1
+metadata_expire=AUTO_VALUE
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
+skip_if_unavailable=True
+
+[azurelinux-debuginfo]
+name=Azure Linux $releasever - $basearch - Debug
+baseurl=REPO_URI_PREFIX/debuginfo/$basearch
+enabled=0
+metadata_expire=AUTO_VALUE
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
+skip_if_unavailable=True
+
+[azurelinux-source]
+name=Azure Linux $releasever - Source
+baseurl=REPO_URI_PREFIX/srpms
+enabled=0
+metadata_expire=AUTO_VALUE
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
+skip_if_unavailable=True


### PR DESCRIPTION
## Overview

The primary goal for this PR is to update `azurelinux-repos` to reflect the paths to which Alpha2 RPMs will be published, and to update for the `base` vs. `sdk` split. Notes:

* Builds with this version of the `azurelinux-repo` package will be locked to the Alpha2 RPMs that aren't yet published. This is an intentional decision until Alpha2 is complete. Once Alpha2 has released, we will update this component back to daily builds.
* It is intentional *not* to include `sdk` repos, even though they are required.

## Resulting .repo file

This results in the following contents for `/etc/yum.repos.d/azurelinux.repo`:

```
[azurelinux-base]
name=Azure Linux $releasever - $basearch
baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch
enabled=1
countme=1
metadata_expire=7d
repo_gpgcheck=0
type=rpm
gpgcheck=0
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
skip_if_unavailable=True

[azurelinux-base-debuginfo]
name=Azure Linux $releasever - $basearch - Debug
baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/debuginfo/$basearch
enabled=0
metadata_expire=7d
repo_gpgcheck=0
type=rpm
gpgcheck=0
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
skip_if_unavailable=True

[azurelinux-base-source]
name=Azure Linux $releasever - Source
baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/srpms
enabled=0
metadata_expire=7d
repo_gpgcheck=0
type=rpm
gpgcheck=0
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
skip_if_unavailable=True
```

## Validation

* Local build via `azldev` + `rpm2cpio` to inspect contents (see above)
* Scratch build against Alpha2 tag.

## Implementation Details

Introduce two repo URL layout templates, selectable at build time:

- azurelinux-unified.repo.in: flat layout (REPO_URI_PREFIX/{arch,debuginfo,srpms}) Used for daily builds; auto-computes prefix from %dist date stamp.
- azurelinux-split.repo.in: split layout (REPO_URI_PREFIX/base/{arch,debuginfo,srpms}) Used for release builds (e.g. Alpha2).

Two orthogonal knobs control the output:
- %bcond split_repos: selects which template ships as azurelinux.repo
- repo_uri_prefix macro: overrides the auto-computed URI prefix

Only one azurelinux.repo file is included in the package; the stable/evergreen toggle logic is unchanged and applies to whichever template is selected.

For Alpha2, comp.toml sets:

```toml
with = ["split_repos"]
defines = { repo_uri_prefix = "https://...alpha2-prod" }
```