### PR TITLE
Fix ptest failure in rng-tools

### DIFF
--- a/SPECS/rng-tools/rng-tools.spec
+++ b/SPECS/rng-tools/rng-tools.spec
@@ -35,7 +35,10 @@ mkdir -p %{buildroot}%{_libdir}/systemd/system
 install -p -m 644 %{SOURCE1} %{buildroot}%{_libdir}/systemd/system/
 
 %check
-make  %{?_smp_mflags} check
+pushd tests
+./rngtestzero.sh
+./rngtesturandom.sh
+popd
 
 %post
 /sbin/ldconfig

--- a/SPECS/rng-tools/rng-tools.spec
+++ b/SPECS/rng-tools/rng-tools.spec
@@ -61,7 +61,7 @@ popd
 %{_mandir}/*
 
 %changelog
-* Wed May 13 2026 BinduSri Adabala <v-badabala@microsoft.com> - 6.16.1-2
+* Wed May 13 2026 BinduSri Adabala <v-badabala@microsoft.com> - 6.16-2
 - Disabled rngtestjitter.sh in check section due to unavailable runtime jitter source.
 
 * Mon Nov 06 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.16-1

--- a/SPECS/rng-tools/rng-tools.spec
+++ b/SPECS/rng-tools/rng-tools.spec
@@ -35,10 +35,10 @@ mkdir -p %{buildroot}%{_libdir}/systemd/system
 install -p -m 644 %{SOURCE1} %{buildroot}%{_libdir}/systemd/system/
 
 %check
-pushd tests
-./rngtestzero.sh
-./rngtesturandom.sh
-popd
+# rngtestjitter.sh is skipped: jitter entropy runtime source
+# (jitterentropy library) is unavailable in the AZL 3.0 build
+# environment. Re-enable once jitterentropy support is added.
+make %{?_smp_mflags} check TESTS="rngtestzero.sh rngtesturandom.sh"
 
 %post
 /sbin/ldconfig

--- a/SPECS/rng-tools/rng-tools.spec
+++ b/SPECS/rng-tools/rng-tools.spec
@@ -1,7 +1,7 @@
 Summary:        RNG deamon and tools
 Name:           rng-tools
 Version:        6.16
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -61,6 +61,9 @@ popd
 %{_mandir}/*
 
 %changelog
+* Wed May 13 2026 BinduSri Adabala <v-badabala@microsoft.com> - 6.16.1-2
+- Disabled rngtestjitter.sh in check section due to unavailable runtime jitter source.
+
 * Mon Nov 06 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.16-1
 - Auto-upgrade to 6.16 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix ptest failure in rng-tools:
- Previously, `rng-tools` package builds, and in `%check` only `rngtestjitter.sh` fails. The other two tests, `rngtestzero.sh` and `rngtesturandom.sh`, run successfully.
- In `tests/rngtestjitter.sh`, the command uses -O jitter:use_aes:1, which shows that this test specifically depends on jitter entropy support.
**../rngd -f -o /dev/stdout -x hwrng -x rdrand -x tpm -O jitter:use_aes:1 $TIMEOUT | ../rngtest -c 100 --pipe > /dev/null**
- The code shows that jitter test needs the jitterentropy library. I checked in the Docker environment, and there is no jitter package, no jitterentropy.h file, and no jitter library available. So, this support is missing in Azure Linux 3.0
- Tested "rngtestjitter.sh" by vendoring  "jitterentropy-library" and rebuilding "rng-tools" with jitter support enabled. The package builds successfully and the binary contains jitter support strings, but the jitter entropy source still does not become available at runtime in the Azure Linux 3.0 build environment. 
Even when all other entropy sources (hwrng, rdrand, tpm, pkcs11, rtlsdr) are explicitly disabled, rngd reports that it cannot open any entropy source.
- Hence, skipped the `rngtesturandom.sh` test.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- ../SPECS/rng-tools/rng-tools.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build:
[rng-tools-6.16-2.azl3.src.rpm.log](https://github.com/user-attachments/files/28942996/rng-tools-6.16-2.azl3.src.rpm.log)
[rng-tools-6.16-2.azl3.src.rpm.test.log](https://github.com/user-attachments/files/28942998/rng-tools-6.16-2.azl3.src.rpm.test.log)
