### PR TITLE
feat(wsl): initial WSL image derived from Fedora kiwi

### DIFF
--- a/base/images/images.toml
+++ b/base/images/images.toml
@@ -18,11 +18,6 @@ definition = { type = "kiwi", path = "container-base/container-base.kiwi", profi
 description = "Container Distroless Debug Image"
 definition = { type = "kiwi", path = "container-base/container-base.kiwi", profile = "distroless-debug" }
 
-# NOTE:
-# sudo dnf install -y kiwi-cli
-# sudo kiwi --loglevel 10 \
-#     --kiwi-file container-base.kiwi \
-#     system build \
-#     --description ./container-base \
-#     --target-dir <output_dir> \
-#     --add-repo='file:///home/username/some/dir/with/private/rpms,rpm-md,azl,1
+[images.wsl]
+description = "WSL Image"
+definition = { type = "kiwi", path = "wsl/wsl.kiwi" }

--- a/base/images/wsl/wsl.kiwi
+++ b/base/images/wsl/wsl.kiwi
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="https://raw.githubusercontent.com/OSInside/kiwi/refs/tags/v10.2.33/kiwi/schema/kiwi.rng" type="application/xml"?>
+<image schemaversion="8.3" name="azl4-wsl">
+    <description type="system">
+        <author>Azure Linux</author>
+        <contact>azurelinux@microsoft.com</contact>
+        <specification>Azure Linux WSL Image</specification>
+    </description>
+    <preferences>
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type image="wsl"/>
+        <rpm-locale-filtering>false</rpm-locale-filtering>
+        <rpm-excludedocs>false</rpm-excludedocs>
+    </preferences>
+
+    <repository type="rpm-md" alias="azurelinux-base">
+        <source
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
+    </repository>
+
+    <repository type="rpm-md" alias="azurelinux-sdk">
+        <source
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
+    </repository>
+
+    <!-- Package list derived from Fedora 43's WSL image composition. -->
+    <packages type="image" patternType="plusRecommended">
+        <package name="attr"/>
+        <package name="acl"/>
+        <package name="bash-color-prompt"/>
+        <package name="bash-completion"/>
+        <package name="bind-utils"/>
+        <package name="bzip2"/>
+        <package name="curl"/>
+        <package name="dbus"/>
+        <package name="default-editor"/>
+        <package name="file"/>
+        <package name="glibc-langpack-en"/>
+        <package name="gnupg2"/>
+        <package name="iproute"/>
+        <package name="iputils"/>
+        <package name="less"/>
+        <package name="lsof"/>
+        <package name="man-db"/>
+        <package name="man-pages"/>
+        <package name="nmap-ncat"/>
+        <package name="openssh-clients"/>
+        <package name="passwd"/>
+        <package name="pciutils"/>
+        <package name="procps-ng"/>
+        <package name="rsync"/>
+        <package name="shadow-utils"/>
+        <package name="sudo"/>
+        <package name="symlinks"/>
+        <package name="systemd-networkd"/>
+        <package name="systemd-udev"/>
+        <package name="systemd-resolved"/>
+        <package name="tar"/>
+        <package name="tcpdump"/>
+        <package name="time"/>
+        <package name="traceroute"/>
+        <package name="tree"/>
+        <package name="unzip"/>
+        <package name="usbutils"/>
+        <package name="util-linux"/>
+        <package name="vim-minimal"/>
+        <package name="wget"/>
+        <package name="which"/>
+        <package name="whois"/>
+        <package name="wsl-setup"/>
+        <package name="zip"/>
+        <package name="zram-generator-defaults"/>
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="bash"/>
+        <package name="coreutils"/>
+        <package name="dnf5"/>
+        <package name="dnf5-plugins"/>
+        <package name="azurelinux-release-wsl"/>
+        <package name="rpm"/>
+    </packages>
+</image>


### PR DESCRIPTION
Adds initial WSL image based on the composition and configuration used by Fedora 43's WSL image: 

> https://pagure.io/fedora-kiwi-descriptions/blob/f43/f/teams/cloud/wsl.xml

I expect we'll need to iterate over time. We've had some previous prototyping work in this area, but I'd like to get something in and building regularly to be able to identify integration issues we'll encounter.