### PR TITLE
feat(iso): add dual-arch (x86_64/aarch64) VM ISO installer

### DIFF
--- a/base/images/images.toml
+++ b/base/images/images.toml
@@ -36,6 +36,10 @@ definition = { type = "kiwi", path = "container-base/container-base.kiwi", profi
 description = "WSL Image"
 definition = { type = "kiwi", path = "wsl/wsl.kiwi" }
 
+[images.vm-iso-installer]
+description = "VM ISO Installer"
+definition = { type = "kiwi", path = "vm-iso-installer/vm-iso-installer.kiwi" }
+
 # ---- Test suites ----
 
 # Single shared pytest suite for static (offline) image validation.

--- a/base/images/vm-iso-installer/20-wired-dhcp.network
+++ b/base/images/vm-iso-installer/20-wired-dhcp.network
@@ -1,0 +1,8 @@
+[Match]
+Name=en* eth*
+
+[Network]
+DHCP=yes
+
+[DHCPv4]
+UseDNS=yes

--- a/base/images/vm-iso-installer/anaconda-launcher.sh
+++ b/base/images/vm-iso-installer/anaconda-launcher.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+mkdir -p /run/install
+
+# Clean up stale PID file from any previous run
+rm -f /run/user/0/anaconda.pid
+
+# Disable all system repos so anaconda only uses the offline repo.
+# This prevents silent network fetches even when a NIC is present.
+for repo_file in /etc/yum.repos.d/*.repo; do
+    [ -f "$repo_file" ] && sed -i -E 's/^enabled\s*=\s*.*/enabled=0/' "$repo_file"
+done
+
+# Check kernel cmdline for custom kickstart (inst.ks=<url>)
+CUSTOM_KS=""
+if grep -qo 'inst\.ks=[^ ]*' /proc/cmdline 2>/dev/null; then
+    CUSTOM_KS=$(grep -o 'inst\.ks=[^ ]*' /proc/cmdline | sed 's/inst\.ks=//')
+    echo ""
+    echo "========================================"
+    echo "  Azure Linux 4.0 Offline Installer"
+    echo "========================================"
+    echo ""
+    echo "  Custom kickstart detected: $CUSTOM_KS"
+    echo "  Launching anaconda with custom kickstart..."
+    echo ""
+    /usr/sbin/anaconda --text --kickstart="$CUSTOM_KS"
+    RC=$?
+    rm -f /run/install/ks.cfg
+    if [ $RC -eq 0 ]; then
+        echo "Installation complete."
+        echo "Press Enter to reboot..."
+        read -r
+        systemctl reboot
+    else
+        echo "Anaconda exited with code $RC. Dropping to shell."
+        exec /bin/bash
+    fi
+    exit 0
+fi
+
+echo ""
+echo "========================================"
+echo "  Azure Linux 4.0 Offline Installer"
+echo "========================================"
+echo ""
+echo "  1) Standard installation"
+echo "  2) Encrypted disk (LUKS)"
+echo ""
+read -rp "Select installation type [1]: " CHOICE
+
+case "$CHOICE" in
+    2)
+        echo "*** Disk encryption ENABLED ***"
+        echo "  Anaconda will prompt you for the LUKS passphrase during install."
+        echo ""
+        cp /root/azl-install-encrypted.ks /run/install/ks.cfg
+        ;;
+    *)
+        echo "*** Standard installation (offline) ***"
+        cp /root/azl-install.ks /run/install/ks.cfg
+        ;;
+esac
+
+echo "=== Kickstart storage config ==="
+grep -E 'autopart|clearpart|part |volgroup|logvol|--encrypted' /run/install/ks.cfg
+echo "==============================="
+echo ""
+/usr/sbin/anaconda --text --kickstart=/run/install/ks.cfg
+RC=$?
+
+rm -f /run/install/ks.cfg
+
+if [ $RC -eq 0 ]; then
+    echo ""
+    echo "Installation complete."
+    echo ""
+    echo "=== Bootloader log (from %post --nochroot) ==="
+    for mnt in /mnt/sysroot /mnt/sysimage; do
+        [ -f "$mnt/var/log/anaconda-bootloader.log" ] && {
+            tail -60 "$mnt/var/log/anaconda-bootloader.log"
+            break
+        }
+    done
+    echo ""
+    echo "Ejecting installation media..."
+    eject /dev/sr0 2>/dev/null || eject /dev/cdrom 2>/dev/null || true
+    echo "Press Enter to reboot into the installed system..."
+    read -r
+    systemctl reboot
+else
+    echo ""
+    echo "======================================================"
+    echo " Anaconda exited with code $RC."
+    echo " You are now in the live ISO shell."
+    echo " Run 'anaconda --text' to retry, or investigate logs."
+    echo " Logs: /tmp/anaconda.log, /tmp/packaging.log"
+    echo "======================================================"
+    exec /bin/bash
+fi

