### PR TITLE
Extend explicit workflow permissions to 19 check/lint/quickstart workflows

### DIFF
--- a/.github/workflows/check-circular-deps.yml
+++ b/.github/workflows/check-circular-deps.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [3.0*, fasttrack/*, "!fasttrack/2.0"]
 
+permissions:
+  contents: read
+
 jobs:
   spec-check:
     name: Circular dependency check

--- a/.github/workflows/check-clean-stage.yml
+++ b/.github/workflows/check-clean-stage.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-clean-stage-check:
     name: Spec %clean stage check

--- a/.github/workflows/check-entangled-specs.yml
+++ b/.github/workflows/check-entangled-specs.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Spec Entanglement Mismatch Check

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/check-kernel-configs.yml
+++ b/.github/workflows/check-kernel-configs.yml
@@ -15,6 +15,9 @@ on:
     paths:
       - 'SPECS/kernel*/config*'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Kernel configs check

--- a/.github/workflows/check-license-map.yml
+++ b/.github/workflows/check-license-map.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Spec License Map Check

--- a/.github/workflows/check-manifests.yml
+++ b/.github/workflows/check-manifests.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Check Manifests

--- a/.github/workflows/check-package-builds.yml
+++ b/.github/workflows/check-package-builds.yml
@@ -28,6 +28,9 @@ on:
       - "toolkit/scripts/*"
       - "toolkit/tools/*"
 
+permissions:
+  contents: read
+
 jobs:
   package-checks:
     name: ${{ matrix.check-name }}

--- a/.github/workflows/check-package-cgmanifest.yml
+++ b/.github/workflows/check-package-cgmanifest.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/check-package-update-gate.yml
+++ b/.github/workflows/check-package-update-gate.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/check-source-signatures.yml
+++ b/.github/workflows/check-source-signatures.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [3.0*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-check:
     name: Source Signature Check

--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-check:
     name: Spec files check

--- a/.github/workflows/check-srpm-duplicates.yml
+++ b/.github/workflows/check-srpm-duplicates.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [main, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: SRPMs duplicates check

--- a/.github/workflows/check-static-glibc.yml
+++ b/.github/workflows/check-static-glibc.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-check:
     name: Static glibc version check

--- a/.github/workflows/go-test-coverage.yml
+++ b/.github/workflows/go-test-coverage.yml
@@ -12,6 +12,9 @@ on:
 env:
   EXPECTED_GO_VERSION: "1.24"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Go Test Coverage

--- a/.github/workflows/lint-specs.yml
+++ b/.github/workflows/lint-specs.yml
@@ -13,6 +13,9 @@ on:
       - '**.spec'
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-lint:
     name: Spec Linting

--- a/.github/workflows/merge-conflict-check.yml
+++ b/.github/workflows/merge-conflict-check.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-check:
     name: Github Merge Conflict Check

--- a/.github/workflows/quickstart_2.0.yml
+++ b/.github/workflows/quickstart_2.0.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 15 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   iso_quickstart:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-osguard-imageconfigs.yml
+++ b/.github/workflows/verify-osguard-imageconfigs.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify-osguard-imageconfigs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following up on #7282, which made a first pass at declaring explicit `permissions:` blocks in this repo. Since then several new check/lint workflows have been added and the 2.0 quickstart was renamed without picking up the same hardening, so most of the validators in `.github/workflows/` are once again running with the repository default token scope.

This patch adds a top-level

```yaml
permissions:
  contents: read
```

to 19 workflows:

```
check-circular-deps.yml            check-package-cgmanifest.yml      check-spec.yml
check-clean-stage.yml              check-package-update-gate.yml     check-srpm-duplicates.yml
check-entangled-specs.yml          check-source-signatures.yml       check-static-glibc.yml
check-files.yml                    go-test-coverage.yml              lint-specs.yml
check-kernel-configs.yml           merge-conflict-check.yml          quickstart_2.0.yml
check-license-map.yml              verify-osguard-imageconfigs.yml
check-manifests.yml                check-package-builds.yml
```

All 19 fire on `push` / `pull_request` (or `schedule` / `workflow_dispatch` for `quickstart_2.0.yml`), check out the repo, and run spec / package / lint validators. None push commits, create releases, or call write APIs.

The two workflows that already declare `permissions: {}` with `pull_request_target` (`check-rendered-specs-stub.yml`, `spec-review-stub.yml`) are intentionally left alone — they have a stub-plus-reusable architecture with explicit scope notes and don't need a different default.

YAML validated locally with PyYAML before commit; diff is +57 lines, no other changes.