### PR TITLE
fix(packages): promote 13 python SRPMs to base to fix repoclosure issues

### DIFF
--- a/base/packages/base.packages.toml
+++ b/base/packages/base.packages.toml
@@ -5906,9 +5906,13 @@ packages = [
     "python-dateutil-doc", # srpm: python-dateutil
     "python-dictdiffer-doc", # srpm: python-dictdiffer
     "python-filelock-doc", # srpm: python-filelock
+    "python-h2-doc", # srpm: python-h2
+    "python-hpack-doc", # srpm: python-hpack
     "python-humanfriendly-doc", # srpm: python-humanfriendly
+    "python-hyperframe-doc", # srpm: python-hyperframe
     "python-kubernetes-doc", # srpm: python-kubernetes
     "python-libcomps-doc", # srpm: libcomps
+    "python-mpmath-doc", # srpm: python-mpmath
     "python-multilib-conf", # srpm: python-multilib
     "python-mysqlclient-doc", # srpm: python-mysqlclient
     "python-networkx-doc", # srpm: python-networkx
@@ -5919,6 +5923,7 @@ packages = [
     "python-pkginfo-doc", # srpm: python-pkginfo
     "python-psycopg2-doc", # srpm: python-psycopg2
     "python-pyasn1-doc", # srpm: python-pyasn1
+    "python-pycares-doc", # srpm: python-pycares
     "python-pygit2-doc", # srpm: python-pygit2
     "python-pymongo-doc", # srpm: python-pymongo
     "python-pyperclip-doc", # srpm: python-pyperclip
@@ -5960,6 +5965,7 @@ packages = [
     "python3-arrow", # srpm: python-arrow
     "python3-asn1crypto", # srpm: python-asn1crypto
     "python3-assimp", # srpm: assimp
+    "python3-asyncmy", # srpm: python-asyncmy
     "python3-asyncpg", # srpm: python-asyncpg
     "python3-asyncpg+gssauth", # srpm: python-asyncpg
     "python3-asyncssh", # srpm: python-asyncssh
@@ -6218,10 +6224,12 @@ packages = [
     "python3-grpcio-testing", # srpm: grpc
     "python3-grpcio-tools", # srpm: grpc
     "python3-gssapi", # srpm: python-gssapi
+    "python3-h2", # srpm: python-h2
     "python3-hacking", # srpm: python-hacking
     "python3-hatchling", # srpm: python-hatchling
     "python3-hawkey", # srpm: libdnf
     "python3-hivex", # srpm: hivex
+    "python3-hpack", # srpm: python-hpack
     "python3-html5lib", # srpm: python-html5lib
     "python3-html5lib+all", # srpm: python-html5lib
     "python3-html5lib+chardet", # srpm: python-html5lib
@@ -6229,6 +6237,7 @@ packages = [
     "python3-html5lib+lxml", # srpm: python-html5lib
     "python3-httplib2", # srpm: python-httplib2
     "python3-humanfriendly", # srpm: python-humanfriendly
+    "python3-hyperframe", # srpm: python-hyperframe
     "python3-i2c-tools", # srpm: i2c-tools
     "python3-idle", # srpm: python3.14
     "python3-idna", # srpm: python-idna
@@ -6330,6 +6339,7 @@ packages = [
     "python3-libvoikko", # srpm: libvoikko
     "python3-libxml2", # srpm: libxml2
     "python3-libxslt", # srpm: libxslt
+    "python3-linkify-it-py", # srpm: python-linkify-it-py
     "python3-linux-procfs", # srpm: python-linux-procfs
     "python3-lit", # srpm: llvm
     "python3-lldb", # srpm: llvm
@@ -6346,13 +6356,17 @@ packages = [
     "python3-markdown-it-py+linkify", # srpm: python-markdown-it-py
     "python3-markdown-it-py+plugins", # srpm: python-markdown-it-py
     "python3-markupsafe", # srpm: python-markupsafe
+    "python3-mccabe", # srpm: python-mccabe
     "python3-mdit-py-plugins", # srpm: python-mdit-py-plugins
+    "python3-mdurl", # srpm: python-mdurl
     "python3-meh", # srpm: python-meh
     "python3-meh-gui", # srpm: python-meh
     "python3-microsoft-security-utilities-secret-masker", # srpm: python-microsoft-security-utilities-secret-masker
     "python3-mod_wsgi", # srpm: mod_wsgi
     "python3-more-itertools", # srpm: python-more-itertools
     "python3-mpich", # srpm: mpich
+    "python3-mpmath", # srpm: python-mpmath
+    "python3-mpmath+gmpy", # srpm: python-mpmath
     "python3-msal", # srpm: python-msal
     "python3-msal-extensions", # srpm: python-msal-extensions
     "python3-msal-extensions+portalocker", # srpm: python-msal-extensions
@@ -6433,11 +6447,14 @@ packages = [
     "python3-pyasn1-modules", # srpm: python-pyasn1
     "python3-pyatspi", # srpm: pyatspi
     "python3-pybind11", # srpm: pybind11
+    "python3-pycares", # srpm: python-pycares
     "python3-pycdio", # srpm: python-pycdio
+    "python3-pycodestyle", # srpm: python-pycodestyle
     "python3-pycomposefile", # srpm: python-pycomposefile
     "python3-pycparser", # srpm: python-pycparser
     "python3-pycurl", # srpm: python-pycurl
     "python3-pyelftools", # srpm: pyelftools
+    "python3-pyflakes", # srpm: pyflakes
     "python3-pygit2", # srpm: python-pygit2
     "python3-pygithub", # srpm: python-PyGithub
     "python3-pygments", # srpm: python-pygments
@@ -6598,6 +6615,7 @@ packages = [
     "python3-typer-slim", # srpm: python-typer
     "python3-typer-slim+standard", # srpm: python-typer
     "python3-typing-extensions", # srpm: python-typing-extensions
+    "python3-uc-micro-py", # srpm: python-uc-micro-py
     "python3-unbound", # srpm: unbound
     "python3-uri-template", # srpm: python-uri-template
     "python3-uritemplate", # srpm: python-uritemplate
@@ -6631,6 +6649,7 @@ packages = [
     "python3-yarl", # srpm: python-yarl
     "python3-yubico", # srpm: python-yubico
     "python3-zc-lockfile", # srpm: python-zc-lockfile
+    "python3-zombie-imp", # srpm: python-zombie-imp
     "python3-zstandard", # srpm: python-zstandard
     "python3-zstandard+cffi", # srpm: python-zstandard
     "python3-zstd", # srpm: python-zstd

--- a/base/packages/sdk.packages.toml
+++ b/base/packages/sdk.packages.toml
@@ -5458,9 +5458,6 @@ packages = [
     "python-gmpy2-doc", # srpm: python-gmpy2
     "python-graphviz-doc", # srpm: python-graphviz
     "python-gunicorn-doc", # srpm: python-gunicorn
-    "python-h2-doc", # srpm: python-h2
-    "python-hpack-doc", # srpm: python-hpack
-    "python-hyperframe-doc", # srpm: python-hyperframe
     "python-hyperlink-doc", # srpm: python-hyperlink
     "python-intbitset-doc", # srpm: python-intbitset
     "python-jsonstreams-doc", # srpm: python-jsonstreams
@@ -5475,7 +5472,6 @@ packages = [
     "python-maxminddb-doc", # srpm: python-maxminddb
     "python-mistralclient-doc", # srpm: python-mistralclient
     "python-mistune-doc", # srpm: python-mistune
-    "python-mpmath-doc", # srpm: python-mpmath
     "python-nbconvert-doc", # srpm: python-nbconvert
     "python-nbdime-doc", # srpm: python-nbdime
     "python-nbsphinx-doc", # srpm: python-nbsphinx
@@ -5502,7 +5498,6 @@ packages = [
     "python-priority-doc", # srpm: python-priority
     "python-pyahocorasick-doc", # srpm: python-pyahocorasick
     "python-pybtex-doc", # srpm: python-pybtex
-    "python-pycares-doc", # srpm: python-pycares
     "python-pydantic-doc", # srpm: python-pydantic
     "python-pygmars-doc", # srpm: python-pygmars
     "python-pygraphviz-doc", # srpm: python-pygraphviz
@@ -5580,7 +5575,6 @@ packages = [
     "python3-astroid", # srpm: python-astroid
     "python3-asttokens", # srpm: python-asttokens
     "python3-async-lru", # srpm: python-async-lru
-    "python3-asyncmy", # srpm: python-asyncmy
     "python3-atpublic", # srpm: python-atpublic
     "python3-autopage", # srpm: python-autopage
     "python3-autowrap", # srpm: autowrap
@@ -5805,7 +5799,6 @@ packages = [
     "python3-gunicorn+gevent", # srpm: python-gunicorn
     "python3-gunicorn+setproctitle", # srpm: python-gunicorn
     "python3-h11", # srpm: python-h11
-    "python3-h2", # srpm: python-h2
     "python3-h5netcdf", # srpm: python-h5netcdf
     "python3-h5py", # srpm: h5py
     "python3-h5py-mpich", # srpm: h5py
@@ -5816,7 +5809,6 @@ packages = [
     "python3-hatch-requirements-txt", # srpm: python-hatch-requirements-txt
     "python3-hatch-vcs", # srpm: python-hatch-vcs
     "python3-heatclient", # srpm: python-heatclient
-    "python3-hpack", # srpm: python-hpack
     "python3-httpbin", # srpm: python-httpbin
     "python3-httpcore", # srpm: python-httpcore
     "python3-httpcore+http2", # srpm: python-httpcore
@@ -5832,7 +5824,6 @@ packages = [
     "python3-hypercorn", # srpm: python-hypercorn
     "python3-hypercorn+h3", # srpm: python-hypercorn
     "python3-hypercorn+trio", # srpm: python-hypercorn
-    "python3-hyperframe", # srpm: python-hyperframe
     "python3-hyperlink", # srpm: python-hyperlink
     "python3-hypothesis", # srpm: python-hypothesis
     "python3-hypothesis+cli", # srpm: python-hypothesis
@@ -5936,7 +5927,6 @@ packages = [
     "python3-libsvm", # srpm: libsvm
     "python3-license-expression", # srpm: python-license-expression
     "python3-lilv", # srpm: lilv
-    "python3-linkify-it-py", # srpm: python-linkify-it-py
     "python3-littleutils", # srpm: python-littleutils
     "python3-llvmlite", # srpm: python-llvmlite
     "python3-locket", # srpm: python-locket
@@ -5960,8 +5950,6 @@ packages = [
     "python3-matplotlib-tk", # srpm: python-matplotlib
     "python3-matplotlib-wx", # srpm: python-matplotlib
     "python3-maxminddb", # srpm: python-maxminddb
-    "python3-mccabe", # srpm: python-mccabe
-    "python3-mdurl", # srpm: python-mdurl
     "python3-memcached", # srpm: python-memcached
     "python3-mercantile", # srpm: python-mercantile
     "python3-merge3", # srpm: python-merge3
@@ -5971,8 +5959,6 @@ packages = [
     "python3-mock", # srpm: python-mock
     "python3-mpi4py-mpich", # srpm: mpi4py
     "python3-mpi4py-openmpi", # srpm: mpi4py
-    "python3-mpmath", # srpm: python-mpmath
-    "python3-mpmath+gmpy", # srpm: python-mpmath
     "python3-msgspec", # srpm: python-msgspec
     "python3-mupdf", # srpm: mupdf
     "python3-mypy", # srpm: python3-mypy
@@ -6109,9 +6095,7 @@ packages = [
     "python3-pybeam", # srpm: python-pybeam
     "python3-pybtex", # srpm: python-pybtex
     "python3-pybtex-docutils", # srpm: python-pybtex-docutils
-    "python3-pycares", # srpm: python-pycares
     "python3-pyclipper", # srpm: python-pyclipper
-    "python3-pycodestyle", # srpm: python-pycodestyle
     "python3-pycosat", # srpm: python-pycosat
     "python3-pycryptodomex", # srpm: python-pycryptodomex
     "python3-pycryptodomex-selftest", # srpm: python-pycryptodomex
@@ -6123,7 +6107,6 @@ packages = [
     "python3-pydoctor", # srpm: python-pydoctor
     "python3-pydot", # srpm: pydot
     "python3-pyfakefs", # srpm: python-pyfakefs
-    "python3-pyflakes", # srpm: pyflakes
     "python3-pyftpdlib", # srpm: python-pyftpdlib
     "python3-pyftpdlib+ssl", # srpm: python-pyftpdlib
     "python3-pygmars", # srpm: python-pygmars
@@ -6389,7 +6372,6 @@ packages = [
     "python3-typogrify", # srpm: python-typogrify
     "python3-tzlocal", # srpm: python-tzlocal
     "python3-u-msgpack-python", # srpm: python-u-msgpack-python
-    "python3-uc-micro-py", # srpm: python-uc-micro-py
     "python3-ufo2ft", # srpm: python-ufo2ft
     "python3-ufo2ft+cffsubr", # srpm: python-ufo2ft
     "python3-ufo2ft+compreffor", # srpm: python-ufo2ft
@@ -6452,7 +6434,6 @@ packages = [
     "python3-zict", # srpm: python-zict
     "python3-zipp", # srpm: python-zipp
     "python3-zlib-ng", # srpm: python-zlib-ng
-    "python3-zombie-imp", # srpm: python-zombie-imp
     "python3-zope-event", # srpm: python-zope-event
     "python3-zope-exceptions", # srpm: python-zope-exceptions
     "python3-zope-interface", # srpm: python-zope-interface


### PR DESCRIPTION
### Summary

Whole-SRPM moves (per channel-consistency policy in sdk.packages.toml):
  pyflakes, python-asyncmy, python-h2, python-hpack, python-hyperframe,
  python-linkify-it-py, python-mccabe, python-mdurl, python-mpmath,
  python-pycares, python-pycodestyle, python-uc-micro-py, python-zombie-imp

Includes sibling sub-packages (-doc, +gmpy) so each SRPM ships entirely in rpm-base.

### Validation

Booted an azl4 container, tried installing the packages listed below (with unresolved deps); saw failures; pulled in just the above listed packages from `sdk`, and saw the packages install cleanly.

---

### Context

```
_______________________________ test_repoclosure_base[x86_64] (package='python3-aiodns-3.6.1-2.azl4.noarch', arch='x86_64') _______________________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-aiodns-3.6.1-2.azl4.noarch (from 'base') has unresolved runtime dep(s):
E     - (python3.14dist(pycares) < 5~~ with python3.14dist(pycares) >= 4.9)
_______________________________ test_repoclosure_base[x86_64] (package='python3-boto-2.49.0-30.azl4.noarch', arch='x86_64') _______________________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-boto-2.49.0-30.azl4.noarch (from 'base') has unresolved runtime dep(s):
E     - (python3-zombie-imp if python3 >= 3.12)
______________________________ test_repoclosure_base[x86_64] (package='python3-flake8-6.1.0-10.azl4.noarch', arch='x86_64') _______________________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-flake8-6.1.0-10.azl4.noarch (from 'base') has unresolved runtime dep(s):
E     - (python3.14dist(mccabe) < 0.8~~ with python3.14dist(mccabe) >= 0.7)
E     - (python3.14dist(pycodestyle) < 2.13~~ with python3.14dist(pycodestyle) >= 2.11)
E     - (python3.14dist(pyflakes) < 3.2~~ with python3.14dist(pyflakes) >= 3.1)
______________________ test_repoclosure_base[x86_64] (package='python3-markdown-it-py+linkify-3.0.0-14.azl4.noarch', arch='x86_64') _______________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-markdown-it-py+linkify-3.0.0-14.azl4.noarch (from 'base') has unresolved runtime dep(s):
E     - (python3.14dist(linkify-it-py) < 3~~ with python3.14dist(linkify-it-py) >= 1)
__________________________ test_repoclosure_base[x86_64] (package='python3-markdown-it-py-3.0.0-14.azl4.noarch', arch='x86_64') ___________________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-markdown-it-py-3.0.0-14.azl4.noarch (from 'base') has unresolved runtime dep(s):
E     - (python3.14dist(mdurl) >= 0.1 with python3.14dist(mdurl) < 1)
________________________ test_repoclosure_base[x86_64] (package='python3-sqlalchemy+asyncmy-2.0.46-2.azl4.x86_64', arch='x86_64') _________________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-sqlalchemy+asyncmy-2.0.46-2.azl4.x86_64 (from 'base') has unresolved runtime dep(s):
E     - ((python3.14dist(asyncmy) < 0.2.4 or python3.14dist(asyncmy) > 0.2.4) with (python3.14dist(asyncmy) < 0.2.6 or python3.14dist(asyncmy) > 0.2.6) with python3.14dist(asyncmy) >= 0.2.3)
_______________________________ test_repoclosure_base[x86_64] (package='python3-sympy-1.14.0-8.azl4.noarch', arch='x86_64') _______________________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-sympy-1.14.0-8.azl4.noarch (from 'base') has unresolved runtime dep(s):
E     - (python3.14dist(mpmath) < 1.4~~ with python3.14dist(mpmath) >= 1.1)
_____________________________ test_repoclosure_base[x86_64] (package='python3-urllib3+h2-2.6.3-2.azl4.noarch', arch='x86_64') _____________________________
cases/test_repoclosure_base.py:27: in test_repoclosure_base
    pytest.fail(
E   Failed: python3-urllib3+h2-2.6.3-2.azl4.noarch (from 'base') has unresolved runtime dep(s):
E     - (python3.14dist(h2) < 5~~ with python3.14dist(h2) >= 4)
```