### PR TITLE
fix: change containers to use azurelinux-release-container instead of system-release

### DIFF
--- a/base/images/container-base/container-base.kiwi
+++ b/base/images/container-base/container-base.kiwi
@@ -39,7 +39,7 @@
     <packages type="image" profiles="core">
         <package name="filesystem" />
         <package name="bash" />
-        <package name="system-release" />
+        <package name="azurelinux-release-container" />
     </packages>
 
     <!-- For distroless profiles ALL packages that should be included in
@@ -47,7 +47,7 @@
          Packages from bootstrap may be removed by config.sh. -->
     <packages type="image" profiles="distroless-minimal">
         <package name="filesystem" />
-        <package name="system-release" />
+        <package name="azurelinux-release-container" />
         <package name="tzdata" />
     </packages>
 
@@ -64,7 +64,7 @@
 
     <packages type="bootstrap" profiles="core,distroless-minimal">
         <package name="filesystem" />
-        <package name="system-release" />
+        <package name="azurelinux-release-container" />
     </packages>
 
     <packages type="bootstrap" profiles="distroless-minimal">


### PR DESCRIPTION
Instead of using the generic system-release (meta)package, containers should use the azurelinux-release-container package, which brings in container-specific settings including container-specific values in the /etc/os-release file.

Fixes: [AB#19090](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19090)
