### PR TITLE
docs(skills): update remove-component for components-publish-channels.toml

### DIFF
--- a/.github/prompts/azl-remove-component.prompt.md
+++ b/.github/prompts/azl-remove-component.prompt.md
@@ -12,9 +12,9 @@ Follow the workflow in the [skill-remove-component skill](../skills/skill-remove
 
 1. Parse the component list from `${input:component_names}` (comma-separated)
 2. For each component, verify it exists: `azldev comp list -p <name> -q -O json`
-3. Find all artifacts: component definition, package list references (look for `# srpm: <name>` in `base/packages/*.toml`), lock file, rendered specs
+3. Find all artifacts: component definition, publish-channel references (component name in `[component-groups.base-packages]` and per-binary `# srpm: <name>` entries under `[package-groups.exceptions-packages]` in `base/comps/components-publish-channels.toml`), lock file, rendered specs
 4. Remove the component entry from `components.toml` (or delete dedicated `base/comps/<name>/` directory)
-5. Remove all subpackage references from `base/packages/base.packages.toml` and `base/packages/sdk.packages.toml`
+5. Remove the component from `[component-groups.base-packages].components` (if present) and any matching `# srpm: <name>` lines from `[package-groups.exceptions-packages].packages` in `base/comps/components-publish-channels.toml`
 6. Delete `locks/<name>.lock` and `specs/<first-char>/<name>/`
 7. Check for references in kiwi image files (`*.kiwi`) and other config (`base/images/`, `comps.xml`)
-8. Verify no references remain: `azldev comp list -p <name> -q -O json` should fail, `grep` of package lists and kiwi files should return nothing
+8. Verify no references remain: `azldev comp list -p <name> -q -O json` should fail, `grep` of `components-publish-channels.toml` and kiwi files should return nothing

--- a/.github/skills/skill-remove-component/SKILL.md
+++ b/.github/skills/skill-remove-component/SKILL.md
@@ -16,7 +16,7 @@ azldev comp list -p <name> -q -O json
 Then check for all artifacts that need to be removed:
 
 1. Component definition — `base/comps/components.toml` (inline) or `base/comps/<name>/<name>.comp.toml` (dedicated)
-2. Package list references — `base/packages/base.packages.toml`, `base/packages/sdk.packages.toml`
+2. Publish-channel references — `base/comps/components-publish-channels.toml` (component name in `component-groups.base-packages.components`, plus any per-binary entries in `package-groups.exceptions-packages.packages`)
 3. Lock file — `locks/<name>.lock`
 4. Rendered specs — `specs/<first-char>/<name>/`
 5. Other references — image definitions (`base/images/`), `comps.xml`, etc.
@@ -28,12 +28,15 @@ Then check for all artifacts that need to be removed:
 - **Inline entry**: remove `[components.<name>]` from `base/comps/components.toml`
 - **Dedicated directory**: delete `base/comps/<name>/` (contains `<name>.comp.toml` and possibly local spec/sources)
 
-### 2. Remove package list references
+### 2. Remove publish-channel references
 
-Components produce subpackages (base, -devel, -doc, -libs, etc.) that may be listed in package manifests. Each line in the package lists has a `# srpm:` comment identifying which component it belongs to — use this to find all subpackages:
+Publishing is configured per *component* (not per binary subpackage) in `base/comps/components-publish-channels.toml`. For each component being removed:
+
+- Remove its entry from the `components = [...]` array in `[component-groups.base-packages]` if present (otherwise it inherits the project-wide `sdk` default and needs no edit there).
+- Remove any per-binary carve-outs for its subpackages from `[package-groups.exceptions-packages].packages`. Exception lines carry a `# srpm: <name>` trailing comment — grep that to find them all:
 
 ```bash
-grep "srpm: <name>" base/packages/base.packages.toml base/packages/sdk.packages.toml
+grep "srpm: <name>" base/comps/components-publish-channels.toml
 ```
 
 Remove every matching line. When removing many components at once, editing by hand is error-prone — prefer using your editor's multi-cursor or find-and-replace to remove all lines matching the SRPM name.
@@ -78,15 +81,15 @@ Kiwi files (`*.kiwi`) define image package lists — if any subpackage produced 
 After removal, confirm nothing was missed:
 
 ```bash
-azldev comp list -p <name> -q -O json          # should fail with "component not found"
-grep -rn "<name>" base/packages/ --include="*.toml"  # should return nothing
-ls locks/<name>.lock specs/*/<name>/ 2>/dev/null      # should return nothing
+azldev comp list -p <name> -q -O json                              # should fail with "component not found"
+grep -n "\"<name>\"\|srpm: <name>" base/comps/components-publish-channels.toml  # should return nothing
+ls locks/<name>.lock specs/*/<name>/ 2>/dev/null                   # should return nothing
 grep -rn "<name>" --include="*.kiwi" .                  # should return nothing
 ```
 
 ## Notes
 
 - **Check for reverse dependencies** before removing a component. If other components depend on it (via `BuildRequires` or `Requires`), removing it will break their builds.
-- **Subpackage naming varies by ecosystem.** Always search by `# srpm:` comment rather than guessing suffix patterns.
+- **Publishing is component-scoped, exceptions are binary-scoped.** The `base-packages` group lists *component* names; the `exceptions-packages` group lists *binary RPM* names with `# srpm: <name>` comments. Always search by `# srpm:` comment rather than guessing suffix patterns.
 - **This is a metadata-only change.** No builds or tests are needed — the component is simply being dropped from the distro definition.
 - **When removing a component and its exclusive dependencies** (packages only needed by the component being removed), remove them all in the same change to keep the tree consistent.


### PR DESCRIPTION
As a follow-up of #17067 where the legacy `base/packages/{base,sdk}.packages.toml` files have been replaced by `base/comps/components-publish-channels.toml`, which is component-scoped with a per-binary exceptions group. This PR updates the remove-component skill and prompt to reference the new file and its two sections (`component-groups.base-packages` and `package-groups.exceptions-packages`).