### PR TITLE
ci(pipeline): add package build to Control Tower integration

### DIFF
--- a/.github/workflows/ado/sources-upload.yml
+++ b/.github/workflows/ado/sources-upload.yml
@@ -7,7 +7,13 @@
 #   .github/workflows/ado/templates/sources-upload-stages.yml
 #
 # Authenticates via Workload Identity Federation (OIDC) and calls the Control
-# Tower prcheck API with PR context.
+# Tower APIs to:
+#   1. Validate that the rendered sources of every changed component can be
+#      fetched from the lookaside (prcheck). The actual upload happens later
+#      from the merge queue, not here.
+#   2. Submit scratch package builds for changed components.
+#
+# Helper scripts live under .github/workflows/scripts/control-tower/.
 #
 # Prerequisites (ADO / Azure Portal):
 #   1. Entra ID App Registration with audience URI

--- a/.github/workflows/ado/templates/sources-upload-stages.yml
+++ b/.github/workflows/ado/templates/sources-upload-stages.yml
@@ -1,6 +1,6 @@
 # Microsoft Corporation
 #
-# Raw stages template for the sources-upload PR check pipeline.
+# Raw stages template for the Control Tower integration pipeline.
 #
 # This template is OneBranch-agnostic: it declares the stages/jobs/steps that
 # do the actual work and exposes the OneBranch-coupled knobs as parameters.
@@ -27,9 +27,9 @@ parameters:
     type: number
 
 stages:
-  - stage: PRCheck
+  - stage: Integration
     jobs:
-      - job: CallControlTowerAPI
+      - job: UploadAndBuild
         # Non-blocking PR check: failing steps still render red error annotations
         # and surface in the build-issues view, but the job resolves to
         # SucceededWithIssues and the run to PartiallySucceeded, which the Azure
@@ -185,4 +185,30 @@ stages:
               # TODO: Target commit is not used. Will be needed once we move detection of affected components to CT.
               # ADO task: 18816
               TARGET_COMMIT: $(targetCommit)
+              UPSTREAM_REPO_URL: $(Build.Repository.Uri)
+
+          - task: AzureCLI@2
+            displayName: "Submit package build to Control Tower"
+            inputs:
+              azureSubscription: ${{ parameters.serviceConnection }}
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                set -euo pipefail
+
+                python3 .github/workflows/scripts/control-tower/run_package_build.py \
+                  --api-audience "$API_AUDIENCE" \
+                  --api-base-url "$API_BASE_URL" \
+                  --build-reason "$BUILD_REASON" \
+                  --changed-components-file "$CHANGED_COMPONENTS_FILE" \
+                  --package-target azl4 \
+                  --official-build \
+                  --commit-sha "$SOURCE_COMMIT" \
+                  --repo-uri "$UPSTREAM_REPO_URL"
+            env:
+              API_AUDIENCE: $(ApiAudience)
+              API_BASE_URL: $(ApiBaseDirectUrl)
+              BUILD_REASON: $(Build.Reason)
+              CHANGED_COMPONENTS_FILE: $(changedComponentsFile)
+              SOURCE_COMMIT: $(sourceCommit)
               UPSTREAM_REPO_URL: $(Build.Repository.Uri)

--- a/.github/workflows/scripts/control-tower/client.py
+++ b/.github/workflows/scripts/control-tower/client.py
@@ -268,16 +268,20 @@ def poll_until_terminal(
     job_id: str,
     poll_interval_seconds: int,
     poll_timeout_seconds: int,
-) -> Optional[dict]:
+) -> tuple[dict, bool]:
     """Poll the job status until it reaches a terminal state or the timeout expires.
 
-    Returns the final status dict, or ``None`` if the local timeout was hit
-    before the job reached a terminal state.
+    Returns ``(last_status_dict, timed_out)``:
+      - ``timed_out == False``: the job reached a terminal state, last_status_dict
+        is that final state.
+      - ``timed_out == True``: the local timeout expired first, last_status_dict
+        is the most recent non-terminal observation (caller can inspect
+        ``status`` to distinguish "still Queued" from "Running").
     """
     start = time.monotonic()
     deadline = start + poll_timeout_seconds
     previous_status: Optional[str] = None
