### PR TITLE
fix(gstreamer1-plugins-bad-free): remove dependency on opus to drop it

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -1146,7 +1146,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.gssntlmssp]
 [components.gssproxy]
 [components.gstreamer1]
-[components.gstreamer1-plugins-bad-free]
 [components.gstreamer1-plugins-good]
 [components.gtest]
 [components.gtk-doc]

--- a/base/comps/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.comp.toml
+++ b/base/comps/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.comp.toml
@@ -1,0 +1,24 @@
+[components.gstreamer1-plugins-bad-free]
+
+# AZL does not ship opus — disable the opus parse plugin and remove its BR.
+
+[[components.gstreamer1-plugins-bad-free.overlays]]
+description = "Remove pkgconfig(opus) BuildRequires (opus not available in AZL)"
+type = "spec-remove-tag"
+tag = "BuildRequires"
+value = "pkgconfig(opus)"
+
+[[components.gstreamer1-plugins-bad-free.overlays]]
+description = "Disable the opus meson option"
+type = "spec-search-replace"
+section = "%build"
+regex = '%meson \\'
+replacement = """%meson \\
+    -D opus=disabled \\"""
+
+[[components.gstreamer1-plugins-bad-free.overlays]]
+description = "Remove libgstopusparse.so from %files"
+type = "spec-search-replace"
+section = "%files"
+regex = '%\{_libdir\}/gstreamer-%\{majorminor\}/libgstopusparse\.so'
+replacement = ''

--- a/locks/gstreamer1-plugins-bad-free.lock
+++ b/locks/gstreamer1-plugins-bad-free.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'b5597ad939bb024c2ab32ef8cf17e2ba2b86ebe5'
 upstream-commit = 'b5597ad939bb024c2ab32ef8cf17e2ba2b86ebe5'
-input-fingerprint = 'sha256:547ebeb71c30f94fcd21621fb087ed46aa700f4e02a166aad20dd1011b52c5e6'
+input-fingerprint = 'sha256:ae3364e70ad43d327aa44c7ccfa30c323951c4f0818885f3cf9bbd6af194ce05'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.spec
+++ b/specs/g/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.spec
@@ -33,7 +33,7 @@
 
 Name:           gstreamer1-plugins-bad-free
 Version:        1.26.10
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary:        GStreamer streaming media framework "bad" plugins
 
 # Automatically converted from old format: LGPLv2+ and LGPLv2 - review is highly recommended.
@@ -89,7 +89,6 @@ BuildRequires:  pkgconfig(libva-x11)
 BuildRequires:  pkgconfig(libwebp)
 BuildRequires:  pkgconfig(libwebpmux)
 BuildRequires:  pkgconfig(openssl)
-BuildRequires:  pkgconfig(opus)
 BuildRequires:  pkgconfig(orc-0.4)
 BuildRequires:  pkgconfig(sbc)
 BuildRequires:  pkgconfig(sndfile)
@@ -321,6 +320,7 @@ aren't tested well enough, or the code is not of good enough quality.
 
 %build
 %meson \
+    -D opus=disabled \
     -D package-name="Fedora GStreamer-plugins-bad package" \
     -D package-origin="http://download.fedoraproject.org" \
     -D gpl=enabled \
@@ -657,7 +657,7 @@ EOF
 %{_libdir}/gstreamer-%{majorminor}/libgstlc3.so
 %{_libdir}/gstreamer-%{majorminor}/libgstnvcodec.so
 %{_libdir}/gstreamer-%{majorminor}/libgstopenjpeg.so
-%{_libdir}/gstreamer-%{majorminor}/libgstopusparse.so
+
 %{_libdir}/gstreamer-%{majorminor}/libgstresindvd.so
 %{_libdir}/gstreamer-%{majorminor}/libgstrsvg.so
 %{_libdir}/gstreamer-%{majorminor}/libgstsbc.so


### PR DESCRIPTION
Remove pkgconfig(opus) BuildRequires, add -Dopus=disabled meson flag,
and remove libgstopusparse.so from %files. This is to allow removal of the opus package from AZL.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Part of the effort to remove `opus`, `opusfile`, and `mingw-opus` from Azure Linux.