### PR TITLE
azurelinux-repos: switch back to daily/timestamp-derived repos

### DIFF
--- a/base/comps/azurelinux-repos/azurelinux-repos.comp.toml
+++ b/base/comps/azurelinux-repos/azurelinux-repos.comp.toml
@@ -2,7 +2,6 @@
 spec = { type = "local", path = "azurelinux-repos.spec" }
 
 [components.azurelinux-repos.build]
-# Alpha2: use split repo layout with Alpha2 blob prefix.
+# Build .repo files that are base/sdk split-aware.
 with = ["split_repos"]
-defines = { repo_uri_prefix = "https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod" }
 check = { skip = true, skip_reason = "Tests fail due to evergreen repos and any repo from this package is currently unavailable anyway." }

--- a/base/comps/azurelinux-repos/azurelinux-repos.spec
+++ b/base/comps/azurelinux-repos/azurelinux-repos.spec
@@ -10,7 +10,7 @@
 Summary:        Azure Linux package repositories
 Name:           azurelinux-repos
 Version:        4.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -273,6 +273,9 @@ rm -f "$TMPRING"
 
 
 %changelog
+* Mon Apr 27 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-7
+- Update repo definitions for next phase of releases.
+
 * Tue Apr 21 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-6
 - Consolidate repo templates: azurelinux-unified.repo.in and azurelinux-split.repo.in.
 - Add split_repos bcond to select between unified and split URL layouts.


### PR DESCRIPTION
Drop the Alpha2 build knob (repo_uri_prefix override) so the package falls back to the auto-computed %dist-derived URI prefix used by daily builds. Daily builds are now repo-split, though, so we leave that config option.

**Validation**: tested locally via azldev; tested via CT/koji in a scratch build against last night's target. In both cases, downloaded/copied the resulting RPM, extracted out the `.repo` file, and used `dnf repoquery` to confirm it resolved.