### PR TITLE
Minor no-op changes to vm-base kiwi definition

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -130,10 +130,4 @@
         <package name="shim" arch="x86_64" />
         <package name="shim" arch="aarch64" />
     </packages>
-
-    <!--
-    <users>
-        <user name="root" password="INSERT-PASSWORD-HERE" groups="root" />
-    </users>
-    -->
 </image>

--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -28,9 +28,6 @@
             rootfs_label="azurelinux">
             <bootloader name="grub2" timeout="0" />
             <size unit="G">5</size>
-            <initrd action="setup">
-                <dracut uefi="false"/>
-            </initrd>
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>


### PR DESCRIPTION
Remove commented-out <user> element and unneeded <initrd> dracut element. This should be a no-op, with no change to generated image.