### PR TITLE
fix(qt6-deps): bump release for qt6-qtwebengine removal rebuild

### DIFF
--- a/locks/gpsbabel.lock
+++ b/locks/gpsbabel.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '076f3d6b98ff16ae7642cacdad27073dd8066d60'
 upstream-commit = '076f3d6b98ff16ae7642cacdad27073dd8066d60'
-input-fingerprint = 'sha256:68ed4b534e828370fa5bb1138e03f7365d4bd76fb877c131bac75f4082d7c6b2'
+manual-bump = 1
+input-fingerprint = 'sha256:42bed1173466af110a9194cb2f38f56c0c4eda1a0e24e6768901bae14dcf8d31'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/locks/libksysguard.lock
+++ b/locks/libksysguard.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '7bedb89d80b65ae9a2630237eef6ccbfcd891077'
 upstream-commit = '7bedb89d80b65ae9a2630237eef6ccbfcd891077'
-input-fingerprint = 'sha256:17a5228a881869514d9c003a5da0b46bbb93c254b2530f1c3226037137d9aaf5'
+manual-bump = 1
+input-fingerprint = 'sha256:a78f0f48692237a6a1dcece15c63e851f194b16957d60f092418dc3ea1cca777'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/locks/python-pyqt6.lock
+++ b/locks/python-pyqt6.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '738c8b3b75dae5380e44eb938565278fda552e70'
 upstream-commit = '738c8b3b75dae5380e44eb938565278fda552e70'
-input-fingerprint = 'sha256:5083db2c3e1e42fea7134d76c86c9faaa33e8222131fd5059de20d9e00344a2b'
+manual-bump = 1
+input-fingerprint = 'sha256:af5bd6b06019197952693ccab10a4b741c81185b99df210fd45261b7fb93aa38'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/locks/python-pyside6.lock
+++ b/locks/python-pyside6.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '3472e506e0ff2e25a03c2104dee5eb69231b119d'
 upstream-commit = '3472e506e0ff2e25a03c2104dee5eb69231b119d'
-input-fingerprint = 'sha256:5d4b6ce1e778d6836b2d400b881447ad4ae6c37c7956a3ef796784dc7c0fe6a3'
+manual-bump = 1
+input-fingerprint = 'sha256:56f1066c6ed3dedb2e5c4cade947390a4ee341cd74d2c398fe7c266780c6ed2b'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/locks/qt6-qtwebview.lock
+++ b/locks/qt6-qtwebview.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '2b4727b190d0d4763a02274e9a3e0449c2273e7e'
 upstream-commit = '2b4727b190d0d4763a02274e9a3e0449c2273e7e'
-input-fingerprint = 'sha256:fec84bdc93952c24084e6a7ab40858e39e6456ee6dac4d742c5ad5610a93e648'
+manual-bump = 1
+input-fingerprint = 'sha256:db64becf96c71a2afee4578495e1fc68b382196c57e231704bf5442f10dac7e3'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/gpsbabel/gpsbabel.spec
+++ b/specs/g/gpsbabel/gpsbabel.spec
@@ -3,7 +3,7 @@
 
 Name:          gpsbabel
 Version:       1.10.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary:       A tool to convert between various formats used by GPS devices
 
 License:       GPL-2.0-or-later

--- a/specs/l/libksysguard/libksysguard.spec
+++ b/specs/l/libksysguard/libksysguard.spec
@@ -4,7 +4,7 @@
 Name:    libksysguard
 Summary: Library for managing processes running on the system
 Version: 6.6.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 License: BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only)
 URL:     https://invent.kde.org/plasma/%{name}

--- a/specs/p/python-pyqt6/python-pyqt6.spec
+++ b/specs/p/python-pyqt6/python-pyqt6.spec
@@ -10,7 +10,7 @@
 Summary: PyQt6 is Python bindings for Qt6
 Name:    python-pyqt6
 Version: 6.10.2
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: gpl-3.0-only
 Url:     http://www.riverbankcomputing.com/software/pyqt/
 Source0: https://pypi.python.org/packages/source/P/PyQt6/pyqt6-%{version}%{?snap:.%{snap}}.tar.gz

--- a/specs/p/python-pyside6/python-pyside6.spec
+++ b/specs/p/python-pyside6/python-pyside6.spec
@@ -13,7 +13,7 @@
 
 Name:           python-%{pypi_name}
 Version:        6.10.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary:        Python bindings for the Qt 6 cross-platform application and UI framework
 
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0

--- a/specs/q/qt6-qtwebview/qt6-qtwebview.spec
+++ b/specs/q/qt6-qtwebview/qt6-qtwebview.spec
@@ -13,7 +13,7 @@
 Summary: Qt6 - WebView component
 Name:    qt6-%{qt_module}
 Version: 6.10.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 License: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 Url:     http://www.qt.io


### PR DESCRIPTION
Bump gpsbabel, libksysguard, python-pyside6, python-pyqt6, and
qt6-qtwebview to trigger rebuilds against the updated qt6-srpm-macros
that clears %qt6_qtwebengine_arches, effectively removing the
qt6-qtwebengine dependency from these packages.

Part of the effort to remove opus, opusfile and mingw-opus from AZL.