--- a/base/images/vm-iso-installer/azl-install-encrypted.ks.in
+++ b/base/images/vm-iso-installer/azl-install-encrypted.ks.in
@@ -1,0 +1,39 @@
+# Azure Linux 4.0 — Anaconda Kickstart (Offline, Encrypted)
+
+# Installation source — local repo bundled on the ISO
+repo --name=azl-offline --baseurl=file:///opt/azl-offline-repo/
+
+# Disable any system repos so only the offline repo is used
+# (handled by disabling .repo files before anaconda starts)
+
+# System settings
+lang en_US.UTF-8
+keyboard us
+timezone UTC --utc
+selinux --enforcing
+firewall --enabled --ssh
+network --hostname=azurelinux
+services --enabled=sshd,systemd-networkd,systemd-resolved
+
+# Bootloader
+bootloader --location=mbr --append="console=ttyS0,115200 console=tty0"
+
+# Eject installation media and reboot automatically after install
+reboot --eject
+
+# Disk layout — LUKS-encrypted LVM via autopart
+# No --passphrase here: anaconda will prompt the user interactively.
+clearpart --all --initlabel
+autopart --type=lvm --encrypted
+
+@@PACKAGES@@
+
+%post --nochroot --log=/mnt/sysroot/var/log/anaconda-post.log
+cp /root/post-install.sh /mnt/sysroot/tmp/
+chroot /mnt/sysroot bash /tmp/post-install.sh
+rm -f /mnt/sysroot/tmp/post-install.sh
+%end
+
+%post --nochroot --log=/mnt/sysroot/var/log/anaconda-bootloader.log
+/root/post-bootloader.sh
+%end

--- a/base/images/vm-iso-installer/azl-install.ks.in
+++ b/base/images/vm-iso-installer/azl-install.ks.in
@@ -1,0 +1,43 @@
+# Azure Linux 4.0 — Anaconda Kickstart (Offline)
+
+# Installation source — local repo bundled on the ISO
+repo --name=azl-offline --baseurl=file:///opt/azl-offline-repo/
+
+# Disable any system repos so only the offline repo is used
+# (handled by disabling .repo files before anaconda starts)
+
+# System settings
+lang en_US.UTF-8
+keyboard us
+timezone UTC --utc
+selinux --enforcing
+firewall --enabled --ssh
+network --hostname=azurelinux
+services --enabled=sshd,systemd-networkd,systemd-resolved
+
+# Bootloader
+bootloader --location=mbr --append="console=ttyS0,115200 console=tty0"
+
+# Eject installation media and reboot automatically after install
+reboot --eject
+
+# Disk layout — LVM without encryption
+clearpart --all --initlabel
+part /boot/efi --fstype=efi --size=600
+part /boot --fstype=ext4 --size=1024
+part pv.01 --size=1 --grow
+volgroup vg_azl pv.01
+logvol swap --vgname=vg_azl --name=lv_swap --fstype=swap --size=512
+logvol / --vgname=vg_azl --name=lv_root --fstype=ext4 --size=1 --grow
+
+@@PACKAGES@@
+
+%post --nochroot --log=/mnt/sysroot/var/log/anaconda-post.log
+cp /root/post-install.sh /mnt/sysroot/tmp/
+chroot /mnt/sysroot bash /tmp/post-install.sh
+rm -f /mnt/sysroot/tmp/post-install.sh
+%end
+
+%post --nochroot --log=/mnt/sysroot/var/log/anaconda-bootloader.log
+/root/post-bootloader.sh
+%end

--- a/base/images/vm-iso-installer/azurelinux.conf
+++ b/base/images/vm-iso-installer/azurelinux.conf
@@ -1,0 +1,25 @@
+# Azure Linux 4.0 — Anaconda configuration overrides
+# Loaded via conf.set_from_files() from /etc/anaconda/conf.d/
+
+[Storage]
+default_scheme = LVM
+file_system_type = ext4
+
+[Storage Constraints]
+root_device_types = LVM PARTITION MD LVM_THINP
+must_not_be_on_root = /boot /boot/efi
+req_partition_sizes =
+    /boot     1 GiB
+    /boot/efi  600 MiB
+
+[Network]
+default_on_boot = DEFAULT_ROUTE_DEVICE
+
+[Bootloader]
+efi_dir = fedora
+
+[User Interface]
+hidden_spokes = NetworkSpoke
+
+[License]
+eula =

