### PR TITLE
[Medium] Patch python-virtualenv for CVE-2026-6357

### DIFF
--- a/SPECS/python-virtualenv/CVE-2026-6357v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-6357v0.patch
@@ -2,6 +2,7 @@ From 8786d084768e0b42afa093083c8c05ee8e525574 Mon Sep 17 00:00:00 2001
 From: Damian Shaw <damian.peter.shaw@gmail.com>
 Date: Fri, 17 Apr 2026 09:52:38 -0400
 Subject: [PATCH 1/3] Split the pip self-version check to get info before run
+
 Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/13923.patch
 ---
  news/13923.trivial.rst               |  2 +
@@ -22,7 +23,7 @@ index 0000000..cb3b0ff
 +Split the pip self-version check into a fetch phase before the command
 +body and an emit phase afterwards.
 diff --git a/pip/_internal/cli/base_command.py b/pip/_internal/cli/base_command.py
-index 362f84b..2ac8671 100644
+index 362f84b..6c2594e 100644
 --- a/pip/_internal/cli/base_command.py
 +++ b/pip/_internal/cli/base_command.py
 @@ -1,11 +1,13 @@
@@ -45,7 +46,7 @@ index 362f84b..2ac8671 100644
  
 -    def handle_pip_version_check(self, options: Values) -> None:
 +    @contextlib.contextmanager
-+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++    def pip_version_check(self, options: Values, args: List[str]) -> Iterator[None]:
          """
          This is a no-op so that commands by default do not do the pip version
          check.
@@ -69,7 +70,7 @@ index 362f84b..2ac8671 100644
          if options.debug_mode:
              rich_traceback.install(show_locals=True)
 diff --git a/pip/_internal/cli/index_command.py b/pip/_internal/cli/index_command.py
-index 295108e..04a25de 100644
+index 295108e..e559316 100644
 --- a/pip/_internal/cli/index_command.py
 +++ b/pip/_internal/cli/index_command.py
 @@ -6,8 +6,10 @@ so commands which don't always hit the network (e.g. list w/o --outdated or
@@ -99,14 +100,14 @@ index 295108e..04a25de 100644
 -    from pip._internal.self_outdated_check import pip_self_version_check as check
 +def _pip_self_version_check_fetch(
 +    session: PipSession, options: Values
-+) -> UpgradePrompt | None:
++-> Optional["UpgradePrompt"]:
 +    from pip._internal.self_outdated_check import pip_self_version_check_fetch
  
 -    check(session, options)
 +    return pip_self_version_check_fetch(session, options)
 +
 +
-+def _pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
++def _pip_self_version_check_emit(upgrade_prompt: Optional["UpgradePrompt"]) -> None:
 +    from pip._internal.self_outdated_check import pip_self_version_check_emit
 +
 +    pip_self_version_check_emit(upgrade_prompt)
@@ -119,7 +120,7 @@ index 295108e..04a25de 100644
  
 -    def handle_pip_version_check(self, options: Values) -> None:
 +    @contextlib.contextmanager
-+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++    def pip_version_check(self, options: Values, args: List[str]) -> Iterator[None]:
          """
          Do the pip version check if not disabled.
  
@@ -130,7 +131,7 @@ index 295108e..04a25de 100644
 +            yield
              return
  
-+        upgrade_prompt: UpgradePrompt | None = None
++        upgrade_prompt: Optional["UpgradePrompt"] = None
          try:
 -            # Otherwise, check if we're using the latest version of pip available.
              session = self._build_session(
@@ -154,7 +155,7 @@ index 295108e..04a25de 100644
 +                logger.warning("There was an error checking the latest version of pip.")
 +                logger.debug("See below for error", exc_info=True)
 diff --git a/pip/_internal/commands/install.py b/pip/_internal/commands/install.py
-index 232a34a..c02884b 100644
+index 232a34a..7341044 100644
 --- a/pip/_internal/commands/install.py
 +++ b/pip/_internal/commands/install.py
 @@ -1,12 +1,15 @@
@@ -193,7 +194,7 @@ index 232a34a..c02884b 100644
          )
  
 +    @contextlib.contextmanager
-+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++    def pip_version_check(self, options: Values, args: List[str]) -> Iterator[None]:
 +        # Skip the self-version check when pip itself is a requirement. The
 +        # running pip may be replaced mid-command, and the upgrade prompt
 +        # is redundant.
@@ -207,7 +208,7 @@ index 232a34a..c02884b 100644
      def run(self, options: Values, args: List[str]) -> int:
          if options.use_user_site and options.target_dir is not None:
 diff --git a/pip/_internal/commands/list.py b/pip/_internal/commands/list.py
-index 8494370..a68f421 100644
+index 8494370..102bfc1 100644
 --- a/pip/_internal/commands/list.py
 +++ b/pip/_internal/commands/list.py
 @@ -1,5 +1,7 @@
@@ -226,7 +227,7 @@ index 8494370..a68f421 100644
 -        if options.outdated or options.uptodate:
 -            super().handle_pip_version_check(options)
 +    @contextlib.contextmanager
-+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++    def pip_version_check(self, options: Values, args: List[str]) -> Iterator[None]:
 +        if not (options.outdated or options.uptodate):
 +            yield
 +            return
