### PR TITLE
fix: remove vm-base packages bc, binutils, elfutils

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -57,8 +57,6 @@
         <package name="attr" />
         <package name="audit" />
         <package name="bash-completion" />
-        <package name="bc" />
-        <package name="binutils" />
         <package name="bind-utils" />
         <package name="brotli" />
         <package name="bzip2" />
@@ -73,7 +71,6 @@
         <package name="device-mapper-event" />
         <package name="dnf5" />
         <package name="dnf5-plugins" />
-        <package name="elfutils" />
         <package name="file" />
         <package name="firewalld" />
         <package name="glibc" />


### PR DESCRIPTION
The base image does not need development tools in it.

The package elfutils-debuginfod-client is also implicitly removed from the base image.

This is on top of #16917 