### PR TITLE
chore(mock-core-configs): update azl4 mock configs to point at PMC

### DIFF
--- a/base/comps/mock-core-configs/azure-linux-4.tpl
+++ b/base/comps/mock-core-configs/azure-linux-4.tpl
@@ -27,7 +27,8 @@ reposdir=/dev/null
 logfile=/var/log/yum.log
 retries=20
 obsoletes=1
-gpgcheck=0
+gpgcheck=1
+repo_gpgcheck=1
 assumeyes=1
 syslog_ident=mock
 syslog_device=
@@ -38,19 +39,18 @@ install_weak_deps=0
 protected_packages=
 user_agent={{ user_agent }}
 
-# Azure Linux 4.0 alpha2-prod blob storage repos.
-# Note: alpha2 staging metadata is unsigned, so gpgcheck=0.
-
 [azurelinux-base]
-name=Azure Linux Base $releasever $basearch
-baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch
-gpgcheck=0
+name=Azure Linux $releasever - $basearch - Base
+baseurl=https://packages.microsoft.com/azurelinux/4.0/beta/base/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
 enabled=1
 
 [azurelinux-build-deps]
-name=Azure Linux Additional Build Dependencies $releasever $basearch
-baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch
-gpgcheck=0
+name=Azure Linux $releasever - $basearch - Additional Build Dependencies
+baseurl=https://packages.microsoft.com/azurelinux/4.0/beta/sdk/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
 enabled=1
 
 """

--- a/locks/mock-core-configs.lock
+++ b/locks/mock-core-configs.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'd657887e0e4eee4a1cc28747a52c514b90f890c7'
 upstream-commit = 'd657887e0e4eee4a1cc28747a52c514b90f890c7'
-input-fingerprint = 'sha256:7edf0b547c246e9555129e0a7b4fadb8346fdb355e73ee4b00eb58fac1cafc45'
+input-fingerprint = 'sha256:efb5a2eb55d3cd0abd29c083f5152c057cae39b906deb4faaecc649d4b17859c'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/m/mock-core-configs/azure-linux-4.tpl
+++ b/specs/m/mock-core-configs/azure-linux-4.tpl
@@ -27,7 +27,8 @@ reposdir=/dev/null
 logfile=/var/log/yum.log
 retries=20
 obsoletes=1
-gpgcheck=0
+gpgcheck=1
+repo_gpgcheck=1
 assumeyes=1
 syslog_ident=mock
 syslog_device=
@@ -38,19 +39,18 @@ install_weak_deps=0
 protected_packages=
 user_agent={{ user_agent }}
 
-# Azure Linux 4.0 alpha2-prod blob storage repos.
-# Note: alpha2 staging metadata is unsigned, so gpgcheck=0.
-
 [azurelinux-base]
-name=Azure Linux Base $releasever $basearch
-baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/base/$basearch
-gpgcheck=0
+name=Azure Linux $releasever - $basearch - Base
+baseurl=https://packages.microsoft.com/azurelinux/4.0/beta/base/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
 enabled=1
 
 [azurelinux-build-deps]
-name=Azure Linux Additional Build Dependencies $releasever $basearch
-baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/alpha2-prod/sdk/$basearch
-gpgcheck=0
+name=Azure Linux $releasever - $basearch - Additional Build Dependencies
+baseurl=https://packages.microsoft.com/azurelinux/4.0/beta/sdk/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
 enabled=1
 
 """

--- a/specs/m/mock-core-configs/mock-core-configs.spec
+++ b/specs/m/mock-core-configs/mock-core-configs.spec
@@ -7,7 +7,7 @@
 
 Name:       mock-core-configs
 Version:    44.1
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary:    Mock core config files basic chroots
 
 License:    GPL-2.0-or-later


### PR DESCRIPTION
Updates mock-core-configs mock config for Azure Linux 4 to point to Beta repos on packages.microsoft.com.

We could alternatively have this first point to `azl4-dev` repos, but since internal team members are not using this for regular testing, I'm proposing that we go right ahead and get this ready for what it should look like for Beta.