### PR TITLE
Fix Ptest for Cython.

### DIFF
--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -61,8 +61,8 @@ sed -i '/\\$/s/\\$//' Cython/Build/IpythonMagic.py
 %{python3_sitearch}/__pycache__/cython.*
 
 %changelog
-* Tue Apr 28 2026 Akarsh Chaudhary <v-akarshc@microsoft.com>- 3.0.5-3
--Applied sed-based fix in %check to remove redundant backslash (E502) in IpythonMagic.py, enabling TestCodeFormat to pass successfully.
+* Tue Apr 28 2026 Akarsh Chaudhary <v-akarshc@microsoft.com> - 3.0.5-3
+- Applied sed-based fix in %check to remove redundant backslash (E502) in IpythonMagic.py, enabling TestCodeFormat to pass successfully.
 
 * Thu Mar 21 2024 Andrew Phelps <anphel@microsoft.com> - 3.0.5-2
 - Switch to test-requirements-312.txt

--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -3,7 +3,7 @@ Cython is an optimising static compiler for both the Python programming language
 Summary:        Language for writing Python extension modules
 Name:           Cython
 Version:        3.0.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -41,6 +41,10 @@ rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %check
 pip3 install -r test-requirements-312.txt
+
+# Fix upstream flake8 E502 (redundant backslash between brackets)
+sed -i '/\\$/s/\\$//' Cython/Build/IpythonMagic.py
+
 # Skip the file based tests, since they typically take over 5 hours to run.
 %python3 runtests.py -vv --no-file
 
@@ -57,6 +61,9 @@ pip3 install -r test-requirements-312.txt
 %{python3_sitearch}/__pycache__/cython.*
 
 %changelog
+* Tue Apr 28 2026 Akarsh Chaudhary <v-akarshc@microsoft.com>- 3.0.5-3
+-Applied sed-based fix in %check to remove redundant backslash (E502) in IpythonMagic.py, enabling TestCodeFormat to pass successfully.
+
 * Thu Mar 21 2024 Andrew Phelps <anphel@microsoft.com> - 3.0.5-2
 - Switch to test-requirements-312.txt
 - Skip long-running file based tests

--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -40,7 +40,7 @@ Provides:       %{name}%{?_isa} = %{version}-%{release}
 rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %check
-pip3 install -r test-requirements-312.txt
+pip3 install -r test-requirements-312.txt 
 
 # Fix upstream flake8 E502 (redundant backslash between brackets)
 sed -i '/\\$/s/\\$//' Cython/Build/IpythonMagic.py
@@ -50,7 +50,7 @@ sed -i '/\\$/s/\\$//' Cython/Build/IpythonMagic.py
 
 %files -n python3-%{name}
 %license LICENSE.txt COPYING.txt
-%doc *.txt Demos docs Tools
+%doc Demos docs Tools
 %{_bindir}/cython
 %{_bindir}/cygdb
 %{_bindir}/cythonize

--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -41,8 +41,7 @@ Provides:       %{name}%{?_isa} = %{version}-%{release}
 rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %check
-pip3 install -r test-requirements-312.txt 
-
+pip3 install -r test-requirements-312.txt
 # Skip the file based tests, since they typically take over 5 hours to run.
 %python3 runtests.py -vv --no-file
 

--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -10,6 +10,7 @@ Distribution:   Azure Linux
 URL:            https://www.cython.org
 Source0:        https://github.com/cython/cython/releases/download/%{version}/%{name}-%{version}.tar.gz
 Patch0:         fix_testcycache.patch
+Patch1:         fix-ipythonmagic-e502.patch
 BuildRequires:  gcc
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -42,9 +43,6 @@ rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 %check
 pip3 install -r test-requirements-312.txt 
 
-# Fix upstream flake8 E502 (redundant backslash between brackets)
-sed -i '/\\$/s/\\$//' Cython/Build/IpythonMagic.py
-
 # Skip the file based tests, since they typically take over 5 hours to run.
 %python3 runtests.py -vv --no-file
 
@@ -62,7 +60,7 @@ sed -i '/\\$/s/\\$//' Cython/Build/IpythonMagic.py
 
 %changelog
 * Tue Apr 28 2026 Akarsh Chaudhary <v-akarshc@microsoft.com> - 3.0.5-3
-- Applied sed-based fix in %check to remove redundant backslash (E502) in IpythonMagic.py, enabling TestCodeFormat to pass successfully.
+- Adding a patch for IpythonMagic.py to fix flake8 E502 without rewriting unrelated line continuations.
 
 * Thu Mar 21 2024 Andrew Phelps <anphel@microsoft.com> - 3.0.5-2
 - Switch to test-requirements-312.txt

