### PR TITLE
feat(vm-base): add nvme-cli to image package list

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -136,6 +136,7 @@
         <package name="ncurses-term" />
         <package name="net-tools" />
         <package name="nftables" />
+        <package name="nvme-cli" />
         <package name="openssh-clients" />
         <package name="openssh-server" />
         <package name="rsync" />


### PR DESCRIPTION
nvme-cli is the user-space tool for managing and inspecting NVMe devices. Including it in the vm-base images makes it possible to query NVMe controller and namespace status (e.g. `nvme list`, `nvme smart-log`) directly from Azure VMs, which is useful for diagnosing and understanding the NVMe-backed local and remote disks exposed to Azure Linux guests.

Fixes: [AB#19698](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19698)