### PR TITLE
ci: Unpin azldev version in toml lint workflow while under development

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
           cache: false
 
       - name: Install azldev
-        run: go install github.com/microsoft/azure-linux-dev-tools/cmd/azldev@0590d38b32c0a414e0969e85aca8542c3d339079
+        run: go install github.com/microsoft/azure-linux-dev-tools/cmd/azldev@main
 
       - name: "Validate config (strict)"
         run: azldev config dump > /dev/null


### PR DESCRIPTION
Rejecting valid changes due to the rapid development of azldev, unpin until dev work stabilizes.