### PR TITLE
systemd: fix unmanaged interface in networkd

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        29%{?dist}
+Release:        30%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-30
+- Bump release to match systemd spec
+
 * Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-29
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch
+++ b/SPECS/systemd/network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch
@@ -1,0 +1,142 @@
+From 2485443518b3bc6ef322696f96293041974bc8fc Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Wed, 11 Jun 2025 18:05:46 +0900
+Subject: [PATCH] network: also check ID_NET_MANAGED_BY property on reconfigure
+
+Previously, the property was checked only when an uevent is received,
+so even if an interface has ID_NET_MANAGED_BY property, the interface
+will be configured by networkd when reconfiguration is triggered e.g.
+when interface state is changed.
+
+Follow-up for ba87a61d05d637be9f0b21707f7fe3b0a74c5a05.
+Fixes #36997.
+
+(cherry picked from commit 78f8d5ed71ecc16ad36d1c215d2d57433d127679)
+---
+ src/network/networkd-link.c                   | 44 ++++++++++++++-----
+ .../test-network/conf/11-dummy-unmanaged.link |  8 ++++
+ test/test-network/systemd-networkd-tests.py   | 11 +++++
+ 3 files changed, 53 insertions(+), 10 deletions(-)
+ create mode 100644 test/test-network/conf/11-dummy-unmanaged.link
+
+diff --git a/src/network/networkd-link.c b/src/network/networkd-link.c
+index 2caf4ff249..6814ef09f0 100644
+--- a/src/network/networkd-link.c
++++ b/src/network/networkd-link.c
+@@ -1213,6 +1213,32 @@ static int link_get_network(Link *link, Network **ret) {
+         return -ENOENT;
+ }
+ 
++static int link_managed_by_us(Link *link) {
++        int r;
++
++        assert(link);
++
++        if (!link->dev)
++                return true;
++
++        const char *s;
++        r = sd_device_get_property_value(link->dev, "ID_NET_MANAGED_BY", &s);
++        if (r == -ENOENT)
++                return true;
++        if (r < 0)
++                return log_link_warning_errno(link, r, "Failed to get ID_NET_MANAGED_BY udev property: %m");
++
++        if (streq(s, "io.systemd.Network"))
++                return true;
++
++        if (link->state == LINK_STATE_UNMANAGED)
++                return false; /* Already in unmanaged state */
++
++        log_link_debug(link, "Interface is requested to be managed by '%s', unmanaging the interface.", s);
++        link_set_state(link, LINK_STATE_UNMANAGED);
++        return false;
++}
++
+ int link_reconfigure_impl(Link *link, bool force) {
+         Network *network = NULL;
+         NetDev *netdev = NULL;
+@@ -1223,6 +1249,10 @@ int link_reconfigure_impl(Link *link, bool force) {
+         if (IN_SET(link->state, LINK_STATE_PENDING, LINK_STATE_LINGER))
+                 return 0;
+ 
++        r = link_managed_by_us(link);
++        if (r <= 0)
++                return r;
++
+         r = netdev_get(link->manager, link->ifname, &netdev);
+         if (r < 0 && r != -ENOENT)
+                 return r;
+@@ -1398,6 +1428,10 @@ static int link_initialized(Link *link, sd_device *device) {
+          * or sysattrs) may be outdated. */
+         device_unref_and_replace(link->dev, device);
+ 
++        r = link_managed_by_us(link);
++        if (r <= 0)
++                return r;
++
+         if (link->dhcp_client) {
+                 r = sd_dhcp_client_attach_device(link->dhcp_client, link->dev);
+                 if (r < 0)
+@@ -1465,7 +1499,6 @@ static int link_check_initialized(Link *link) {
+ 
+ int manager_udev_process_link(Manager *m, sd_device *device, sd_device_action_t action) {
+         int r, ifindex;
+-        const char *s;
+         Link *link;
+ 
+         assert(m);
+@@ -1500,15 +1533,6 @@ int manager_udev_process_link(Manager *m, sd_device *device, sd_device_action_t
+                 return 0;
+         }
+ 
+-        r = sd_device_get_property_value(device, "ID_NET_MANAGED_BY", &s);
+-        if (r < 0 && r != -ENOENT)
+-                log_device_debug_errno(device, r, "Failed to get ID_NET_MANAGED_BY udev property, ignoring: %m");
+-        if (r >= 0 && !streq(s, "io.systemd.Network")) {
+-                log_device_debug(device, "Interface is requested to be managed by '%s', not managing the interface.", s);
+-                link_set_state(link, LINK_STATE_UNMANAGED);
+-                return 0;
+-        }
+-
+         r = link_initialized(link, device);
+         if (r < 0)
+                 link_enter_failed(link);
+diff --git a/test/test-network/conf/11-dummy-unmanaged.link b/test/test-network/conf/11-dummy-unmanaged.link
+new file mode 100644
+index 0000000000..99c07a72ce
+--- /dev/null
++++ b/test/test-network/conf/11-dummy-unmanaged.link
+@@ -0,0 +1,8 @@
++# SPDX-License-Identifier: MIT-0
++[Match]
++Kind=dummy
++OriginalName=test1
++
++[Link]
++NamePolicy=keep
++Property=ID_NET_MANAGED_BY=hoge
+diff --git a/test/test-network/systemd-networkd-tests.py b/test/test-network/systemd-networkd-tests.py
+index f49438ecd1..80085b919a 100755
+--- a/test/test-network/systemd-networkd-tests.py
++++ b/test/test-network/systemd-networkd-tests.py
+@@ -2436,6 +2436,17 @@ class NetworkdNetworkTests(unittest.TestCase, Utilities):
+     def tearDown(self):
+         tear_down_common()
+ 
++    def test_ID_NET_MANAGED_BY(self):
++        copy_network_unit('11-dummy.netdev', '11-dummy-unmanaged.link', '11-dummy.network')
++        start_networkd()
++        self.wait_online('test1:off', setup_state='unmanaged')
++
++        check_output('ip link set dev test1 up')
++        self.wait_online('test1:degraded', setup_state='unmanaged')
++
++        check_output('ip link set dev test1 down')
++        self.wait_online('test1:off', setup_state='unmanaged')
++
+     def verify_address_static(
+             self,
+             label1: str,
+-- 
+2.45.4

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        29%{?dist}
+Release:        30%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -153,6 +153,7 @@ Patch0909:      fix-pcrlock-hyperv-hash-algorithm-ordering.patch
 Patch0910:      CVE-2026-40226.patch
 Patch0911:      CVE-2026-40225.patch
 Patch0912:      networkd-address-skip-firewall-init.patch
+Patch0913:      network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1238,6 +1239,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-30
+- Backport upstream commit 78f8d5e: network: also check ID_NET_MANAGED_BY
+  property on reconfigure.
+
 * Thu May 28 2026 Nikola Bojanic <nbojanic@microsoft.com> - 255-29
 - Fix unwanted nftables initialization in systemd-networkd by backporting
   upstream commit 58c6e75 from systemd v256 (PR #30318).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backport upstream fix for `networkd` unmanaged interfaces from upstream ([upstream issue 36997](https://github.com/systemd/systemd/issues/36997)).

In systemd v255, unmanaged interfaces may be unexpectedly configured. This can happen on Azure SR-IOV devices which are marked as unmanaged by `01-azure-unmanaged-sriov.network/10-azure-unmanaged-sriov.rules`.

The backported upstream fix ([upstream PR 37809](https://github.com/systemd/systemd/pull/37809)) ensures unmanaged interfaces are not configured by networkd.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport `network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch` from upstream commit 78f8d5e.
- Bump release

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
