### PR TITLE
versionsprocessor: sanitize dots and plus signs in RPM macro names

### DIFF
--- a/toolkit/tools/versionsprocessor/versionsprocessor.go
+++ b/toolkit/tools/versionsprocessor/versionsprocessor.go
@@ -189,9 +189,12 @@ func processPackageVersionString(packageVersionString string, specFileName strin
 	release := releaseVerSplit[2]
 	releaseClean := strings.Replace(release, distTag, "", 1)
 
-	// strip out the .spec suffix and replace '-' with '_' as RPM macros cannot have '-'
+	// strip out the .spec suffix and replace characters invalid in RPM macro names with '_'
+	// RPM macro names may only contain alphanumeric characters and underscores.
 	packageFileNameMacroFormat := strings.Replace(specFileName, ".spec", "", 1)
 	packageFileNameMacroFormat = strings.ReplaceAll(packageFileNameMacroFormat, "-", "_")
+	packageFileNameMacroFormat = strings.ReplaceAll(packageFileNameMacroFormat, ".", "_")
+	packageFileNameMacroFormat = strings.ReplaceAll(packageFileNameMacroFormat, "+", "_")
 
 	epochReleaseString := prefix + "_" + packageFileNameMacroFormat + "_epoch"
 	versionMacroString := prefix + "_" + packageFileNameMacroFormat + "_version"

--- a/toolkit/tools/versionsprocessor/versionsprocessor.go
+++ b/toolkit/tools/versionsprocessor/versionsprocessor.go
@@ -29,6 +29,7 @@ import (
 )
 
 var packageVersionRegexp = regexp.MustCompile(`^[^:]+: (?:(.+):)?(.+)-(.+)$`)
+var invalidMacroCharRegexp = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 var (
 	app           = kingpin.New("versionsprocessor", "A tool to generate a macro file of all specs version and release")
@@ -192,9 +193,7 @@ func processPackageVersionString(packageVersionString string, specFileName strin
 	// strip out the .spec suffix and replace characters invalid in RPM macro names with '_'
 	// RPM macro names may only contain alphanumeric characters and underscores.
 	packageFileNameMacroFormat := strings.Replace(specFileName, ".spec", "", 1)
-	packageFileNameMacroFormat = strings.ReplaceAll(packageFileNameMacroFormat, "-", "_")
-	packageFileNameMacroFormat = strings.ReplaceAll(packageFileNameMacroFormat, ".", "_")
-	packageFileNameMacroFormat = strings.ReplaceAll(packageFileNameMacroFormat, "+", "_")
+	packageFileNameMacroFormat = invalidMacroCharRegexp.ReplaceAllString(packageFileNameMacroFormat, "_")
 
 	epochReleaseString := prefix + "_" + packageFileNameMacroFormat + "_epoch"
 	versionMacroString := prefix + "_" + packageFileNameMacroFormat + "_version"

--- a/toolkit/tools/versionsprocessor/versionsprocessor_test.go
+++ b/toolkit/tools/versionsprocessor/versionsprocessor_test.go
@@ -127,6 +127,38 @@ func TestProcessPackageVersionString_TableDriven(t *testing.T) {
 			expectedVersion: "%azl_openssl_version 3.3.0",
 			expectedRelease: "%azl_openssl_release 1.1",
 		},
+		{
+			name:            "dot in spec name replaced with underscore",
+			input:           "rubygem-cool.io: 1.8.0-1.azl3",
+			specFile:        "rubygem-cool.io.spec",
+			prefix:          "azl",
+			expectedVersion: "%azl_rubygem_cool_io_version 1.8.0",
+			expectedRelease: "%azl_rubygem_cool_io_release 1",
+		},
+		{
+			name:            "plus in spec name replaced with underscore",
+			input:           "libxml++: 5.0.3-1.azl3",
+			specFile:        "libxml++.spec",
+			prefix:          "azl",
+			expectedVersion: "%azl_libxml___version 5.0.3",
+			expectedRelease: "%azl_libxml___release 1",
+		},
+		{
+			name:            "versioned spec name with dot",
+			input:           "rust-1.75: 1.75.0-27.azl3",
+			specFile:        "rust-1.75.spec",
+			prefix:          "azl",
+			expectedVersion: "%azl_rust_1_75_version 1.75.0",
+			expectedRelease: "%azl_rust_1_75_release 27",
+		},
+		{
+			name:            "golang versioned spec with dot",
+			input:           "golang-1.25: 1.25.9-1.azl3",
+			specFile:        "golang-1.25.spec",
+			prefix:          "azl",
+			expectedVersion: "%azl_golang_1_25_version 1.25.9",
+			expectedRelease: "%azl_golang_1_25_release 1",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
RPM macro names may only contain alphanumeric characters and underscores. The versionsprocessor was only replacing dashes with underscores, leaving dots and plus signs from spec filenames (e.g., rubygem-cool.io, libxml++, rust-1.75, golang-1.25) in the generated macro names. This caused repeated 'Macro %azl_<name> needs whitespace before body' warnings during every rpmbuild invocation.

Replace '.' and '+' with '_' alongside the existing '-' replacement when constructing macro names from spec filenames.

Add table-driven test cases covering dot, plus, and versioned spec names.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Replaced the invalid characters in macro names with underscores

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

- Pipeline build id: xxxx