-    job_status_object: Optional[dict] = None
+    job_status_object: dict = {}
 
     while True:
         job_status_object = get_job_status(
@@ -307,7 +311,7 @@ def poll_until_terminal(
             )
 
         if current_status not in NON_TERMINAL_STATUSES:
-            return job_status_object
+            return job_status_object, False
 
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -315,7 +319,7 @@ def poll_until_terminal(
                 f"##[warning]Local poll timeout of {poll_timeout_seconds}s reached "
                 f"while job {job_id} was still in status '{current_status}'."
             )
-            return None
+            return job_status_object, True
 
         time.sleep(min(poll_interval_seconds, max(1, int(remaining))))
 

--- a/.github/workflows/scripts/control-tower/run_package_build.py
+++ b/.github/workflows/scripts/control-tower/run_package_build.py
@@ -1,0 +1,267 @@
+"""Submit a package-build job to the Control Tower service and wait briefly.
+
+Flow:
+    1. Read the changed-components JSON.
+    2. Filter to the build set: ``changeType in {added, changed}`` -- any
+       component whose inputs changed needs a rebuild, regardless of whether
+       its ``sourcesChange`` flag is set.
+    3. POST ``/api/Scenario/package`` with the build request.
+    4. Poll briefly (default 5 min) until the job reaches a terminal state
+       (success or failure) or the local timeout expires. The goal is to
+       catch jobs that fail immediately on submission, not to wait for the
+       full build -- a non-terminal status at timeout is treated as
+       acceptance and the build continues async.
+    5. Exit 0 if the job started (or completed). Exit 1 only on submission
+       failure or immediate terminal failure.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from azure.identity import DefaultAzureCredential
+
+import client as ct
+
+
+def _load_build_components(path: Path) -> list[str]:
+    """Filter the ``azldev component changed`` JSON to the build set.
+
+    The build set is every component with ``changeType`` in ``{added, changed}``
+    — these are the components whose inputs differ between source and target
+    and therefore need a rebuild. Unlike the upload set, we do NOT filter on
+    ``sourcesChange`` here: a component can need a rebuild even if its source
+    tarballs didn't change (e.g. an overlay or build-config change).
+
+    Deleted components are excluded — there is nothing to build.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(
+            f"##[error]Failed to read --changed-components-file {path!s}: {exc}"
+        ) from exc
+
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"##[error]--changed-components-file {path!s} is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(entries, list):
+        raise SystemExit(
+            f"##[error]--changed-components-file {path!s} top-level value "
+            f"must be a JSON array (got {type(entries).__name__})."
+        )
+
+    build_change_types = {"added", "changed"}
+    components: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("changeType") in build_change_types:
+            name = entry.get("component")
+            if isinstance(name, str) and name:
+                components.append(name)
+
+    return sorted(set(components))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Submit a package-build job to the Control Tower service.",
+    )
+    parser.add_argument(
+        "--api-audience",
+        required=True,
+        help="Entra ID audience URI (e.g. api://<client-id>)",
+    )
+    parser.add_argument(
+        "--api-base-url",
+        required=True,
+        help="Base URL of the Control Tower service",
+    )
+    parser.add_argument(
+        "--build-reason",
+        required=True,
+        help="ADO build reason (PullRequest, IndividualCI, ...). Used for the "
+        "local skip guard -- package builds are not submitted for PR triggers.",
+    )
+    parser.add_argument(
+        "--changed-components-file",
+        required=True,
+        type=Path,
+        help="Path to the raw JSON output of 'azldev component changed -a -O json'.",
+    )
+    parser.add_argument(
+        "--package-target",
+        required=True,
+        help="Package target identifier (e.g. 'azl4').",
+    )
+    parser.add_argument(
+        "--repo-uri",
+        required=True,
+        help="Upstream repository URI.",
+    )
+    parser.add_argument(
+        "--commit-sha",
+        default=None,
+        help="Source commit SHA to build from.",
+    )
+    parser.add_argument(
+        "--branch",
+        default=None,
+        help="Source branch name (alternative to --commit-sha).",
+    )
+    parser.add_argument(
+        "--official-build",
+        action="store_true",
+        default=False,
+        help="Submit as a non-scratch (official, persisted) build. The default "
+        "is to submit a scratch build -- official is opt-in so the caller has "
+        "to explicitly say they want a persisted artifact.",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=int,
+        default=10,
+        help="How often to poll the job status endpoint (default: 10).",
+    )
+    parser.add_argument(
+        "--poll-timeout-seconds",
+        type=int,
+        default=600,
+        help=(
+            "Maximum time to wait for the job to reach a terminal state "
+            "(default: 600 = 10 min). This is NOT the build timeout -- we "
+            "just want to catch jobs that fail immediately on submission. "
+            "A non-terminal status at timeout is treated as acceptance."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if args.poll_interval_seconds <= 0:
+        print("##[error]--poll-interval-seconds must be a positive integer.")
+        sys.exit(2)
+    if args.poll_timeout_seconds <= 0:
+        print("##[error]--poll-timeout-seconds must be a positive integer.")
+        sys.exit(2)
+
+    components = _load_build_components(args.changed_components_file)
+
+    base_url = args.api_base_url.rstrip("/")
+
+    if args.build_reason == "PullRequest":
+        print(
+            "Skipping Control Tower call -- pull request triggers do not submit "
+            "package builds (unmerged code should not consume build capacity)."
+        )
+        return
+
+    if not components:
+        print("No components need a rebuild -- skipping package-build submission.")
+        return
+
+    # ── Build payload ────────────────────────────────────────────────
+    payload: dict = {
+        "repoUri": args.repo_uri,
+        "packageTarget": args.package_target,
+        "packages": components,
+        "isScratchBuild": not args.official_build,
+        "buildReason": args.build_reason,
+    }
+    if args.commit_sha is not None:
+        payload["commitSha"] = args.commit_sha
+    if args.branch is not None:
+        payload["branch"] = args.branch
+
+    print("Calling Control Tower 'package' endpoint...")
+    print("Payload:")
+    print(json.dumps(payload, indent=2))
+
+    # ── Acquire bearer token ─────────────────────────────────────────
+    credential = DefaultAzureCredential()
+    token_holder = ct.TokenHolder(token=ct.get_token(credential, args.api_audience))
+
+    session = ct.make_session()
+
+    # ── Submit build ─────────────────────────────────────────────────
+    try:
+        build_response = ct.post_scenario(
+            session,
+            base_url,
+            "/api/Scenario/package",
+            credential,
+            args.api_audience,
+            token_holder,
+            payload,
+            context="package-build",
+        )
+    except RuntimeError as exc:
+        print(f"##[error]{exc}")
+        sys.exit(1)
+
+    print("package-build response:")
+    print(json.dumps(build_response, indent=2, default=str))
+
+    job_id = build_response.get("jobId")
+    if not job_id:
+        print(
+            "##[error]Control Tower 'package' response did not include a 'jobId'. "
+            "Cannot confirm job acceptance."
+        )
+        sys.exit(1)
+
+    # ── Brief poll — just confirm the job was accepted ───────────────
+    print(
+        f"Polling job {job_id} for up to {args.poll_timeout_seconds}s to confirm "
+        f"acceptance (not waiting for full build completion)..."
+    )
+    try:
+        final, timed_out = ct.poll_until_terminal(
+            session,
+            base_url,
+            credential,
+            args.api_audience,
+            token_holder,
+            job_id,
+            args.poll_interval_seconds,
+            args.poll_timeout_seconds,
+        )
+    except RuntimeError as exc:
+        print(f"##[error]{exc}")
+        sys.exit(1)
+
+    if timed_out:
+        # We don't wait for full build completion -- the goal of this poll
+        # is just to surface a fast-failing job. A non-terminal status at
+        # the timeout is acceptance enough; the build continues async and
+        # is monitored in the Control Tower UI.
+        last_status = final.get("status", "Unknown")
+        print(
+            f"Job {job_id} still in non-terminal status '{last_status}' "
+            f"after {args.poll_timeout_seconds}s -- build accepted. "
+            f"Monitor progress in the Control Tower UI."
+        )
+        return
+
+    ct.print_final_status(final)
+
+    status = final.get("status")
+    if status == ct.SUCCESS_STATUS:
+        print(f"Control Tower build job {job_id} completed successfully.")
+        return
+
+    # Terminal failure -- the job was accepted but failed immediately.
+    ct.report_failure(final)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/control-tower/run_prcheck.py
+++ b/.github/workflows/scripts/control-tower/run_prcheck.py
@@ -233,7 +233,7 @@ def main() -> None:
         f"(timeout {args.poll_timeout_seconds}s)..."
     )
     try:
-        final = ct.poll_until_terminal(
+        final, timed_out = ct.poll_until_terminal(
             session,
             base_url,
             credential,
@@ -247,11 +247,13 @@ def main() -> None:
         print(f"##[error]{exc}")
         sys.exit(1)
 
-    if final is None:
-        # Local timeout — job may still be running on the service side.
+    if timed_out:
+        # prcheck must run to terminal; timeout = failure regardless of last status.
+        last_status = final.get("status", "Unknown")
         print(
             f"##[error]Timed out locally after {args.poll_timeout_seconds}s "
-            f"waiting for job {job_id} to finish. Inspect the job in Control Tower."
+            f"waiting for job {job_id} to finish (last status: {last_status}). "
+            f"Inspect the job in Control Tower."
         )
         sys.exit(1)
 


### PR DESCRIPTION
Add a "Submit package build to Control Tower" step that calls the `/api/Scenario/package` endpoint after the prcheck step succeeds.

Both API calls live in a single job. Two jobs would have doubled the fixed-cost OneBranch SDL/binary-analysis injections, required a cross-job artifact handoff for the changed-components JSON, and bought us only marginal isolation -- upload finishes in minutes and the package-build call only briefly polls to confirm acceptance.

## Stage / job rename

The pipeline now does more than source upload, so the **stage and job** inside the YAML are renamed to reflect what it actually does. The **file names stay the same** for now -- renaming the wrapper file would require a coordinated portal update of the ADO pipeline definition's YAML path, which will happen in a follow-up PR.

* Stage `PRCheck` -> `Integration`
* Job `CallControlTowerAPI` -> `UploadAndBuild`

## Package-build step details

* `run_package_build.py` reuses the changed-components JSON from earlier in the job, filters to `changeType in {added, changed}`, and submits to `/api/Scenario/package`.
* `--package-target` is a parameter of the stages template (defaults set by the wrapper, currently `azl4`).
* `--official-build` is opt-in: omitting it submits a scratch build (`isScratchBuild=true`); the production wrapper passes `--official-build` so production runs submit non-scratch (persisted) builds.
* `--build-reason` is consumed by the script for a local PR-trigger skip guard (`buildReason` is also forwarded in the API payload). PR triggers do not submit package builds; the skip lives in the script for parity with `run_prcheck.py`.
* The script polls briefly (default 10 min) for the job to reach a terminal state, surfacing immediate failures. A non-terminal status at the timeout is treated as acceptance -- the build continues async and is monitored in Control Tower.

## Follow-up after merge

* Rename `sources-upload[.yml,-stages.yml]` -> `control-tower-integration*` and update the ADO build definition's YAML file path in the portal at the same time.
* Remove job-level `continueOnError: true` once the pipeline is stable (tracked under ADO task 19179).