### PR TITLE
feat: set vm-base grub menu to 1 second timeout

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -26,7 +26,7 @@
             bootpartition="false"
             efipartsize="200"
             rootfs_label="azurelinux">
-            <bootloader name="grub2" bls="true" console="serial" timeout="0" />
+            <bootloader name="grub2" bls="true" console="serial" timeout="1" />
             <size unit="G">5</size>
             <oemconfig>
                 <oem-resize>false</oem-resize>


### PR DESCRIPTION
Without a timeout, it's not possible to enter the grub menu from the azure serial console, which prevents debugging and/or recovery using the grub menu.

This also increases the default boot time of all vm-base image deployments; 1 second was chosen as a compromise between reducing boot time delays, and allowing end user access to the grub menu (without needing to change grub configuration).
