### PR TITLE
[Medium] Patch Python-virtualenv for CVE-2026-3219

### DIFF
--- a/SPECS/python-virtualenv/CVE-2026-3219v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-3219v0.patch
@@ -1,0 +1,87 @@
+From 9b08c2b910fc9ec45a0c1b6cc041a934dfecd1b7 Mon Sep 17 00:00:00 2001
+From: Dmitrii Sutiagin <f3flight@gmail.com>
+Date: Thu, 26 Mar 2026 09:37:36 -0700
+Subject: [PATCH] Fix ambiguous archive detection in unpack_file
+
+Upstream Patch Reference: https://github.com/pypa/pip/pull/13870.patch
+
+---
+ pip/_internal/utils/unpacking.py | 49 ++++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 34 insertions(+), 15 deletions(-)
+
+diff --git a/pip/_internal/utils/unpacking.py b/pip/_internal/utils/unpacking.py
+index bc950ac..1234567 100644
+--- a/pip/_internal/utils/unpacking.py
++++ b/pip/_internal/utils/unpacking.py
+@@ -311,27 +311,47 @@
+     location: str,
+     content_type: Optional[str] = None,
+ ) -> None:
++    """Unpack ``filename`` into ``location``.
++
++    Archive format is chosen in order of decreasing reliability:
++    ``content_type``, then filename extension, then magic signature
++    (unambiguous matches only).
++    """
+     filename = os.path.realpath(filename)
+-    if (
+-        content_type == "application/zip"
+-        or filename.lower().endswith(ZIP_EXTENSIONS)
+-        or zipfile.is_zipfile(filename)
+-    ):
+-        unzip_file(filename, location, flatten=not filename.endswith(".whl"))
+-    elif (
+-        content_type == "application/x-gzip"
+-        or tarfile.is_tarfile(filename)
+-        or filename.lower().endswith(TAR_EXTENSIONS + BZ2_EXTENSIONS + XZ_EXTENSIONS)
+-    ):
++    zip_flatten = not filename.endswith(".whl")
++
++    def _unzip() -> None:
++        unzip_file(filename, location, flatten=zip_flatten)
++
++    def _untar() -> None:
+         untar_file(filename, location)
+-    else:
+-        # FIXME: handle?
+-        # FIXME: magic signatures?
+-        logger.critical(
+-            "Cannot unpack file %s (downloaded from %s, content-type: %s); "
+-            "cannot detect archive format",
+-            filename,
+-            location,
+-            content_type,
+-        )
+-        raise InstallationError(f"Cannot determine archive format of {location}")
++
++    if content_type == "application/zip":
++        return _unzip()
++    if content_type == "application/x-gzip":
++        return _untar()
++
++    if filename.lower().endswith(ZIP_EXTENSIONS):
++        return _unzip()
++    if filename.lower().endswith(TAR_EXTENSIONS + BZ2_EXTENSIONS + XZ_EXTENSIONS):
++        return _untar()
++
++    # avoid ambiguous case where both signature checks return True
++    is_zipfile = zipfile.is_zipfile(filename)
++    is_tarfile = tarfile.is_tarfile(filename)
++    if is_zipfile and not is_tarfile:
++        return _unzip()
++    if is_tarfile and not is_zipfile:
++        return _untar()
++
++    if is_zipfile and is_tarfile:
++        logger.error("Ambiguous file signature in %s.", filename)
++
++    logger.critical(
++        "Cannot unpack file %s (downloaded from %s, content-type: %s); "
++        "cannot detect archive format",
++        filename,
++        location,
++        content_type,
++    )
++    raise InstallationError(f"Cannot determine archive format of {location}")
+-- 
+2.45.4