@@ -236,7 +237,7 @@ index 8494370..a68f421 100644
      def _build_package_finder(
          self, options: Values, session: "PipSession"
 diff --git a/pip/_internal/self_outdated_check.py b/pip/_internal/self_outdated_check.py
-index 2e0e3df..092164a 100644
+index 2e0e3df..5c3f8ee 100644
 --- a/pip/_internal/self_outdated_check.py
 +++ b/pip/_internal/self_outdated_check.py
 @@ -1,5 +1,4 @@
@@ -312,7 +313,7 @@ index 2e0e3df..092164a 100644
 -    """Check for an update for pip.
 +def pip_self_version_check_fetch(
 +    session: PipSession, options: optparse.Values
-+) -> UpgradePrompt | None:
++) -> Optional["UpgradePrompt"]:
 +    """Compute the pip upgrade prompt, if any, before the command runs.
  
      Limit the frequency of checks to once per week. State is stored either in
@@ -355,7 +356,7 @@ index 2e0e3df..092164a 100644
      )
 +
 +
-+def pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
++def pip_self_version_check_emit(upgrade_prompt: Optional["UpgradePrompt"]) -> None:
 +    """Emit the upgrade prompt captured by :func:`pip_self_version_check_fetch`."""
      if upgrade_prompt is not None:
          logger.warning("%s", upgrade_prompt, extra={"rich": True})