--- a/SPECS/Cython/fix-ipythonmagic-e502.patch
+++ b/SPECS/Cython/fix-ipythonmagic-e502.patch
@@ -1,0 +1,14 @@
+diff --git a/Cython/Build/IpythonMagic.py b/Cython/Build/IpythonMagic.py
+index 343c6d8..83583e2 100644
+--- a/Cython/Build/IpythonMagic.py
++++ b/Cython/Build/IpythonMagic.py
+@@ -565,7 +565,7 @@ __doc__ = __doc__.format(
+     # rST doesn't see the -+ flag as part of an option list, so we
+     # hide it from the module-level docstring.
+-    CYTHON_DOC=dedent(CythonMagics.cython.__doc__\
+-                                  .replace('-+, --cplus', '--cplus    ')),
++    CYTHON_DOC=dedent(
++        CythonMagics.cython.__doc__.replace('-+, --cplus', '--cplus    ')),
+     CYTHON_INLINE_DOC=dedent(CythonMagics.cython_inline.__doc__),
+     CYTHON_PYXIMPORT_DOC=dedent(CythonMagics.cython_pyximport.__doc__),
+ )

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -71,7 +71,7 @@ curl-8.11.1-6.azl3.aarch64.rpm
 curl-debuginfo-8.11.1-6.azl3.aarch64.rpm
 curl-devel-8.11.1-6.azl3.aarch64.rpm
 curl-libs-8.11.1-6.azl3.aarch64.rpm
-Cython-debuginfo-3.0.5-2.azl3.aarch64.rpm
+Cython-debuginfo-3.0.5-3.azl3.aarch64.rpm
 debugedit-5.0-2.azl3.aarch64.rpm
 debugedit-debuginfo-5.0-2.azl3.aarch64.rpm
 diffutils-3.10-1.azl3.aarch64.rpm
@@ -535,7 +535,7 @@ python3-3.12.9-10.azl3.aarch64.rpm
 python3-audit-3.1.2-1.azl3.aarch64.rpm
 python3-cracklib-2.9.11-1.azl3.aarch64.rpm
 python3-curses-3.12.9-10.azl3.aarch64.rpm
-python3-Cython-3.0.5-2.azl3.aarch64.rpm
+python3-Cython-3.0.5-3.azl3.aarch64.rpm
 python3-debuginfo-3.12.9-10.azl3.aarch64.rpm
 python3-devel-3.12.9-10.azl3.aarch64.rpm
 python3-flit-core-3.9.0-1.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -76,7 +76,7 @@ curl-8.11.1-6.azl3.x86_64.rpm
 curl-debuginfo-8.11.1-6.azl3.x86_64.rpm
 curl-devel-8.11.1-6.azl3.x86_64.rpm
 curl-libs-8.11.1-6.azl3.x86_64.rpm
-Cython-debuginfo-3.0.5-2.azl3.x86_64.rpm
+Cython-debuginfo-3.0.5-3.azl3.x86_64.rpm
 debugedit-5.0-2.azl3.x86_64.rpm
 debugedit-debuginfo-5.0-2.azl3.x86_64.rpm
 diffutils-3.10-1.azl3.x86_64.rpm
@@ -543,7 +543,7 @@ python3-3.12.9-10.azl3.x86_64.rpm
 python3-audit-3.1.2-1.azl3.x86_64.rpm
 python3-cracklib-2.9.11-1.azl3.x86_64.rpm
 python3-curses-3.12.9-10.azl3.x86_64.rpm
-python3-Cython-3.0.5-2.azl3.x86_64.rpm
+python3-Cython-3.0.5-3.azl3.x86_64.rpm
 python3-debuginfo-3.12.9-10.azl3.x86_64.rpm
 python3-devel-3.12.9-10.azl3.x86_64.rpm
 python3-flit-core-3.9.0-1.azl3.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

The Cython test suite was failing during %check due to a code formatting violation reported by the upstream style checker (TestCodeFormat). The failure specifically originated from a flake8 error:

E502: redundant backslash between brackets
File affected: Cython/Build/IpythonMagic.py

This issue is purely a style/linting problem and does not impact build correctness or runtime functionality. However, since the upstream test suite enforces formatting checks, it caused the overall test execution to fail.
To resolve this we applied a targeted in-place fix during the %check phase using a sed command. This removes trailing backslashes from affected lines, eliminating the E502 violation

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/Cython/Cython.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**Yes**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Successful Build Screenshot-
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/e92a4020-99e0-4862-b15a-38f5fb3d8c84" />

