### PR TITLE
Fix IC golden container pip install failure under CFSClean network isolation

### DIFF
--- a/.pipelines/containerSourceData/imagecustomizer/Dockerfile-imagecustomizer
+++ b/.pipelines/containerSourceData/imagecustomizer/Dockerfile-imagecustomizer
@@ -25,6 +25,7 @@ RUN tdnf update -y && \
 
 # Create virtual environment and install Python dependencies for telemetry
 RUN python3 -m venv /usr/lib/imagecustomizer/telemetry-venv
-RUN /usr/lib/imagecustomizer/telemetry-venv/bin/pip install --no-cache-dir -r /usr/lib/imagecustomizer/telemetry-requirements.txt
+RUN --mount=type=secret,id=pip_cfg,target=/usr/lib/imagecustomizer/telemetry-venv/pip.conf \
+    /usr/lib/imagecustomizer/telemetry-venv/bin/pip install --no-cache-dir -r /usr/lib/imagecustomizer/telemetry-requirements.txt
 
 ENTRYPOINT ["/usr/lib/imagecustomizer/entrypoint.sh"]

--- a/.pipelines/containerSourceData/scripts/BuildGoldenContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenContainer.sh
@@ -247,6 +247,21 @@ function prepare_docker_directory {
     # we look for the toolchain rpms in the same directory as the rpms tarball
     tar -xvf "$TOOLCHAIN_RPMS_TARBALL" -C "$HOST_MOUNTED_DIR/RPMS"/
     cp -v "$CONTAINER_SRC_DIR/azurelinuxlocal.repo" "$HOST_MOUNTED_DIR"/
+
+    PIP_CFG_PATH="$WORK_DIR/pip.cfg"
+    PIP_CFG_ARG=""
+    if [ -n "$PIP_INDEX_URL" ] || [ -n "$PIP_EXTRA_INDEX_URL" ]; then
+        cat > "$PIP_CFG_PATH" << EOF
+[global]
+EOF
+        if [ -n "$PIP_INDEX_URL" ]; then
+            echo "index-url = $PIP_INDEX_URL" >> "$PIP_CFG_PATH"
+        fi
+        if [ -n "$PIP_EXTRA_INDEX_URL" ]; then
+            echo "extra-index-url = $PIP_EXTRA_INDEX_URL" >> "$PIP_CFG_PATH"
+        fi
+        PIP_CFG_ARG="--secret id=pip_cfg,src=$PIP_CFG_PATH"
+    fi
 }
 
 function docker_build {
@@ -257,6 +272,7 @@ function docker_build {
     echo "docker buildx build $DOCKER_BUILD_ARGS" \
     "--build-arg BASE_IMAGE=$BASE_IMAGE_NAME_FULL" \
     "--build-arg RPMS_TO_INSTALL=$PACKAGES_TO_INSTALL" \
+    "$PIP_CFG_ARG" \
     "-t $CONTAINER_IMAGE_NAME --no-cache --progress=plain" \
     "-f $WORK_DIR/Dockerfile ."
 
@@ -264,6 +280,7 @@ function docker_build {
     docker buildx build $DOCKER_BUILD_ARGS \
         --build-arg BASE_IMAGE="$BASE_IMAGE_NAME_FULL" \
         --build-arg RPMS_TO_INSTALL="$PACKAGES_TO_INSTALL" \
+        $PIP_CFG_ARG \
         -t "$CONTAINER_IMAGE_NAME" --no-cache --progress=plain \
         -f "$WORK_DIR/Dockerfile" .
     popd > /dev/null


### PR DESCRIPTION
The Image Customizer golden container build fails in the Official pipeline because the CFSClean network isolation policy (added in 1ESNetworkIsolation 1.0.143) blocks outbound access to pypi.org during docker build. IC is the only golden container that uses pip install.

This fix passes the authenticated Mariner-Pypi-Feed URL (set by PipAuthenticate@1) into the Docker build as a BuildKit secret, mirroring the pattern already used in the image-tools repo (build-container.sh). When PIP_INDEX_URL or PIP_EXTRA_INDEX_URL are not set, the behavior is unchanged, so no impact on other golden containers.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
