### PR TITLE
[High] patch keda for CVE-2026-35469

### DIFF
--- a/SPECS/keda/CVE-2026-35469.patch
+++ b/SPECS/keda/CVE-2026-35469.patch
@@ -1,0 +1,703 @@
+From f9b42b44f9b95640d7e2cef945e6bcd3047dbb75 Mon Sep 17 00:00:00 2001
+From: AllSpark <allspark@microsoft.com>
+Date: Wed, 6 May 2026 09:37:23 +0000
+Subject: [PATCH] Add options to customize SPDY frame limits and
+ guard against oversized frames
+
+Upgraded github.com/moby/spdystream from v0.2.0 to v0.5.1
+using `go get github.com/moby/spdystream@v0.5.1`
+
+Upstream Patch reference: https://github.com/moby/spdystream/compare/v0.2.0...v0.5.1.patch
+Fixed Version: https://github.com/moby/spdystream/releases/tag/v0.5.1
+---
+ vendor/github.com/moby/spdystream/NOTICE      | 12 +++
+ .../github.com/moby/spdystream/connection.go  | 72 ++++++++++++-----
+ .../github.com/moby/spdystream/spdy/LICENSE   | 27 +++++++
+ .../github.com/moby/spdystream/spdy/PATENTS   | 22 +++++
+ .../moby/spdystream/spdy/dictionary.go        | 16 ----
+ .../moby/spdystream/spdy/options.go           | 25 ++++++
+ .../github.com/moby/spdystream/spdy/read.go   | 58 ++++++++-----
+ .../github.com/moby/spdystream/spdy/types.go  | 49 +++++++----
+ .../github.com/moby/spdystream/spdy/write.go  | 81 ++++++++++++-------
+ vendor/github.com/moby/spdystream/stream.go   |  2 +
+ 10 files changed, 260 insertions(+), 104 deletions(-)
+ create mode 100644 vendor/github.com/moby/spdystream/spdy/LICENSE
+ create mode 100644 vendor/github.com/moby/spdystream/spdy/PATENTS
+ create mode 100644 vendor/github.com/moby/spdystream/spdy/options.go
+
+diff --git a/vendor/github.com/moby/spdystream/NOTICE b/vendor/github.com/moby/spdystream/NOTICE
+index b9b11c9a..24e2e2aa 100644
+--- a/vendor/github.com/moby/spdystream/NOTICE
++++ b/vendor/github.com/moby/spdystream/NOTICE
+@@ -3,3 +3,15 @@ Copyright 2014-2021 Docker Inc.
+ 
+ This product includes software developed at
+ Docker Inc. (https://www.docker.com/).
++
++SPDY implementation (spdy/)
++
++The spdy directory contains code derived from the Go project (golang.org/x/net).
++
++Copyright 2009-2013 The Go Authors.
++Licensed under the BSD 3-Clause License.
++
++Modifications Copyright 2014-2021 Docker Inc.
++
++The BSD license text and Go patent grant are included in
++spdy/LICENSE and spdy/PATENTS.
+diff --git a/vendor/github.com/moby/spdystream/connection.go b/vendor/github.com/moby/spdystream/connection.go
+index d906bb05..69ce4777 100644
+--- a/vendor/github.com/moby/spdystream/connection.go
++++ b/vendor/github.com/moby/spdystream/connection.go
+@@ -208,9 +208,10 @@ type Connection struct {
+ 	nextStreamId     spdy.StreamId
+ 	receivedStreamId spdy.StreamId
+ 
+-	pingIdLock sync.Mutex
+-	pingId     uint32
+-	pingChans  map[uint32]chan error
++	// pingLock protects pingChans and pingId
++	pingLock  sync.Mutex
++	pingId    uint32
++	pingChans map[uint32]chan error
+ 
+ 	shutdownLock sync.Mutex
+ 	shutdownChan chan error
+@@ -223,7 +224,13 @@ type Connection struct {
+ // NewConnection creates a new spdy connection from an existing
+ // network connection.
+ func NewConnection(conn net.Conn, server bool) (*Connection, error) {
+-	framer, framerErr := spdy.NewFramer(conn, conn)
++	return NewConnectionWithOptions(conn, server)
++}
++
++// NewConnectionWithOptions creates a new spdy connection and applies frame
++// parsing limits via options.
++func NewConnectionWithOptions(conn net.Conn, server bool, opts ...spdy.FramerOption) (*Connection, error) {
++	framer, framerErr := spdy.NewFramerWithOptions(conn, conn, opts...)
+ 	if framerErr != nil {
+ 		return nil, framerErr
+ 	}
+@@ -274,16 +281,20 @@ func NewConnection(conn net.Conn, server bool) (*Connection, error) {
+ // returns the response time
+ func (s *Connection) Ping() (time.Duration, error) {
+ 	pid := s.pingId
+-	s.pingIdLock.Lock()
++	s.pingLock.Lock()
+ 	if s.pingId > 0x7ffffffe {
+ 		s.pingId = s.pingId - 0x7ffffffe
+ 	} else {
+ 		s.pingId = s.pingId + 2
+ 	}
+-	s.pingIdLock.Unlock()
+ 	pingChan := make(chan error)
+ 	s.pingChans[pid] = pingChan
+-	defer delete(s.pingChans, pid)
++	s.pingLock.Unlock()
++	defer func() {
++		s.pingLock.Lock()
++		delete(s.pingChans, pid)
++		s.pingLock.Unlock()
++	}()
+ 
+ 	frame := &spdy.PingFrame{Id: pid}
+ 	startTime := time.Now()
+@@ -345,6 +356,9 @@ Loop:
+ 			} else {
+ 				debugMessage("(%p) EOF received", s)
+ 			}
++			if spdyErr, ok := err.(*spdy.Error); ok && spdyErr.Err == spdy.InvalidControlFrame {
++				_ = s.conn.Close()
++			}
+ 			break
+ 		}
+ 		var priority uint8
+@@ -612,10 +626,14 @@ func (s *Connection) handleDataFrame(frame *spdy.DataFrame) error {
+ }
+ 
+ func (s *Connection) handlePingFrame(frame *spdy.PingFrame) error {
+-	if s.pingId&0x01 != frame.Id&0x01 {
++	s.pingLock.Lock()
++	pingId := s.pingId
++	pingChan, pingOk := s.pingChans[frame.Id]
++	s.pingLock.Unlock()
++
++	if pingId&0x01 != frame.Id&0x01 {
+ 		return s.framer.WriteFrame(frame)
+ 	}
+-	pingChan, pingOk := s.pingChans[frame.Id]
+ 	if pingOk {
+ 		close(pingChan)
+ 	}
+@@ -703,7 +721,9 @@ func (s *Connection) shutdown(closeTimeout time.Duration) {
+ 
+ 	var timeout <-chan time.Time
+ 	if closeTimeout > time.Duration(0) {
+-		timeout = time.After(closeTimeout)
++		timer := time.NewTimer(closeTimeout)
++		defer timer.Stop()
++		timeout = timer.C
+ 	}
+ 	streamsClosed := make(chan bool)
+ 
+@@ -730,17 +750,23 @@ func (s *Connection) shutdown(closeTimeout time.Duration) {
+ 	}
+ 
+ 	if err != nil {
+-		duration := 10 * time.Minute
+-		time.AfterFunc(duration, func() {
+-			select {
+-			case err, ok := <-s.shutdownChan:
+-				if ok {
+-					debugMessage("Unhandled close error after %s: %s", duration, err)
+-				}
+-			default:
+-			}
+-		})
+-		s.shutdownChan <- err
++		// default to 1 second
++		duration := time.Second
++		// if a closeTimeout was given, use that, clipped to 1s-10m
++		if closeTimeout > time.Second {
++			duration = closeTimeout
++		}
++		if duration > 10*time.Minute {
++			duration = 10 * time.Minute
++		}
++		timer := time.NewTimer(duration)
++		defer timer.Stop()
++		select {
++		case s.shutdownChan <- err:
++			// error was handled
++		case <-timer.C:
++			debugMessage("Unhandled close error after %s: %s", duration, err)
++		}
+ 	}
+ 	close(s.shutdownChan)
+ }
+@@ -799,7 +825,9 @@ func (s *Connection) CloseWait() error {
+ func (s *Connection) Wait(waitTimeout time.Duration) error {
+ 	var timeout <-chan time.Time
+ 	if waitTimeout > time.Duration(0) {
+-		timeout = time.After(waitTimeout)
++		timer := time.NewTimer(waitTimeout)
++		defer timer.Stop()
++		timeout = timer.C
+ 	}
+ 
+ 	select {
+diff --git a/vendor/github.com/moby/spdystream/spdy/LICENSE b/vendor/github.com/moby/spdystream/spdy/LICENSE
+new file mode 100644
+index 00000000..6a66aea5
+--- /dev/null
++++ b/vendor/github.com/moby/spdystream/spdy/LICENSE
+@@ -0,0 +1,27 @@
++Copyright (c) 2009 The Go Authors. All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are
++met:
++
++   * Redistributions of source code must retain the above copyright
++notice, this list of conditions and the following disclaimer.
++   * Redistributions in binary form must reproduce the above
++copyright notice, this list of conditions and the following disclaimer
++in the documentation and/or other materials provided with the
++distribution.
++   * Neither the name of Google Inc. nor the names of its
++contributors may be used to endorse or promote products derived from
++this software without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/vendor/github.com/moby/spdystream/spdy/PATENTS b/vendor/github.com/moby/spdystream/spdy/PATENTS
+new file mode 100644
+index 00000000..73309904
+--- /dev/null
++++ b/vendor/github.com/moby/spdystream/spdy/PATENTS
+@@ -0,0 +1,22 @@
++Additional IP Rights Grant (Patents)
++
++"This implementation" means the copyrightable works distributed by
++Google as part of the Go project.
++
++Google hereby grants to You a perpetual, worldwide, non-exclusive,
++no-charge, royalty-free, irrevocable (except as stated in this section)
++patent license to make, have made, use, offer to sell, sell, import,
++transfer and otherwise run, modify and propagate the contents of this
++implementation of Go, where such license applies only to those patent
++claims, both currently owned or controlled by Google and acquired in
++the future, licensable by Google that are necessarily infringed by this
++implementation of Go.  This grant does not include claims that would be
++infringed only as a consequence of further modification of this
++implementation.  If you or your agent or exclusive licensee institute or
++order or agree to the institution of patent litigation against any
++entity (including a cross-claim or counterclaim in a lawsuit) alleging
++that this implementation of Go or any code incorporated within this
++implementation of Go constitutes direct or contributory patent
++infringement, or inducement of patent infringement, then any patent
++rights granted to you under this License for this implementation of Go
++shall terminate as of the date such litigation is filed.
+diff --git a/vendor/github.com/moby/spdystream/spdy/dictionary.go b/vendor/github.com/moby/spdystream/spdy/dictionary.go
+index 392232f1..5a5ff0e1 100644
+--- a/vendor/github.com/moby/spdystream/spdy/dictionary.go
++++ b/vendor/github.com/moby/spdystream/spdy/dictionary.go
+@@ -1,19 +1,3 @@
+-/*
+-   Copyright 2014-2021 Docker Inc.
+-
+-   Licensed under the Apache License, Version 2.0 (the "License");
+-   you may not use this file except in compliance with the License.
+-   You may obtain a copy of the License at
+-
+-       http://www.apache.org/licenses/LICENSE-2.0
+-
+-   Unless required by applicable law or agreed to in writing, software
+-   distributed under the License is distributed on an "AS IS" BASIS,
+-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-   See the License for the specific language governing permissions and
+-   limitations under the License.
+-*/
+-
+ // Copyright 2013 The Go Authors. All rights reserved.
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+diff --git a/vendor/github.com/moby/spdystream/spdy/options.go b/vendor/github.com/moby/spdystream/spdy/options.go
+new file mode 100644
+index 00000000..ec03e0b9
+--- /dev/null
++++ b/vendor/github.com/moby/spdystream/spdy/options.go
+@@ -0,0 +1,25 @@
++package spdy
++
++// FramerOption allows callers to customize frame parsing limits.
++type FramerOption func(*Framer)
++
++// WithMaxControlFramePayloadSize sets the control-frame payload limit.
++func WithMaxControlFramePayloadSize(size uint32) FramerOption {
++	return func(f *Framer) {
++		f.maxFrameLength = size
++	}
++}
++
++// WithMaxHeaderFieldSize sets the per-header name/value size limit.
++func WithMaxHeaderFieldSize(size uint32) FramerOption {
++	return func(f *Framer) {
++		f.maxHeaderFieldSize = size
++	}
++}
++
++// WithMaxHeaderCount sets the maximum number of headers in a frame.
++func WithMaxHeaderCount(count uint32) FramerOption {
++	return func(f *Framer) {
++		f.maxHeaderCount = count
++	}
++}
+diff --git a/vendor/github.com/moby/spdystream/spdy/read.go b/vendor/github.com/moby/spdystream/spdy/read.go
+index 75ea045b..2abb6943 100644
+--- a/vendor/github.com/moby/spdystream/spdy/read.go
++++ b/vendor/github.com/moby/spdystream/spdy/read.go
+@@ -1,19 +1,3 @@
+-/*
+-   Copyright 2014-2021 Docker Inc.
+-
+-   Licensed under the Apache License, Version 2.0 (the "License");
+-   you may not use this file except in compliance with the License.
+-   You may obtain a copy of the License at
+-
+-       http://www.apache.org/licenses/LICENSE-2.0
+-
+-   Unless required by applicable law or agreed to in writing, software
+-   distributed under the License is distributed on an "AS IS" BASIS,
+-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-   See the License for the specific language governing permissions and
+-   limitations under the License.
+-*/
+-
+ // Copyright 2011 The Go Authors. All rights reserved.
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+@@ -24,6 +8,7 @@ import (
+ 	"compress/zlib"
+ 	"encoding/binary"
+ 	"io"
++	"io/ioutil"
+ 	"net/http"
+ 	"strings"
+ )
+@@ -59,6 +44,11 @@ func (frame *SettingsFrame) read(h ControlFrameHeader, f *Framer) error {
+ 	if err := binary.Read(f.r, binary.BigEndian, &numSettings); err != nil {
+ 		return err
+ 	}
++	// Each setting is 8 bytes (4-byte id + 4-byte value).
++	// Payload is 4 bytes for numSettings + numSettings*8.
++	if h.length < 4 || numSettings > (h.length-4)/8 {
++		return &Error{InvalidControlFrame, 0}
++	}
+ 	frame.FlagIdValues = make([]SettingsFlagIdValue, numSettings)
+ 	for i := uint32(0); i < numSettings; i++ {
+ 		if err := binary.Read(f.r, binary.BigEndian, &frame.FlagIdValues[i].Id); err != nil {
+@@ -177,8 +167,19 @@ func (f *Framer) parseControlFrame(version uint16, frameType ControlFrameType) (
+ 	if err := binary.Read(f.r, binary.BigEndian, &length); err != nil {
+ 		return nil, err
+ 	}
++	maxControlFramePayload := uint32(MaxDataLength)
++	if f.maxFrameLength > 0 {
++		maxControlFramePayload = f.maxFrameLength
++	}
++
+ 	flags := ControlFlags((length & 0xff000000) >> 24)
+ 	length &= 0xffffff
++	if length > maxControlFramePayload {
++		if _, err := io.CopyN(ioutil.Discard, f.r, int64(length)); err != nil {
++			return nil, err
++		}
++		return nil, &Error{InvalidControlFrame, 0}
++	}
+ 	header := ControlFrameHeader{version, frameType, flags, length}
+ 	cframe, err := newControlFrame(frameType)
+ 	if err != nil {
+@@ -190,11 +191,22 @@ func (f *Framer) parseControlFrame(version uint16, frameType ControlFrameType) (
+ 	return cframe, nil
+ }
+ 
+-func parseHeaderValueBlock(r io.Reader, streamId StreamId) (http.Header, error) {
++func (f *Framer) parseHeaderValueBlock(r io.Reader, streamId StreamId) (http.Header, error) {
+ 	var numHeaders uint32
+ 	if err := binary.Read(r, binary.BigEndian, &numHeaders); err != nil {
+ 		return nil, err
+ 	}
++	maxHeaders := defaultMaxHeaderCount
++	if f.maxHeaderCount > 0 {
++		maxHeaders = f.maxHeaderCount
++	}
++	if numHeaders > maxHeaders {
++		return nil, &Error{InvalidControlFrame, streamId}
++	}
++	maxFieldSize := defaultMaxHeaderFieldSize
++	if f.maxHeaderFieldSize > 0 {
++		maxFieldSize = f.maxHeaderFieldSize
++	}
+ 	var e error
+ 	h := make(http.Header, int(numHeaders))
+ 	for i := 0; i < int(numHeaders); i++ {
+@@ -202,6 +214,9 @@ func parseHeaderValueBlock(r io.Reader, streamId StreamId) (http.Header, error)
+ 		if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+ 			return nil, err
+ 		}
++		if length > maxFieldSize {
++			return nil, &Error{InvalidControlFrame, streamId}
++		}
+ 		nameBytes := make([]byte, length)
+ 		if _, err := io.ReadFull(r, nameBytes); err != nil {
+ 			return nil, err
+@@ -217,6 +232,9 @@ func parseHeaderValueBlock(r io.Reader, streamId StreamId) (http.Header, error)
+ 		if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+ 			return nil, err
+ 		}
++		if length > maxFieldSize {
++			return nil, &Error{InvalidControlFrame, streamId}
++		}
+ 		value := make([]byte, length)
+ 		if _, err := io.ReadFull(r, value); err != nil {
+ 			return nil, err
+@@ -256,7 +274,7 @@ func (f *Framer) readSynStreamFrame(h ControlFrameHeader, frame *SynStreamFrame)
+ 		}
+ 		reader = f.headerDecompressor
+ 	}
+-	frame.Headers, err = parseHeaderValueBlock(reader, frame.StreamId)
++	frame.Headers, err = f.parseHeaderValueBlock(reader, frame.StreamId)
+ 	if !f.headerCompressionDisabled && (err == io.EOF && f.headerReader.N == 0 || f.headerReader.N != 0) {
+ 		err = &Error{WrongCompressedPayloadSize, 0}
+ 	}
+@@ -288,7 +306,7 @@ func (f *Framer) readSynReplyFrame(h ControlFrameHeader, frame *SynReplyFrame) e
+ 		}
+ 		reader = f.headerDecompressor
+ 	}
+-	frame.Headers, err = parseHeaderValueBlock(reader, frame.StreamId)
++	frame.Headers, err = f.parseHeaderValueBlock(reader, frame.StreamId)
+ 	if !f.headerCompressionDisabled && (err == io.EOF && f.headerReader.N == 0 || f.headerReader.N != 0) {
+ 		err = &Error{WrongCompressedPayloadSize, 0}
+ 	}
+@@ -320,7 +338,7 @@ func (f *Framer) readHeadersFrame(h ControlFrameHeader, frame *HeadersFrame) err
+ 		}
+ 		reader = f.headerDecompressor
+ 	}
+-	frame.Headers, err = parseHeaderValueBlock(reader, frame.StreamId)
++	frame.Headers, err = f.parseHeaderValueBlock(reader, frame.StreamId)
+ 	if !f.headerCompressionDisabled && (err == io.EOF && f.headerReader.N == 0 || f.headerReader.N != 0) {
+ 		err = &Error{WrongCompressedPayloadSize, 0}
+ 	}
+diff --git a/vendor/github.com/moby/spdystream/spdy/types.go b/vendor/github.com/moby/spdystream/spdy/types.go
+index a254a43a..a5528618 100644
+--- a/vendor/github.com/moby/spdystream/spdy/types.go
++++ b/vendor/github.com/moby/spdystream/spdy/types.go
+@@ -1,23 +1,9 @@
+-/*
+-   Copyright 2014-2021 Docker Inc.
+-
+-   Licensed under the Apache License, Version 2.0 (the "License");
+-   you may not use this file except in compliance with the License.
+-   You may obtain a copy of the License at
+-
+-       http://www.apache.org/licenses/LICENSE-2.0
+-
+-   Unless required by applicable law or agreed to in writing, software
+-   distributed under the License is distributed on an "AS IS" BASIS,
+-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-   See the License for the specific language governing permissions and
+-   limitations under the License.
+-*/
+-
+ // Copyright 2011 The Go Authors. All rights reserved.
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
++// Modifications Copyright 2014-2021 Docker Inc.
++
+ // Package spdy implements the SPDY protocol (currently SPDY/3), described in
+ // http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3.
+ package spdy
+@@ -63,8 +49,20 @@ const (
+ )
+ 
+ // MaxDataLength is the maximum number of bytes that can be stored in one frame.
++//
++// SPDY frame headers encode the payload length using a 24-bit field,
++// so the maximum representable size for both data and control frames
++// is 2^24-1 bytes.
++//
++// See the SPDY/3 specification, "Frame Format":
++// https://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1/
+ const MaxDataLength = 1<<24 - 1
+ 
++const (
++	defaultMaxHeaderFieldSize uint32 = 1 << 20
++	defaultMaxHeaderCount     uint32 = 1000
++)
++
+ // headerValueSepator separates multiple header values.
+ const headerValueSeparator = "\x00"
+ 
+@@ -269,6 +267,10 @@ type Framer struct {
+ 	r                         io.Reader
+ 	headerReader              io.LimitedReader
+ 	headerDecompressor        io.ReadCloser
++
++	maxFrameLength       uint32 // overrides the default frame payload length limit.
++	maxHeaderFieldSize   uint32 // overrides the default per-header name/value length limit.
++	maxHeaderCount       uint32 // overrides the default header count limit.
+ }
+ 
+ // NewFramer allocates a new Framer for a given SPDY connection, represented by
+@@ -276,6 +278,16 @@ type Framer struct {
+ // from/to the Reader and Writer, so the caller should pass in an appropriately
+ // buffered implementation to optimize performance.
+ func NewFramer(w io.Writer, r io.Reader) (*Framer, error) {
++	return newFramer(w, r)
++}
++
++// NewFramerWithOptions allocates a new Framer for a given SPDY connection and
++// applies frame parsing limits via options.
++func NewFramerWithOptions(w io.Writer, r io.Reader, opts ...FramerOption) (*Framer, error) {
++	return newFramer(w, r, opts...)
++}
++
++func newFramer(w io.Writer, r io.Reader, opts ...FramerOption) (*Framer, error) {
+ 	compressBuf := new(bytes.Buffer)
+ 	compressor, err := zlib.NewWriterLevelDict(compressBuf, zlib.BestCompression, []byte(headerDictionary))
+ 	if err != nil {
+@@ -287,5 +299,10 @@ func NewFramer(w io.Writer, r io.Reader) (*Framer, error) {
+ 		headerCompressor: compressor,
+ 		r:                r,
+ 	}
++	for _, opt := range opts {
++		if opt != nil {
++			opt(framer)
++		}
++	}
+ 	return framer, nil
+ }
+diff --git a/vendor/github.com/moby/spdystream/spdy/write.go b/vendor/github.com/moby/spdystream/spdy/write.go
+index ab6d91f3..75084d35 100644
+--- a/vendor/github.com/moby/spdystream/spdy/write.go
++++ b/vendor/github.com/moby/spdystream/spdy/write.go
+@@ -1,19 +1,3 @@
+-/*
+-   Copyright 2014-2021 Docker Inc.
+-
+-   Licensed under the Apache License, Version 2.0 (the "License");
+-   you may not use this file except in compliance with the License.
+-   You may obtain a copy of the License at
+-
+-       http://www.apache.org/licenses/LICENSE-2.0
+-
+-   Unless required by applicable law or agreed to in writing, software
+-   distributed under the License is distributed on an "AS IS" BASIS,
+-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-   See the License for the specific language governing permissions and
+-   limitations under the License.
+-*/
+-
+ // Copyright 2011 The Go Authors. All rights reserved.
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+@@ -23,6 +7,7 @@ package spdy
+ import (
+ 	"encoding/binary"
+ 	"io"
++	"math"
+ 	"net/http"
+ 	"strings"
+ )
+@@ -63,13 +48,21 @@ func (frame *RstStreamFrame) write(f *Framer) (err error) {
+ func (frame *SettingsFrame) write(f *Framer) (err error) {
+ 	frame.CFHeader.version = Version
+ 	frame.CFHeader.frameType = TypeSettings
+-	frame.CFHeader.length = uint32(len(frame.FlagIdValues)*8 + 4)
++	payloadLen := len(frame.FlagIdValues)*8 + 4
++	if payloadLen > MaxDataLength {
++		return &Error{InvalidControlFrame, 0}
++	}
++	frame.CFHeader.length = uint32(payloadLen)
+ 
+ 	// Serialize frame to Writer.
+ 	if err = writeControlFrameHeader(f.w, frame.CFHeader); err != nil {
+ 		return
+ 	}
+-	if err = binary.Write(f.w, binary.BigEndian, uint32(len(frame.FlagIdValues))); err != nil {
++	n := len(frame.FlagIdValues)
++	if uint64(n) > math.MaxUint32 {
++		return &Error{InvalidControlFrame, 0}
++	}
++	if err = binary.Write(f.w, binary.BigEndian, uint32(n)); err != nil {
+ 		return
+ 	}
+ 	for _, flagIdValue := range frame.FlagIdValues {
+@@ -170,29 +163,41 @@ func writeControlFrameHeader(w io.Writer, h ControlFrameHeader) error {
+ 
+ func writeHeaderValueBlock(w io.Writer, h http.Header) (n int, err error) {
+ 	n = 0
+-	if err = binary.Write(w, binary.BigEndian, uint32(len(h))); err != nil {
++	numHeaders := len(h)
++	if numHeaders > math.MaxInt32 {
++		return n, &Error{InvalidControlFrame, 0}
++	}
++	if err = binary.Write(w, binary.BigEndian, uint32(numHeaders)); err != nil {
+ 		return
+ 	}
+-	n += 2
++	n += 4
+ 	for name, values := range h {
+-		if err = binary.Write(w, binary.BigEndian, uint32(len(name))); err != nil {
++		nameLen := len(name)
++		if nameLen > math.MaxInt32 {
++			return n, &Error{InvalidControlFrame, 0}
++		}
++		if err = binary.Write(w, binary.BigEndian, uint32(nameLen)); err != nil {
+ 			return
+ 		}
+-		n += 2
++		n += 4
+ 		name = strings.ToLower(name)
+ 		if _, err = io.WriteString(w, name); err != nil {
+ 			return
+ 		}
+-		n += len(name)
++		n += nameLen
+ 		v := strings.Join(values, headerValueSeparator)
+-		if err = binary.Write(w, binary.BigEndian, uint32(len(v))); err != nil {
++		vLen := len(v)
++		if vLen > math.MaxInt32 {
++			return n, &Error{InvalidControlFrame, 0}
++		}
++		if err = binary.Write(w, binary.BigEndian, uint32(vLen)); err != nil {
+ 			return
+ 		}
+-		n += 2
++		n += 4
+ 		if _, err = io.WriteString(w, v); err != nil {
+ 			return
+ 		}
+-		n += len(v)
++		n += vLen
+ 	}
+ 	return
+ }
+@@ -216,7 +221,11 @@ func (f *Framer) writeSynStreamFrame(frame *SynStreamFrame) (err error) {
+ 	// Set ControlFrameHeader.
+ 	frame.CFHeader.version = Version
+ 	frame.CFHeader.frameType = TypeSynStream
+-	frame.CFHeader.length = uint32(len(f.headerBuf.Bytes()) + 10)
++	hLen := len(f.headerBuf.Bytes()) + 10
++	if hLen > MaxDataLength {
++		return &Error{InvalidControlFrame, 0}
++	}
++	frame.CFHeader.length = uint32(hLen)
+ 
+ 	// Serialize frame to Writer.
+ 	if err = writeControlFrameHeader(f.w, frame.CFHeader); err != nil {
+@@ -260,7 +269,11 @@ func (f *Framer) writeSynReplyFrame(frame *SynReplyFrame) (err error) {
+ 	// Set ControlFrameHeader.
+ 	frame.CFHeader.version = Version
+ 	frame.CFHeader.frameType = TypeSynReply
+-	frame.CFHeader.length = uint32(len(f.headerBuf.Bytes()) + 4)
++	hLen := len(f.headerBuf.Bytes()) + 4
++	if hLen > MaxDataLength {
++		return &Error{InvalidControlFrame, 0}
++	}
++	frame.CFHeader.length = uint32(hLen)
+ 
+ 	// Serialize frame to Writer.
+ 	if err = writeControlFrameHeader(f.w, frame.CFHeader); err != nil {
+@@ -295,7 +308,11 @@ func (f *Framer) writeHeadersFrame(frame *HeadersFrame) (err error) {
+ 	// Set ControlFrameHeader.
+ 	frame.CFHeader.version = Version
+ 	frame.CFHeader.frameType = TypeHeaders
+-	frame.CFHeader.length = uint32(len(f.headerBuf.Bytes()) + 4)
++	hLen := len(f.headerBuf.Bytes()) + 4
++	if hLen > MaxDataLength {
++		return &Error{InvalidControlFrame, 0}
++	}
++	frame.CFHeader.length = uint32(hLen)
+ 
+ 	// Serialize frame to Writer.
+ 	if err = writeControlFrameHeader(f.w, frame.CFHeader); err != nil {
+@@ -323,7 +340,11 @@ func (f *Framer) writeDataFrame(frame *DataFrame) (err error) {
+ 	if err = binary.Write(f.w, binary.BigEndian, frame.StreamId); err != nil {
+ 		return
+ 	}
+-	flagsAndLength := uint32(frame.Flags)<<24 | uint32(len(frame.Data))
++	dLen := len(frame.Data)
++	if dLen > MaxDataLength {
++		return &Error{InvalidDataFrame, frame.StreamId}
++	}
++	flagsAndLength := uint32(frame.Flags)<<24 | uint32(dLen)
+ 	if err = binary.Write(f.w, binary.BigEndian, flagsAndLength); err != nil {
+ 		return
+ 	}
+diff --git a/vendor/github.com/moby/spdystream/stream.go b/vendor/github.com/moby/spdystream/stream.go
+index 404e3c02..171c1e9e 100644
+--- a/vendor/github.com/moby/spdystream/stream.go
++++ b/vendor/github.com/moby/spdystream/stream.go
+@@ -305,6 +305,8 @@ func (s *Stream) Identifier() uint32 {
+ // IsFinished returns whether the stream has finished
+ // sending data
+ func (s *Stream) IsFinished() bool {
++	s.finishLock.Lock()
++	defer s.finishLock.Unlock()
+ 	return s.finished
+ }
+ 
+-- 
+2.43.0
+

--- a/SPECS/keda/keda.spec
+++ b/SPECS/keda/keda.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes-based Event Driven Autoscaling
 Name:           keda
 Version:        2.14.1
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -38,6 +38,8 @@ Patch12:        CVE-2025-11065.patch
 Patch13:        CVE-2025-47911.patch
 Patch14:        CVE-2025-58190.patch
 Patch15:        CVE-2026-2303.patch
+Patch16:        CVE-2026-35469.patch
+
 BuildRequires:  golang >= 1.15
 
 %description
@@ -73,6 +75,9 @@ cp ./bin/keda-admission-webhooks %{buildroot}%{_bindir}
 %{_bindir}/%{name}-admission-webhooks
 
 %changelog
+* Thu May 07 2026 Akhila Guruju <v-guakhila@microsoft.com> - 2.14.1-12
+- Patch CVE-2026-34569
+
 * Thu Feb 19 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.14.1-11
 - Patch for CVE-2026-2303, CVE-2025-58190, CVE-2025-47911
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch keda for CVE-2026-35469

Upgraded github.com/moby/spdystream from v0.2.0 to v0.5.1
using `go get github.com/moby/spdystream@v0.5.1`

Upstream Patch reference: https://github.com/moby/spdystream/compare/v0.2.0...v0.5.1.patch
Fixed Version: https://github.com/moby/spdystream/releases/tag/v0.5.1

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/keda/CVE-2026-35469.patch
- modified:   SPECS/keda/keda.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-35469

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
