### PR TITLE
Resolved ptest failure in `libical` by upgrading to version 3.0.10

### DIFF
--- a/SPECS/libical/libical.signatures.json
+++ b/SPECS/libical/libical.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libical-3.0.9.tar.gz": "bd26d98b7fcb2eb0cd5461747bbb02024ebe38e293ca53a7dfdcb2505265a728"
+  "libical-3.0.10.tar.gz": "f933b3e6cf9d56a35bb5625e8e4a9c3a50239a85aea05ed842932c1a1dc336b4"
  }
 }

--- a/SPECS/libical/libical.spec
+++ b/SPECS/libical/libical.spec
@@ -1,7 +1,7 @@
 Summary:        Reference implementation of the iCalendar data type and serialization format
 Name:           libical
-Version:        3.0.9
-Release:        5%{?dist}
+Version:        3.0.10
+Release:        1%{?dist}
 License:        LGPLv2 OR MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -24,6 +24,7 @@ BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  pkgconfig(icu-i18n)
 BuildRequires:  pkgconfig(icu-uc)
 BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  tzdata
 Requires:       tzdata
 
 %description
@@ -77,7 +78,7 @@ Development files needed for building things which link against %{name}-glib.
 rm %{buildroot}/%{_libexecdir}/libical/ical-glib-src-generator
 
 %check
-make test ARGS="-V" -C %{_target_platform}
+make test ARGS="-V"
 
 %ldconfig_scriptlets
 
@@ -123,6 +124,9 @@ make test ARGS="-V" -C %{_target_platform}
 %{_datadir}/vala/vapi/libical-glib.vapi
 
 %changelog
+* Wed May 13 2026 Aditya Singh <v-aditysing@microsoft.com> - 3.0.10-1
+- Update to 3.0.10 to fix ptest failure.
+
 * Wed Jul 13 2022 Dallas Delaney <dadelan@microsoft.com> - 3.0.9-5
 - Promote to Mariner base repo
 - Lint spec

--- a/SPECS/libical/libical.spec
+++ b/SPECS/libical/libical.spec
@@ -25,6 +25,7 @@ BuildRequires:  pkgconfig(icu-i18n)
 BuildRequires:  pkgconfig(icu-uc)
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  tzdata
+Requires:       tzdata
 
 %description
 Reference implementation of the iCalendar data type and serialization format

--- a/SPECS/libical/libical.spec
+++ b/SPECS/libical/libical.spec
@@ -25,7 +25,6 @@ BuildRequires:  pkgconfig(icu-i18n)
 BuildRequires:  pkgconfig(icu-uc)
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  tzdata
-Requires:       tzdata
 
 %description
 Reference implementation of the iCalendar data type and serialization format

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -9911,8 +9911,8 @@
         "type": "other",
         "other": {
           "name": "libical",
-          "version": "3.0.9",
-          "downloadUrl": "https://github.com/libical/libical/archive/v3.0.9/libical-3.0.9.tar.gz"
+          "version": "3.0.10",
+          "downloadUrl": "https://github.com/libical/libical/archive/v3.0.10/libical-3.0.10.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Resolved ptest failure in `libical` by upgrading to version 3.0.10
- **Issue**
   - `-C %{_target_platform}` in `%check` section was not recognizable by the `make test` script.
   - Multiple ptests were getting failed as `tzdata` was not available at build time.
   - 
- **Fix**
   - Removed `-C %{_target_platform}` from `%check` section as it was not recognizable by the `make test` script. 
   - Added `tzdata` in BuildRequires.  
   - Upgraded to version `3.0.10` to fix test case no. 41.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/libical/libical.signatures.json
- modified: SPECS/libical/libical.spec
- modified: cgmanifest.json

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.
   <img width="815" height="836" alt="image" src="https://github.com/user-attachments/assets/7971895f-3e63-4299-9f80-e17462e2287c" />

- Build log
[libical-3.0.10-1.azl3.src.rpm.log](https://github.com/user-attachments/files/27702440/libical-3.0.10-1.azl3.src.rpm.log)
[libical-3.0.10-1.azl3.src.rpm.test.log](https://github.com/user-attachments/files/27702431/libical-3.0.10-1.azl3.src.rpm.test.log)

- License check script shows no warning.
- Installation and uninstallation check on docker image was successful.