--- a/SPECS/python-virtualenv/CVE-2026-6357v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-6357v0.patch
@@ -1,0 +1,364 @@
+From 8786d084768e0b42afa093083c8c05ee8e525574 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Fri, 17 Apr 2026 09:52:38 -0400
+Subject: [PATCH 1/3] Split the pip self-version check to get info before run
+Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/13923.patch
+---
+ news/13923.trivial.rst               |  2 +
+ pip/_internal/cli/base_command.py    | 10 ++--
+ pip/_internal/cli/index_command.py   | 34 +++++++++++---
+ pip/_internal/commands/install.py    | 22 +++++++++
+ pip/_internal/commands/list.py       | 12 +++--
+ pip/_internal/self_outdated_check.py | 69 +++++++++++++---------------
+ 6 files changed, 98 insertions(+), 51 deletions(-)
+ create mode 100644 news/13923.trivial.rst
+
+diff --git a/news/13923.trivial.rst b/news/13923.trivial.rst
+new file mode 100644
+index 0000000..cb3b0ff
+--- /dev/null
++++ b/news/13923.trivial.rst
+@@ -0,0 +1,2 @@
++Split the pip self-version check into a fetch phase before the command
++body and an emit phase afterwards.
+diff --git a/pip/_internal/cli/base_command.py b/pip/_internal/cli/base_command.py
+index 362f84b..2ac8671 100644
+--- a/pip/_internal/cli/base_command.py
++++ b/pip/_internal/cli/base_command.py
+@@ -1,11 +1,13 @@
+ """Base Command class, and related routines"""
+ 
++import contextlib
+ import logging
+ import logging.config
+ import optparse
+ import os
+ import sys
+ import traceback
++from collections.abc import Iterator
+ from optparse import Values
+ from typing import List, Optional, Tuple
+ 
+@@ -79,7 +81,8 @@ class Command(CommandContextMixIn):
+     def add_options(self) -> None:
+         pass
+ 
+-    def handle_pip_version_check(self, options: Values) -> None:
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
+         """
+         This is a no-op so that commands by default do not do the pip version
+         check.
+@@ -87,16 +90,15 @@ class Command(CommandContextMixIn):
+         # Make sure we do the pip version check if the index_group options
+         # are present.
+         assert not hasattr(options, "no_index")
++        yield
+ 
+     def run(self, options: Values, args: List[str]) -> int:
+         raise NotImplementedError
+ 
+     def _run_wrapper(self, level_number: int, options: Values, args: List[str]) -> int:
+         def _inner_run() -> int:
+-            try:
++            with self.pip_version_check(options, args):
+                 return self.run(options, args)
+-            finally:
+-                self.handle_pip_version_check(options)
+ 
+         if options.debug_mode:
+             rich_traceback.install(show_locals=True)
+diff --git a/pip/_internal/cli/index_command.py b/pip/_internal/cli/index_command.py
+index 295108e..04a25de 100644
+--- a/pip/_internal/cli/index_command.py
++++ b/pip/_internal/cli/index_command.py
+@@ -6,8 +6,10 @@ so commands which don't always hit the network (e.g. list w/o --outdated or
+ --uptodate) don't need waste time importing PipSession and friends.
+ """
+ 
++import contextlib
+ import logging
+ import os
++from collections.abc import Iterator
+ import sys
+ from optparse import Values
+ from typing import TYPE_CHECKING, List, Optional
+@@ -21,6 +23,7 @@ if TYPE_CHECKING:
+     from ssl import SSLContext
+ 
+     from pip._internal.network.session import PipSession
++    from pip._internal.self_outdated_check import UpgradePrompt
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -132,10 +135,18 @@ class SessionCommandMixin(CommandContextMixIn):
+         return session
+ 
+ 
+-def _pip_self_version_check(session: "PipSession", options: Values) -> None:
+-    from pip._internal.self_outdated_check import pip_self_version_check as check
++def _pip_self_version_check_fetch(
++    session: PipSession, options: Values
++) -> UpgradePrompt | None:
++    from pip._internal.self_outdated_check import pip_self_version_check_fetch
+ 
+-    check(session, options)
++    return pip_self_version_check_fetch(session, options)
++
++
++def _pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
++    from pip._internal.self_outdated_check import pip_self_version_check_emit
++
++    pip_self_version_check_emit(upgrade_prompt)
+ 
+ 
+ class IndexGroupCommand(Command, SessionCommandMixin):
+@@ -145,7 +156,8 @@ class IndexGroupCommand(Command, SessionCommandMixin):
+     This also corresponds to the commands that permit the pip version check.
+     """
+ 
+-    def handle_pip_version_check(self, options: Values) -> None:
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
+         """
+         Do the pip version check if not disabled.
+ 
+@@ -155,17 +167,27 @@ class IndexGroupCommand(Command, SessionCommandMixin):
+         assert hasattr(options, "no_index")
+ 
+         if options.disable_pip_version_check or options.no_index:
++            yield
+             return
+ 
++        upgrade_prompt: UpgradePrompt | None = None
+         try:
+-            # Otherwise, check if we're using the latest version of pip available.
+             session = self._build_session(
+                 options,
+                 retries=0,
+                 timeout=min(5, options.timeout),
+             )
+             with session:
+-                _pip_self_version_check(session, options)
++                upgrade_prompt = _pip_self_version_check_fetch(session, options)
+         except Exception:
+             logger.warning("There was an error checking the latest version of pip.")
+             logger.debug("See below for error", exc_info=True)
++
++        try:
++            yield
++        finally:
++            try:
++                _pip_self_version_check_emit(upgrade_prompt)
++            except Exception:
++                logger.warning("There was an error checking the latest version of pip.")
++                logger.debug("See below for error", exc_info=True)
+diff --git a/pip/_internal/commands/install.py b/pip/_internal/commands/install.py
+index 232a34a..c02884b 100644
+--- a/pip/_internal/commands/install.py
++++ b/pip/_internal/commands/install.py
+@@ -1,12 +1,15 @@
++import contextlib
+ import errno
+ import json
+ import operator
+ import os
+ import shutil
+ import site
++from collections.abc import Iterator
+ from optparse import SUPPRESS_HELP, Values
+ from typing import List, Optional
+ 
++from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+ from pip._vendor.packaging.utils import canonicalize_name
+ from pip._vendor.rich import print_json
+ 
+@@ -57,6 +60,14 @@ from pip._internal.wheel_builder import build, should_build_for_install_command
+ logger = getLogger(__name__)
+ 
+ 
++def _arg_refers_to_pip(arg: str) -> bool:
++    try:
++        req = Requirement(arg)
++    except InvalidRequirement:
++        return False
++    return canonicalize_name(req.name) == "pip"
++
++
+ class InstallCommand(RequirementCommand):
+     """
+     Install packages from:
+@@ -270,6 +281,17 @@ class InstallCommand(RequirementCommand):
+             ),
+         )
+ 
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++        # Skip the self-version check when pip itself is a requirement. The
++        # running pip may be replaced mid-command, and the upgrade prompt
++        # is redundant.
++        if any(_arg_refers_to_pip(arg) for arg in args):
++            yield
++            return
++        with super().pip_version_check(options, args):
++            yield
++
+     @with_cleanup
+     def run(self, options: Values, args: List[str]) -> int:
+         if options.use_user_site and options.target_dir is not None:
+diff --git a/pip/_internal/commands/list.py b/pip/_internal/commands/list.py
+index 8494370..a68f421 100644
+--- a/pip/_internal/commands/list.py
++++ b/pip/_internal/commands/list.py
+@@ -1,5 +1,7 @@
++import contextlib
+ import json
+ import logging
++from collections.abc import Iterator
+ from optparse import Values
+ from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Tuple, cast
+ 
+@@ -134,9 +136,13 @@ class ListCommand(IndexGroupCommand):
+         self.parser.insert_option_group(0, index_opts)
+         self.parser.insert_option_group(0, self.cmd_opts)
+ 
+-    def handle_pip_version_check(self, options: Values) -> None:
+-        if options.outdated or options.uptodate:
+-            super().handle_pip_version_check(options)
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++        if not (options.outdated or options.uptodate):
++            yield
++            return
++        with super().pip_version_check(options, args):
++            yield
+ 
+     def _build_package_finder(
+         self, options: Values, session: "PipSession"
+diff --git a/pip/_internal/self_outdated_check.py b/pip/_internal/self_outdated_check.py
+index 2e0e3df..092164a 100644
+--- a/pip/_internal/self_outdated_check.py
++++ b/pip/_internal/self_outdated_check.py
+@@ -1,5 +1,4 @@
+ import datetime
+-import functools
+ import hashlib
+ import json
+ import logging
+@@ -7,7 +6,7 @@ import optparse
+ import os.path
+ import sys
+ from dataclasses import dataclass
+-from typing import Any, Callable, Dict, Optional
++from typing import Any, Dict, Optional
+ 
+ from pip._vendor.packaging.version import Version
+ from pip._vendor.packaging.version import parse as parse_version
+@@ -153,16 +152,6 @@ class UpgradePrompt:
+         )
+ 
+ 
+-def was_installed_by_pip(pkg: str) -> bool:
+-    """Checks whether pkg was installed by pip
+-
+-    This is used not to display the upgrade message when pip is in fact
+-    installed by system package manager, such as dnf on Fedora.
+-    """
+-    dist = get_default_environment().get_distribution(pkg)
+-    return dist is not None and "pip" == dist.installer
+-
+-
+ def _get_current_remote_pip_version(
+     session: PipSession, options: optparse.Values
+ ) -> Optional[str]:
+@@ -191,28 +180,16 @@ def _get_current_remote_pip_version(
+     return str(best_candidate.version)
+ 
+ 
+-def _self_version_check_logic(
+-    *,
+-    state: SelfCheckState,
+-    current_time: datetime.datetime,
+-    local_version: Version,
+-    get_remote_version: Callable[[], Optional[str]],
++def _compute_upgrade_prompt(
++    local_version: Version, remote_version_str: str, installed_by_pip: bool
+ ) -> Optional[UpgradePrompt]:
+-    remote_version_str = state.get(current_time)
+-    if remote_version_str is None:
+-        remote_version_str = get_remote_version()
+-        if remote_version_str is None:
+-            logger.debug("No remote pip version found")
+-            return None
+-        state.set(remote_version_str, current_time)
+ 
+     remote_version = parse_version(remote_version_str)
+     logger.debug("Remote version of pip: %s", remote_version)
+     logger.debug("Local version of pip:  %s", local_version)
++    logger.debug("Was pip installed by pip? %s", installed_by_pip)
+ 
+-    pip_installed_by_pip = was_installed_by_pip("pip")
+-    logger.debug("Was pip installed by pip? %s", pip_installed_by_pip)
+-    if not pip_installed_by_pip:
++    if not installed_by_pip:
+         return None  # Only suggest upgrade if pip is installed by pip.
+ 
+     local_version_is_older = (
+@@ -225,28 +202,44 @@ def _self_version_check_logic(
+     return None
+ 
+ 
+-def pip_self_version_check(session: PipSession, options: optparse.Values) -> None:
+-    """Check for an update for pip.
++def pip_self_version_check_fetch(
++    session: PipSession, options: optparse.Values
++) -> UpgradePrompt | None:
++    """Compute the pip upgrade prompt, if any, before the command runs.
+ 
+     Limit the frequency of checks to once per week. State is stored either in
+     the active virtualenv or in the user's USER_CACHE_DIR keyed off the prefix
+     of the pip script path.
++
++    Pair with :func:`pip_self_version_check_emit`, which displays the prompt
++    after the command body runs.
+     """
+     installed_dist = get_default_environment().get_distribution("pip")
+     if not installed_dist:
+-        return
++        return None
+     try:
+         check_externally_managed()
+     except ExternallyManagedEnvironment:
+-        return
++        return None
+ 
+-    upgrade_prompt = _self_version_check_logic(
+-        state=SelfCheckState(cache_dir=options.cache_dir),
+-        current_time=datetime.datetime.now(datetime.timezone.utc),
++    state = SelfCheckState(cache_dir=options.cache_dir)
++    current_time = datetime.datetime.now(datetime.timezone.utc)
++    remote_version_str = state.get(current_time)
++    if remote_version_str is None:
++        remote_version_str = _get_current_remote_pip_version(session, options)
++        if remote_version_str is None:
++            logger.debug("No remote pip version found")
++            return None
++        state.set(remote_version_str, current_time)
++
++    return _compute_upgrade_prompt(
+         local_version=installed_dist.version,
+-        get_remote_version=functools.partial(
+-            _get_current_remote_pip_version, session, options
+-        ),
++        remote_version_str=remote_version_str,
++        installed_by_pip=installed_dist.installer == "pip",
+     )
++
++
++def pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
++    """Emit the upgrade prompt captured by :func:`pip_self_version_check_fetch`."""
+     if upgrade_prompt is not None:
+         logger.warning("%s", upgrade_prompt, extra={"rich": True})
+-- 
+2.43.0
+

--- a/SPECS/python-virtualenv/CVE-2026-6357v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-6357v0.patch
@@ -60,7 +60,7 @@ index 362f84b..6c2594e 100644
          if options.debug_mode:
              rich_traceback.install(show_locals=True)
 diff --git a/pip/_internal/cli/index_command.py b/pip/_internal/cli/index_command.py
-index 295108e..e559316 100644
+index 295108e..ed3944a 100644
 --- a/pip/_internal/cli/index_command.py
 +++ b/pip/_internal/cli/index_command.py
 @@ -6,8 +6,10 @@ so commands which don't always hit the network (e.g. list w/o --outdated or
@@ -90,7 +90,7 @@ index 295108e..e559316 100644
 -    from pip._internal.self_outdated_check import pip_self_version_check as check
 +def _pip_self_version_check_fetch(
 +    session: PipSession, options: Values
-+-> Optional["UpgradePrompt"]:
++)-> Optional["UpgradePrompt"]:
 +    from pip._internal.self_outdated_check import pip_self_version_check_fetch
  
 -    check(session, options)

--- a/SPECS/python-virtualenv/CVE-2026-6357v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-6357v0.patch
@@ -5,23 +5,13 @@ Subject: [PATCH 1/3] Split the pip self-version check to get info before run
 
 Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/13923.patch
 ---
- news/13923.trivial.rst               |  2 +
  pip/_internal/cli/base_command.py    | 10 ++--
  pip/_internal/cli/index_command.py   | 34 +++++++++++---
  pip/_internal/commands/install.py    | 22 +++++++++
  pip/_internal/commands/list.py       | 12 +++--
  pip/_internal/self_outdated_check.py | 69 +++++++++++++---------------
- 6 files changed, 98 insertions(+), 51 deletions(-)
- create mode 100644 news/13923.trivial.rst
+ 5 files changed, 96 insertions(+), 51 deletions(-)
 
-diff --git a/news/13923.trivial.rst b/news/13923.trivial.rst
-new file mode 100644
-index 0000000..cb3b0ff
---- /dev/null
-+++ b/news/13923.trivial.rst
-@@ -0,0 +1,2 @@
-+Split the pip self-version check into a fetch phase before the command
-+body and an emit phase afterwards.
 diff --git a/pip/_internal/cli/base_command.py b/pip/_internal/cli/base_command.py
 index 362f84b..6c2594e 100644
 --- a/pip/_internal/cli/base_command.py

--- a/SPECS/python-virtualenv/CVE-2026-6357v1.patch
+++ b/SPECS/python-virtualenv/CVE-2026-6357v1.patch
@@ -4,25 +4,14 @@ Date: Fri, 17 Apr 2026 09:52:38 -0400
 Subject: [PATCH 1/3] Split the pip self-version check to get info before run
 
 Upstream Patch reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/13923.patch
-
 ---
- news/13923.trivial.rst               |  2 +
  pip/_internal/cli/base_command.py    | 10 ++--
  pip/_internal/cli/index_command.py   | 34 +++++++++++---
  pip/_internal/commands/install.py    | 21 +++++++++
  pip/_internal/commands/list.py       | 13 ++++--
  pip/_internal/self_outdated_check.py | 69 +++++++++++++---------------
- 6 files changed, 97 insertions(+), 52 deletions(-)
- create mode 100644 news/13923.trivial.rst
+ 5 files changed, 95 insertions(+), 52 deletions(-)
 
-diff --git a/news/13923.trivial.rst b/news/13923.trivial.rst
-new file mode 100644
-index 0000000..cb3b0ff
---- /dev/null
-+++ b/news/13923.trivial.rst
-@@ -0,0 +1,2 @@
-+Split the pip self-version check into a fetch phase before the command
-+body and an emit phase afterwards.
 diff --git a/pip/_internal/cli/base_command.py b/pip/_internal/cli/base_command.py
 index 7acc29c..2c22085 100644
 --- a/pip/_internal/cli/base_command.py

--- a/SPECS/python-virtualenv/CVE-2026-6357v1.patch
+++ b/SPECS/python-virtualenv/CVE-2026-6357v1.patch
@@ -1,0 +1,373 @@
+From 8786d084768e0b42afa093083c8c05ee8e525574 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Fri, 17 Apr 2026 09:52:38 -0400
+Subject: [PATCH 1/3] Split the pip self-version check to get info before run
+
+Upstream Patch reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/13923.patch
+
+---
+ news/13923.trivial.rst               |  2 +
+ pip/_internal/cli/base_command.py    | 10 ++--
+ pip/_internal/cli/index_command.py   | 34 +++++++++++---
+ pip/_internal/commands/install.py    | 21 +++++++++
+ pip/_internal/commands/list.py       | 13 ++++--
+ pip/_internal/self_outdated_check.py | 69 +++++++++++++---------------
+ 6 files changed, 97 insertions(+), 52 deletions(-)
+ create mode 100644 news/13923.trivial.rst
+
+diff --git a/news/13923.trivial.rst b/news/13923.trivial.rst
+new file mode 100644
+index 0000000..cb3b0ff
+--- /dev/null
++++ b/news/13923.trivial.rst
+@@ -0,0 +1,2 @@
++Split the pip self-version check into a fetch phase before the command
++body and an emit phase afterwards.
+diff --git a/pip/_internal/cli/base_command.py b/pip/_internal/cli/base_command.py
+index 7acc29c..2c22085 100644
+--- a/pip/_internal/cli/base_command.py
++++ b/pip/_internal/cli/base_command.py
+@@ -2,12 +2,14 @@
+ 
+ from __future__ import annotations
+ 
++import contextlib
+ import logging
+ import logging.config
+ import optparse
+ import os
+ import sys
+ import traceback
++from collections.abc import Iterator
+ from optparse import Values
+ from typing import Callable
+ 
+@@ -80,7 +82,8 @@ class Command(CommandContextMixIn):
+     def add_options(self) -> None:
+         pass
+ 
+-    def handle_pip_version_check(self, options: Values) -> None:
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
+         """
+         This is a no-op so that commands by default do not do the pip version
+         check.
+@@ -88,16 +91,15 @@ class Command(CommandContextMixIn):
+         # Make sure we do the pip version check if the index_group options
+         # are present.
+         assert not hasattr(options, "no_index")
++        yield
+ 
+     def run(self, options: Values, args: list[str]) -> int:
+         raise NotImplementedError
+ 
+     def _run_wrapper(self, level_number: int, options: Values, args: list[str]) -> int:
+         def _inner_run() -> int:
+-            try:
++            with self.pip_version_check(options, args):
+                 return self.run(options, args)
+-            finally:
+-                self.handle_pip_version_check(options)
+ 
+         if options.debug_mode:
+             rich_traceback.install(show_locals=True)
+diff --git a/pip/_internal/cli/index_command.py b/pip/_internal/cli/index_command.py
+index f6a82c8..c890fa1 100644
+--- a/pip/_internal/cli/index_command.py
++++ b/pip/_internal/cli/index_command.py
+@@ -8,8 +8,10 @@ so commands which don't always hit the network (e.g. list w/o --outdated or
+ 
+ from __future__ import annotations
+ 
++import contextlib
+ import logging
+ import os
++from collections.abc import Iterator
+ import sys
+ from functools import lru_cache
+ from optparse import Values
+@@ -24,6 +26,7 @@ if TYPE_CHECKING:
+     from ssl import SSLContext
+ 
+     from pip._internal.network.session import PipSession
++    from pip._internal.self_outdated_check import UpgradePrompt
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -136,10 +139,18 @@ class SessionCommandMixin(CommandContextMixIn):
+         return session
+ 
+ 
+-def _pip_self_version_check(session: PipSession, options: Values) -> None:
+-    from pip._internal.self_outdated_check import pip_self_version_check as check
++def _pip_self_version_check_fetch(
++    session: PipSession, options: Values
++) -> UpgradePrompt | None:
++    from pip._internal.self_outdated_check import pip_self_version_check_fetch
+ 
+-    check(session, options)
++    return pip_self_version_check_fetch(session, options)
++
++
++def _pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
++    from pip._internal.self_outdated_check import pip_self_version_check_emit
++
++    pip_self_version_check_emit(upgrade_prompt)
+ 
+ 
+ class IndexGroupCommand(Command, SessionCommandMixin):
+@@ -149,7 +160,8 @@ class IndexGroupCommand(Command, SessionCommandMixin):
+     This also corresponds to the commands that permit the pip version check.
+     """
+ 
+-    def handle_pip_version_check(self, options: Values) -> None:
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
+         """
+         Do the pip version check if not disabled.
+ 
+@@ -159,17 +171,27 @@ class IndexGroupCommand(Command, SessionCommandMixin):
+         assert hasattr(options, "no_index")
+ 
+         if options.disable_pip_version_check or options.no_index:
++            yield
+             return
+ 
++        upgrade_prompt: UpgradePrompt | None = None
+         try:
+-            # Otherwise, check if we're using the latest version of pip available.
+             session = self._build_session(
+                 options,
+                 retries=0,
+                 timeout=min(5, options.timeout),
+             )
+             with session:
+-                _pip_self_version_check(session, options)
++                upgrade_prompt = _pip_self_version_check_fetch(session, options)
+         except Exception:
+             logger.warning("There was an error checking the latest version of pip.")
+             logger.debug("See below for error", exc_info=True)
++
++        try:
++            yield
++        finally:
++            try:
++                _pip_self_version_check_emit(upgrade_prompt)
++            except Exception:
++                logger.warning("There was an error checking the latest version of pip.")
++                logger.debug("See below for error", exc_info=True)
+diff --git a/pip/_internal/commands/install.py b/pip/_internal/commands/install.py
+index b16b8e3..4559f23 100644
+--- a/pip/_internal/commands/install.py
++++ b/pip/_internal/commands/install.py
+@@ -1,14 +1,17 @@
+ from __future__ import annotations
+ 
++import contextlib
+ import errno
+ import json
+ import operator
+ import os
+ import shutil
+ import site
++from collections.abc import Iterator
+ from optparse import SUPPRESS_HELP, Values
+ from pathlib import Path
+ 
++from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+ from pip._vendor.packaging.utils import canonicalize_name
+ from pip._vendor.requests.exceptions import InvalidProxyURL
+ from pip._vendor.rich import print_json
+@@ -62,6 +65,13 @@ from pip._internal.wheel_builder import build
+ 
+ logger = getLogger(__name__)
+ 
++def _arg_refers_to_pip(arg: str) -> bool:
++    try:
++        req = Requirement(arg)
++    except InvalidRequirement:
++        return False
++    return canonicalize_name(req.name) == "pip"
++
+ 
+ class InstallCommand(RequirementCommand):
+     """
+@@ -275,6 +285,17 @@ class InstallCommand(RequirementCommand):
+             ),
+         )
+ 
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++        # Skip the self-version check when pip itself is a requirement. The
++        # running pip may be replaced mid-command, and the upgrade prompt
++        # is redundant.
++        if any(_arg_refers_to_pip(arg) for arg in args):
++            yield
++            return
++        with super().pip_version_check(options, args):
++            yield
++
+     @with_cleanup
+     def run(self, options: Values, args: list[str]) -> int:
+         if options.use_user_site and options.target_dir is not None:
+diff --git a/pip/_internal/commands/list.py b/pip/_internal/commands/list.py
+index ad27e45..f317778 100644
+--- a/pip/_internal/commands/list.py
++++ b/pip/_internal/commands/list.py
+@@ -1,8 +1,9 @@
+ from __future__ import annotations
+ 
++import contextlib
+ import json
+ import logging
+-from collections.abc import Generator, Sequence
++from collections.abc import Generator, Iterator, Sequence
+ from email.parser import Parser
+ from optparse import Values
+ from typing import TYPE_CHECKING, cast
+@@ -138,9 +139,13 @@ class ListCommand(IndexGroupCommand):
+         self.parser.insert_option_group(0, index_opts)
+         self.parser.insert_option_group(0, self.cmd_opts)
+ 
+-    def handle_pip_version_check(self, options: Values) -> None:
+-        if options.outdated or options.uptodate:
+-            super().handle_pip_version_check(options)
++    @contextlib.contextmanager
++    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
++        if not (options.outdated or options.uptodate):
++            yield
++            return
++        with super().pip_version_check(options, args):
++            yield
+ 
+     def _build_package_finder(
+         self, options: Values, session: PipSession
+diff --git a/pip/_internal/self_outdated_check.py b/pip/_internal/self_outdated_check.py
+index 5999ddb..f1a14b7 100644
+--- a/pip/_internal/self_outdated_check.py
++++ b/pip/_internal/self_outdated_check.py
+@@ -1,7 +1,6 @@
+ from __future__ import annotations
+ 
+ import datetime
+-import functools
+ import hashlib
+ import json
+ import logging
+@@ -9,7 +8,7 @@ import optparse
+ import os.path
+ import sys
+ from dataclasses import dataclass
+-from typing import Any, Callable
++from typing import Any
+ 
+ from pip._vendor.packaging.version import Version
+ from pip._vendor.packaging.version import parse as parse_version
+@@ -163,16 +162,6 @@ class UpgradePrompt:
+         )
+ 
+ 
+-def was_installed_by_pip(pkg: str) -> bool:
+-    """Checks whether pkg was installed by pip
+-
+-    This is used not to display the upgrade message when pip is in fact
+-    installed by system package manager, such as dnf on Fedora.
+-    """
+-    dist = get_default_environment().get_distribution(pkg)
+-    return dist is not None and "pip" == dist.installer
+-
+-
+ def _get_current_remote_pip_version(
+     session: PipSession, options: optparse.Values
+ ) -> str | None:
+@@ -201,28 +190,16 @@ def _get_current_remote_pip_version(
+     return str(best_candidate.version)
+ 
+ 
+-def _self_version_check_logic(
+-    *,
+-    state: SelfCheckState,
+-    current_time: datetime.datetime,
+-    local_version: Version,
+-    get_remote_version: Callable[[], str | None],
++def _compute_upgrade_prompt(
++    local_version: Version, remote_version_str: str, installed_by_pip: bool
+ ) -> UpgradePrompt | None:
+-    remote_version_str = state.get(current_time)
+-    if remote_version_str is None:
+-        remote_version_str = get_remote_version()
+-        if remote_version_str is None:
+-            logger.debug("No remote pip version found")
+-            return None
+-        state.set(remote_version_str, current_time)
+ 
+     remote_version = parse_version(remote_version_str)
+     logger.debug("Remote version of pip: %s", remote_version)
+     logger.debug("Local version of pip:  %s", local_version)
++    logger.debug("Was pip installed by pip? %s", installed_by_pip)
+ 
+-    pip_installed_by_pip = was_installed_by_pip("pip")
+-    logger.debug("Was pip installed by pip? %s", pip_installed_by_pip)
+-    if not pip_installed_by_pip:
++    if not installed_by_pip:
+         return None  # Only suggest upgrade if pip is installed by pip.
+ 
+     local_version_is_older = (
+@@ -235,28 +212,44 @@ def _self_version_check_logic(
+     return None
+ 
+ 
+-def pip_self_version_check(session: PipSession, options: optparse.Values) -> None:
+-    """Check for an update for pip.
++def pip_self_version_check_fetch(
++    session: PipSession, options: optparse.Values
++) -> UpgradePrompt | None:
++    """Compute the pip upgrade prompt, if any, before the command runs.
+ 
+     Limit the frequency of checks to once per week. State is stored either in
+     the active virtualenv or in the user's USER_CACHE_DIR keyed off the prefix
+     of the pip script path.
++
++    Pair with :func:`pip_self_version_check_emit`, which displays the prompt
++    after the command body runs.
+     """
+     installed_dist = get_default_environment().get_distribution("pip")
+     if not installed_dist:
+-        return
++        return None
+     try:
+         check_externally_managed()
+     except ExternallyManagedEnvironment:
+-        return
++        return None
++
++    state = SelfCheckState(cache_dir=options.cache_dir)
++    current_time = datetime.datetime.now(datetime.timezone.utc)
++    remote_version_str = state.get(current_time)
++    if remote_version_str is None:
++        remote_version_str = _get_current_remote_pip_version(session, options)
++        if remote_version_str is None:
++            logger.debug("No remote pip version found")
++            return None
++        state.set(remote_version_str, current_time)
+ 
+-    upgrade_prompt = _self_version_check_logic(
+-        state=SelfCheckState(cache_dir=options.cache_dir),
+-        current_time=datetime.datetime.now(datetime.timezone.utc),
++    return _compute_upgrade_prompt(
+         local_version=installed_dist.version,
+-        get_remote_version=functools.partial(
+-            _get_current_remote_pip_version, session, options
+-        ),
++        remote_version_str=remote_version_str,
++        installed_by_pip=installed_dist.installer == "pip",
+     )
++
++
++def pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
++    """Emit the upgrade prompt captured by :func:`pip_self_version_check_fetch`."""
+     if upgrade_prompt is not None:
+         logger.warning("%s", upgrade_prompt, extra={"rich": True})
+-- 
+2.43.0
+

--- a/SPECS/python-virtualenv/python-virtualenv.spec
+++ b/SPECS/python-virtualenv/python-virtualenv.spec
@@ -1,7 +1,7 @@
 Summary:        Virtual Python Environment builder
 Name:           python-virtualenv
 Version:        20.36.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -16,6 +16,8 @@ Patch1003:      CVE-2026-24049v0.patch
 Patch1004:      CVE-2026-24049v1.patch
 Patch1005:      CVE-2026-3219v0.patch
 Patch1006:      CVE-2026-3219v1.patch
+Patch1007:      CVE-2026-6357v0.patch
+Patch1008:      CVE-2026-6357v1.patch
 BuildArch:      noarch
 
 %description
@@ -60,8 +62,15 @@ unzip src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl -d unpacked_p
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1000}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py"
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1001}
-echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1005}
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+echo "Manually Patching
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/cli/base_command.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/cli/index_command.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/commands/install.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/commands/list.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/self_outdated_check.py"
+patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1007}
 # Remove the original file
 rm -f src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl
 # After patching, re-zip the contents back into a .whl
@@ -77,8 +86,15 @@ unzip src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl -d unpacked_pip
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1000}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py"
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1002}
-echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1006}
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+echo "Manually Patching
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/cli/base_command.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/cli/index_command.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/commands/install.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/commands/list.py
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/self_outdated_check.py"
+patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1008}
 rm -f src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl
 pushd unpacked_pip-25.3-py3-none-any
 zip -r ../src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl *
@@ -141,6 +157,9 @@ tox -e py
 %{_bindir}/virtualenv
 
 %changelog
+* Mon May 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 20.36.1-4
+- Patch for CVE-2026-6357
+
 * Thu Apr 23 2026 Akarsh Chaudhary <v-akarshc@microsoft.com>- 20.36.1-3
 - Patch for CVE-2026-3219
 

--- a/SPECS/python-virtualenv/python-virtualenv.spec
+++ b/SPECS/python-virtualenv/python-virtualenv.spec
@@ -62,14 +62,14 @@ unzip src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl -d unpacked_p
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1000}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py"
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1001}
-patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1005}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1005}
 echo "Manually Patching
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/cli/base_command.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/cli/index_command.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/commands/install.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/commands/list.py
-virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/self_outdated_check.py"
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/self_outdated_check.py for CVE-2026-6357"
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1007}
 # Remove the original file
 rm -f src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl
@@ -86,14 +86,14 @@ unzip src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl -d unpacked_pip
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1000}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py"
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1002}
-patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1006}
 echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/utils/unpacking.py for CVE-2026-3219"
+patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1006}
 echo "Manually Patching
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/cli/base_command.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/cli/index_command.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/commands/install.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/commands/list.py
-virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/self_outdated_check.py"
+virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/self_outdated_check.py for CVE-2026-6357"
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1008}
 rm -f src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl
 pushd unpacked_pip-25.3-py3-none-any


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch python-virtualenv for CVE-2026-6357
- Both versions of `pip` in python-virtualenv package is affected by this CVE as it is in affected range affected from 0 before 26.1.
- Backported patch manually due to version differences between upstream and current codebase.
- `news/13923.trivial.rst` is an upstream changelog fragment, not part of the functional CVE fix, and in this packaging model it becomes an unintended installed artifact that breaks %check. So, removing it is a packaging-safe backport adjustment.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   ../SPECS/python-virtualenv/CVE-2026-6357v0.patch
- new file:   ../SPECS/python-virtualenv/CVE-2026-6357v1.patch
- modified:   ../SPECS/python-virtualenv/python-virtualenv.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-6357

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build: 
[python-virtualenv-20.36.1-4.azl3.src.rpm.log](https://github.com/user-attachments/files/27588881/python-virtualenv-20.36.1-4.azl3.src.rpm.log)
[python-virtualenv-20.36.1-4.azl3.src.rpm.test.log](https://github.com/user-attachments/files/27588891/python-virtualenv-20.36.1-4.azl3.src.rpm.test.log)

- Patch applies cleanly:
<img width="1908" height="426" alt="image" src="https://github.com/user-attachments/assets/80d64b2b-f59d-48c9-a302-ff7b0945bb5a" />
<img width="1402" height="156" alt="image" src="https://github.com/user-attachments/assets/20a1a62d-5d85-472e-9d10-9354d2e0d8ee" />