--- a/base/images/vm-iso-installer/config.sh
+++ b/base/images/vm-iso-installer/config.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# KIWI config.sh — post-bootstrap configuration for Anaconda TUI Offline Installer ISO
+set -euo pipefail
+
+#----------------------------------------------------------------------
+# Architecture detection — set arch-specific package and EFI names
+#----------------------------------------------------------------------
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        GRUB_EFI_PKG="grub2-efi-x64"
+        GRUB_EFI_MOD_PKG="grub2-efi-x64-modules"
+        GRUB_EFI_CDBOOT_PKG="grub2-efi-x64-cdboot"
+        SHIM_EFI="shimx64.efi"
+        GRUB_EFI="grubx64.efi"
+        BOOT_EFI="BOOTX64.EFI"
+        ;;
+    aarch64)
+        GRUB_EFI_PKG="grub2-efi-aa64"
+        GRUB_EFI_MOD_PKG="grub2-efi-aa64-modules"
+        GRUB_EFI_CDBOOT_PKG="grub2-efi-aa64-cdboot"
+        SHIM_EFI="shimaa64.efi"
+        GRUB_EFI="grubaa64.efi"
+        BOOT_EFI="BOOTAA64.EFI"
+        ;;
+    *)
+        echo "ERROR: Unsupported architecture: $ARCH" >&2
+        exit 1
+        ;;
+esac
+echo "=== Architecture: $ARCH ==="
+echo "  GRUB EFI package: $GRUB_EFI_PKG"
+echo "  Shim EFI binary:  $SHIM_EFI"
+
+#----------------------------------------------------------------------
+# Download all target-install packages + deps for the offline repo
+#----------------------------------------------------------------------
+# During the ISO build we have network access to the repo.
+# Download every package that anaconda will install on the target,
+# including all transitive dependencies, into /opt/azl-offline-repo/.
+# This lets the offline kickstart install from file:// with no network.
+
+OFFLINE_REPO="/opt/azl-offline-repo"
+mkdir -p "$OFFLINE_REPO"
+
+# === Single source of truth for target-install packages ===
+# These go into the kickstart %packages and the offline repo.
+# Any package needed on the installed system belongs here.
+INSTALL_PKGS=(
+    bash
+    coreutils
+    systemd
+    systemd-networkd
+    systemd-resolved
+    dnf5
+    grub2
+    "$GRUB_EFI_PKG"
+    "$GRUB_EFI_MOD_PKG"
+    shim
+    efibootmgr
+    kernel
+    kernel-modules
+    openssh-server
+    openssh-clients
+    sudo
+    vim-minimal
+    ca-certificates
+    azurelinux-release
+    setup
+    shadow-utils
+    util-linux
+    selinux-policy-targeted
+    audit
+    chrony
+    cracklib-dicts
+    glibc
+    glibc-langpack-en
+    cryptsetup
+    firewalld
+    iproute
+)
+
+# Extra packages needed in the offline repo for anaconda's runtime deps
+# but not listed in kickstart %packages (pulled via --resolve --alldeps).
+EXTRA_REPO_PKGS=(
+    "$GRUB_EFI_CDBOOT_PKG"
+    lvm2
+    e2fsprogs
+    dosfstools
+    device-mapper-persistent-data
+    mtools
+    grub2-tools-extra
+    libaio
+)
+
+echo "=== Downloading target-install packages + dependencies ==="
+# Kiwi removes repo configs after package installation, so repos from the .kiwi
+# file are NOT available during config.sh. Use --repofrompath with the CDN URL
+# directly. The URL matches the "azurelinux-base" repo in vm-iso-installer.kiwi.
+
+AZL_BASE_URL="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$ARCH"
+dnf5 download \
+    --setopt=reposdir=/dev/null \
+    --repofrompath=azl-base,"$AZL_BASE_URL" \
+    --repo=azl-base \
+    --resolve \
+    --alldeps \
+    --skip-unavailable \
+    --destdir="$OFFLINE_REPO" \
+    "${INSTALL_PKGS[@]}" "${EXTRA_REPO_PKGS[@]}" || {
+    echo "WARNING: dnf download had errors — some packages may be missing"
+}
+
+RPM_COUNT=$(ls "$OFFLINE_REPO"/*.rpm 2>/dev/null | wc -l)
+echo "=== Downloaded $RPM_COUNT RPMs ==="
+ls "$OFFLINE_REPO"/*.rpm 2>/dev/null | head -20 || true
+echo "..."
+
+# Build repo metadata
+createrepo_c "$OFFLINE_REPO"
+
+#----------------------------------------------------------------------
+# Validate offline repo completeness (dry-run install)
+#----------------------------------------------------------------------
+echo "=== Validating offline repo completeness ==="
+
+DRYRUN_ROOT=$(mktemp -d /tmp/azl-dryrun-XXXXXX)
+DRYRUN_ERRORS=$(dnf5 install \
+    --assumeno \
+    --installroot="$DRYRUN_ROOT" \
+    --releasever=4.0 \
+    --setopt=reposdir=/dev/null \
+    --repofrompath=offline,"file://$OFFLINE_REPO" \
+    --repo=offline \
+    "${INSTALL_PKGS[@]}" 2>&1) || true
+
+rm -rf "$DRYRUN_ROOT"
+
+if echo "$DRYRUN_ERRORS" | grep -qiE "No match for argument|nothing provides|cannot install"; then
+    echo "!!!"
+    echo "!!! FATAL: Offline repo is missing packages required by the kickstart!"
+    echo "!!!"
+    echo "$DRYRUN_ERRORS" | grep -iE "No match for argument|nothing provides|cannot install"
+    echo ""
+    echo "Fix: add the missing packages to INSTALL_PKGS."
+    exit 1
+else
+    echo "=== Dry-run passed — all kickstart packages resolve from offline repo ==="
+fi
+
+echo "=== Offline repo ready at $OFFLINE_REPO ==="
+
+#----------------------------------------------------------------------
+# Anaconda launcher symlink (script deployed via kiwi <file>)
+#----------------------------------------------------------------------
+ln -sf /usr/local/bin/anaconda-launcher.sh /usr/local/bin/install-azl
+
+#----------------------------------------------------------------------
+# Welcome banner
+#----------------------------------------------------------------------
+
+cat > /root/.bash_profile << 'PROFILEEOF'
+# Auto-install mode: if "azl.autoinstall" is on the kernel cmdline
+# (selected via the "Install Azure Linux 4.0" GRUB entry), launch
+# the installer automatically.
+#
+# Console selection logic:
+#   - Hyper-V (systemd-detect-virt = "microsoft") → user is on VGA (tty1)
+#   - QEMU/KVM/bare-metal with serial in cmdline  → user is on serial (ttyS0)
+#   - QEMU/KVM/bare-metal without serial          → user is on VGA (tty1)
+# This prevents the invisible tty1 from stealing the installer on QEMU -nographic.
+if grep -q 'azl\.autoinstall' /proc/cmdline 2>/dev/null; then
+    MY_TTY=$(tty 2>/dev/null)
+    VIRT=$(systemd-detect-virt 2>/dev/null)
+    LAUNCH=false
+    if [ "$VIRT" = "microsoft" ]; then
+        # Hyper-V: user interacts via VGA console
+        [ "$MY_TTY" = "/dev/tty1" ] && LAUNCH=true
+    else
+        # QEMU/KVM/bare-metal
+        case "$MY_TTY" in
+            /dev/ttyS0)
+                LAUNCH=true
+                ;;
+            /dev/tty1|/dev/hvc0)
+                # Only autoinstall on VGA if serial is NOT in kernel cmdline
+                # (otherwise ttyS0 will handle it)
+                if ! grep -q 'console=ttyS' /proc/cmdline 2>/dev/null; then
+                    LAUNCH=true
+                fi
+                ;;
+        esac
+    fi
+    if [ "$LAUNCH" = true ]; then
+        echo ""
+        echo "========================================"
+        echo "  Azure Linux 4.0 — Offline Installer"
+        echo "========================================"
+        echo ""
+        echo "  Starting installer automatically..."
+        echo ""
+        exec /usr/local/bin/anaconda-launcher.sh
+    fi
+fi
+echo ""
+echo "========================================"
+echo "  Azure Linux 4.0 — Offline Installer"
+echo "========================================"
+echo ""
+echo "  To start the installer, run:"
+echo ""
+echo "    install-azl"
+echo ""
+echo "========================================"
+echo ""
+PROFILEEOF
+
+cat > /root/.bashrc << 'RCEOF'
+if [[ $- == *i* ]] && [ ! -f /tmp/.azl-banner-shown ]; then
+    touch /tmp/.azl-banner-shown
+    source /root/.bash_profile
+fi
+RCEOF
+
+#----------------------------------------------------------------------
+# Autologin on serial and VGA consoles
+#----------------------------------------------------------------------
+
+mkdir -p /etc/systemd/system/serial-getty@ttyS0.service.d
+cat > /etc/systemd/system/serial-getty@ttyS0.service.d/autologin.conf << 'AUTOEOF'
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear %I 115200 linux
+AUTOEOF
+
+mkdir -p /etc/systemd/system/getty@tty1.service.d
+cat > /etc/systemd/system/getty@tty1.service.d/autologin.conf << 'AUTOEOF'
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear %I linux
+AUTOEOF
+
+#----------------------------------------------------------------------
+# Generate kickstart files from templates (deployed via kiwi <file>)
+#----------------------------------------------------------------------
+
+# Helper: generate %packages section from INSTALL_PKGS array.
+generate_packages_section() {
+    echo "# Packages — minimal Azure Linux system"
+    echo "# --nocore: AZL repo has no comps groups, so @core would fail"
+    echo "%packages --nocore"
+    for pkg in "${INSTALL_PKGS[@]}"; do
+        echo "$pkg"
+    done
+    echo "%end"
+}
+
+# Expand @@PACKAGES@@ placeholder in each template
+for ks_in in /root/azl-install.ks.in /root/azl-install-encrypted.ks.in; do
+    ks_out="${ks_in%.in}"
+    {
+        sed '/@@PACKAGES@@/,$d' "$ks_in"
+        generate_packages_section
+        sed '1,/@@PACKAGES@@/d' "$ks_in"
+    } > "$ks_out"
+    rm -f "$ks_in"
+done

--- a/base/images/vm-iso-installer/grub_template.cfg
+++ b/base/images/vm-iso-installer/grub_template.cfg
@@ -1,0 +1,22 @@
+set default=0
+set timeout=${boot_timeout}
+
+serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1
+terminal_output console serial
+terminal_input console serial
+
+menuentry "Install Azure Linux 4.0" --class os {
+    search ${search_params}
+    echo 'Loading kernel...'
+    linux ($$root)/${bootpath}/${kernel_file} ${boot_options} azl.autoinstall inst.nosave=all_ks
+    echo 'Loading initrd...'
+    initrd ($$root)/${bootpath}/${initrd_file}
+}
+
+menuentry "Try Azure Linux 4.0 (Live)" --class os {
+    search ${search_params}
+    echo 'Loading kernel...'
+    linux ($$root)/${bootpath}/${kernel_file} ${boot_options} inst.nosave=all_ks
+    echo 'Loading initrd...'
+    initrd ($$root)/${bootpath}/${initrd_file}
+}

--- a/base/images/vm-iso-installer/post-bootloader.sh
+++ b/base/images/vm-iso-installer/post-bootloader.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# post-bootloader.sh — UEFI bootloader setup (%post --nochroot script for kickstart)
+# Runs in the installer environment (NOT chrooted into the target).
+# Generates grub.cfg, copies EFI binaries to fallback path, fixes NVRAM.
+set -x
+SYSROOT=/mnt/sysroot
+
+echo "=== Target mounts ==="
+findmnt -R "$SYSROOT" 2>/dev/null || mount | grep sysroot
+
+echo "=== fstab ==="
+cat "$SYSROOT/etc/fstab" 2>/dev/null
+echo "=== crypttab ==="
+cat "$SYSROOT/etc/crypttab" 2>/dev/null
+
+# --- Get partition UUIDs via blkid (direct device access) ---
+BOOT_DEV=$(findmnt -n -o SOURCE "$SYSROOT/boot" 2>/dev/null)
+BOOT_UUID=$(blkid -s UUID -o value "$BOOT_DEV" 2>/dev/null)
+ROOT_DEV=$(findmnt -n -o SOURCE "$SYSROOT" 2>/dev/null)
+ROOT_UUID=$(blkid -s UUID -o value "$ROOT_DEV" 2>/dev/null)
+
+echo "Boot: dev=$BOOT_DEV uuid=$BOOT_UUID"
+echo "Root: dev=$ROOT_DEV uuid=$ROOT_UUID"
+
+# Fallback: parse fstab
+if [ -z "$BOOT_UUID" ]; then
+    BOOT_UUID=$(awk '$2 == "/boot" { sub(/^UUID=/, "", $1); print $1 }' "$SYSROOT/etc/fstab" 2>/dev/null)
+fi
+if [ -z "$ROOT_UUID" ]; then
+    ROOT_UUID=$(awk '$2 == "/" { sub(/^UUID=/, "", $1); print $1 }' "$SYSROOT/etc/fstab" 2>/dev/null)
+fi
+
+# --- Find installed kernel and initramfs ---
+KERNEL=$(ls "$SYSROOT"/boot/vmlinuz-* 2>/dev/null | sort -V | tail -1)
+INITRD=$(ls "$SYSROOT"/boot/initramfs-*.img 2>/dev/null | sort -V | tail -1)
+KERNEL_NAME=$(basename "$KERNEL")
+INITRD_NAME=$(basename "$INITRD")
+echo "Kernel: $KERNEL_NAME  Initrd: $INITRD_NAME"
+
+if [ -z "$BOOT_UUID" ] || [ -z "$ROOT_UUID" ]; then
+    echo "!!! FATAL: Could not determine boot ($BOOT_UUID) or root ($ROOT_UUID) UUID"
+    echo "!!! Bootloader setup SKIPPED — system may not boot"
+    echo "=== blkid output ==="
+    blkid 2>/dev/null
+    echo "=== mount output ==="
+    mount 2>/dev/null
+    exit 0
+fi
+
+if [ -z "$KERNEL_NAME" ] || [ -z "$INITRD_NAME" ]; then
+    echo "!!! FATAL: No kernel ($KERNEL_NAME) or initramfs ($INITRD_NAME) found in $SYSROOT/boot/"
+    ls -la "$SYSROOT/boot/" 2>/dev/null
+    exit 0
+fi
+
+# --- Detect LUKS encryption ---
+LUKS_PARAMS=""
+for luks_dev in $(blkid -t TYPE=crypto_LUKS -o device 2>/dev/null); do
+    LUKS_UUID=$(cryptsetup luksUUID "$luks_dev" 2>/dev/null) && {
+        LUKS_PARAMS="rd.luks.uuid=luks-${LUKS_UUID}"
+        echo "Detected LUKS device: $luks_dev UUID=$LUKS_UUID"
+        break
+    }
+done
+
+# --- Find or create EFI vendor directory ---
+EFI_VENDOR=""
+for d in "$SYSROOT/boot/efi/EFI/fedora" "$SYSROOT/boot/efi/EFI/azurelinux"; do
+    [ -d "$d" ] && { EFI_VENDOR="$d"; break; }
+done
+[ -z "$EFI_VENDOR" ] && { EFI_VENDOR="$SYSROOT/boot/efi/EFI/fedora"; mkdir -p "$EFI_VENDOR"; }
+echo "EFI vendor dir: $EFI_VENDOR"
+ls -la "$EFI_VENDOR/" 2>/dev/null
+
+# --- Generate /boot/grub2/grub.cfg ---
+mkdir -p "$SYSROOT/boot/grub2"
+cat > "$SYSROOT/boot/grub2/grub.cfg" << GRUBCFG
+set default=0
+set timeout=2
+serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1
+terminal_output console serial
+terminal_input console serial
+
+menuentry "Azure Linux" {
+    search --no-floppy --fs-uuid --set=root ${BOOT_UUID}
+    linux /${KERNEL_NAME} root=UUID=${ROOT_UUID} ${LUKS_PARAMS} console=ttyS0,115200 console=tty0 ro
+    initrd /${INITRD_NAME}
+}
+
+menuentry "Azure Linux (rescue)" {
+    search --no-floppy --fs-uuid --set=root ${BOOT_UUID}
+    linux /${KERNEL_NAME} root=UUID=${ROOT_UUID} ${LUKS_PARAMS} console=ttyS0,115200 console=tty0 ro systemd.unit=rescue.target
+    initrd /${INITRD_NAME}
+}
+
+menuentry "UEFI Firmware Settings" --id "uefi-firmware" {
+    fwsetup
+}
+GRUBCFG
+echo "--- /boot/grub2/grub.cfg ---"
+cat "$SYSROOT/boot/grub2/grub.cfg"
+
+# --- Create EFI stub grub.cfg ---
+if [ -n "$BOOT_UUID" ]; then
+    cat > "$EFI_VENDOR/grub.cfg" << STUBCFG
+search --no-floppy --root-dev-only --fs-uuid --set=dev ${BOOT_UUID}
+set prefix=(\$dev)/grub2
+export \$prefix
+configfile \$prefix/grub.cfg
+STUBCFG
+fi
+
+# --- Detect architecture for EFI binary names ---
+EFI_ARCH=$(uname -m)
+case "$EFI_ARCH" in
+    x86_64)  SHIM_EFI="shimx64.efi"; GRUB_EFI="grubx64.efi"; BOOT_EFI="BOOTX64.EFI" ;;
+    aarch64) SHIM_EFI="shimaa64.efi"; GRUB_EFI="grubaa64.efi"; BOOT_EFI="BOOTAA64.EFI" ;;
+esac
+
+# --- Copy EFI binaries + grub.cfg to fallback boot path ---
+mkdir -p "$SYSROOT/boot/efi/EFI/BOOT"
+if [ -f "$EFI_VENDOR/$SHIM_EFI" ]; then
+    cp -vf "$EFI_VENDOR/$SHIM_EFI"   "$SYSROOT/boot/efi/EFI/BOOT/$BOOT_EFI"
+    cp -vf "$EFI_VENDOR/$GRUB_EFI"   "$SYSROOT/boot/efi/EFI/BOOT/$GRUB_EFI"   2>/dev/null || true
+    cp -vf "$EFI_VENDOR/grub.cfg"    "$SYSROOT/boot/efi/EFI/BOOT/grub.cfg"     2>/dev/null || true
+elif [ -f "$EFI_VENDOR/$GRUB_EFI" ]; then
+    cp -vf "$EFI_VENDOR/$GRUB_EFI"   "$SYSROOT/boot/efi/EFI/BOOT/$BOOT_EFI"
+    cp -vf "$EFI_VENDOR/grub.cfg"    "$SYSROOT/boot/efi/EFI/BOOT/grub.cfg"     2>/dev/null || true
+else
+    echo "!!! WARNING: No EFI binaries found!"
+    find "$SYSROOT/boot/efi" -type f -name "*.efi" 2>/dev/null
+fi
+
+echo "=== Final ESP contents ==="
+ls -laR "$SYSROOT/boot/efi/" 2>/dev/null
+
+# --- Fix UEFI NVRAM boot entry ---
+ESP_DEV=$(findmnt -n -o SOURCE "$SYSROOT/boot/efi" 2>/dev/null)
+if [ -n "$ESP_DEV" ]; then
+    ESP_DISK=$(echo "$ESP_DEV" | sed 's/[0-9]*$//')
+    ESP_PART=$(echo "$ESP_DEV" | grep -o '[0-9]*$')
+    echo "ESP: dev=$ESP_DEV disk=$ESP_DISK part=$ESP_PART"
+
+    echo "=== Current UEFI boot entries ==="
+    efibootmgr 2>/dev/null
+    for bootnum in $(efibootmgr 2>/dev/null | grep -i 'default\\\|anaconda\|fedora' | sed 's/Boot\([0-9A-Fa-f]*\).*/\1/'); do
+        echo "Removing stale entry Boot$bootnum"
+        efibootmgr -b "$bootnum" -B 2>/dev/null || true
+    done
+
+    efibootmgr -c -d "$ESP_DISK" -p "$ESP_PART" \
+        -L "Azure Linux" -l "\\EFI\\fedora\\$SHIM_EFI" 2>/dev/null && \
+        echo "Created UEFI boot entry: Azure Linux -> \\EFI\\fedora\\$SHIM_EFI" || \
+        echo "WARNING: efibootmgr -c failed"
+
+    echo "=== Updated UEFI boot entries ==="
+    efibootmgr 2>/dev/null
+else
+    echo "WARNING: Could not find ESP mount — skipping NVRAM fix"
+fi

--- a/base/images/vm-iso-installer/post-install.sh
+++ b/base/images/vm-iso-installer/post-install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# post-install.sh — Target system configuration (%post script for kickstart)
+# Called from within the installed chroot during anaconda %post.
+set -x
+
+# --- Network configuration ---
+cat > /etc/systemd/network/20-wired-dhcp.network << 'NET'
+[Match]
+Name=en* eth*
+
+[Network]
+DHCP=yes
+
+[DHCPv4]
+UseDNS=yes
+NET
+
+# --- GRUB defaults ---
+cat > /etc/default/grub << 'GRUBDEF'
+GRUB_TIMEOUT=2
+GRUB_DISTRIBUTOR="Azure Linux"
+GRUB_DEFAULT=0
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console serial"
+GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+GRUB_CMDLINE_LINUX="console=ttyS0,115200 console=tty0"
+GRUB_DISABLE_RECOVERY=true
+GRUBDEF
+
+# --- Encrypted disk: regenerate initramfs with LUKS support ---
+if [ -f /etc/crypttab ] && [ -s /etc/crypttab ]; then
+    echo "LUKS detected — regenerating initramfs with crypt module..."
+    dracut --regenerate-all --force --add crypt
+fi
+
+# --- Security hardening ---
+# Remove SSH host keys — sshd-keygen regenerates on first boot
+rm -f /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub
+
+# Reset machine-id — systemd regenerates on first boot
+: > /etc/machine-id
+
+# Disable root SSH login with password (key-based only)
+sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config 2>/dev/null || true
+
+# Trigger SELinux relabel on first boot
+touch /.autorelabel

--- a/base/images/vm-iso-installer/vm-iso-installer.kiwi
+++ b/base/images/vm-iso-installer/vm-iso-installer.kiwi
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model
+    href="https://raw.githubusercontent.com/OSInside/kiwi/refs/tags/v10.2.33/kiwi/schema/kiwi.rng"
+    type="application/xml"?>
+<image schemaversion="8.3" name="azl4-iso-installer">
+    <description type="system">
+        <author>Azure Linux</author>
+        <contact>azurelinux@microsoft.com</contact>
+        <specification>Azure Linux 4.0 ISO Installer</specification>
+    </description>
+    <preferences>
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type
+            image="iso"
+            flags="dmsquash"
+            filesystem="ext4"
+            kernelcmdline="console=ttyS0,115200 console=tty0 enforcing=0 audit=0 inst.text inst.lang=en_US.UTF-8 inst.nokill"
+            firmware="uefi"
+            hybridpersistent="false"
+            mediacheck="true">
+            <bootloader name="grub2" timeout="5" grub_template="grub_template.cfg" />
+        </type>
+    </preferences>
+
+    <repository type="rpm-md" alias="azurelinux-base">
+        <source
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
+    </repository>
+    <repository type="rpm-md" alias="azurelinux-sdk">
+        <source
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
+    </repository>
+
+    <packages type="image">
+        <!-- Distro identity -->
+        <package name="azurelinux-release" />
+        <package name="azurelinux-rpm-config" />
+        <package name="azurelinux-repos" />
+
+        <!-- Core system -->
+        <package name="bash" />
+        <package name="ca-certificates" />
+        <package name="coreutils" />
+        <package name="cracklib-dicts" />
+        <package name="dnf5" />
+        <package name="glibc" />
+        <package name="glibc-langpack-en" />
+        <package name="hostname" />
+        <package name="iproute" />
+        <package name="kernel" />
+        <package name="kernel-modules" />
+        <package name="selinux-policy-targeted" />
+        <package name="setup" />
+        <package name="shadow-utils" />
+        <package name="systemd" />
+        <package name="systemd-networkd" />
+        <package name="systemd-resolved" />
+        <package name="tar" />
+        <package name="util-linux" />
+        <file
+            name="20-wired-dhcp.network"
+            target="/etc/systemd/network/20-wired-dhcp.network"
+            permissions="0644" />
+        <file
+            name="azurelinux.conf"
+            target="/etc/anaconda/conf.d/azurelinux.conf"
+            permissions="0644" />
+        <file
+            name="anaconda-launcher.sh"
+            target="/usr/local/bin/anaconda-launcher.sh"
+            permissions="0755" />
+        <file
+            name="azl-install.ks.in"
+            target="/root/azl-install.ks.in"
+            permissions="0644" />
+        <file
+            name="azl-install-encrypted.ks.in"
+            target="/root/azl-install-encrypted.ks.in"
+            permissions="0644" />
+        <file
+            name="post-install.sh"
+            target="/root/post-install.sh"
+            permissions="0755" />
+        <file
+            name="post-bootloader.sh"
+            target="/root/post-bootloader.sh"
+            permissions="0755" />
+
+        <!-- UEFI boot -->
+        <package name="grub2" />
+        <package name="grub2-efi-x64" arch="x86_64" />
+        <package name="grub2-efi-x64-modules" arch="x86_64" />
+        <package name="grub2-efi-aa64" arch="aarch64" />
+        <package name="grub2-efi-aa64-modules" arch="aarch64" />
+        <package name="shim" arch="x86_64" />
+        <package name="shim" arch="aarch64" />
+        <package name="efibootmgr" />
+
+        <!-- ISO live boot (Fedora dmsquash-live) -->
+        <package name="dracut-live" />
+
+        <!-- Hyper-V guest integration -->
+        <package name="hyperv-daemons" />
+
+        <!-- Anaconda TUI installer (deps resolved automatically) -->
+        <package name="anaconda-core" />
+        <package name="anaconda-tui" />
+        <package name="anaconda-install-env-deps" />
+
+        <!-- Offline repo creation -->
+        <package name="createrepo_c" />
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="dracut-network" />
+        <package name="filesystem" />
+        <package name="grub2-efi-x64-modules" arch="x86_64" />
+        <package name="grub2-efi-x64" arch="x86_64" />
+        <package name="grub2-efi-aa64-modules" arch="aarch64" />
+        <package name="grub2-efi-aa64" arch="aarch64" />
+        <package name="shim" arch="x86_64" />
+        <package name="shim" arch="aarch64" />
+    </packages>
+
+    <users>
+        <user name="root" password="" groups="root" />
+    </users>
+</image>


### PR DESCRIPTION
Add a kiwi-based ISO installer image that builds and installs Azure Linux on both x86_64 and aarch64 using runtime architecture detection.

Image definition:
- vm-iso-installer: kiwi ISO image with dual-arch repos (alpha2-prod) and arch-filtered package entries for grub2-efi-* and shim
- config.sh: runtime uname -m detection for GRUB/shim/EFI variables; placeholder substitution in kickstart heredocs for arch-specific package names; independent arch detection in %post --nochroot sections for EFI binary paths
- Build-time dry-run validation of offline repo completeness to catch missing packages before producing the ISO
- Standard and LUKS-encrypted installation modes via embedded kickstarts with offline repo (file://)
- Security hardening: SSH key regeneration, machine-id reset, PermitRootLogin prohibit-password, SELinux autorelabel
- Register image in images.toml

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
