### PR TITLE
fix(nbd): regenerate TLS test certificates at build time

### DIFF
--- a/base/comps/nbd/nbd.comp.toml
+++ b/base/comps/nbd/nbd.comp.toml
@@ -1,8 +1,1 @@
 [components.nbd]
-
-[[components.nbd.overlays]]
-description = "Mark tls and tlshuge tests as expected failures — shipped test certificates expired on 2026-04-17 (10-year certs generated 2016-04-19). Fixed upstream in nbd 3.27.0 (commit 58b356b) but not backported to 3.25."
-type = "spec-search-replace"
-section = "%check"
-regex = 'make check'
-replacement = 'make check XFAIL_TESTS="tls tlshuge"'

--- a/specs/n/nbd/nbd.spec
+++ b/specs/n/nbd/nbd.spec
@@ -26,6 +26,7 @@ BuildRequires: make
 BuildRequires:  gcc
 BuildRequires:  glib2-devel >= 2.26
 BuildRequires:  gnutls-devel
+BuildRequires:  gnutls-utils
 BuildRequires:  zlib-devel
 BuildRequires:  libnl3-devel
 BuildRequires:  bison
@@ -58,9 +59,28 @@ install -pDm644 %{S:1} %{buildroot}%{_unitdir}/nbd-server.service
 install -pDm644 %{S:2} %{buildroot}%{_sysconfdir}/sysconfig/nbd-server
 
 %check
+# Regenerate TLS test certificates at build time so they are always valid.
+# The shipped certs (generated 2016) expired on 2026-04-17.
+# See tests/run/certs/README.md for the upstream procedure.
+pushd tests/run/certs
+certtool --generate-privkey --outfile ca-key.pem 2>/dev/null
+certtool --generate-self-signed --load-privkey ca-key.pem \
+  --template ca.info --outfile ca-cert.pem 2>/dev/null
+certtool --generate-privkey --outfile server-key.pem 2>/dev/null
+certtool --generate-certificate --load-ca-certificate ca-cert.pem \
+  --load-ca-privkey ca-key.pem --load-privkey server-key.pem \
+  --template server.info --outfile server-cert.pem 2>/dev/null
+certtool --generate-privkey --outfile client-key.pem 2>/dev/null
+certtool --generate-certificate --load-ca-certificate ca-cert.pem \
+  --load-ca-privkey ca-key.pem --load-privkey client-key.pem \
+  --template client.info --outfile client-cert.pem 2>/dev/null
+certtool --generate-privkey --outfile selfsigned-key.pem 2>/dev/null
+certtool --generate-self-signed --load-privkey selfsigned-key.pem \
+  --template ca.info --outfile selfsigned-cert.pem 2>/dev/null
+popd
 # wait longer for nbd-server to fully start,
 # one second may not be enough on Fedora building infra
-DELAY=10 make check XFAIL_TESTS="tls tlshuge"
+DELAY=10 make check
 
 %post
 %systemd_post nbd-server.service


### PR DESCRIPTION
The nbd 3.25 test suite ships pre-built TLS certificates that were generated on 2016-04-19 with a 10-year expiration
(expiration_days=3650), meaning they expired on 2026-04-17. This causes the tls and tlshuge tests to fail with 'Error in the certificate' from GnuTLS.

Rather than marking the tests as expected failures (the previous workaround) or backporting static certs from nbd 3.27.0 (which will expire again in 2033), regenerate all test certificates fresh at build time using certtool and the .info template files already present in the source tree. This ensures the certs are always valid regardless of when the package is built.

Changes:
- Add BuildRequires: gnutls-utils (provides certtool)
- Regenerate CA, server, client, and selfsigned certs in %check
- Remove XFAIL_TESTS="tls tlshuge" workaround
- Remove spec-search-replace overlay from nbd.comp.toml

Ref: tests/run/certs/README.md (upstream cert generation procedure) Ref: upstream fix in nbd 3.27.0 (commit 58b356b)
Precedent: rubygem-excon, libserf (Fedora specs that regenerate test certs)

Testing: 
   PASS: tls
   PASS: tlswrongcert
   PASS: tlshuge
   All 19 tests passed — including tls, tlswrongcert, and tlshuge. 



<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
