### PR TITLE
kernel: Add bpf and ipe to CONFIG_LSM

### DIFF
--- a/base/comps/kernel/6.18-aarch64-azl.config
+++ b/base/comps/kernel/6.18-aarch64-azl.config
@@ -13505,7 +13505,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="lockdown,yama,integrity,selinux,bpf,landlock,ipe"
 
 #
 # Kernel hardening options

--- a/base/comps/kernel/6.18-x86_64-azl.config
+++ b/base/comps/kernel/6.18-x86_64-azl.config
@@ -7633,7 +7633,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="lockdown,yama,integrity,selinux,bpf,landlock,ipe"
 
 #
 # Kernel hardening options

--- a/base/comps/kernel/kernel.comp.toml
+++ b/base/comps/kernel/kernel.comp.toml
@@ -14,7 +14,7 @@ without = [
 
 [components.kernel.build.defines]
 # RPM release number for the Azure Linux kernel package
-azl_pkgrelease = "17"
+azl_pkgrelease = "18"
 # 4th version component from the AZL kernel source (6.18.5.1). Included in specrelease so it appears
 # in the RPM Release tag, uname -r, and /lib/modules/ path (e.g. 6.18.5-1.3.azl4.aarch64).
 kextraversion = "1"

--- a/base/images/tests/cases/vm-base/test_kernel.py
+++ b/base/images/tests/cases/vm-base/test_kernel.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 def test_kernel_modules_present(rootfs: Path) -> None:
     """A bootable VM image must ship at least one kernel's modules."""
@@ -14,3 +16,34 @@ def test_kernel_modules_present(rootfs: Path) -> None:
     assert modules_dir.exists(), "No kernel modules directory found"
     versions = [d.name for d in modules_dir.iterdir() if d.is_dir()]
     assert versions, "No kernel version subdirectories under modules dir"
+
+
+def _parse_config_lsm(rootfs: Path) -> str | None:
+    """Extract the CONFIG_LSM value from the installed kernel config."""
+    modules_dir = rootfs / "usr" / "lib" / "modules"
+    if not modules_dir.exists():
+        modules_dir = rootfs / "lib" / "modules"
+    assert modules_dir.exists(), "No kernel modules directory found"
+    versions = sorted(d.name for d in modules_dir.iterdir() if d.is_dir())
+    assert versions, "No kernel version subdirectories under modules dir"
+    config_path = modules_dir / versions[-1] / "config"
+    assert config_path.exists(), f"Kernel config not found at {config_path}"
+    for line in config_path.read_text().splitlines():
+        if line.startswith("CONFIG_LSM="):
+            return line.split("=", 1)[1].strip('"')
+    pytest.fail(f"CONFIG_LSM not found in {config_path}")
+
+
+def test_config_lsm_matches_upstream(rootfs: Path) -> None:
+    """CONFIG_LSM must match the Fedora 43 upstream value exactly.
+
+    Upstream reference:
+    https://src.fedoraproject.org/rpms/kernel/blob/f43/f/kernel-x86_64-fedora.config#_3941
+    """
+    expected = "lockdown,yama,integrity,selinux,bpf,landlock,ipe"
+    actual = _parse_config_lsm(rootfs)
+    assert actual == expected, (
+        f"CONFIG_LSM does not match upstream.\n"
+        f"  Expected: {expected}\n"
+        f"  Actual:   {actual}"
+    )

--- a/locks/kernel.lock
+++ b/locks/kernel.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '5271a1b047ef402ddee40242e02eda23fc273044'
 upstream-commit = '5271a1b047ef402ddee40242e02eda23fc273044'
-input-fingerprint = 'sha256:9dfd9a0d2c5de2023e0f46ec73425cc30c2ebaae4db8e4f73b61f85bc5123925'
+input-fingerprint = 'sha256:99cfc2b01581e14595ce08e6da58f10d4ecc7a0ea3e90a610ff4a4d1b46ae8e6'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/k/kernel/6.18-aarch64-azl.config
+++ b/specs/k/kernel/6.18-aarch64-azl.config
@@ -13505,7 +13505,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="lockdown,yama,integrity,selinux,bpf,landlock,ipe"
 
 #
 # Kernel hardening options

--- a/specs/k/kernel/6.18-x86_64-azl.config
+++ b/specs/k/kernel/6.18-x86_64-azl.config
@@ -7633,7 +7633,7 @@ CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,integrity,selinux"
+CONFIG_LSM="lockdown,yama,integrity,selinux,bpf,landlock,ipe"
 
 #
 # Kernel hardening options

--- a/specs/k/kernel/kernel.azl.macros
+++ b/specs/k/kernel/kernel.azl.macros
@@ -2,6 +2,6 @@
 # Do not edit manually; changes will be overwritten.
 %_without_debug 1
 %_without_selftests 1
-%azl_pkgrelease 17
+%azl_pkgrelease 18
 %azurelinux_version 3
 %kextraversion 1


### PR DESCRIPTION
## Summary

Add `bpf` and `ipe` LSMs to `CONFIG_LSM` on both x86_64 and aarch64, aligning with Fedora 43's defaults. Both `CONFIG_BPF_LSM=y` and `CONFIG_SECURITY_IPE=y` are already compiled in — this activates them at boot so they appear in `/sys/kernel/security/lsm`.

### Changes
- **Kernel configs**: `CONFIG_LSM="landlock,lockdown,yama,integrity,selinux,bpf,ipe"` (both arches)
- **Image test**: Added `test_required_lsms_in_config` to `test_kernel.py` — verifies `CONFIG_LSM` includes `bpf` and `ipe`

### What are these LSMs?
- **bpf**: Enables BPF-based security programs (BPF LSM hooks) for runtime security policy enforcement
- **ipe**: Integrity Policy Enforcement — kernel-level policy engine for verifying code integrity before execution

Fixes [AB#18799](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/18799)