### PR TITLE
Resolved ptest failure in `lujavrite` package

### DIFF
--- a/SPECS/lujavrite/lujavrite.spec
+++ b/SPECS/lujavrite/lujavrite.spec
@@ -1,6 +1,6 @@
 Name:           lujavrite
 Version:        1.0.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Lua library for calling Java code
 License:        Apache-2.0
 URL:            https://github.com/mizdebsk/lujavrite
@@ -30,6 +30,7 @@ export JAVA_HOME=$(find %{_libdir}/jvm -name "msopenjdk*")
 install -D -p -m 0755 lujavrite.so %{buildroot}%{lua_libdir}/%{name}.so
 
 %check
+export JAVA_HOME=$(find %{_libdir}/jvm -name "msopenjdk*")
 lua test.lua
 
 %files
@@ -38,6 +39,9 @@ lua test.lua
 %doc README.md
 
 %changelog
+* Wed May 13 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.0.2-7
+- Resolved ptest failure by exporting JAVA_HOME in check section.
+
 * Tue Sep 03 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 1.0.2-6
 - Add missing Vendor and Distribution tags.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
**Resolved ptest failure in `lujavrite` package**
- **Issue** - The `%check` section runs `lua test.lua`, which tries to `dlopen(libjvm.so)` at the path `/usr/lib/jvm/jre/lib/server/libjvm.so` but this path does not exist there and hence ptest fails.
- **Fix -** In the `%build` section, the spec already handles this correctly by locating the JDK, but this JAVA_HOME env variable is not carried into the `%check` section, so `libjvm.so` cannot be found at runtime via the dynamic linker. Exporting `JAVA_HOME` in `%check` section resolves the ptest failure.

###### AI Analysis relevance (In %) / Reasoning <!-- REQUIRED -->
AI Analysis relevance (In %): N/A (no work Item was created for it)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/lujavrite/lujavrite.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build was successful.
  <img width="815" height="836" alt="image" src="https://github.com/user-attachments/assets/41200666-0e2f-4ea4-bcda-bbe337787f0a" />

- Build logs -
[lujavrite-1.0.2-7.azl3.src.rpm.log](https://github.com/user-attachments/files/27691312/lujavrite-1.0.2-7.azl3.src.rpm.log)
[lujavrite-1.0.2-7.azl3.src.rpm.test.log](https://github.com/user-attachments/files/27691315/lujavrite-1.0.2-7.azl3.src.rpm.test.log)

- License check script shows no warning.
- Installation and uninstallation check of generated RPMs on docker image have been done.