### PR TITLE
fix(rubygem-nokogiri): drop rubygem(minitest-mock) BuildRequires

### DIFF
--- a/base/comps/rubygem-nokogiri/rubygem-nokogiri.comp.toml
+++ b/base/comps/rubygem-nokogiri/rubygem-nokogiri.comp.toml
@@ -1,3 +1,16 @@
 [components.rubygem-nokogiri]
 # Release: %{?prever:0.}%{baserelease}%{?prever:.%{prerpmver}}%{?dist}
 release = { calculation = "manual" }
+
+# Azure Linux ships rubygem-minitest 5.25.5, which still bundles Minitest::Mock
+# internally. Upstream Fedora split minitest-mock into a separate gem with
+# minitest 6.x (F44+); the BR was first added in Fedora rpms/rubygem-nokogiri
+# commit 3c9b3b0 (Dec 2025, 1.18.10-2 "Handle minitest 6 compatibility") under
+# `%if !0%{?rhel}`, then moved unconditionally in f64183f (Jan 2026). AZL has
+# no rubygem-minitest-mock package, so the BR cannot resolve regardless of
+# which form is used.
+[[components.rubygem-nokogiri.overlays]]
+description = "Drop rubygem(minitest-mock) BuildRequires - provided by bundled minitest 5.x in AZL (minitest-mock was split out only in minitest 6/F44+)"
+type = "spec-remove-tag"
+tag = "BuildRequires"
+value = "rubygem(minitest-mock)"

--- a/locks/rubygem-nokogiri.lock
+++ b/locks/rubygem-nokogiri.lock
@@ -2,4 +2,4 @@
 version = 1
 import-commit = 'bd53c9fdecabc71015ec523d9be11d50b9a83302'
 upstream-commit = 'bd53c9fdecabc71015ec523d9be11d50b9a83302'
-input-fingerprint = 'sha256:cca08a10cee968dd02b4030743008cd3ecb50a05bd1cea0922846329a507f4db'
+input-fingerprint = 'sha256:17a046cf658a7adba622f9a9d5e77698e49aed8b9904ee8579388f736a22d442'

--- a/specs/r/rubygem-nokogiri/rubygem-nokogiri.spec
+++ b/specs/r/rubygem-nokogiri/rubygem-nokogiri.spec
@@ -37,7 +37,6 @@ BuildRequires:	ruby(rubygems)
 ##
 ## For %%check
 BuildRequires:	rubygem(minitest)
-BuildRequires:	rubygem(minitest-mock)
 %if !0%{?rhel}
 # For test/xml/test_document_encoding.rb
 # Drop rubygem(rubyzip) build dependency in RHEL


### PR DESCRIPTION
Upstream Fedora rubygem-nokogiri added BuildRequires: rubygem(minitest-mock)
in commit 3c9b3b0 (Dec 2025, 1.18.10-2 'Handle minitest 6 compatibility')
under '%if !0%{?rhel}', then moved it unconditionally in f64183f (Jan 2026).
The dep was introduced because Fedora 44+ ships rubygem-minitest 6.x where
Minitest::Mock was split out into its own gem.

Azure Linux ships rubygem-minitest 5.25.5, which still bundles Minitest::Mock
internally, and has no rubygem-minitest-mock package. The BR cannot resolve
regardless of which guard form upstream uses.

Add a spec-remove-tag overlay to drop the BR. Verified: build succeeds and
%check runs cleanly (2749 runs, 9837 assertions, 0 failures, 0 errors).