### PR TITLE
anaconda: drop flatpak deps and guard gi import for missing typelib

### DIFF
--- a/base/comps/anaconda/0001-flatpak_manager-guard-gi-import-for-missing-typelib.patch
+++ b/base/comps/anaconda/0001-flatpak_manager-guard-gi-import-for-missing-typelib.patch
@@ -1,0 +1,40 @@
+From 9aeb84c88573daff0a579edf5f9ef521032edaf9 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Wed, 6 May 2026 10:22:21 +0000
+Subject: [PATCH] flatpak_manager: guard gi import for missing typelib
+
+On Azure Linux the flatpak-libs package (and its GI typelib) is not
+available in the base image. Wrap the gi.require_version / import in a
+try/except so that the Flatpak payload module loads without crashing.
+The payload will be inert when Flatpak is unavailable.
+---
+ .../payloads/payload/flatpak/flatpak_manager.py     | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+index 09a01bd..30e8ba3 100644
+--- a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
++++ b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+@@ -40,10 +40,15 @@ from pyanaconda.modules.payloads.source.source_base import (
+     RepositorySourceMixin,
+ )
+ 
+-gi.require_version("Flatpak", "1.0")
+-gi.require_version("Gio", "2.0")
+-
+-from gi.repository.Flatpak import Installation, Transaction, TransactionOperationType
++try:
++    gi.require_version("Gio", "2.0")
++    gi.require_version("Flatpak", "1.0")
++    from gi.repository.Flatpak import Installation, Transaction, TransactionOperationType
++except (ImportError, ValueError):
++    # flatpak-libs / typelib not installed -- stubs so module loads but is inert
++    Installation = None
++    Transaction = None
++    TransactionOperationType = None
+ 
+ log = get_module_logger(__name__)
+ 
+-- 
+2.43.0
+

--- a/base/comps/anaconda/anaconda.comp.toml
+++ b/base/comps/anaconda/anaconda.comp.toml
@@ -19,3 +19,8 @@ type = "spec-remove-tag"
 tag = "Requires"
 value = "flatpak-libs"
 package = "core"
+
+[[components.anaconda.overlays]]
+description = "Guard gi.require_version('Flatpak') so the module loads even without flatpak-libs typelib"
+type = "patch-add"
+source = "0001-flatpak_manager-guard-gi-import-for-missing-typelib.patch"

--- a/locks/anaconda.lock
+++ b/locks/anaconda.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '61136adc419b826bd32cc84aff4be08a2ffe7c5b'
 upstream-commit = '61136adc419b826bd32cc84aff4be08a2ffe7c5b'
-input-fingerprint = 'sha256:defe9e5749b4e09a6ed77998cca72f9f2b699b0f4ce595a37991c4da8e96f720'
+input-fingerprint = 'sha256:f62d14b5257c4367ab60269ff00ee8b90efdcf4420cabdf17059d1a06fff36a7'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/a/anaconda/0001-flatpak_manager-guard-gi-import-for-missing-typelib.patch
+++ b/specs/a/anaconda/0001-flatpak_manager-guard-gi-import-for-missing-typelib.patch
@@ -1,0 +1,40 @@
+From 9aeb84c88573daff0a579edf5f9ef521032edaf9 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Wed, 6 May 2026 10:22:21 +0000
+Subject: [PATCH] flatpak_manager: guard gi import for missing typelib
+
+On Azure Linux the flatpak-libs package (and its GI typelib) is not
+available in the base image. Wrap the gi.require_version / import in a
+try/except so that the Flatpak payload module loads without crashing.
+The payload will be inert when Flatpak is unavailable.
+---
+ .../payloads/payload/flatpak/flatpak_manager.py     | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+index 09a01bd..30e8ba3 100644
+--- a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
++++ b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+@@ -40,10 +40,15 @@ from pyanaconda.modules.payloads.source.source_base import (
+     RepositorySourceMixin,
+ )
+ 
+-gi.require_version("Flatpak", "1.0")
+-gi.require_version("Gio", "2.0")
+-
+-from gi.repository.Flatpak import Installation, Transaction, TransactionOperationType
++try:
++    gi.require_version("Gio", "2.0")
++    gi.require_version("Flatpak", "1.0")
++    from gi.repository.Flatpak import Installation, Transaction, TransactionOperationType
++except (ImportError, ValueError):
++    # flatpak-libs / typelib not installed -- stubs so module loads but is inert
++    Installation = None
++    Transaction = None
++    TransactionOperationType = None
+ 
+ log = get_module_logger(__name__)
+ 
+-- 
+2.43.0
+

--- a/specs/a/anaconda/anaconda.spec
+++ b/specs/a/anaconda/anaconda.spec
@@ -4,7 +4,7 @@
 Summary: Graphical system installer
 Name:    anaconda
 Version: 43.44
-Release: 4%{?dist}
+Release: 5%{?dist}
 ExcludeArch: %{ix86}
 License: GPL-2.0-or-later
 URL:     http://fedoraproject.org/wiki/Anaconda
@@ -87,6 +87,7 @@ BuildRequires: libxml2
 Requires: anaconda-gui = %{version}-%{release}
 Requires: anaconda-tui = %{version}-%{release}
 
+Patch2: 0001-flatpak_manager-guard-gi-import-for-missing-typelib.patch
 %description
 The anaconda package is a metapackage for the Anaconda installer.
 


### PR DESCRIPTION
AZL does not ship the flatpak source-type installer feature, so flatpak-libs and its GI typelib are not available in the base image.

- Remove Requires: flatpak and flatpak-libs from anaconda-core
- Add patch to wrap gi.require_version("Flatpak") in try/except so the payload module loads without crashing when the typelib is absent