### PR TITLE
systemd: fix unnecessary nftables initialization by backporting upstream

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        28%{?dist}
+Release:        29%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-29
+- Bump release to match systemd spec
+
 * Tue Apr 21 2026 Akhila Guruju <v-guakhila@microsoft.com> - 255-28
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/networkd-address-skip-firewall-init.patch
+++ b/SPECS/systemd/networkd-address-skip-firewall-init.patch
@@ -1,0 +1,30 @@
+From 0d7bbcef27b8f435640427ae1f28627e46fe514d Mon Sep 17 00:00:00 2001
+From: Topi Miettinen <toiwoton@gmail.com>
+Date: Mon, 4 Dec 2023 21:49:12 +0200
+Subject: [PATCH] network/networkd-address: don't set up firewall rules here
+
+Don't set up firewall rules when we're just initializing the firewall context
+for NFT sets.
+
+Fixes: #30257
+(cherry picked from commit 58c6e75f263a1562f5550221af1ec1a9b6046143)
+---
+ src/network/networkd-address.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/network/networkd-address.c b/src/network/networkd-address.c
+index c1a8cd884a..7071137676 100644
+--- a/src/network/networkd-address.c
++++ b/src/network/networkd-address.c
+@@ -645,7 +645,7 @@ static void address_modify_nft_set_context(Address *address, bool add, NFTSetCon
+         assert(nft_set_context);
+ 
+         if (!address->link->manager->fw_ctx) {
+-                r = fw_ctx_new(&address->link->manager->fw_ctx);
++                r = fw_ctx_new_full(&address->link->manager->fw_ctx, /* init_tables= */ false);
+                 if (r < 0)
+                         return;
+         }
+-- 
+2.45.4
+

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        28%{?dist}
+Release:        29%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -152,6 +152,7 @@ Patch0908:      ipc-call-0004-core-validate-input-cgroup-path-more-prudently.pat
 Patch0909:      fix-pcrlock-hyperv-hash-algorithm-ordering.patch
 Patch0910:      CVE-2026-40226.patch
 Patch0911:      CVE-2026-40225.patch
+Patch0912:      networkd-address-skip-firewall-init.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1237,6 +1238,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-29
+- Fix unwanted nftables initialization in systemd-networkd by backporting
+  upstream commit 58c6e75 from systemd v256 (PR #30318).
+
 * Tue Apr 21 2026 Akhila Guruju <v-guakhila@microsoft.com> - 255-28
 - Patch CVE-2026-40226, CVE-2026-40225
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backport upstream systemd fix for `networkd` unwanted firewall initialization.

systemd v255 initializes firewall context/nftables when handling `RTM_NEWADDR` from rtnetlink. This can cause networkd to hang when an interface receives a new address in an environment where nftables is not present.

The upstream fix (commit [b368900](https://github.com/systemd/systemd/commit/b368900552949568299bd55257b62bee93739ceb) from systemd v256 PR [30318](https://github.com/systemd/systemd/pull/30318)) removes the nftables initialization, ensuring networkd does not touch nftables unless requested.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `networkd-address-skip-firewall-init.patch` from upstream systemd v256
- Bump release

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
