### PR TITLE
Fix ptest issue for c-ares

### DIFF
--- a/SPECS/c-ares/c-ares.spec
+++ b/SPECS/c-ares/c-ares.spec
@@ -1,7 +1,7 @@
 Summary:        A library that performs asynchronous DNS operations
 Name:           c-ares
 Version:        1.30.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -65,10 +65,6 @@ if [[ $? -ne 0 ]]; then
 	check_status=1
 fi
 
-${TOOLSBIN}/acountry www.google.com
-if [[ $? -ne 0 ]]; then
-	check_status=1
-fi
 
 ${TOOLSBIN}/ahost www.google.com
 if [[ $? -ne 0 ]]; then
@@ -120,6 +116,9 @@ fi
 %{_mandir}/man3/ares_*
 
 %changelog
+* Mon Apr 27 2026 Akarsh Chaudhary <v-akarshc@microsoft.com>- 1.30.0-2
+- Fixed ptest by removing acountry test from %check since it is removed upstream and no longer built.
+
 * Tue Jun 25 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 1.30.0-1
 - Upgrade to v1.30.0 to fix CVE-2024-25629
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

This PR fixes a ptest failure in c-ares by removing the acountry tool invocation from the %check section.

Upstream has removed the acountry utility starting from c‑ares 1.28.0 because it depended on the external service countries.nerd.dk, which is no longer available. As a result, acountry is no longer built or shipped in current versions.

The %check section previously attempted to run acountry, causing test failures. This PR removes that invocation while keeping the remaining tests intact.

reference-https://github.com/c-ares/c-ares/issues/718

I checked the commits in above link the changes done in upstream commits to remove acountry tool are present in our source code too.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/c-ares/c-ares.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Screenshot of successful build-
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/2ae9a125-4b14-4fdd-abe2-882fce755072" />

