### PR TITLE
[Medium] patch shim-unsigned-aarch64 and shim-unsigned-x64 for CVE-2017-3735

### DIFF
--- a/SPECS/shim-unsigned-aarch64/CVE-2017-3735.patch
+++ b/SPECS/shim-unsigned-aarch64/CVE-2017-3735.patch
@@ -1,0 +1,46 @@
+From 068b963bb7afc57f5bdd723de0dd15e7795d5822 Mon Sep 17 00:00:00 2001
+From: Rich Salz <rsalz@openssl.org>
+Date: Tue, 22 Aug 2017 11:44:41 -0400
+Subject: [PATCH] Avoid out-of-bounds read
+
+Fixes CVE 2017-3735
+
+Reviewed-by: Kurt Roeckx <kurt@roeckx.be>
+(Merged from https://github.com/openssl/openssl/pull/4276)
+
+(cherry picked from commit b23171744b01e473ebbfd6edad70c1c3825ffbcd)
+
+------
+Modified to apply to Azure Linux.
+Slight variation around the patched line.
+Upstream patch has the func name as `X509v3_addr_get_afi()` but in Azure Linux codebase it is `v3_addr_get_afi()`.
+
+Upstream Patch reference: https://github.com/openssl/openssl/commit/068b963bb7afc57f5bdd723de0dd15e7795d5822.patch
+---
+ Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c b/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c
+index 1290dec..af080a0 100644
+--- a/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c
++++ b/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c
+@@ -130,10 +130,12 @@ static int length_from_afi(const unsigned afi)
+  */
+ unsigned int v3_addr_get_afi(const IPAddressFamily *f)
+ {
+-    return ((f != NULL &&
+-             f->addressFamily != NULL && f->addressFamily->data != NULL)
+-            ? ((f->addressFamily->data[0] << 8) | (f->addressFamily->data[1]))
+-            : 0);
++    if (f == NULL
++            || f->addressFamily == NULL
++            || f->addressFamily->data == NULL
++            || f->addressFamily->length < 2)
++        return 0;
++    return (f->addressFamily->data[0] << 8) | f->addressFamily->data[1];
+ }
+ 
+ /*
+-- 
+2.43.0
+

--- a/SPECS/shim-unsigned-aarch64/shim-unsigned-aarch64.spec
+++ b/SPECS/shim-unsigned-aarch64/shim-unsigned-aarch64.spec
@@ -33,7 +33,7 @@ Name:		shim-unsigned-aarch64
 Provides:       shim-unsigned-%{efiarch}
 
 Version:	16.1
-Release:	2%{?dist}
+Release:	3%{?dist}
 Summary:	First-stage UEFI bootloader
 ExclusiveArch:	aarch64
 License:	BSD
@@ -51,6 +51,8 @@ Source4:	shim.patches
 Source100:	shim-find-debuginfo.sh
 
 %include %{SOURCE4}
+
+Patch0:         CVE-2017-3735.patch
 
 BuildRequires:	gcc make
 BuildRequires:	elfutils-libelf-devel
@@ -93,7 +95,7 @@ BuildArch:	noarch
 %debug_desc
 
 %prep
-%autosetup -S git_am -n shim-%{version}
+%autosetup -p1 -S git_am -n shim-%{version}
 git config --unset user.email
 git config --unset user.name
 mkdir build-%{efiarch}
@@ -162,6 +164,9 @@ HASH=$(cat %{buildroot}%{shimdir}/shim%{efiarch}.hash | cut -d ' ' -f 1)
 %files debugsource -f build-%{efiarch}/debugsource.list
 
 %changelog
+* Thu Apr 30 2026 Akhila Guruju <v-guakhila@microsoft.com> - 16.1-3
+- Patch CVE-2017-3735
+
 * Tue Apr 07 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 16.1-2
 - Update sbat csv to match architecture
 

--- a/SPECS/shim-unsigned-x64/CVE-2017-3735.patch
+++ b/SPECS/shim-unsigned-x64/CVE-2017-3735.patch
@@ -1,0 +1,46 @@
+From 068b963bb7afc57f5bdd723de0dd15e7795d5822 Mon Sep 17 00:00:00 2001
+From: Rich Salz <rsalz@openssl.org>
+Date: Tue, 22 Aug 2017 11:44:41 -0400
+Subject: [PATCH] Avoid out-of-bounds read
+
+Fixes CVE 2017-3735
+
+Reviewed-by: Kurt Roeckx <kurt@roeckx.be>
+(Merged from https://github.com/openssl/openssl/pull/4276)
+
+(cherry picked from commit b23171744b01e473ebbfd6edad70c1c3825ffbcd)
+
+------
+Modified to apply to Azure Linux.
+Slight variation around the patched line.
+Upstream patch has the func name as `X509v3_addr_get_afi()` but in Azure Linux codebase it is `v3_addr_get_afi()`.
+
+Upstream Patch reference: https://github.com/openssl/openssl/commit/068b963bb7afc57f5bdd723de0dd15e7795d5822.patch
+---
+ Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c b/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c
+index 1290dec..af080a0 100644
+--- a/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c
++++ b/Cryptlib/OpenSSL/crypto/x509v3/v3_addr.c
+@@ -130,10 +130,12 @@ static int length_from_afi(const unsigned afi)
+  */
+ unsigned int v3_addr_get_afi(const IPAddressFamily *f)
+ {
+-    return ((f != NULL &&
+-             f->addressFamily != NULL && f->addressFamily->data != NULL)
+-            ? ((f->addressFamily->data[0] << 8) | (f->addressFamily->data[1]))
+-            : 0);
++    if (f == NULL
++            || f->addressFamily == NULL
++            || f->addressFamily->data == NULL
++            || f->addressFamily->length < 2)
++        return 0;
++    return (f->addressFamily->data[0] << 8) | f->addressFamily->data[1];
+ }
+ 
+ /*
+-- 
+2.43.0
+

--- a/SPECS/shim-unsigned-x64/shim-unsigned-x64.spec
+++ b/SPECS/shim-unsigned-x64/shim-unsigned-x64.spec
@@ -37,7 +37,7 @@
 
 Name:		shim-unsigned-%{efiarch}
 Version:	16.1
-Release:	2%{?dist}
+Release:	3%{?dist}
 Summary:	First-stage UEFI bootloader
 ExclusiveArch:	x86_64
 License:	BSD
@@ -55,6 +55,8 @@ Source4:	shim.patches
 Source100:	shim-find-debuginfo.sh
 
 %include %{SOURCE4}
+
+Patch0:         CVE-2017-3735.patch
 
 BuildRequires:	gcc make
 BuildRequires:	elfutils-libelf-devel
@@ -116,7 +118,7 @@ BuildArch:	noarch
 %debug_desc
 
 %prep
-%autosetup -S git_am -n shim-%{version}
+%autosetup -p1 -S git_am -n shim-%{version}
 git config --unset user.email
 git config --unset user.name
 mkdir build-%{efiarch}
@@ -223,6 +225,9 @@ HASH=$(cat %{buildroot}%{shimdir}/shim%{efiarch}.hash | cut -d ' ' -f 1)
 %files debugsource -f build-%{efiarch}/debugsource.list
 
 %changelog
+* Thu Apr 30 2026 Akhila Guruju <v-guakhila@microsoft.com> - 16.1-3
+- Patch CVE-2017-3735
+
 * Tue Apr 07 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 16.1-2
 - Bump to match shim-unsigned-aarch64
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
patch shim-unsigned-x64 for CVE-2017-3735

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/shim-unsigned-aarch64/CVE-2017-3735.patch
- modified:   SPECS/shim-unsigned-aarch64/shim-unsigned-aarch64.spec
- new file:   SPECS/shim-unsigned-x64/CVE-2017-3735.patch
- modified:   SPECS/shim-unsigned-x64/shim-unsigned-x64.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2017-3735

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
<img width="386" height="136" alt="image" src="https://github.com/user-attachments/assets/63a19021-48a1-478e-ac13-8fafa7e3226f" />
<img width="645" height="176" alt="image" src="https://github.com/user-attachments/assets/74263186-80f4-4345-a448-03f402ac80c4" />

