### PR TITLE
images: add dev variant alongside each canonical image

### DIFF
--- a/.github/instructions/kiwi.instructions.md
+++ b/.github/instructions/kiwi.instructions.md
@@ -8,15 +8,34 @@ Kiwi files define Azure Linux image builds. They use the [KIWI NG](https://osins
 
 ## How images are registered
 
-Images are defined in `base/images/images.toml`:
+Images are defined in `base/images/images.toml`. Each image is
+declared as a canonical (unsuffixed) entry plus a `-dev` variant,
+each selecting the matching kiwi `profile`:
 
 ```toml
 [images.container-base]
 description = "Container Base Image"
-definition = { type = "kiwi", path = "container-base/container-base.kiwi" }
+definition = { type = "kiwi", path = "container-base/container-base.kiwi", profile = "core" }
+
+[images.container-base-dev]
+description = "Container Base Image (dev)"
+definition = { type = "kiwi", path = "container-base/container-base.kiwi", profile = "core-dev" }
 ```
 
-Each image has its own directory under `base/images/` containing the `.kiwi` file.
+The two variants share the same kiwi description; they differ only
+in which `azurelinux-repos*` package is shipped (controlling where
+the resulting OS points at runtime), and — for the `core` container
+specifically — the OCI tag (`:4.0` + `:latest` for canonical,
+`:4.0-dev` for the dev variant). Both variants build their RPMs
+from the same source (the kiwi `<repository>`); koji overrides this
+during distro builds.
+
+Distroless container images strip the package manager entirely, so
+they ship no `-repos` package and have only a single (canonical)
+entry — there's no `-dev` sibling because it would be byte-identical.
+
+Each image has its own directory under `base/images/` containing the
+`.kiwi` file.
 
 ## Image types
 

--- a/base/images/container-base/container-base.kiwi
+++ b/base/images/container-base/container-base.kiwi
@@ -6,22 +6,69 @@
         <contact>user@example.com</contact>
         <specification>Azure Linux Container Image Example</specification>
     </description>
+    <!--
+        Profile axes
+        ============
+        This kiwi description has two related axes that produce a flat
+        list of single-string profiles (azldev only forwards a single
+        profile value to kiwi):
+
+          shape:    core | distroless-minimal | distroless-base | distroless-debug
+          variant:  canonical (unsuffixed) | -dev   ← only for `core`
+
+        Variant semantics:
+          - canonical (e.g. `core`):     ships azurelinux-repos
+                                          (runtime → PMC beta);
+                                          OCI tag :4.0 + :latest
+          - `-dev` (e.g. `core-dev`):    ships azurelinux-repos-dev
+                                          (runtime → azl4-dev);
+                                          OCI tag :4.0-dev only
+
+        Distroless variants strip the package manager entirely in
+        config.sh, so they do not ship a `-repos` package and have no
+        runtime repo selection. With the build-time repo unified across
+        variants (see <repository> below — koji overrides this anyway),
+        a `-dev` distroless build would be byte-identical to its
+        canonical sibling, so distroless has only the canonical profile.
+
+        Shape-shared sections are scoped via comma-list profiles so
+        each shape's body is shared between its variants where
+        applicable.
+    -->
     <profiles>
-        <profile name="core" description="Core Container" import="true" />
-        <profile name="distroless-minimal" description="Distroless Minimal Container" import="true" />
-        <profile name="distroless-base" description="Distroless Base Container" import="true" />
-        <profile name="distroless-debug" description="Distroless Debug Container" import="true" />
+        <profile name="core"                description="Core Container"               import="false" />
+        <profile name="core-dev"            description="Core Container (dev)"         import="false" />
+        <profile name="distroless-minimal"  description="Distroless Minimal Container" import="false" />
+        <profile name="distroless-base"     description="Distroless Base Container"    import="false" />
+        <profile name="distroless-debug"    description="Distroless Debug Container"   import="false" />
     </profiles>
     <preferences>
         <version>0.1</version>
         <packagemanager>dnf5</packagemanager>
     </preferences>
+    <!--
+        OCI containerconfig: only `core` has a variant split (canonical
+        publishes :4.0 + :latest, dev publishes :4.0-dev with no
+        :latest, so the two builds don't collide if loaded into the
+        same registry). Distroless containers have no `-dev` sibling.
+    -->
     <preferences profiles="core">
         <type image="oci">
             <containerconfig
                 name="microsoft/azurelinux/base/core"
                 tag="4.0"
                 additionalnames=":latest"
+                user="root"
+                workingdir="/">
+                <subcommand execute="/bin/bash"/>
+            </containerconfig>
+        </type>
+    </preferences>
+    <preferences profiles="core-dev">
+        <type image="oci">
+            <containerconfig
+                name="microsoft/azurelinux/base/core"
+                tag="4.0-dev"
                 user="root"
                 workingdir="/">
                 <subcommand execute="/bin/bash"/>
@@ -65,28 +112,50 @@
         </type>
     </preferences>
 
+    <!--
+        Single build-time repository for all profiles — koji overrides
+        this for distro builds; for local builds this is the only blob
+        currently populated for AZL4. The variant only affects which
+        `azurelinux-repos*` package ships in `core` and the OCI tag
+        for `core` — NOT where build-time RPMs come from.
+    -->
     <repository type="rpm-md" alias="azurelinux-base">
         <source
             path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
     </repository>
 
-    <packages type="image" profiles="core">
+    <packages type="image" profiles="core,core-dev">
         <package name="filesystem" />
         <package name="bash" />
         <package name="azurelinux-release-container" />
+    </packages>
+
+    <!--
+        Variant-scoped repos package (core only). The `azurelinux-repos`
+        and `azurelinux-repos-dev` packages conflict, so each variant
+        gets its own section. Distroless variants intentionally do NOT
+        ship a repos package: config.sh strips the package manager
+        (and /etc/yum.repos.d/) entirely.
+    -->
+    <packages type="image" profiles="core-dev">
         <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="image" profiles="core">
+        <package name="azurelinux-repos" />
     </packages>
 
     <!-- For distroless profiles ALL packages that should be included in
          the final image must be listed in the "image" packages section.
          Packages from bootstrap may be removed by config.sh. -->
-    <packages type="image" profiles="distroless-minimal,distroless-base,distroless-debug">
+    <packages type="image"
+              profiles="distroless-minimal,distroless-base,distroless-debug">
         <package name="filesystem" />
         <package name="azurelinux-release-container" />
         <package name="tzdata" />
     </packages>
 
-    <packages type="image" profiles="distroless-base,distroless-debug">
+    <packages type="image"
+              profiles="distroless-base,distroless-debug">
         <package name="glibc" />
         <package name="libgcc" />
         <package name="openssl-libs" />
@@ -97,16 +166,21 @@
         <package name="busybox" />
     </packages>
 
-    <packages type="bootstrap" profiles="core">
+    <packages type="bootstrap" profiles="core-dev">
         <package name="azurelinux-repos-dev" />
     </packages>
+    <packages type="bootstrap" profiles="core">
+        <package name="azurelinux-repos" />
+    </packages>
 
-    <packages type="bootstrap" profiles="core,distroless-minimal,distroless-base,distroless-debug">
+    <packages type="bootstrap"
+              profiles="core,core-dev,distroless-minimal,distroless-base,distroless-debug">
         <package name="filesystem" />
         <package name="azurelinux-release-container" />
     </packages>
 
-    <packages type="bootstrap" profiles="distroless-minimal,distroless-base,distroless-debug">
+    <packages type="bootstrap"
+              profiles="distroless-minimal,distroless-base,distroless-debug">
         <package name="busybox" />
     </packages>
 </image>

--- a/base/images/images.toml
+++ b/base/images/images.toml
@@ -1,6 +1,37 @@
+# ============================================================================
+# Image registry
+# ============================================================================
+#
+# Most images come in two variants — a canonical (unsuffixed) build and
+# a `-dev` build — each backed by a kiwi profile inside the matching
+# `*.kiwi` file:
+#
+#   <name>      : ships `azurelinux-repos`     so the resulting OS points
+#                 at packages.microsoft.com/azurelinux/4.0/beta at runtime.
+#                 (For the `core` container, this is also the variant
+#                  published with the `:4.0` + `:latest` OCI tags.)
+#   <name>-dev  : ships `azurelinux-repos-dev` so the resulting OS points
+#                 at the azl4-dev blob at runtime. (For the `core`
+#                  container, the OCI image is tagged `:4.0-dev` only.)
+#
+# Distroless container images strip the package manager entirely, so
+# they ship no `-repos` package and are not built per-variant — only
+# the canonical (unsuffixed) entries exist for those.
+#
+# Both variants build their RPMs from the same source (the kiwi
+# `<repository>` points at azl4-dev for local builds; koji overrides
+# this for distro builds).
+#
+# Capabilities and test-suites are identical between a canonical / `-dev`
+# pair (the variants only differ in what `-repos` package ships and,
+# for `core`, the OCI tag).
+# ============================================================================
+
+# ---- vm-base -----------------------------------------------------------
+
 [images.vm-base]
 description = "VM Base Image"
-definition = { type = "kiwi", path = "vm-base/vm-base.kiwi" }
+definition = { type = "kiwi", path = "vm-base/vm-base.kiwi", profile = "vm-base" }
 tests.test-suites = [{ name = "static-image-checks" }]
 
 [images.vm-base.capabilities]
@@ -8,6 +39,19 @@ machine-bootable = true
 container = false
 systemd = true
 runtime-package-management = true
+
+[images.vm-base-dev]
+description = "VM Base Image (dev)"
+definition = { type = "kiwi", path = "vm-base/vm-base.kiwi", profile = "vm-base-dev" }
+tests.test-suites = [{ name = "static-image-checks" }]
+
+[images.vm-base-dev.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
+# ---- container-base (core profile) -------------------------------------
 
 [images.container-base]
 description = "Container Base Image"
@@ -19,6 +63,21 @@ machine-bootable = false
 container = true
 systemd = false
 runtime-package-management = true
+
+[images.container-base-dev]
+description = "Container Base Image (dev)"
+definition = { type = "kiwi", path = "container-base/container-base.kiwi", profile = "core-dev" }
+tests.test-suites = [{ name = "static-image-checks" }]
+
+[images.container-base-dev.capabilities]
+machine-bootable = false
+container = true
+systemd = false
+runtime-package-management = true
+
+# ---- distroless containers (single-variant only) -----------------------
+# No -dev sibling: with a single build-time repo and no runtime package
+# management, a -dev distroless build would be byte-identical.
 
 [images.container-distroless-minimal]
 description = "Container Distroless Minimal Image"
@@ -32,15 +91,29 @@ definition = { type = "kiwi", path = "container-base/container-base.kiwi", profi
 description = "Container Distroless Debug Image"
 definition = { type = "kiwi", path = "container-base/container-base.kiwi", profile = "distroless-debug" }
 
+# ---- wsl ---------------------------------------------------------------
+
 [images.wsl]
 description = "WSL Image"
-definition = { type = "kiwi", path = "wsl/wsl.kiwi" }
+definition = { type = "kiwi", path = "wsl/wsl.kiwi", profile = "wsl" }
+
+[images.wsl-dev]
+description = "WSL Image (dev)"
+definition = { type = "kiwi", path = "wsl/wsl.kiwi", profile = "wsl-dev" }
+
+# ---- vm-iso-installer --------------------------------------------------
 
 [images.vm-iso-installer]
 description = "VM ISO Installer"
-definition = { type = "kiwi", path = "vm-iso-installer/vm-iso-installer.kiwi" }
+definition = { type = "kiwi", path = "vm-iso-installer/vm-iso-installer.kiwi", profile = "vm-iso-installer" }
 
-# ---- Test suites ----
+[images.vm-iso-installer-dev]
+description = "VM ISO Installer (dev)"
+definition = { type = "kiwi", path = "vm-iso-installer/vm-iso-installer.kiwi", profile = "vm-iso-installer-dev" }
+
+# ============================================================================
+# Test suites
+# ============================================================================
 
 # Single shared pytest suite for static (offline) image validation.
 [test-suites.static-image-checks]

--- a/base/images/tests/README.md
+++ b/base/images/tests/README.md
@@ -18,6 +18,14 @@ azldev image build container-base
 azldev image test  container-base
 ```
 
+(Most images come in two variants. The canonical/unsuffixed name
+ships `azurelinux-repos` so the resulting OS points at PMC's
+`azurelinux/4.0/beta` repo at runtime; the `-dev` variant ships
+`azurelinux-repos-dev` so the OS points at the azl4-dev blob.
+Distroless container images strip the package manager entirely and
+have only the canonical entry. Append `-dev` to the image name —
+where present — to validate the dev variant.)
+
 `azldev` creates a per-suite Python venv, installs this directory's
 `pyproject.toml`, and invokes pytest with the right `--image-path`,
 `--image-name`, and `--capabilities` arguments.
@@ -41,15 +49,16 @@ uv run pytest cases/ \
 ```
 
 Test selection follows standard pytest positional arguments. Tests
-under `cases/<image-name>/` are auto-skipped when `--image-name`
-doesn't match — the `image` marker is applied during collection by
+under `cases/<image-family>/` are auto-skipped when `--image-name`
+doesn't belong to that family — the `image` marker is applied
+during collection by
 `utils.pytest_plugin.pytest_collection_modifyitems` (see "Adding
 tests" below for the convention). Tests marked
 `@pytest.mark.require_capability("…")` skip when the named
 capability isn't in `--capabilities`.
 
 > Always pass `--image-name` when running manually if you want
-> image-specific tests under `cases/<image-name>/` to run. Without
+> image-specific tests under `cases/<image-family>/` to run. Without
 > it, every `@pytest.mark.image(...)`-tagged test is skipped.
 
 ## Prerequisites
@@ -85,10 +94,10 @@ base/images/
     └── cases/                           # Test cases
         ├── test_os_release.py           # Shared: /etc/os-release
         ├── test_packages.py             # Shared: rpm-db checks (capability-gated)
-        ├── vm-base/                     # VM-specific tests (auto-restricted to vm-base)
+        ├── vm-base/                     # VM-specific tests (auto-restricted to the vm-base family — vm-base, vm-base-dev)
         │   ├── test_kernel.py
         │   └── test_partitions.py
-        └── container-base/              # Container-specific tests (auto-restricted to container-base)
+        └── container-base/              # Container-specific tests (auto-restricted to the container-base family)
             └── test_container.py
 ```
 
@@ -112,10 +121,14 @@ base/images/
 - **Shared (every image):** add a `cases/test_<topic>.py`. Use
   `@pytest.mark.require_capability("…")` if the test only applies to
   images with a given capability.
-- **Image-specific:** add `cases/<image-name>/test_<topic>.py`. Tests
+- **Image-specific:** add `cases/<image-family>/test_<topic>.py`. Tests
   in such subdirectories are **automatically** restricted to that
-  `--image-name` (the plugin applies `@pytest.mark.image("<dir>")`
-  during collection — no boilerplate per file or per subdir).
+  image family (the plugin applies `@pytest.mark.image("<dir>")`
+  during collection — no boilerplate per file or per subdir). The
+  directory name is treated as a *family*: an `--image-name` matches
+  the family if it equals the family exactly OR has the form
+  `<family>-<variant>` (so `cases/vm-base/` runs for both `vm-base`
+  and `vm-base-dev`).
 
 ## Adding a native-tool dependency
 

--- a/base/images/tests/utils/pytest_plugin.py
+++ b/base/images/tests/utils/pytest_plugin.py
@@ -106,7 +106,8 @@ def pytest_configure(config) -> None:  # type: ignore[no-untyped-def]
     )
     config.addinivalue_line(
         "markers",
-        "image(name): only run this test when --image-name matches",
+        "image(name): only run this test when --image-name matches the named image family "
+        "(exact match, or a ``<family>-<variant>`` image-name)",
     )
 
     from utils.tools import check_tools
@@ -145,21 +146,39 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         if required and required not in caps:
             pytest.skip(f"requires capability '{required}' (not in: {sorted(caps)})")
 
-    # image: skip if --image-name doesn't match.
+    # image: skip if --image-name doesn't match the marker's family.
+    # Family matching: the marker's value is treated as a family name that
+    # matches an image-name exactly OR matches a `<family>-<variant>` name
+    # (e.g. ``image("vm-base")`` matches both ``vm-base`` and
+    # ``vm-base-dev``). This lets tests under ``cases/<family>/`` apply
+    # to every variant of an image without per-variant duplication.
     image_name = item.config.getoption("--image-name", default=None)
     for marker in item.iter_markers("image"):
         expected = marker.args[0] if marker.args else None
-        if expected and image_name != expected:
-            pytest.skip(f"test is specific to image '{expected}' (running: '{image_name}')")
+        if not expected:
+            continue
+        if image_name == expected:
+            continue
+        if image_name and image_name.startswith(expected + "-"):
+            continue
+        pytest.skip(
+            f"test is specific to image family '{expected}' "
+            f"(running: '{image_name}')"
+        )
 
 
 def pytest_collection_modifyitems(config, items) -> None:  # type: ignore[no-untyped-def]
     """Auto-apply ``@pytest.mark.image("<dir>")`` to tests under ``cases/<dir>/``.
 
-    Convention: any test file inside ``cases/<image-name>/`` (at any
-    depth) is automatically restricted to that ``--image-name``. This
-    keeps the routing rule co-located with the directory layout — no
-    per-subdir conftest, and no per-file ``pytestmark`` boilerplate
+    Convention: any test file inside ``cases/<image-family>/`` (at any
+    depth) is automatically restricted to images whose name belongs to
+    that family. The directory name is the family; an ``--image-name``
+    matches the family if it equals the family exactly OR if it has the
+    form ``<family>-<variant>`` (e.g. ``vm-base-dev`` matches the
+    ``vm-base`` family). See :func:`pytest_runtest_setup`.
+
+    This keeps the routing rule co-located with the directory layout —
+    no per-subdir conftest, and no per-file ``pytestmark`` boilerplate
     that contributors might forget to add.
 
     Tests directly under ``cases/`` (no image subdir) get no marker
@@ -175,7 +194,7 @@ def pytest_collection_modifyitems(config, items) -> None:  # type: ignore[no-unt
             cases_idx = len(parts) - 1 - parts[::-1].index("cases")
         except ValueError:
             continue
-        # Need at least cases/<image-name>/<file>.py to derive an image name.
+        # Need at least cases/<image-family>/<file>.py to derive a family name.
         if cases_idx + 2 < len(parts):
             image_dir = parts[cases_idx + 1]
             item.add_marker(pytest.mark.image(image_dir))

--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -6,6 +6,21 @@
         <contact>user@example.com</contact>
         <specification>Azure Linux VM Image Example</specification>
     </description>
+    <!--
+        Two build profiles control which `azurelinux-repos*` package is
+        baked into the image, which determines where the OS points at
+        runtime:
+          - vm-base:     ships azurelinux-repos     (runtime → PMC beta)
+          - vm-base-dev: ships azurelinux-repos-dev (runtime → azl4-dev)
+        Both variants build from the same source (`azl4-dev` blob below);
+        koji overrides this for distro builds. Exactly one profile must
+        be selected per build, matching the corresponding entry in
+        base/images/images.toml.
+    -->
+    <profiles>
+        <profile name="vm-base"     description="Ships azurelinux-repos (runtime → PMC beta)" import="false" />
+        <profile name="vm-base-dev" description="Ships azurelinux-repos-dev (runtime → azl4-dev)" import="false" />
+    </profiles>
     <preferences arch="x86_64">
         <version>0.1</version>
         <packagemanager>dnf5</packagemanager>
@@ -62,6 +77,13 @@
         </type>
     </preferences>
 
+    <!--
+        Single build-time repository (azl4-dev) for both variants —
+        koji overrides this for distro builds; for local builds this
+        is the only blob currently populated for AZL4. The variant
+        only affects which `azurelinux-repos*` package ships, NOT
+        where build-time RPMs come from.
+    -->
     <repository type="rpm-md" alias="azurelinux-base">
         <source
             path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
@@ -70,7 +92,6 @@
     <packages type="image">
         <!-- Core group -->
         <package name="azurelinux-release-cloud" />
-        <package name="azurelinux-repos-dev" />
         <package name="bash" />
         <package name="ca-certificates" />
         <package name="coreutils" />
@@ -141,9 +162,21 @@
         <package name="kernel-modules" />
     </packages>
 
+    <!--
+        Variant-scoped repos package: governs the .repo files written
+        into /etc/yum.repos.d/ in the built image (runtime). The two
+        packages conflict, so they're separated into per-variant
+        sections rather than relying on the variant's bootstrap section.
+    -->
+    <packages type="image" profiles="vm-base-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="image" profiles="vm-base">
+        <package name="azurelinux-repos" />
+    </packages>
+
     <packages type="bootstrap">
         <package name="azurelinux-release-cloud" />
-        <package name="azurelinux-repos-dev" />
         <package name="filesystem" />
         <package name="grub2-efi-x64-modules" arch="x86_64" />
         <package name="grub2-efi-x64" arch="x86_64" />
@@ -151,5 +184,12 @@
         <package name="grub2-efi-aa64" arch="aarch64" />
         <package name="shim" arch="x86_64" />
         <package name="shim" arch="aarch64" />
+    </packages>
+
+    <packages type="bootstrap" profiles="vm-base-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="bootstrap" profiles="vm-base">
+        <package name="azurelinux-repos" />
     </packages>
 </image>

--- a/base/images/vm-iso-installer/config.sh
+++ b/base/images/vm-iso-installer/config.sh
@@ -33,6 +33,37 @@ echo "  GRUB EFI package: $GRUB_EFI_PKG"
 echo "  Shim EFI binary:  $SHIM_EFI"
 
 #----------------------------------------------------------------------
+# Variant detection
+#----------------------------------------------------------------------
+# kiwi sets `kiwi_profiles` to a comma-separated list of active profiles
+# (one per build, set by --profile). The variant decides which
+# `azurelinux-repos*` package goes into the image and the kickstart,
+# which in turn controls the runtime repo of the installed system.
+#
+# OFFLINE_REPO_BLOCKLIST lists packages that must NOT appear in the
+# offline repo. The opposite-variant repos package goes here:
+# `azurelinux-repos` and `-dev` Conflict: with each other, and
+# `azurelinux-release-common` has `Recommends: azurelinux-repos`, which
+# would otherwise drag the canonical package into the dev offline repo
+# via --resolve --alldeps and risk dnf picking the wrong one.
+case ",${kiwi_profiles:-}," in
+    *,vm-iso-installer-dev,*)
+        AZL_REPOS_PKG="azurelinux-repos-dev"
+        OFFLINE_REPO_BLOCKLIST=( "azurelinux-repos" )
+        ;;
+    *,vm-iso-installer,*)
+        AZL_REPOS_PKG="azurelinux-repos"
+        OFFLINE_REPO_BLOCKLIST=( "azurelinux-repos-dev" )
+        ;;
+    *)
+        echo "ERROR: cannot determine variant from kiwi_profiles='${kiwi_profiles:-}'" >&2
+        exit 1
+        ;;
+esac
+echo "  Variant repos pkg:      $AZL_REPOS_PKG"
+echo "  Offline repo blocklist: ${OFFLINE_REPO_BLOCKLIST[*]}"
+
+#----------------------------------------------------------------------
 # Download all target-install packages + deps for the offline repo
 #----------------------------------------------------------------------
 # During the ISO build we have network access to the repo.
@@ -66,7 +97,7 @@ INSTALL_PKGS=(
     vim-minimal
     ca-certificates
     azurelinux-release
-    azurelinux-repos-dev
+    "$AZL_REPOS_PKG"
     setup
     shadow-utils
     util-linux
@@ -97,9 +128,16 @@ EXTRA_REPO_PKGS=(
 echo "=== Downloading target-install packages + dependencies ==="
 # Kiwi removes repo configs after package installation, so repos from the .kiwi
 # file are NOT available during config.sh. Use --repofrompath with the CDN URL
-# directly. The URL matches the "azurelinux-base" repo in vm-iso-installer.kiwi.
+# directly. Keep this URL in sync with the `azurelinux-base` repo in
+# vm-iso-installer.kiwi.
 
 AZL_BASE_URL="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$ARCH"
+
+EXCLUDE_ARGS=()
+for pkg in "${OFFLINE_REPO_BLOCKLIST[@]}"; do
+    EXCLUDE_ARGS+=( --exclude="$pkg" )
+done
+
 dnf5 download \
     --setopt=reposdir=/dev/null \
     --repofrompath=azl-base,"$AZL_BASE_URL" \
@@ -107,6 +145,7 @@ dnf5 download \
     --resolve \
     --alldeps \
     --skip-unavailable \
+    "${EXCLUDE_ARGS[@]}" \
     --destdir="$OFFLINE_REPO" \
     "${INSTALL_PKGS[@]}" "${EXTRA_REPO_PKGS[@]}" || {
     echo "WARNING: dnf download had errors — some packages may be missing"
@@ -124,6 +163,21 @@ createrepo_c "$OFFLINE_REPO"
 # Validate offline repo completeness (dry-run install)
 #----------------------------------------------------------------------
 echo "=== Validating offline repo completeness ==="
+
+# Verify that no blocklisted package landed in the offline repo.
+# The `-[0-9]*` boundary disambiguates the package name from prefix
+# overlap (e.g. `foo` vs `foo-bar`) since RPM filenames are
+# `<name>-<version>-<release>.<arch>.rpm` with version starting in a digit.
+for pkg in "${OFFLINE_REPO_BLOCKLIST[@]}"; do
+    if ls "$OFFLINE_REPO/${pkg}"-[0-9]*.rpm >/dev/null 2>&1; then
+        echo "!!!"
+        echo "!!! FATAL: blocklisted package landed in offline repo:"
+        echo "!!!   $(ls "$OFFLINE_REPO/${pkg}"-[0-9]*.rpm)"
+        echo "!!!"
+        echo "Fix: ensure the dnf5 download command excludes $pkg."
+        exit 1
+    fi
+done
 
 DRYRUN_ROOT=$(mktemp -d /tmp/azl-dryrun-XXXXXX)
 DRYRUN_ERRORS=$(dnf5 install \

--- a/base/images/vm-iso-installer/vm-iso-installer.kiwi
+++ b/base/images/vm-iso-installer/vm-iso-installer.kiwi
@@ -8,6 +8,11 @@
         <contact>azurelinux@microsoft.com</contact>
         <specification>Azure Linux 4.0 ISO Installer</specification>
     </description>
+    <!-- See vm-base.kiwi for an explanation of the canonical / -dev profiles. -->
+    <profiles>
+        <profile name="vm-iso-installer"     description="Ships azurelinux-repos (runtime → PMC beta)" import="false" />
+        <profile name="vm-iso-installer-dev" description="Ships azurelinux-repos-dev (runtime → azl4-dev)" import="false" />
+    </profiles>
     <preferences>
         <version>0.1</version>
         <packagemanager>dnf5</packagemanager>
@@ -27,6 +32,10 @@
         </type>
     </preferences>
 
+    <!-- Single build-time repository (see vm-base.kiwi).
+         vm-iso-installer/config.sh ALSO uses this URL directly to populate
+         the offline repo bundled on the ISO; if this URL changes, update
+         AZL_BASE_URL in config.sh too. -->
     <repository type="rpm-md" alias="azurelinux-base">
         <source
             path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
@@ -36,7 +45,6 @@
         <!-- Distro identity -->
         <package name="azurelinux-release" />
         <package name="azurelinux-rpm-config" />
-        <package name="azurelinux-repos-dev" />
 
         <!-- Core system -->
         <package name="bash" />
@@ -112,8 +120,19 @@
         <package name="createrepo_c" />
     </packages>
 
-    <packages type="bootstrap">
+    <!--
+        Variant-scoped repos package: governs the .repo files written
+        into /etc/yum.repos.d/ in the built image (runtime). The two
+        packages conflict, so they're separated into per-variant sections.
+    -->
+    <packages type="image" profiles="vm-iso-installer-dev">
         <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="image" profiles="vm-iso-installer">
+        <package name="azurelinux-repos" />
+    </packages>
+
+    <packages type="bootstrap">
         <package name="dracut-network" />
         <package name="filesystem" />
         <package name="grub2-efi-x64-modules" arch="x86_64" />
@@ -122,6 +141,13 @@
         <package name="grub2-efi-aa64" arch="aarch64" />
         <package name="shim" arch="x86_64" />
         <package name="shim" arch="aarch64" />
+    </packages>
+
+    <packages type="bootstrap" profiles="vm-iso-installer-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="bootstrap" profiles="vm-iso-installer">
+        <package name="azurelinux-repos" />
     </packages>
 
     <users>

--- a/base/images/wsl/wsl.kiwi
+++ b/base/images/wsl/wsl.kiwi
@@ -6,6 +6,11 @@
         <contact>azurelinux@microsoft.com</contact>
         <specification>Azure Linux WSL Image</specification>
     </description>
+    <!-- See vm-base.kiwi for an explanation of the canonical / -dev profiles. -->
+    <profiles>
+        <profile name="wsl"     description="Ships azurelinux-repos (runtime → PMC beta)" import="false" />
+        <profile name="wsl-dev" description="Ships azurelinux-repos-dev (runtime → azl4-dev)" import="false" />
+    </profiles>
     <preferences>
         <version>0.1</version>
         <packagemanager>dnf5</packagemanager>
@@ -17,6 +22,7 @@
         <rpm-excludedocs>false</rpm-excludedocs>
     </preferences>
 
+    <!-- Single build-time repository (see vm-base.kiwi). -->
     <repository type="rpm-md" alias="azurelinux-base">
         <source
             path="https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch" />
@@ -72,12 +78,23 @@
     </packages>
 
     <packages type="bootstrap">
-        <package name="azurelinux-repos-dev"/>
         <package name="bash"/>
         <package name="coreutils"/>
         <package name="dnf5"/>
         <package name="dnf5-plugins"/>
         <package name="azurelinux-release-wsl"/>
         <package name="rpm"/>
+    </packages>
+
+    <!--
+        Variant-scoped repos package: governs the .repo files written
+        into /etc/yum.repos.d/ in the built image (runtime). The two
+        packages conflict, so they're separated into per-variant sections.
+    -->
+    <packages type="bootstrap" profiles="wsl-dev">
+        <package name="azurelinux-repos-dev"/>
+    </packages>
+    <packages type="bootstrap" profiles="wsl">
+        <package name="azurelinux-repos"/>
     </packages>
 </image>

--- a/scripts/build-vm-images.sh
+++ b/scripts/build-vm-images.sh
@@ -5,8 +5,8 @@ set -euxo pipefail
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 . "$SCRIPTS_DIR/common.sh"
 
-sudo rm -rf "$REPO_ROOT/base/build/work/vm-base/*"
+sudo rm -rf "$REPO_ROOT/base/build/work/vm-base-dev/*"
 sudo rm -rf "$REPO_ROOT/base/out/images/*"
 
-# Build vm-base image using azldev
-azldev image build vm-base --local-repo "$REPO_ROOT/base/out" --remote-repo "$REMOTE_KOJI_REPO_URL" --remote-repo-no-gpgcheck
+# Build vm-base-dev image using azldev
+azldev image build vm-base-dev --local-repo "$REPO_ROOT/base/out" --remote-repo "$REMOTE_KOJI_REPO_URL" --remote-repo-no-gpgcheck

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Set local image path
-export IMAGE_PATH="$REPO_ROOT/base/out/images/vm-base/azl4-vm-base.x86_64-0.1.vhdfixed"
+export IMAGE_PATH="$REPO_ROOT/base/out/images/vm-base-dev/azl4-vm-base.x86_64-0.1.vhdfixed"
 
 # Set gallery configuration
 export GALLERY_NAME="<your-gallery-name>"

--- a/scripts/demo-build.sh
+++ b/scripts/demo-build.sh
@@ -24,8 +24,8 @@ done
 azldev comp build --local-repo-with-publish ./base/out azurelinux-rpm-config azurelinux-release azurelinux-repos rpm
 
 # Build a base container image using these private RPMs and upstream Fedora packages.
-azldev image build --local-repo ./base/out container-base
+azldev image build --local-repo ./base/out container-base-dev
 
 # Run a command in the container to verify.
-xzcat ./base/out/images/container-base/azl4-container-base.x86_64-0.1.docker.tar.xz | docker load
-docker run -it --rm microsoft/azurelinux/base/core:4.0 cat /etc/os-release
+xzcat ./base/out/images/container-base-dev/azl4-container-base.x86_64-0.1.docker.tar.xz | docker load
+docker run -it --rm microsoft/azurelinux/base/core:4.0-dev cat /etc/os-release

--- a/scripts/update-components-list.py
+++ b/scripts/update-components-list.py
@@ -298,7 +298,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         required=True,
         help="Path to the .packages file "
-        "(e.g. ./base/out/images/vm-base/azl4-vm-base.x86_64-0.1.packages)",
+        "(e.g. ./base/out/images/vm-base-dev/azl4-vm-base.x86_64-0.1.packages)",
     )
     add_missing.add_argument(
         "-r",


### PR DESCRIPTION
Each non-distroless image under base/images/ now ships in two variants:

  - canonical (unsuffixed): runtime points at packages.microsoft.com/ azurelinux/4.0/beta and ships azurelinux-repos.
  - <name>-dev: runtime points at the daily azl4-dev blob and ships azurelinux-repos-dev.

Variants share a single build-time repository (azl4-dev) and differ only in the runtime -repos package. For the `core` container the canonical variant tags :4.0 + :latest, while -dev tags :4.0-dev only.

vm-iso-installer threads the variant into config.sh so the offline package bundle and the kickstart %packages section pick up the matching -repos package; the opposite variant is held out of the offline repo to keep the dnf resolver unambiguous at install time.

Distroless containers strip the package manager and have no runtime repo, so they remain single-variant.