--- a/SPECS/python-virtualenv/CVE-2026-3219v1.patch
+++ b/SPECS/python-virtualenv/CVE-2026-3219v1.patch
@@ -1,0 +1,87 @@
+From 9b08c2b910fc9ec45a0c1b6cc041a934dfecd1b7 Mon Sep 17 00:00:00 2001
+From: Dmitrii Sutiagin <f3flight@gmail.com>
+Date: Thu, 26 Mar 2026 09:37:36 -0700
+Subject: [PATCH] Fix ambiguous archive detection in unpack_file
+
+Upstream Patch Reference: https://github.com/pypa/pip/pull/13870.patch
+
+---
+ pip/_internal/utils/unpacking.py | 49 ++++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 34 insertions(+), 15 deletions(-)
+
+diff --git a/pip/_internal/utils/unpacking.py b/pip/_internal/utils/unpacking.py
+index bc950ac..1234568 100644
+--- a/pip/_internal/utils/unpacking.py
++++ b/pip/_internal/utils/unpacking.py
+@@ -336,27 +336,47 @@
+     location: str,
+     content_type: str | None = None,
+ ) -> None:
++    """Unpack ``filename`` into ``location``.
++
++    Archive format is chosen in order of decreasing reliability:
++    ``content_type``, then filename extension, then magic signature
++    (unambiguous matches only).
++    """
+     filename = os.path.realpath(filename)
+-    if (
+-        content_type == "application/zip"
+-        or filename.lower().endswith(ZIP_EXTENSIONS)
+-        or zipfile.is_zipfile(filename)
+-    ):
+-        unzip_file(filename, location, flatten=not filename.endswith(".whl"))
+-    elif (
+-        content_type == "application/x-gzip"
+-        or tarfile.is_tarfile(filename)
+-        or filename.lower().endswith(TAR_EXTENSIONS + BZ2_EXTENSIONS + XZ_EXTENSIONS)
+-    ):
++    zip_flatten = not filename.endswith(".whl")
++
++    def _unzip() -> None:
++        unzip_file(filename, location, flatten=zip_flatten)
++
++    def _untar() -> None:
+         untar_file(filename, location)
+-    else:
+-        # FIXME: handle?
+-        # FIXME: magic signatures?
+-        logger.critical(
+-            "Cannot unpack file %s (downloaded from %s, content-type: %s); "
+-            "cannot detect archive format",
+-            filename,
+-            location,
+-            content_type,
+-        )
+-        raise InstallationError(f"Cannot determine archive format of {location}")
++
++    if content_type == "application/zip":
++        return _unzip()
++    if content_type == "application/x-gzip":
++        return _untar()
++
++    if filename.lower().endswith(ZIP_EXTENSIONS):
++        return _unzip()
++    if filename.lower().endswith(TAR_EXTENSIONS + BZ2_EXTENSIONS + XZ_EXTENSIONS):
++        return _untar()
++
++    # avoid ambiguous case where both signature checks return True
++    is_zipfile = zipfile.is_zipfile(filename)
++    is_tarfile = tarfile.is_tarfile(filename)
++    if is_zipfile and not is_tarfile:
++        return _unzip()
++    if is_tarfile and not is_zipfile:
++        return _untar()
++
++    if is_zipfile and is_tarfile:
++        logger.error("Ambiguous file signature in %s.", filename)
++
++    logger.critical(
++        "Cannot unpack file %s (downloaded from %s, content-type: %s); "
++        "cannot detect archive format",
++        filename,
++        location,
++        content_type,
++    )
++    raise InstallationError(f"Cannot determine archive format of {location}")
+-- 
+2.45.4

--- a/SPECS/python-virtualenv/python-virtualenv.spec
+++ b/SPECS/python-virtualenv/python-virtualenv.spec
@@ -1,7 +1,7 @@
 Summary:        Virtual Python Environment builder
 Name:           python-virtualenv
 Version:        20.36.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -14,6 +14,8 @@ Patch1001:      CVE-2026-1703v0.patch
 Patch1002:      CVE-2026-1703v1.patch
 Patch1003:      CVE-2026-24049v0.patch
 Patch1004:      CVE-2026-24049v1.patch
+Patch1005:      CVE-2026-3219v0.patch
+Patch1006:      CVE-2026-3219v1.patch
 BuildArch:      noarch
 
 %description
@@ -114,6 +116,28 @@ zip -r ../src/virtualenv/seed/wheels/embed/unpacked_wheel-0.45.1-py3-none-any.wh
 popd
 rm -rf unpacked_wheel-0.45.1-py3-none-any
 
