### PR TITLE
Fix kiwi repository sources to use azurelinux-base and azurelinux-sdk repos

### DIFF
--- a/base/images/container-base/container-base.kiwi
+++ b/base/images/container-base/container-base.kiwi
@@ -65,9 +65,14 @@
         </type>
     </preferences>
 
-    <repository type="rpm-md" alias="fedora-43-everything">
+    <repository type="rpm-md" alias="azurelinux-base">
         <source
-            path="https://fedora.mirrorservice.org/fedora/linux/releases/43/Everything/x86_64/os/" />
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
+    </repository>
+
+    <repository type="rpm-md" alias="azurelinux-sdk">
+        <source
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
     </repository>
 
     <packages type="image" profiles="core">

--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -34,9 +34,14 @@
         </type>
     </preferences>
 
-    <repository type="rpm-md" alias="fedora-43-everything">
+    <repository type="rpm-md" alias="azurelinux-base">
         <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/daily-repo-non-prod/20260303/x86_64/" />
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
+    </repository>
+
+    <repository type="rpm-md" alias="azurelinux-sdk">
+        <source
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
     </repository>
 
     <packages type="image">


### PR DESCRIPTION
## Summary

Update both `container-base.kiwi` and `vm-base.kiwi` to use the correct Azure Linux DNF repositories instead of incorrect/stale sources:

- **container-base**: was pointing at a Fedora mirror placeholder URL (completely wrong)
- **vm-base**: was pointing at a stale dated ControlTower snapshot (`20260303`)

Both now declare two repositories:
- `azurelinux-base` -> `alpha2-prod/base/$basearch`
- `azurelinux-sdk` -> `alpha2-prod/sdk/$basearch`

## Testing

Verified on Fedora dev machine:
- amd64: kiwi/dnf5 resolves `\$basearch` correctly, packages install from azurelinux-base and azurelinux-sdk
- arm64: same -- `\$basearch` expands to `aarch64` and resolves correctly

## Fixes

[AB#19379](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19379) -- Fix container-base.kiwi repository sources for AZL4 DNF repos
[AB#19380](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19380) -- Update vm-base.kiwi DNF repo snapshot timestamp