### PR TITLE
fix(anaconda): drop flatpak Requires from anaconda-core

### DIFF
--- a/base/comps/anaconda/anaconda.comp.toml
+++ b/base/comps/anaconda/anaconda.comp.toml
@@ -1,0 +1,21 @@
+[components.anaconda]
+
+# Drop the flatpak Requires from anaconda-core. Anaconda's flatpak
+# source-type lets the installer install OCI/flatpak refs from a
+# CDROM at install time -- a desktop-installer feature that AZL
+# doesn't ship. Removing these Requires unhooks anaconda-core from
+# the flatpak chain so flatpak can be demoted to sdk.
+
+[[components.anaconda.overlays]]
+description = "Drop Requires: flatpak from anaconda-core (flatpak source-type unused on AZL)"
+type = "spec-remove-tag"
+tag = "Requires"
+value = "flatpak"
+package = "core"
+
+[[components.anaconda.overlays]]
+description = "Drop Requires: flatpak-libs from anaconda-core (flatpak source-type unused on AZL)"
+type = "spec-remove-tag"
+tag = "Requires"
+value = "flatpak-libs"
+package = "core"

--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -73,7 +73,7 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml"]
 [components.alsa-lib]
 [components.aml]
 [components.amtterm]
-[components.anaconda]
+
 [components.annobin]
 [components.ansible]
 [components.ansible-collection-ansible-posix]

--- a/specs/a/anaconda/anaconda.spec
+++ b/specs/a/anaconda/anaconda.spec
@@ -121,8 +121,6 @@ Requires: python3-systemd
 Requires: python3-productmd
 Requires: python3-dasbus >= %{dasbusver}
 Requires: python3-xkbregistry
-Requires: flatpak
-Requires: flatpak-libs
 %if %{defined rhel} && %{undefined centos}
 Requires: subscription-manager >= %{subscriptionmanagerver}
 %endif


### PR DESCRIPTION
Anaconda's flatpak source-type lets the installer install OCI/flatpak
refs from a disk at install time -- a desktop-installer feature that
AZL doesn't ship. Drop the runtime Requires on flatpak and flatpak-libs
so anaconda-core is unhooked from the flatpak chain.

---
Validated build via local azldev build and koji build.