### PR TITLE
chore: Convert per-component snapshots into commits

### DIFF
--- a/base/comps/java-25-openjdk-portable/java-25-openjdk-portable.comp.toml
+++ b/base/comps/java-25-openjdk-portable/java-25-openjdk-portable.comp.toml
@@ -5,10 +5,10 @@
 #
 # The second workaround is to deliver the appropriate minor version of java portable.
 # Java 25 sdk needs 25.0.0.0.32 version of the -sources as a build requires. We pull
-# from the last snapshot of the spec at that version. 
+# from the last snapshot of the spec at that version.
 
 [components.java-25-openjdk-portable]
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-07-22T00:00:00-08:00" } }
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "cad9d5a1ed48cf7e9e12cfadfdacc11f523d46cb" }
 
 [[components.java-25-openjdk-portable.overlays]]
 description = "Override buildjdkver to use Java 25 instead of 24 for bootstrap"

--- a/base/comps/java-25-openjdk/java-25-openjdk.comp.toml
+++ b/base/comps/java-25-openjdk/java-25-openjdk.comp.toml
@@ -1,5 +1,5 @@
 [components.java-25-openjdk]
 # Current java-25 build requires java-25-openjdk-portable-sources version 25.0.20.0.10.
 # Fed43 portable rpm delivers 25.0.0.0.32. Fedora43 builds work with Fed42 rpm. To
-# unbock our build, we pull the last Fedora 43 snapshot when version was 25.0.0.0.32. 
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-07-30T00:00:00-08:00" } }
+# unblock our build, we pin to the last Fedora 43 commit when version was 25.0.0.0.32.
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "6011214a0e0e5c6302d0d59b6e8805d049749420" }

--- a/base/comps/lilv/lilv.comp.toml
+++ b/base/comps/lilv/lilv.comp.toml
@@ -1,4 +1,4 @@
 [components.lilv]
-# Pin to a Fedora 43 snapshot that predates the lilv 0.26.x update, which requires sord >= 0.16.20.
-# The build tag currently has sord 0.16.18. Remove the snapshot once sord is updated to >= 0.16.20.
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-06-01T00:00:00-08:00" } }
+# Pin to a Fedora 43 commit that predates the lilv 0.26.x update, which requires sord >= 0.16.20.
+# The build tag currently has sord 0.16.18. Remove the pin once sord is updated to >= 0.16.20.
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "af7aeb0a17c70fe0d4e4045943bfa275dacfa141" }

--- a/base/comps/python-jaraco-context/python-jaraco-context.comp.toml
+++ b/base/comps/python-jaraco-context/python-jaraco-context.comp.toml
@@ -1,6 +1,6 @@
 [components.python-jaraco-context]
-# TODO: Remove snapshot pin once python-coherent-licensed lands in F43 stable (or F44+ is adopted).
-# Pin snapshot to before the broken 6.0.2/6.1.0 updates were pushed to the f43 branch.
+# TODO: Remove upstream-commit pin once python-coherent-licensed lands in F43 stable (or F44+ is adopted).
+# Pin to commit before the broken 6.0.2/6.1.0 updates were pushed to the f43 branch.
 # These updates added a dynamic BuildRequires on python-coherent-licensed, which was never
 # shipped in F43 stable (the Fedora Koji build was trashcanned and the Bodhi update abandoned).
 # The last good f43 version is 6.0.1-9.fc43.
@@ -8,4 +8,4 @@
 #   https://packages.fedoraproject.org/pkgs/python-jaraco-context/python3-jaraco-context/
 #   https://koji.fedoraproject.org/koji/buildinfo?buildID=2919309 (coherent-licensed trashcanned)
 #   https://src.fedoraproject.org/rpms/python-jaraco-context/tree/f43
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2026-01-05T00:00:00Z" } }
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "828a76324409d043e3236220a62bdd21a99107cb" }

--- a/base/comps/shim-unsigned-aarch64/shim-unsigned-aarch64.comp.toml
+++ b/base/comps/shim-unsigned-aarch64/shim-unsigned-aarch64.comp.toml
@@ -1,5 +1,5 @@
 [components.shim-unsigned-aarch64]
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-06-01T00:00:00-08:00" } }
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "67c1d520f9a8080f6b689714099f813f23154c8f" }
 
 overlays = [
     # Workaround: add dist tag to the release to avoid NEVR conflicts

--- a/base/comps/shim-unsigned-x64/shim-unsigned-x64.comp.toml
+++ b/base/comps/shim-unsigned-x64/shim-unsigned-x64.comp.toml
@@ -1,5 +1,5 @@
 [components.shim-unsigned-x64]
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-06-01T00:00:00-08:00" } }
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "bacb81905ea6806b97b968527e5ca9b2e3f0f7b4" }
 
 overlays = [
     # Workaround: add dist tag to the release to avoid NEVR conflicts

--- a/base/comps/shim/shim.comp.toml
+++ b/base/comps/shim/shim.comp.toml
@@ -1,5 +1,5 @@
 [components.shim]
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-06-01T00:00:00-08:00" } }
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "7b08c421ed4dbca88af0cbaabb73332d08944c86" }
 
 overlays = [
   # TEMPORARILY force dist tag to be present in release to avoid NEVR conflicts


### PR DESCRIPTION
`azldev` will soon start enforcing timestamps only occur at the global or group level, never at the component level. This converts the current timestamps into their effective commits (using the same logic as the build process uses).