+# Manual patching for CVE-2026-3219v0
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+mkdir -p unpacked_pip-25.0.1-py3-none-any_3219
+unzip src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl -d unpacked_pip-25.0.1-py3-none-any_3219
+patch -p1 -d unpacked_pip-25.0.1-py3-none-any_3219 < %{PATCH1005}
+rm -f src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl
+pushd unpacked_pip-25.0.1-py3-none-any_3219
+zip -r ../src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl *
+popd
+rm -rf unpacked_pip-25.0.1-py3-none-any_3219
+
+# Manual patching for CVE-2026-3219v1
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+mkdir -p unpacked_pip-25.3-py3-none-any_3219
+unzip src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl -d unpacked_pip-25.3-py3-none-any_3219
+patch -p1 -d unpacked_pip-25.3-py3-none-any_3219 < %{PATCH1006}
+rm -f src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl
+pushd unpacked_pip-25.3-py3-none-any_3219
+zip -r ../src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl *
+popd
+rm -rf unpacked_pip-25.3-py3-none-any_3219
+
 
 %generate_buildrequires
 
@@ -136,6 +160,9 @@ tox -e py
 %{_bindir}/virtualenv
 
 %changelog
+* Thu Apr 23 2026 Akarsh Chaudhary <v-akarshc@microsoft.com>- 20.36.1-3
+- Patch for CVE-2026-3219
+
 * Mon Feb 23 2026 BinduSri Adabala <v-badabala@microsoft.com> - 20.36.1-2
 - Patch for CVE-2025-50181, CVE-2026-24049 and CVE-2026-1703
 

--- a/SPECS/python-virtualenv/python-virtualenv.spec
+++ b/SPECS/python-virtualenv/python-virtualenv.spec
@@ -60,6 +60,8 @@ unzip src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl -d unpacked_p
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1000}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py"
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1001}
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1005}
 # Remove the original file
 rm -f src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl
 # After patching, re-zip the contents back into a .whl
@@ -75,6 +77,8 @@ unzip src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl -d unpacked_pip
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1000}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py"
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1002}
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1006}
 rm -f src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl
 pushd unpacked_pip-25.3-py3-none-any
 zip -r ../src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl *
@@ -115,29 +119,6 @@ pushd unpacked_wheel-0.45.1-py3-none-any
 zip -r ../src/virtualenv/seed/wheels/embed/unpacked_wheel-0.45.1-py3-none-any.whl *
 popd
 rm -rf unpacked_wheel-0.45.1-py3-none-any
-
-# Manual patching for CVE-2026-3219v0
-echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
-mkdir -p unpacked_pip-25.0.1-py3-none-any_3219
-unzip src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl -d unpacked_pip-25.0.1-py3-none-any_3219
-patch -p1 -d unpacked_pip-25.0.1-py3-none-any_3219 < %{PATCH1005}
-rm -f src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl
-pushd unpacked_pip-25.0.1-py3-none-any_3219
-zip -r ../src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl *
-popd
-rm -rf unpacked_pip-25.0.1-py3-none-any_3219
-
-# Manual patching for CVE-2026-3219v1
-echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
-mkdir -p unpacked_pip-25.3-py3-none-any_3219
-unzip src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl -d unpacked_pip-25.3-py3-none-any_3219
-patch -p1 -d unpacked_pip-25.3-py3-none-any_3219 < %{PATCH1006}
-rm -f src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl
-pushd unpacked_pip-25.3-py3-none-any_3219
-zip -r ../src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl *
-popd
-rm -rf unpacked_pip-25.3-py3-none-any_3219
-
 
 %generate_buildrequires
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch python-virtualenv for CVE-2026-3219.
Upstream Patch Link-https://github.com/pypa/pip/pull/13870.patch

### CVE-2026-3219 - Manual patching

CVE-2026-3219 affects pip’s archive handling logic in `unpacking.py`, where pip may incorrectly detect archive formats when a file can be interpreted as both ZIP and tar.  

This ambiguity can lead to incorrect extraction behavior and unintended file installation, as pip previously treated such cases as ZIP archives regardless of content or filename.

The fix ensures that archive extraction only proceeds when the format is **unambiguous and correctly identified**.

---

### Affected files

These files are embedded inside `.whl` archives within the source tarball: with different versions of pip hence we need to create two different patches for both affected files.

- **virtualenv-20.36.1.tar.gz**
  - `src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py`
  - `src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py`

---

### Notes

- Files are packaged inside Python wheel (`.whl`) archives  
- Require:
  - Unpacking  
  - Applying patch  
  - Re-packaging during build
  - 
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/python-virtualenv/CVE-2026-3219v0.patch
- SPECS/python-virtualenv/CVE-2026-3219v1.patch
- SPECS/python-virtualenv/python-virtualenv.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-3219

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Screenshot of successful build-
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/4750e921-d5fa-4471-9258-cca6209aa417" />

