### PR TITLE
chore(images): update .kiwi repo references to azl4-dev repos

### DIFF
--- a/base/images/container-base/container-base.kiwi
+++ b/base/images/container-base/container-base.kiwi
@@ -67,12 +67,7 @@
 
     <repository type="rpm-md" alias="azurelinux-base">
         <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
-    </repository>
-
-    <repository type="rpm-md" alias="azurelinux-sdk">
-        <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
     </repository>
 
     <packages type="image" profiles="core">

--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -64,12 +64,7 @@
 
     <repository type="rpm-md" alias="azurelinux-base">
         <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
-    </repository>
-
-    <repository type="rpm-md" alias="azurelinux-sdk">
-        <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
     </repository>
 
     <packages type="image">

--- a/base/images/vm-iso-installer/config.sh
+++ b/base/images/vm-iso-installer/config.sh
@@ -66,6 +66,7 @@ INSTALL_PKGS=(
     vim-minimal
     ca-certificates
     azurelinux-release
+    azurelinux-repos-dev
     setup
     shadow-utils
     util-linux
@@ -98,7 +99,7 @@ echo "=== Downloading target-install packages + dependencies ==="
 # file are NOT available during config.sh. Use --repofrompath with the CDN URL
 # directly. The URL matches the "azurelinux-base" repo in vm-iso-installer.kiwi.
 
-AZL_BASE_URL="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$ARCH"
+AZL_BASE_URL="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$ARCH"
 dnf5 download \
     --setopt=reposdir=/dev/null \
     --repofrompath=azl-base,"$AZL_BASE_URL" \

--- a/base/images/vm-iso-installer/vm-iso-installer.kiwi
+++ b/base/images/vm-iso-installer/vm-iso-installer.kiwi
@@ -29,11 +29,7 @@
 
     <repository type="rpm-md" alias="azurelinux-base">
         <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
-    </repository>
-    <repository type="rpm-md" alias="azurelinux-sdk">
-        <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
     </repository>
 
     <packages type="image">
@@ -117,6 +113,7 @@
     </packages>
 
     <packages type="bootstrap">
+        <package name="azurelinux-repos-dev" />
         <package name="dracut-network" />
         <package name="filesystem" />
         <package name="grub2-efi-x64-modules" arch="x86_64" />

--- a/base/images/wsl/wsl.kiwi
+++ b/base/images/wsl/wsl.kiwi
@@ -19,12 +19,7 @@
 
     <repository type="rpm-md" alias="azurelinux-base">
         <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch" />
-    </repository>
-
-    <repository type="rpm-md" alias="azurelinux-sdk">
-        <source
-            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch" />
+            path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
     </repository>
 
     <!-- Package list derived from Fedora 43's WSL image composition. -->
@@ -77,6 +72,7 @@
     </packages>
 
     <packages type="bootstrap">
+        <package name="azurelinux-repos-dev"/>
         <package name="bash"/>
         <package name="coreutils"/>
         <package name="dnf5"/>


### PR DESCRIPTION
Updates .kiwi image definitions' repository references to point at `azl4-dev` repo. Removes references to `sdk` repo now that all required packages should be present in `base`.

Most of these references are only used by local image builds (not used by koji builds); one notable exception is the ISO definition, which has an embedded reference to the RPM repos it will use to populate the offline packages embedded into the image.

**_Validation_**: built all images locally via azldev; built ISO image via CT + koji as well.