### PR TITLE
rust: Add wasm32-wasip1 std support in subpackage

### DIFF
--- a/SPECS/rust/CC0-1.0.txt
+++ b/SPECS/rust/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/SPECS/rust/rust.signatures.json
+++ b/SPECS/rust/rust.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "CC0-1.0.txt": "a2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499",
   "cargo-1.89.0-aarch64-unknown-linux-gnu.tar.xz": "f9df3ee6d55a2387459b843477743fa386c3c0f126bd0be01691ee49309681b8",
   "cargo-1.89.0-x86_64-unknown-linux-gnu.tar.xz": "99fc10be2aeedf2c23a484f217bfa76458494495a0eee33e280d3616bb08282d",
   "rust-std-1.89.0-aarch64-unknown-linux-gnu.tar.xz": "abea0955dded88c68d731524ab9d29b162fae23bf5805b9f1dec063cba37c2aa",

--- a/SPECS/rust/rust.signatures.json
+++ b/SPECS/rust/rust.signatures.json
@@ -7,6 +7,8 @@
   "rustc-1.89.0-aarch64-unknown-linux-gnu.tar.xz": "16ed8d8c7628a481c8501e7cd1022a123269b297bdedbb7f211f37a15e937e0e",
   "rustc-1.89.0-x86_64-unknown-linux-gnu.tar.xz": "b42c254e1349df86bd40bc28fdf386172a1a46f2eeabe3c7a08a75cf1fb60e27",
   "rustc-1.90.0-src-cargo.tar.gz": "72f6a52e8c4df6047b51bea1e6231faf7ff43a0cedddad6a91e14f9a6f924c17",
-  "rustc-1.90.0-src.tar.xz": "6bfeaddd90ffda2f063492b092bfed925c4b8c701579baf4b1316e021470daac"
+  "rustc-1.90.0-src.tar.xz": "6bfeaddd90ffda2f063492b092bfed925c4b8c701579baf4b1316e021470daac",
+  "wasi-libc-2fc32bc81b9f07f8d9525edea59bfbaf760c06d6.tar.gz": "d12a1568d9394e693e6b189277ba70446f96b81a4790c515427865a0d5412372",
+  "wasi-sysroot-32.0.tar.gz": "f2537f6e5804f7f24e32dd140e9371e9670a9fd2646b6a813ddb896b29954b12"
  }
 }

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -5,11 +5,14 @@
 # Look for "date:" and "rustc:".
 %define release_date 2025-08-07
 %define stage0_version 1.89.0
+%global wasi_sdk_release 32
+%global wasi_sdk_version 32.0
+%global wasi_libc_commit 2fc32bc81b9f07f8d9525edea59bfbaf760c06d6
 
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.90.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -41,6 +44,9 @@ Source4:        https://static.rust-lang.org/dist/%{release_date}/rust-std-%{sta
 Source5:        https://static.rust-lang.org/dist/%{release_date}/cargo-%{stage0_version}-aarch64-unknown-linux-gnu.tar.xz
 Source6:        https://static.rust-lang.org/dist/%{release_date}/rustc-%{stage0_version}-aarch64-unknown-linux-gnu.tar.xz
 Source7:        https://static.rust-lang.org/dist/%{release_date}/rust-std-%{stage0_version}-aarch64-unknown-linux-gnu.tar.xz
+Source8:        https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-%{wasi_sdk_release}/wasi-sysroot-%{wasi_sdk_version}.tar.gz
+Source9:        https://github.com/WebAssembly/wasi-libc/archive/%{wasi_libc_commit}/wasi-libc-%{wasi_libc_commit}.tar.gz
+Source10:       CC0-1.0.txt
 Patch0:         CVE-2025-4574.patch
 Patch1:         CVE-2025-53605.patch
 Patch2:         CVE-2024-11738.patch
@@ -93,6 +99,14 @@ BuildArch:      noarch
 %description doc
 Documentation package for Rust.
 
