### PR TITLE
fix(erlang): disable erlang-wx wxWidgets bindings sub-package

### DIFF
--- a/base/comps/erlang/erlang.comp.toml
+++ b/base/comps/erlang/erlang.comp.toml
@@ -4,3 +4,40 @@
 
 [components.erlang.build]
 without = ["doc"]
+
+# Disable the erlang-wx sub-package (Erlang's wxWidgets bindings). AZL is a
+# headless cloud distro and does not ship wxGTK; building erlang-wx would
+# pull in a desktop GUI stack at build time and would force every other
+# erlang sub-package whose %if %{__with_wxwidgets} block adds a
+# `Requires: erlang-wx` (erlang-meta, -debugger, -dialyzer, -et, -observer,
+# -reltool, -src) to drag the wx subpackage into the runtime closure.
+#
+# The upstream spec already supports this configuration via the
+# `%global __with_wxwidgets` toggle: when set to 0, every wx-conditional
+# `%package wx` definition, every `Requires: %{name}-wx` line, and the
+# wxGTK BuildRequires are skipped wholesale. Flipping the global is by
+# far the most surgical fix.
+[[components.erlang.overlays]]
+description = "Disable erlang-wx sub-package (wxGTK GUI bindings) — AZL is a headless cloud distro"
+type = "spec-search-replace"
+regex = '^%global __with_wxwidgets 1$'
+replacement = '%global __with_wxwidgets 0'
+
+# The erlang-src %package preamble lives inside `%if %{__with_sources}` and
+# carries unconditional `Requires: %{name}-<sub>` lines for every other
+# sub-package — including all of the wxwidgets-gated ones (common_test,
+# debugger, dialyzer, et, megaco, observer, reltool, wx). Because these
+# Requires are NOT wrapped in `%if %{__with_wxwidgets}`, flipping the
+# toggle alone leaves erlang-src demanding sub-packages that are no longer
+# built. Strip every such line so the rebuilt erlang-src RPM does not pull
+# in now-nonexistent sub-packages. Scope the regex to `%package src` so it
+# only targets these unconditional Requires; equivalent lines elsewhere in
+# the spec are already inside `%if %{__with_wxwidgets}` blocks and are
+# dead code under the toggle, so they stay untouched.
+[[components.erlang.overlays]]
+description = "Drop unconditional Requires for wxwidgets-gated sub-packages from erlang-src (paired with __with_wxwidgets=0 above)"
+type = "spec-search-replace"
+section = "%package"
+package = "src"
+regex = '^Requires: %\{name\}-(common_test|debugger|dialyzer|et|megaco|observer|reltool|wx)%\{\?_isa\} = %\{version\}-%\{release\}$'
+replacement = ''

--- a/locks/erlang.lock
+++ b/locks/erlang.lock
@@ -2,4 +2,4 @@
 version = 1
 import-commit = '8783ca4c69ad2bb0ad3cf6a97759a8c76fbc2d63'
 upstream-commit = '8783ca4c69ad2bb0ad3cf6a97759a8c76fbc2d63'
-input-fingerprint = 'sha256:457bae0a3b68379eb942124731d1339506186a2e3710ee7f875f1428356d7f03'
+input-fingerprint = 'sha256:45d333fd054afd42ac0a9f364cd608df7f50de34649dffb91c7abb298671767c'

--- a/specs/e/erlang/erlang.spec
+++ b/specs/e/erlang/erlang.spec
@@ -70,7 +70,7 @@
 # reltool (*)
 # wx
 #
-%global __with_wxwidgets 1
+%global __with_wxwidgets 0
 
 
 Name:		erlang
@@ -613,29 +613,29 @@ MIB compiler and tools for creating SNMP agents.
 %package src
 Summary: Erlang sources
 Requires: %{name}-asn1%{?_isa} = %{version}-%{release}
-Requires: %{name}-common_test%{?_isa} = %{version}-%{release}
+
 Requires: %{name}-compiler%{?_isa} = %{version}-%{release}
 Requires: %{name}-crypto%{?_isa} = %{version}-%{release}
-Requires: %{name}-debugger%{?_isa} = %{version}-%{release}
-Requires: %{name}-dialyzer%{?_isa} = %{version}-%{release}
+
+
 Requires: %{name}-diameter%{?_isa} = %{version}-%{release}
 Requires: %{name}-edoc%{?_isa} = %{version}-%{release}
 Requires: %{name}-eldap%{?_isa} = %{version}-%{release}
 Requires: %{name}-erl_docgen%{?_isa} = %{version}-%{release}
 Requires: %{name}-erts%{?_isa} = %{version}-%{release}
-Requires: %{name}-et%{?_isa} = %{version}-%{release}
+
 Requires: %{name}-eunit%{?_isa} = %{version}-%{release}
 Requires: %{name}-ftp%{?_isa} = %{version}-%{release}
 Requires: %{name}-inets%{?_isa} = %{version}-%{release}
 Requires: %{name}-kernel%{?_isa} = %{version}-%{release}
-Requires: %{name}-megaco%{?_isa} = %{version}-%{release}
+
 Requires: %{name}-mnesia%{?_isa} = %{version}-%{release}
-Requires: %{name}-observer%{?_isa} = %{version}-%{release}
+
 Requires: %{name}-odbc%{?_isa} = %{version}-%{release}
 Requires: %{name}-os_mon%{?_isa} = %{version}-%{release}
 Requires: %{name}-parsetools%{?_isa} = %{version}-%{release}
 Requires: %{name}-public_key%{?_isa} = %{version}-%{release}
-Requires: %{name}-reltool%{?_isa} = %{version}-%{release}
+
 Requires: %{name}-runtime_tools%{?_isa} = %{version}-%{release}
 Requires: %{name}-sasl%{?_isa} = %{version}-%{release}
 Requires: %{name}-snmp%{?_isa} = %{version}-%{release}
@@ -645,7 +645,7 @@ Requires: %{name}-stdlib%{?_isa} = %{version}-%{release}
 Requires: %{name}-syntax_tools%{?_isa} = %{version}-%{release}
 Requires: %{name}-tftp%{?_isa} = %{version}-%{release}
 Requires: %{name}-tools%{?_isa} = %{version}-%{release}
-Requires: %{name}-wx%{?_isa} = %{version}-%{release}
+
 Requires: %{name}-xmerl%{?_isa} = %{version}-%{release}
 
 %description src


### PR DESCRIPTION
We do not plan to ship wxGTK and need to remove the dependency.
The upstream spec already supports this configuration via the
`%global __with_wxwidgets` toggle: when set to 0, every wx-conditional
`%package wx` definition, every `Requires: %{name}-wx` line, and the
wxGTK BuildRequires are skipped wholesale. Flipping the global is the
most surgical fix.

The `Requires: %{name}-wx` line in the erlang-src %package preamble is
the only such line in the upstream spec that is NOT wrapped in a
`%if %{__with_wxwidgets}` block (it lives directly inside
`%if %{__with_sources}`), so the toggle alone cannot drop it. Strip it
explicitly so the rebuilt erlang-src RPM does not pull in a now-
nonexistent erlang-wx package.

---
**Validated**: via local azldev build + koji build