### PR TITLE
Fix distroless containers inheriting /bin/bash CMD from core profile

### DIFF
--- a/base/images/container-base/config.sh
+++ b/base/images/container-base/config.sh
@@ -76,9 +76,12 @@ KEEP_PKGS=$(get_image_packages 'not(@profiles)')
 # Packages scoped to specific profiles.  kiwi_profiles is a comma-separated
 # list of active profiles, set by kiwi at build time (e.g.,
 # "distroless-debug,distroless-core,distroless-minimal").
+# Note: the @profiles attribute in the XML may also be comma-separated
+# (e.g., "distroless-minimal,distroless-base,distroless-debug"), so we
+# use contains() with comma-wrapping for safe substring matching.
 IFS=',' read -ra PROFILES <<< "${kiwi_profiles:-}"
 for profile in "${PROFILES[@]}"; do
-    KEEP_PKGS+=$'\n'$(get_image_packages "@profiles='${profile}'")
+    KEEP_PKGS+=$'\n'$(get_image_packages "contains(concat(',',@profiles,','), ',${profile},')")
 done
 
 # Deduplicate.

--- a/base/images/container-base/container-base.kiwi
+++ b/base/images/container-base/container-base.kiwi
@@ -9,16 +9,14 @@
     <profiles>
         <profile name="core" description="Core Container" import="true" />
         <profile name="distroless-minimal" description="Distroless Minimal Container" import="true" />
-        <profile name="distroless-base" description="Distroless Base Container" import="true">
-            <requires profile="distroless-minimal" />
-        </profile>
-        <profile name="distroless-debug" description="Distroless Debug Container" import="true">
-            <requires profile="distroless-base" />
-        </profile>
+        <profile name="distroless-base" description="Distroless Base Container" import="true" />
+        <profile name="distroless-debug" description="Distroless Debug Container" import="true" />
     </profiles>
     <preferences>
         <version>0.1</version>
         <packagemanager>dnf5</packagemanager>
+    </preferences>
+    <preferences profiles="core">
         <type image="oci">
             <containerconfig
                 name="microsoft/azurelinux/base/core"
@@ -27,6 +25,42 @@
                 user="root"
                 workingdir="/">
                 <subcommand execute="/bin/bash"/>
+            </containerconfig>
+        </type>
+    </preferences>
+    <preferences profiles="distroless-minimal">
+        <type image="oci">
+            <containerconfig
+                name="microsoft/azurelinux/distroless/minimal"
+                tag="4.0"
+                additionalnames=":latest"
+                user="root"
+                workingdir="/">
+                <subcommand clear="true"/>
+            </containerconfig>
+        </type>
+    </preferences>
+    <preferences profiles="distroless-base">
+        <type image="oci">
+            <containerconfig
+                name="microsoft/azurelinux/distroless/base"
+                tag="4.0"
+                additionalnames=":latest"
+                user="root"
+                workingdir="/">
+                <subcommand clear="true"/>
+            </containerconfig>
+        </type>
+    </preferences>
+    <preferences profiles="distroless-debug">
+        <type image="oci">
+            <containerconfig
+                name="microsoft/azurelinux/distroless/debug"
+                tag="4.0"
+                additionalnames=":latest"
+                user="root"
+                workingdir="/">
+                <subcommand clear="true"/>
             </containerconfig>
         </type>
     </preferences>
@@ -45,13 +79,13 @@
     <!-- For distroless profiles ALL packages that should be included in
          the final image must be listed in the "image" packages section.
          Packages from bootstrap may be removed by config.sh. -->
-    <packages type="image" profiles="distroless-minimal">
+    <packages type="image" profiles="distroless-minimal,distroless-base,distroless-debug">
         <package name="filesystem" />
         <package name="azurelinux-release-container" />
         <package name="tzdata" />
     </packages>
 
-    <packages type="image" profiles="distroless-base">
+    <packages type="image" profiles="distroless-base,distroless-debug">
         <package name="glibc" />
         <package name="libgcc" />
         <package name="openssl-libs" />
@@ -62,12 +96,12 @@
         <package name="busybox" />
     </packages>
 
-    <packages type="bootstrap" profiles="core,distroless-minimal">
+    <packages type="bootstrap" profiles="core,distroless-minimal,distroless-base,distroless-debug">
         <package name="filesystem" />
         <package name="azurelinux-release-container" />
     </packages>
 
-    <packages type="bootstrap" profiles="distroless-minimal">
+    <packages type="bootstrap" profiles="distroless-minimal,distroless-base,distroless-debug">
         <package name="busybox" />
     </packages>
 </image>


### PR DESCRIPTION
Distroless container images incorrectly advertise `/bin/bash` as their OCI CMD metadata, despite bash not being present. This causes runtime failures when the container is launched without an explicit command.

**Root cause:** Kiwi defaults to `CMD ["/bin/bash"]` when no `<subcommand>` is specified. The shared `<preferences>` block applied this default to all profiles, including distroless variants.

**Fix:**
- Split `<preferences>` into per-profile blocks so each container gets its own `<containerconfig>` (with distinct image names/tags).
- Add `<subcommand clear="true"/>` to all distroless profiles, which explicitly sets CMD to `[]` (matching AZL3 behavior where distroless Dockerfiles had no CMD).
- Fix `config.sh` XPath to handle comma-separated `profiles` attributes using `contains(concat(',',@profiles,','), ',PROFILE,')`.

**Tested:** All 4 profiles (core, distroless-minimal, distroless-base, distroless-debug) build successfully. Core launches bash; distroless variants correctly report "no command specified" when run without an explicit command.

Fixes [AB#19163](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19163)

Built on build server. Downloaded the oci files and manually ran them with docker.