### PR TITLE
feat(vm-base): install efibootmgr in Gen2 (UEFI) VM image

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -94,6 +94,7 @@
         <package name="device-mapper-event" />
         <package name="dnf5" />
         <package name="dnf5-plugins" />
+        <package name="efibootmgr" />
         <package name="file" />
         <package name="firewalld" />
         <package name="glibc" />


### PR DESCRIPTION
Add efibootmgr to the vm-base image package list so users can manage
UEFI boot entries out of the box. efibootmgr can also be used during
bootloader reinstalls to register boot entries with firmware via the
standard UEFI tooling. Standard cloud distros (AZL3, Ubuntu, RHEL,
Fedora) ship efibootmgr in their UEFI cloud images.

Fixes: [AB#19697](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19697)