### PR TITLE
kernel: Add bpf and ipe to CONFIG_LSM

### DIFF
--- a/base/comps/kernel/6.18-aarch64-azl.config
+++ b/base/comps/kernel/6.18-aarch64-azl.config
@@ -13505,7 +13505,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="landlock,lockdown,yama,integrity,selinux,bpf,ipe"
 
 #
 # Kernel hardening options

--- a/base/comps/kernel/6.18-x86_64-azl.config
+++ b/base/comps/kernel/6.18-x86_64-azl.config
@@ -7633,7 +7633,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="landlock,lockdown,yama,integrity,selinux,bpf,ipe"
 
 #
 # Kernel hardening options

--- a/base/images/tests/cases/vm-base/test_kernel.py
+++ b/base/images/tests/cases/vm-base/test_kernel.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 def test_kernel_modules_present(rootfs: Path) -> None:
     """A bootable VM image must ship at least one kernel's modules."""
@@ -14,3 +16,32 @@ def test_kernel_modules_present(rootfs: Path) -> None:
     assert modules_dir.exists(), "No kernel modules directory found"
     versions = [d.name for d in modules_dir.iterdir() if d.is_dir()]
     assert versions, "No kernel version subdirectories under modules dir"
+
+
+def _parse_config_lsm(rootfs: Path) -> set[str]:
+    """Extract the CONFIG_LSM value from the installed kernel config."""
+    boot = rootfs / "boot"
+    configs = sorted(boot.glob("config-*"))
+    assert configs, f"No kernel config found under {boot}"
+    config_path = configs[-1]
+    for line in config_path.read_text().splitlines():
+        if line.startswith("CONFIG_LSM="):
+            value = line.split("=", 1)[1].strip('"')
+            return set(value.split(","))
+    pytest.fail(f"CONFIG_LSM not found in {config_path}")
+
+
+def test_required_lsms_in_config(rootfs: Path) -> None:
+    """CONFIG_LSM must list bpf and ipe so they are active at boot.
+
+    At runtime these appear in /sys/kernel/security/lsm. This static
+    check verifies the kernel config will produce that result without
+    needing to boot the image.
+    """
+    required = {"bpf", "ipe"}
+    active = _parse_config_lsm(rootfs)
+    missing = required - active
+    assert not missing, (
+        f"CONFIG_LSM is missing required LSMs: {', '.join(sorted(missing))}. "
+        f"Current value: {', '.join(sorted(active))}"
+    )

--- a/specs/k/kernel/6.18-aarch64-azl.config
+++ b/specs/k/kernel/6.18-aarch64-azl.config
@@ -13505,7 +13505,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="landlock,lockdown,yama,integrity,selinux,bpf,ipe"
 
 #
 # Kernel hardening options

--- a/specs/k/kernel/6.18-x86_64-azl.config
+++ b/specs/k/kernel/6.18-x86_64-azl.config
@@ -7633,7 +7633,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="landlock,lockdown,yama,integrity,selinux,bpf,ipe"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
## Summary

Add `bpf` and `ipe` LSMs to `CONFIG_LSM` on both x86_64 and aarch64, aligning with Fedora 43's defaults. Both `CONFIG_BPF_LSM=y` and `CONFIG_SECURITY_IPE=y` are already compiled in — this activates them at boot so they appear in `/sys/kernel/security/lsm`.

### Changes
- **Kernel configs**: `CONFIG_LSM="landlock,lockdown,yama,integrity,selinux,bpf,ipe"` (both arches)
- **Image test**: Added `test_required_lsms_in_config` to `test_kernel.py` — verifies `CONFIG_LSM` includes `bpf` and `ipe`

### What are these LSMs?
- **bpf**: Enables BPF-based security programs (BPF LSM hooks) for runtime security policy enforcement
- **ipe**: Integrity Policy Enforcement — kernel-level policy engine for verifying code integrity before execution

Fixes [AB#18799](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/18799)