### PR TITLE
feat: add Copilot plugin manifest for cross-repo skill access

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "azurelinux",
+  "description": "Azure Linux OS development skills — component builds, overlays, mock testing, Koji triage, AKS health",
+  "version": "1.0.0",
+  "author": "Azure Linux Team",
+  "skills": ".github/skills/",
+  "agents": ".github/agents/"
+}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Example: select **azl-diagnose** from the dropdown, then type:
 The skills and instructions are also compatible with the [GitHub Copilot CLI](https://github.com/features/copilot/cli/) which can be used directly from the terminal without opening VSCode.
 
 ```bash
-# Fully interactive mode
+# Fully interactive mode (from the repo root)
 copilot --add-dir .
 ```
 
@@ -97,6 +97,24 @@ copilot --add-dir . -i "Upgrade vim to the next stable release"
 ```
 
 Note: `copilot` supports fully autonomous operation (no interactive mode) with `-p <prompt>` however, until azldev supports a full MCP mode the tool approvals are very difficult. `--yolo` (same as `--allow-all-tools --allow-all-paths --allow-all-urls`) is an option, but use with extreme caution since it grants the agent unrestricted access to your filesystem and network. For now, it's recommended to use `-i` to at least have visibility into the agent's thought process and tool usage.
+
+#### Using as a plugin (cross-repo access)
+
+This repo includes a [Copilot plugin manifest](.claude-plugin/plugin.json) that makes its skills available from **any** working directory — not just the repo root. This is useful when you're working in another repo but want access to azurelinux skills (component builds, overlay debugging, Koji triage, etc.).
+
+**Install as a plugin (local clone):**
+
+```bash
+# One-time install — skills persist across sessions
+copilot plugin install --plugin-dir /path/to/azurelinux
+
+# Or load for a single session
+copilot --plugin-dir /path/to/azurelinux
+```
+
+After installing, all skills are available regardless of your current directory. Use `/skills` to list them.
+
+> **Note:** Remote install via `copilot plugin install microsoft/azurelinux` will work once this branch (`tomls/base/main`) becomes the repo's default branch on GitHub. Until then, use the local path.
 
 ### Dockerized Batch Triage
 


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/plugin.json` so azurelinux's 13 skills and 2 agents become installable as a Copilot CLI plugin from any working directory.

## What this enables

Developers working in other repos can load azurelinux skills without changing directories:

```bash
# One-time install
copilot plugin install --plugin-dir /path/to/azurelinux

# Or per-session
copilot --plugin-dir /path/to/azurelinux
```

After loading, all skills and agents appear in `/skills list` and `/agent` and can be invoked by name.

## Changes

- **`.claude-plugin/plugin.json`** - Plugin manifest (8 lines). Points `skills` and `agents` at their existing `.github/` paths. No files moved or renamed.
- **`README.md`** - Adds a "Using as a plugin" subsection under the existing Copilot CLI heading.

## Notes

- `.claude-plugin/plugin.json` is a [standard Copilot CLI primitive](https://docs.github.com/en/copilot/reference/cli-plugin-reference) - no internal tooling is referenced or exposed.
- Remote install via `copilot plugin install microsoft/azurelinux` will work once `tomls/base/main` becomes the default branch. Until then, local path install works.