+%package std-wasm32-wasip1
+Summary:        Rust standard library for the wasm32-wasip1 target.
+License:        (Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-3.0 AND CC0-1.0
+Requires:       rust%{?_isa} = %{version}-%{release}
+
+%description std-wasm32-wasip1
+Rust standard library and self-contained WASI runtime files for the wasm32-wasip1 target.
+
 %prep
 # Setup .cargo directory
 mkdir -p $HOME
@@ -115,6 +129,11 @@ cp %{SOURCE6} "$BUILD_CACHE_DIR"
 cp %{SOURCE7} "$BUILD_CACHE_DIR"
 %endif
 
+mkdir -p wasi-root
+tar -xf %{SOURCE8} --strip-components=1 -C wasi-root
+mkdir -p wasi-libc-source
+tar -xf %{SOURCE9} --strip-components=1 -C wasi-libc-source
+
 %build
 # Disable symbol generation
 export CFLAGS="`echo " %{build_cflags} " | sed 's/ -g//'`"
@@ -128,9 +147,17 @@ sh ./configure \
     --release-channel="stable" \
     --release-description="Azure Linux %{version}-%{release}"
 
+cat >> bootstrap.toml <<EOF
+
+[target.wasm32-wasip1]
+wasi-root = "$(pwd)/wasi-root"
+optimized-compiler-builtins = false
+EOF
+
 # SUDO_USER=root bypasses a check in the python bootstrap that
 # makes rust refuse to pull sources from the internet
 USER=root SUDO_USER=root %make_build
+USER=root SUDO_USER=root ./x dist %{?_smp_mflags} rust-std --target wasm32-wasip1
 
 %check
 # We expect to generate dynamic CI contents in this folder, but it will fail since the .github folder is not included
@@ -149,6 +176,36 @@ sudo -u test %make_build check
 userdel -r test
 %install
 USER=root SUDO_USER=root %make_install
+WASM_STD_DIST_DIR=$(mktemp -d)
+tar -xf build/dist/rust-std-%{version}-wasm32-wasip1.tar.xz -C "$WASM_STD_DIST_DIR"
+install -d %{buildroot}%{_libdir}/rustlib
+cp -a \
+    "$WASM_STD_DIST_DIR"/rust-std-%{version}-wasm32-wasip1/rust-std-wasm32-wasip1/lib/rustlib/wasm32-wasip1 \
+    %{buildroot}%{_libdir}/rustlib/
+mkdir -p rust-std-wasm32-wasip1-licenses/rust
+cp \
+    "$WASM_STD_DIST_DIR"/rust-std-%{version}-wasm32-wasip1/LICENSE-APACHE \
+    "$WASM_STD_DIST_DIR"/rust-std-%{version}-wasm32-wasip1/LICENSE-MIT \
+    "$WASM_STD_DIST_DIR"/rust-std-%{version}-wasm32-wasip1/COPYRIGHT \
+    rust-std-wasm32-wasip1-licenses/rust/
+mkdir -p rust-std-wasm32-wasip1-licenses/wasi-libc
+cp \
+    wasi-libc-source/LICENSE \
+    wasi-libc-source/LICENSE-APACHE \
+    wasi-libc-source/LICENSE-APACHE-LLVM \
+    wasi-libc-source/LICENSE-MIT \
+    rust-std-wasm32-wasip1-licenses/wasi-libc/
+cp %{SOURCE10} rust-std-wasm32-wasip1-licenses/wasi-libc/CC0-1.0.txt
+cp wasi-libc-source/libc-bottom-half/cloudlibc/LICENSE \
+    rust-std-wasm32-wasip1-licenses/wasi-libc/cloudlibc-LICENSE
+cp wasi-libc-source/libc-top-half/musl/COPYRIGHT \
+    rust-std-wasm32-wasip1-licenses/wasi-libc/musl-COPYRIGHT
+cp wasi-libc-source/fts/musl-fts/COPYING \
+    rust-std-wasm32-wasip1-licenses/wasi-libc/musl-fts-COPYING
+rm -rf "$WASM_STD_DIST_DIR"
+for file in libc.a crt1-command.o crt1-reactor.o; do
+    test -f %{buildroot}%{_libdir}/rustlib/wasm32-wasip1/lib/self-contained/${file}
+done
 mv %{buildroot}%{_docdir}/cargo/LICENSE-THIRD-PARTY .
 rm %{buildroot}%{_docdir}/rustc/{COPYRIGHT-library.html,COPYRIGHT.html}
 rm %{buildroot}%{_docdir}/cargo/{LICENSE-APACHE,LICENSE-MIT}
@@ -164,6 +221,7 @@ rm %{buildroot}%{_docdir}/docs/html/.lock
 %{_bindir}/rustdoc
 %{_bindir}/rust-lldb
 %{_libdir}/lib*.so
+%exclude %{_libdir}/rustlib/wasm32-wasip1
 %{_libdir}/rustlib/*
 %{_libexecdir}/rust-analyzer-proc-macro-srv
 %{_bindir}/rust-gdb
@@ -189,7 +247,15 @@ rm %{buildroot}%{_docdir}/docs/html/.lock
 %doc src/tools/rustfmt/Configurations.md
 %{_mandir}/man1/*
 
+%files std-wasm32-wasip1
+%license rust-std-wasm32-wasip1-licenses
+%dir %{_libdir}/rustlib/wasm32-wasip1
+%{_libdir}/rustlib/wasm32-wasip1/*
+
 %changelog
+* Thu Apr 23 2026 Burak Ok <burakok@microsoft.com> - 1.90.0-7
+- Add a rust-std-wasm32-wasip1 subpackage with the wasm32-wasip1 target artifacts, self-contained WASI runtime files, and corresponding license notices
+
 * Wed Mar 25 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.90.0-6
 - Bump to rebuild with updated glibc
 


### PR DESCRIPTION
Package the wasm32-wasip1 target as a rust-std-wasm32-wasip1 subpackage, install it without installer metadata bleed, and ship the corresponding wasi-libc license notices.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR adds `wasm32-wasip1` target suport to Azure Linux's `rust` package, so Rust-based WASI workloads can build with the distro-provided Rust toolchain. For that it introduces a new `rust-std-wasm32-wasip1` subpackage

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `wasm32-wasip1` target support to `rust` with a new `rust-std-wasm32-wasip1` subpackage and the required WASI source/signature/license updates

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Locally built the packages and used the package to build the Inspektor Gadget builder which compiles Rust to WASM