### PR TITLE
fix(openssl): pin to Fedora f43 commit with CVE fixes

### DIFF
--- a/base/comps/openssl/openssl.comp.toml
+++ b/base/comps/openssl/openssl.comp.toml
@@ -1,4 +1,9 @@
 [components.openssl]
+# Pin to Fedora f43 openssl-3.5.4-3 which includes CVE patches 0073–0079 fixing:
+# CVE-2026-31789 (Critical), CVE-2026-28387, CVE-2026-31790, CVE-2026-2673,
+# CVE-2026-28390, CVE-2026-28389, CVE-2026-28388 (all High).
+# Fedora commit: https://src.fedoraproject.org/rpms/openssl/c/0990e54a2f6b6b8e4f3e238175382505fff8be51
+spec = { type = "upstream", upstream-commit = "0990e54a2f6b6b8e4f3e238175382505fff8be51" }
 
 # AZL4 does not ship fips.so. Extend the existing RHEL fips.so-deletion
 # path to cover AZL4 so the module and its config are excluded from the package.

--- a/locks/openssl.lock
+++ b/locks/openssl.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '8e2fde9ae8b83393b6d58c62492106751e52a696'
-upstream-commit = '8e2fde9ae8b83393b6d58c62492106751e52a696'
-input-fingerprint = 'sha256:6559a6460e7d84a1c4377e7411db502fd5586db147ca5a1f0add987eee6190a9'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '0990e54a2f6b6b8e4f3e238175382505fff8be51'
+input-fingerprint = 'sha256:e32077b5155981d98a2f48e92da88f8ef676ab311ffc3dc5dbabf8eea97a67c6'
+resolution-input-hash = 'sha256:888b19e73f615d9932deea30309a22436c3d0f059c9f14437204e2e1887dc692'

--- a/specs/o/openssl/0073-CVE-2026-2673.patch
+++ b/specs/o/openssl/0073-CVE-2026-2673.patch
@@ -1,0 +1,423 @@
+From 9c5f04d1a9cc067bb8a6a1181d3d42bfd0a62762 Mon Sep 17 00:00:00 2001
+From: Viktor Dukhovni <openssl-users@dukhovni.org>
+Date: Tue, 17 Feb 2026 18:37:06 +1100
+Subject: [PATCH] Fix group tuple handling in DEFAULT expansion
+
+Also fine-tune docs and add tests.
+
+Fixes: #30109
+Fixes: CVE-2026-2673
+
+Reviewed-by: Matt Caswell <matt@openssl.foundation>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+MergeDate: Fri Mar 13 12:44:06 2026
+(Merged from https://github.com/openssl/openssl/pull/30110)
+---
+ doc/man3/SSL_CTX_set1_curves.pod | 123 +++++++++++++++++++++----------
+ ssl/t1_lib.c                     |  95 ++++++++++++++----------
+ test/tls13groupselection_test.c  |  36 +++++++--
+ 3 files changed, 172 insertions(+), 82 deletions(-)
+
+diff --git a/doc/man3/SSL_CTX_set1_curves.pod b/doc/man3/SSL_CTX_set1_curves.pod
+index 017eefd317..472d385831 100755
+--- a/doc/man3/SSL_CTX_set1_curves.pod
++++ b/doc/man3/SSL_CTX_set1_curves.pod
+@@ -40,13 +40,13 @@ SSL_get1_curves, SSL_get_shared_curve, SSL_CTX_get0_implemented_groups
+ 
+ For all of the functions below that set the supported groups there must be at
+ least one group in the list. A number of these functions identify groups via a
+-unique integer NID value. However, support for some groups may be added by
+-external providers. In this case there will be no NID assigned for the group.
++unique integer B<NID> value. However, support for some groups may be added by
++external providers. In this case there will be no B<NID> assigned for the group.
+ When setting such groups applications should use the "list" form of these
+ functions (i.e. SSL_CTX_set1_groups_list() and SSL_set1_groups_list()).
+ 
+ SSL_CTX_set1_groups() sets the supported groups for B<ctx> to B<glistlen>
+-groups in the array B<glist>. The array consist of all NIDs of supported groups.
++groups in the array B<glist>. The array consist of all B<NIDs> of supported groups.
+ The supported groups for B<TLSv1.3> include:
+ B<NID_X9_62_prime256v1>,
+ B<NID_secp384r1>,
+@@ -73,20 +73,27 @@ B<SSL_OP_CIPHER_SERVER_PREFERENCE> is set, the order of the elements in the
+ array determines the selected group. Otherwise, the order is ignored and the
+ client's order determines the selection.
+ 
+-For a TLS 1.3 server, the groups determine the selected group, but
+-selection is more complex. A TLS 1.3 client sends both a group list as well as a
+-predicted subset of groups. Choosing a group outside the predicted subset incurs
+-an extra roundtrip. However, in some situations, the most preferred group may
+-not be predicted. OpenSSL considers all supported groups in I<clist> to be comparable
+-in security and prioritizes avoiding roundtrips above either client or server
+-preference order. If an application uses an external provider to extend OpenSSL
+-with, e.g., a post-quantum algorithm, this behavior may allow a network attacker
+-to downgrade connections to a weaker algorithm. It is therefore recommended
+-to use SSL_CTX_set1_groups_list() with the ability to specify group tuples.
++For a TLS 1.3 server, the groups determine the selected group, but selection is
++more complex.
++A TLS 1.3 client sends both a group list and predicted keyshares for a subset
++of groups.
++A server choosing a group outside the client's predicted subset incurs an extra
++roundtrip.
++However, in some situations, the most preferred group may not be predicted.
++
++When groups are specified via SSL_CTX_set1_groups() as a list of B<NID>
++values, OpenSSL considers all supported groups in I<clist> to be comparable in
++security and prioritises avoiding roundtrips above either client or server
++preference order.
++If an application uses an external provider to extend OpenSSL with, e.g., a
++post-quantum algorithm, this behavior may allow a network attacker to downgrade
++connections to a weaker algorithm.
++It is therefore recommended to use SSL_CTX_set1_groups_list() instead, making
++it possible to specify group tuples as described below.
+ 
+ SSL_CTX_set1_groups_list() sets the supported groups for B<ctx> to
+ string I<list>. In contrast to SSL_CTX_set1_groups(), the names of the
+-groups, rather than their NIDs, are used.
++groups, rather than their B<NIDs>, are used.
+ 
+ The commands below list the available groups for TLS 1.2 and TLS 1.3,
+ respectively:
+@@ -102,30 +109,72 @@ The preferred group names are those defined by
+ L<IANA|https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8>.
+ 
+ The I<list> can be used to define several group tuples of comparable security
+-levels, and can specify which key shares should be sent by a client.
+-The specified list elements can optionally be ignored, if not implemented
++levels, and can specify which predicted key shares should be sent by a client.
++Group tuples are used by OpenSSL TLS servers to decide whether to request a
++stronger keyshare than those predicted by sending a Hello Retry Request
++(B<HRR>) even if some of the predicted groups are supported.
++OpenSSL clients ignore tuple boundaries, and pay attenion only to the overall
++order of I<list> elements and which groups are selected as predicted keyshares
++as described below.
++
++The specified list elements can optionally be ignored if not implemented
+ (listing unknown groups otherwise results in error).
+-It is also possible to specify the built-in default set of groups, and to explicitly
+-remove a group from that list.
+-
+-In its simplest form, the string I<list> is just a colon separated list
+-of group names, for example "P-521:P-384:P-256:X25519:ffdhe2048". The first
+-group listed will also be used for the B<key_share> sent by a client in a
+-TLSv1.3 B<ClientHello>. For servers note the discussion above. The list should
+-be in order of preference with the most preferred group first.
+-
+-Group tuples of comparable security are defined by separating them from each
+-other by a tuple separator C</>. Keyshares to be sent by a client are specified
+-by prepending a C<*> to the group name, while any C<*> will be ignored by a
+-server. The following string I<list> for example defines three tuples when
+-used on the server-side, and triggers the generation of three key shares
+-when used on the client-side: P-521:*P-256/*P-384/*X25519:P-384:ffdhe2048.
+-
+-If a group name is preceded with the C<?> character, it will be ignored if an
+-implementation is missing. If a group name is preceded with the C<-> character, it
+-will be removed from the list of groups if present (including not sending a
+-key share for this group), ignored otherwise. The pseudo group name
+-C<DEFAULT> can be used to select the OpenSSL built-in default list of groups.
++It is also possible to specify the built-in default set of groups, and to
++explicitly remove a group from that list.
++
++In its simplest legacy form, the string I<list> is just a colon separated list
++of group names, for example "P-521:P-384:P-256:X25519:ffdhe2048".
++The first group listed will in this case be used as the sole predicted
++B<key_share> sent by a client in a TLSv1.3 B<ClientHello>.
++The list should be in order of preference with the most preferred group first.
++
++A more expressive syntax supports definition of group tuples of comparable
++security by separating them from each other with C</> characters.
++
++The predicted keyshares to be sent by clients can be explicitly specified by
++adding a C<*> prefix to the associated group name.
++These C<*> prefixes are ignored by servers.
++
++If a group name is prefixed with the C<?> character, it will be ignored if an
++implementation is missing.
++Otherwise, listing an unknown group name will cause a failure to parse the
++I<list>.
++Note that whether a group is known or not may depend on the OpenSSL version,
++how OpenSSL was compiled and/or which providers are loaded.
++Make sure you have the correct spelling of the group name and when in doubt
++prefix it with a C<?> to handle configurations in which it might nevertheless
++be unknown.
++
++If a group name is prefixed with the C<-> character, it will be removed from
++the list of groups specified up to that point.
++It can be added again if specified later.
++Removal of groups that have not been included earlier in the list is silently
++ignored.
++
++The pseudo group name C<DEFAULT> can be used to select the OpenSSL built-in
++default list of groups.
++Prepending one or more groups to C<DEFAULT> using only C<:> separators prepends those
++groups to the built-in default list's first tuple.
++Additional tuples can be prepended by use of the C</> separator.
++Appending a set of groups to C<DEFAULT> using only C<:> separators appends those
++groups to the built-in default list's last tuple.
++Additional tuples can be appended by use of the C</> separator.
++
++The B<DEFAULT> list selects B<X25519MLKEM768> as one of the predicted keyshares.
++In rare cases this can lead to failures or timeouts because the resulting
++larger TLS Client Hello message may no longer fit in a single TCP segment and
++firewall software may erroneously disrupt the TLS handshake.
++If this is an issue or concern, prepending C<?X25519MLKEM768:> without a C<*>
++prefix leads to its occurrence in the default list to be ignored as a duplicate,
++and along with that also the keyshare prediction.
++The group will then only be selected by servers that specifically expect it,
++after a Hello Retry Request (HRR).
++Servers that specifically prefer B<X25519MLKEM768>, are much less likely to be
++found behind problematic firewalls.
++
++The following string I<list> for example defines three tuples when used on the
++server-side, and triggers the generation of three key shares when used on the
++client-side: P-521:*P-256/*P-384/*X25519:P-384:ffdhe2048.
+ 
+ For a TLS 1.3 client, all the groups in the string I<list> are added to the
+ supported groups extension of a C<ClientHello>, in the order in which they are listed,
+diff --git a/ssl/t1_lib.c b/ssl/t1_lib.c
+index 2f71f95438..8a8c9ba9d1 100644
+--- a/ssl/t1_lib.c
++++ b/ssl/t1_lib.c
+@@ -211,7 +211,7 @@ static const uint16_t suiteb_curves[] = {
+ 
+ /* Group list string of the built-in pseudo group DEFAULT_SUITE_B */
+ #define SUITE_B_GROUP_NAME "DEFAULT_SUITE_B"
+-#define SUITE_B_GROUP_LIST "secp256r1:secp384r1",
++#define SUITE_B_GROUP_LIST "?secp256r1:?secp384r1",
+ 
+ struct provider_ctx_data_st {
+     SSL_CTX *ctx;
+@@ -1237,8 +1237,8 @@ typedef struct {
+     size_t ksidcnt; /* Number of key shares */
+     uint16_t *ksid_arr; /* The IDs of the key share groups (flat list) */
+     /* Variable to keep state between execution of callback or helper functions */
+-    size_t tuple_mode; /* Keeps track whether tuple_cb called from 'the top' or from gid_cb */
+-    int ignore_unknown_default; /* Flag such that unknown groups for DEFAULT[_XYZ] are ignored */
++    int inner; /* Are we expanding a DEFAULT list */
++    int first; /* First tuple of possibly nested expansion? */
+ } gid_cb_st;
+ 
+ /* Forward declaration of tuple callback function */
+@@ -1313,16 +1313,16 @@ static int gid_cb(const char *elem, int len, void *arg)
+             for (i = 0; i < OSSL_NELEM(default_group_strings); i++) {
+                 if ((size_t)len == (strlen(default_group_strings[i].list_name))
+                     && OPENSSL_strncasecmp(default_group_strings[i].list_name, elem, len) == 0) {
++                    int saved_first;
++
+                     /*
+                      * We're asked to insert an entire list of groups from a
+                      * DEFAULT[_XYZ] 'pseudo group' which we do by
+                      * recursively calling this function (indirectly via
+                      * CONF_parse_list and tuple_cb); essentially, we treat a DEFAULT
+                      * group string like a tuple which is appended to the current tuple
+-                     * rather then starting a new tuple. Variable tuple_mode is the flag which
+-                     * controls append tuple vs start new tuple.
++                     * rather then starting a new tuple.
+                      */
+-
+                     if (ignore_unknown || remove_group)
+                         return -1; /* removal or ignore not allowed here -> syntax error */
+ 
+@@ -1347,15 +1347,17 @@ static int gid_cb(const char *elem, int len, void *arg)
+                            strlen(default_group_strings[i].group_string));
+                     restored_default_group_string[strlen(default_group_strings[i].group_string) +
+                                                   restored_prefix_index] = '\0';
+-                    /* We execute the recursive call */
+-                    garg->ignore_unknown_default = 1; /* We ignore unknown groups for DEFAULT_XYZ */
+-                    /* we enforce group mode (= append tuple) for DEFAULT_XYZ group lists */
+-                    garg->tuple_mode = 0;
+-                    /* We use the tuple_cb callback to process the pseudo group tuple */
++                    /*
++                     * Append first tuple of result to current tuple, and don't
++                     * terminate the last tuple until we return to a top-level
++                     * tuple_cb.
++                     */
++                    saved_first = garg->first;
++                    garg->inner = garg->first = 1;
+                     retval = CONF_parse_list(restored_default_group_string,
+-                                             TUPLE_DELIMITER_CHARACTER, 1, tuple_cb, garg);
+-                    garg->tuple_mode = 1; /* next call to tuple_cb will again start new tuple */
+-                    garg->ignore_unknown_default = 0; /* reset to original value */
++                        TUPLE_DELIMITER_CHARACTER, 1, tuple_cb, garg);
++                    garg->inner = 0;
++                    garg->first = saved_first;
+                     /* We don't need the \0-terminated string anymore */
+                     OPENSSL_free(restored_default_group_string);
+ 
+@@ -1375,9 +1377,6 @@ static int gid_cb(const char *elem, int len, void *arg)
+     if (len == 0)
+         return -1; /* Seems we have prefxes without a group name -> syntax error */
+ 
+-    if (garg->ignore_unknown_default == 1) /* Always ignore unknown groups for DEFAULT[_XYZ] */
+-        ignore_unknown = 1;
+-
+     /* Memory management in case more groups are present compared to initial allocation */
+     if (garg->gidcnt == garg->gidmax) {
+         uint16_t *tmp =
+@@ -1513,7 +1512,7 @@ static int gid_cb(const char *elem, int len, void *arg)
+         /* and update the book keeping for the number of groups in current tuple */
+         garg->tuplcnt_arr[garg->tplcnt]++;
+ 
+-        /* We memorize if needed that we want to add a key share for the current group */
++        /* We want to add a key share for the current group */
+         if (add_keyshare)
+             garg->ksid_arr[garg->ksidcnt++] = gid;
+     }
+@@ -1522,6 +1521,39 @@ done:
+     return retval;
+ }
+ 
++static int grow_tuples(gid_cb_st *garg)
++{
++    static size_t max_tplcnt = (~(size_t)0) / sizeof(size_t);
++
++    /* This uses OPENSSL_realloc_array() in newer releases */
++    if (garg->tplcnt == garg->tplmax) {
++        size_t newcnt = garg->tplmax + GROUPLIST_INCREMENT;
++        size_t newsz = newcnt * sizeof(size_t);
++        size_t *tmp;
++
++        if (newsz > max_tplcnt
++            || (tmp = OPENSSL_realloc(garg->tuplcnt_arr, newsz)) == NULL)
++            return 0;
++
++        garg->tplmax = newcnt;
++        garg->tuplcnt_arr = tmp;
++    }
++    return 1;
++}
++
++static int close_tuple(gid_cb_st *garg)
++{
++    size_t gidcnt = garg->tuplcnt_arr[garg->tplcnt];
++
++    if (gidcnt == 0)
++        return 1;
++    if (!grow_tuples(garg))
++        return 0;
++
++    garg->tuplcnt_arr[++garg->tplcnt] = 0;
++    return 1;
++}
++
+ /* Extract and process a tuple of groups */
+ static int tuple_cb(const char *tuple, int len, void *arg)
+ {
+@@ -1535,17 +1567,9 @@ static int tuple_cb(const char *tuple, int len, void *arg)
+         return 0;
+     }
+ 
+-    /* Memory management for tuples */
+-    if (garg->tplcnt == garg->tplmax) {
+-        size_t *tmp =
+-            OPENSSL_realloc(garg->tuplcnt_arr,
+-                            (garg->tplmax + GROUPLIST_INCREMENT) * sizeof(*garg->tuplcnt_arr));
+-
+-        if (tmp == NULL)
+-            return 0;
+-        garg->tplmax += GROUPLIST_INCREMENT;
+-        garg->tuplcnt_arr = tmp;
+-    }
++    if (garg->inner && !garg->first && !close_tuple(garg))
++        return 0;
++    garg->first = 0;
+ 
+     /* Convert to \0-terminated string */
+     restored_tuple_string = OPENSSL_malloc((len + 1 /* \0 */) * sizeof(char));
+@@ -1560,15 +1584,8 @@ static int tuple_cb(const char *tuple, int len, void *arg)
+     /* We don't need the \o-terminated string anymore */
+     OPENSSL_free(restored_tuple_string);
+ 
+-    if (garg->tuplcnt_arr[garg->tplcnt] > 0) { /* Some valid groups are present in current tuple... */
+-        if (garg->tuple_mode) {
+-            /* We 'close' the tuple */
+-            garg->tplcnt++;
+-            garg->tuplcnt_arr[garg->tplcnt] = 0; /* Next tuple is initialized to be empty */
+-            garg->tuple_mode = 1; /* next call will start a tuple (unless overridden in gid_cb) */
+-        }
+-    }
+-
++    if (!garg->inner && !close_tuple(garg))
++        return 0;
+     return retval;
+ }
+ 
+@@ -1599,8 +1616,6 @@ int tls1_set_groups_list(SSL_CTX *ctx,
+     }
+ 
+     memset(&gcb, 0, sizeof(gcb));
+-    gcb.tuple_mode = 1; /* We prepare to collect the first tuple */
+-    gcb.ignore_unknown_default = 0;
+     gcb.gidmax = GROUPLIST_INCREMENT;
+     gcb.tplmax = GROUPLIST_INCREMENT;
+     gcb.ksidmax = GROUPLIST_INCREMENT;
+diff --git a/test/tls13groupselection_test.c b/test/tls13groupselection_test.c
+index 351b3102c7..3c2814c54e 100644
+--- a/test/tls13groupselection_test.c
++++ b/test/tls13groupselection_test.c
+@@ -38,6 +38,12 @@ typedef enum SERVER_RESPONSE {
+     SH   = 2
+ } SERVER_RESPONSE;
+ 
++static const char *response_desc[] = {
++    "HRR",
++    "INIT",
++    "SH",
++};
++
+ static char *cert = NULL;
+ static char *privkey = NULL;
+ 
+@@ -348,7 +354,26 @@ static const struct tls13groupselection_test_st tls13groupselection_tests[] =
+           "X25519",
+           SERVER_PREFERENCE,
+           NEGOTIATION_FAILURE, INIT
+-        }
++        },
++        /* DEFAULT retains tuple structure */
++        { "*X25519:secp256r1",
++          "secp256r1:DEFAULT", /* test 44 */
++          SERVER_PREFERENCE,
++          "secp256r1", HRR
++        },
++#ifndef OPENSSL_NO_DH
++        { "*ffdhe2048:secp256r1",
++          "DEFAULT:ffdhe4096", /* test 45 */
++          CLIENT_PREFERENCE,
++          "secp256r1", HRR
++        },
++        { "x25519:ffdhe2048:*ffdhe4096",
++          "DEFAULT:ffdhe4096", /* test 46 */
++          SERVER_PREFERENCE,
++          "x25519",
++          HRR
++        },
++#endif
+     };
+ 
+ static void server_response_check_cb(int write_p, int version,
+@@ -492,15 +517,16 @@ static int test_groupnegotiation(const struct tls13groupselection_test_st *curre
+         group_name_client = SSL_group_to_name(clientssl, negotiated_group_client);
+         if (!TEST_int_eq(negotiated_group_client, negotiated_group_server))
+             goto end;
+-        if (!TEST_int_eq((int)current_test_vector->expected_server_response, (int)server_response))
++        if (!TEST_str_eq(response_desc[current_test_vector->expected_server_response],
++                response_desc[server_response]))
+             goto end;
+         if (TEST_str_eq(group_name_client, current_test_vector->expected_group))
+             ok = 1;
+     } else {
+         TEST_false_or_end(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE));
+-        if (test_type == TEST_NEGOTIATION_FAILURE &&
+-                !TEST_int_eq((int)current_test_vector->expected_server_response,
+-                             (int)server_response))
++        if (test_type == TEST_NEGOTIATION_FAILURE
++            && !TEST_str_eq(response_desc[current_test_vector->expected_server_response],
++                response_desc[server_response]))
+             goto end;
+         ok = 1;
+     }
+-- 
+2.53.0
+

--- a/specs/o/openssl/0074-CVE-2026-28387.patch
+++ b/specs/o/openssl/0074-CVE-2026-28387.patch
@@ -1,0 +1,33 @@
+From 444958deaf450aea819171f97ae69eaedede42c3 Mon Sep 17 00:00:00 2001
+From: Alexandr Nedvedicky <sashan@openssl.org>
+Date: Tue, 3 Mar 2026 13:23:46 +0100
+Subject: [PATCH] dane_match_cert() should X509_free() on ->mcert instead of
+ OPENSSL_free()
+
+Fixes: 170b735820ac "DANE support for X509_verify_cert()"
+
+Reviewed-by: Eugene Syromiatnikov <esyr@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+MergeDate: Thu Mar  5 12:37:17 2026
+(Merged from https://github.com/openssl/openssl/pull/30250)
+
+(cherry picked from commit 8b5cd6a682f0f6e7b8bf55137137c567d1899c4a)
+---
+ crypto/x509/x509_vfy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 8f1b9f58cacdb..01ce14982d6e0 100644
+--- a/crypto/x509/x509_vfy.c
++++ b/crypto/x509/x509_vfy.c
+@@ -3016,7 +3016,7 @@ static int dane_match_cert(X509_STORE_CTX *ctx, X509 *cert, int depth)
+                     break;
+                 }
+ 
+-                OPENSSL_free(dane->mcert);
++                X509_free(dane->mcert);
+                 dane->mcert = cert;
+                 dane->mdpth = depth;
+                 dane->mtlsa = t;

--- a/specs/o/openssl/0075-CVE-2026-28388.patch
+++ b/specs/o/openssl/0075-CVE-2026-28388.patch
@@ -1,0 +1,34 @@
+From d3a901e8d9f021f3e67d6cfbc12e768129862726 Mon Sep 17 00:00:00 2001
+From: Daniel Kubec <kubec@openssl.org>
+Date: Tue, 17 Mar 2026 11:11:22 +0100
+Subject: [PATCH] Fix NULL Dereference When Delta CRL Lacks CRL Number
+ Extension
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes CVE-2026-28388
+
+Co-authored-by: Igor Morgenstern <igor.morgenstern@aisle.com>
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.foundation>
+MergeDate: Mon Apr  6 19:27:16 2026
+(cherry picked from commit d6ad8595e86dc96ca8771f0a1714b31794befa75)
+---
+ crypto/x509/x509_vfy.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 01ce14982d6e0..d55141e014d84 100644
+--- a/crypto/x509/x509_vfy.c
++++ b/crypto/x509/x509_vfy.c
+@@ -1308,6 +1308,8 @@ static int check_delta_base(X509_CRL *delta, X509_CRL *base)
+     if (ASN1_INTEGER_cmp(delta->base_crl_number, base->crl_number) > 0)
+         return 0;
+     /* Delta CRL number must exceed full CRL number */
++    if (delta->crl_number == NULL)
++        return 0;
+     return ASN1_INTEGER_cmp(delta->crl_number, base->crl_number) > 0;
+ }
+ 

--- a/specs/o/openssl/0076-CVE-2026-28389.patch
+++ b/specs/o/openssl/0076-CVE-2026-28389.patch
@@ -1,0 +1,111 @@
+From c30b9a4b6e3f3b6377c02964a936352f9e206a20 Mon Sep 17 00:00:00 2001
+From: Neil Horman <nhorman@openssl.org>
+Date: Mon, 16 Mar 2026 13:49:07 -0400
+Subject: [PATCH] Fix NULL deref in [ec]dh_cms_set_shared_info
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Multiple independent reports indicated a SIGSEGV was possible in CMS
+processing when a crafted CMS EnvelopedData message using A Key
+Agreement Recipient Info field.  If the
+KeyEncryptionAlgorithmIdentifier omits the optional parameter field, the
+referenced functions above will attempt to dereference the
+alg->parameter data prior to checking if the parameter field is NULL.
+
+Confirmed to resolve the issues using the reproducers provided in the
+security reports.
+
+Co-authored-by: Tomas Mraz <tomas@openssl.foundation>
+
+Fixes CVE-2026-28389
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
+MergeDate: Mon Apr  6 19:07:41 2026
+---
+ crypto/cms/cms_dh.c | 13 +++++++++----
+ crypto/cms/cms_ec.c | 14 ++++++++++----
+ 2 files changed, 19 insertions(+), 8 deletions(-)
+
+diff --git a/crypto/cms/cms_dh.c b/crypto/cms/cms_dh.c
+index b49e5f7f53..9b19e675da 100644
+--- a/crypto/cms/cms_dh.c
++++ b/crypto/cms/cms_dh.c
+@@ -89,16 +89,21 @@ static int dh_cms_set_shared_info(EVP_PKEY_CTX *pctx, CMS_RecipientInfo *ri)
+     int keylen, plen;
+     EVP_CIPHER *kekcipher = NULL;
+     EVP_CIPHER_CTX *kekctx;
++    const ASN1_OBJECT *aoid;
++    const void *parameter = NULL;
++    int ptype = 0;
+     char name[OSSL_MAX_NAME_SIZE];
+ 
+     if (!CMS_RecipientInfo_kari_get0_alg(ri, &alg, &ukm))
+         goto err;
+ 
++    X509_ALGOR_get0(&aoid, &ptype, &parameter, alg);
++
+     /*
+      * For DH we only have one OID permissible. If ever any more get defined
+      * we will need something cleverer.
+      */
+-    if (OBJ_obj2nid(alg->algorithm) != NID_id_smime_alg_ESDH) {
++    if (OBJ_obj2nid(aoid) != NID_id_smime_alg_ESDH) {
+         ERR_raise(ERR_LIB_CMS, CMS_R_KDF_PARAMETER_ERROR);
+         goto err;
+     }
+@@ -107,11 +112,11 @@ static int dh_cms_set_shared_info(EVP_PKEY_CTX *pctx, CMS_RecipientInfo *ri)
+             || EVP_PKEY_CTX_set_dh_kdf_md(pctx, EVP_sha1()) <= 0)
+         goto err;
+ 
+-    if (alg->parameter->type != V_ASN1_SEQUENCE)
++    if (ptype != V_ASN1_SEQUENCE)
+         goto err;
+ 
+-    p = alg->parameter->value.sequence->data;
+-    plen = alg->parameter->value.sequence->length;
++    p = ASN1_STRING_get0_data(parameter);
++    plen = ASN1_STRING_length(parameter);
+     kekalg = d2i_X509_ALGOR(NULL, &p, plen);
+     if (kekalg == NULL)
+         goto err;
+diff --git a/crypto/cms/cms_ec.c b/crypto/cms/cms_ec.c
+index 6e9962ed6e..07456dcaa1 100644
+--- a/crypto/cms/cms_ec.c
++++ b/crypto/cms/cms_ec.c
+@@ -166,21 +166,27 @@ static int ecdh_cms_set_shared_info(EVP_PKEY_CTX *pctx, CMS_RecipientInfo *ri)
+     int plen, keylen;
+     EVP_CIPHER *kekcipher = NULL;
+     EVP_CIPHER_CTX *kekctx;
++    const ASN1_OBJECT *aoid = NULL;
++    int ptype = 0;
++    const void *parameter = NULL;
++
+     char name[OSSL_MAX_NAME_SIZE];
+ 
+     if (!CMS_RecipientInfo_kari_get0_alg(ri, &alg, &ukm))
+         return 0;
+ 
+-    if (!ecdh_cms_set_kdf_param(pctx, OBJ_obj2nid(alg->algorithm))) {
++    X509_ALGOR_get0(&aoid, &ptype, &parameter, alg);
++
++    if (!ecdh_cms_set_kdf_param(pctx, OBJ_obj2nid(aoid))) {
+         ERR_raise(ERR_LIB_CMS, CMS_R_KDF_PARAMETER_ERROR);
+         return 0;
+     }
+ 
+-    if (alg->parameter->type != V_ASN1_SEQUENCE)
++    if (ptype != V_ASN1_SEQUENCE)
+         return 0;
+ 
+-    p = alg->parameter->value.sequence->data;
+-    plen = alg->parameter->value.sequence->length;
++    p = ASN1_STRING_get0_data(parameter);
++    plen = ASN1_STRING_length(parameter);
+     kekalg = d2i_X509_ALGOR(NULL, &p, plen);
+     if (kekalg == NULL)
+         goto err;
+-- 
+2.53.0
+

--- a/specs/o/openssl/0077-CVE-2026-28390.patch
+++ b/specs/o/openssl/0077-CVE-2026-28390.patch
@@ -1,0 +1,93 @@
+From 6ee9a73e9f489faa546f09cfbf9c63c8f8798445 Mon Sep 17 00:00:00 2001
+From: Neil Horman <nhorman@openssl.org>
+Date: Wed, 1 Apr 2026 10:56:44 +0200
+Subject: [PATCH] Fix NULL deref in rsa_cms_decrypt
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Very simmilar to CVE-2026-28389, ensure that if we are missing
+parameters in RSA-OAEP SourceFunc in CMS KeyTransportRecipientInfo,
+we don't segfault when decrypting.
+
+Co-authored-by: Tomas Mraz <tomas@openssl.foundation>
+
+Fixes CVE-2026-28390
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
+MergeDate: Mon Apr  6 19:07:44 2026
+---
+ crypto/cms/cms_rsa.c | 31 +++++++++++++++++++------------
+ 1 file changed, 19 insertions(+), 12 deletions(-)
+
+diff --git a/crypto/cms/cms_rsa.c b/crypto/cms/cms_rsa.c
+index f132df5c8a..a1e26d3c3d 100644
+--- a/crypto/cms/cms_rsa.c
++++ b/crypto/cms/cms_rsa.c
+@@ -42,10 +42,13 @@ static int rsa_cms_decrypt(CMS_RecipientInfo *ri)
+     X509_ALGOR *cmsalg;
+     int nid;
+     int rv = -1;
+-    unsigned char *label = NULL;
++    const unsigned char *label = NULL;
+     int labellen = 0;
+     const EVP_MD *mgf1md = NULL, *md = NULL;
+     RSA_OAEP_PARAMS *oaep;
++    const ASN1_OBJECT *aoid;
++    const void *parameter = NULL;
++    int ptype = 0;
+ 
+     pkctx = CMS_RecipientInfo_get0_pkey_ctx(ri);
+     if (pkctx == NULL)
+@@ -75,21 +78,19 @@ static int rsa_cms_decrypt(CMS_RecipientInfo *ri)
+         goto err;
+ 
+     if (oaep->pSourceFunc != NULL) {
+-        X509_ALGOR *plab = oaep->pSourceFunc;
++        X509_ALGOR_get0(&aoid, &ptype, &parameter, oaep->pSourceFunc);
+ 
+-        if (OBJ_obj2nid(plab->algorithm) != NID_pSpecified) {
++        if (OBJ_obj2nid(aoid) != NID_pSpecified) {
+             ERR_raise(ERR_LIB_CMS, CMS_R_UNSUPPORTED_LABEL_SOURCE);
+             goto err;
+         }
+-        if (plab->parameter->type != V_ASN1_OCTET_STRING) {
++        if (ptype != V_ASN1_OCTET_STRING) {
+             ERR_raise(ERR_LIB_CMS, CMS_R_INVALID_LABEL);
+             goto err;
+         }
+ 
+-        label = plab->parameter->value.octet_string->data;
+-        /* Stop label being freed when OAEP parameters are freed */
+-        plab->parameter->value.octet_string->data = NULL;
+-        labellen = plab->parameter->value.octet_string->length;
++        label = ASN1_STRING_get0_data(parameter);
++        labellen = ASN1_STRING_length(parameter);
+     }
+ 
+     if (EVP_PKEY_CTX_set_rsa_padding(pkctx, RSA_PKCS1_OAEP_PADDING) <= 0)
+@@ -98,10 +99,16 @@ static int rsa_cms_decrypt(CMS_RecipientInfo *ri)
+         goto err;
+     if (EVP_PKEY_CTX_set_rsa_mgf1_md(pkctx, mgf1md) <= 0)
+         goto err;
+-    if (label != NULL
+-            && EVP_PKEY_CTX_set0_rsa_oaep_label(pkctx, label, labellen) <= 0) {
+-        OPENSSL_free(label);
+-        goto err;
++    if (label != NULL) {
++        unsigned char *dup_label = OPENSSL_memdup(label, labellen);
++
++        if (dup_label == NULL)
++            goto err;
++
++        if (EVP_PKEY_CTX_set0_rsa_oaep_label(pkctx, dup_label, labellen) <= 0) {
++            OPENSSL_free(dup_label);
++            goto err;
++        }
+     }
+     /* Carry on */
+     rv = 1;
+-- 
+2.53.0
+

--- a/specs/o/openssl/0078-CVE-2026-31789.patch
+++ b/specs/o/openssl/0078-CVE-2026-31789.patch
@@ -1,0 +1,49 @@
+From 945b935ac66cc7f1a41f1b849c7c25adb5351f49 Mon Sep 17 00:00:00 2001
+From: Igor Ustinov <igus68@gmail.com>
+Date: Thu, 5 Mar 2026 15:47:34 +0100
+Subject: [PATCH] Avoid possible buffer overflow in buf2hex conversion
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes CVE-2026-31789
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.foundation>
+MergeDate: Mon Apr  6 19:39:23 2026
+(cherry picked from commit 3244aa4b9d6ea0220cc14fd97d951c67b5052837)
+---
+ crypto/o_str.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/o_str.c b/crypto/o_str.c
+index 35540630be25f..9b9e7751fdd9e 100644
+--- a/crypto/o_str.c
++++ b/crypto/o_str.c
+@@ -296,6 +296,11 @@ static int buf2hexstr_sep(char *str, size_t str_n, size_t *strlength,
+     int has_sep = (sep != CH_ZERO);
+     size_t i, len = has_sep ? buflen * 3 : 1 + buflen * 2;
+ 
++    if (buflen > (has_sep ? SIZE_MAX / 3 : (SIZE_MAX - 1) / 2)) {
++        ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_TOO_MANY_BYTES);
++        return 0;
++    }
++
+     if (len == 0)
+         ++len;
+     if (strlength != NULL)
+@@ -339,7 +344,13 @@ char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep)
+     if (buflen == 0)
+         return OPENSSL_zalloc(1);
+ 
+-    tmp_n = (sep != CH_ZERO) ? buflen * 3 : 1 + buflen * 2;
++    if ((sep != CH_ZERO && (size_t)buflen > SIZE_MAX / 3)
++        || (sep == CH_ZERO && (size_t)buflen > (SIZE_MAX - 1) / 2)) {
++        ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_TOO_MANY_BYTES);
++        return NULL;
++    }
++
++    tmp_n = (sep != CH_ZERO) ? (size_t)buflen * 3 : 1 + (size_t)buflen * 2;
+     if ((tmp = OPENSSL_malloc(tmp_n)) == NULL)
+         return NULL;
+ 

--- a/specs/o/openssl/0079-CVE-2026-31790.patch
+++ b/specs/o/openssl/0079-CVE-2026-31790.patch
@@ -1,0 +1,63 @@
+From 001e01db3e996e13ffc72386fe79d03a6683b5ac Mon Sep 17 00:00:00 2001
+From: Nikola Pajkovsky <nikolap@openssl.org>
+Date: Thu, 19 Mar 2026 12:16:08 +0100
+Subject: [PATCH] rsa_kem: validate RSA_public_encrypt() result in RSASVE
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+RSA_public_encrypt() returns the number of bytes written on success and
+-1 on failure. With the existing `if (ret)` check, a provider-side RSA KEM
+encapsulation can incorrectly succeed when the underlying RSA public
+encrypt operation fails. In that case the code reports success, returns
+lengths as if encapsulation completed normally, and leaves the freshly
+generated secret available instead of discarding it.
+
+Tighten the success condition so RSASVE only succeeds when
+RSA_public_encrypt() returns a positive value equal to the modulus-sized
+output expected for RSA_NO_PADDING. Any other return value is treated as
+failure, and the generated secret is cleansed before returning.
+
+Fixes CVE-2026-31790
+Signed-off-by: Nikola Pajkovsky <nikolap@openssl.org>
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.foundation>
+MergeDate: Mon Apr  6 19:51:30 2026
+---
+ providers/implementations/kem/rsa_kem.c | 20 +++++++++++---------
+ 1 file changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/providers/implementations/kem/rsa_kem.c b/providers/implementations/kem/rsa_kem.c
+index f7bf368a0dfc7..74dfafddd9e06 100644
+--- a/providers/implementations/kem/rsa_kem.c
++++ b/providers/implementations/kem/rsa_kem.c
+@@ -316,17 +316,19 @@ static int rsasve_generate(PROV_RSA_CTX *prsactx,
+         return 0;
+ 
+     /* Step(3): out = RSAEP((n,e), z) */
+-    ret = RSA_public_encrypt(nlen, secret, out, prsactx->rsa, RSA_NO_PADDING);
+-    if (ret) {
+-        ret = 1;
+-        if (outlen != NULL)
+-            *outlen = nlen;
+-        if (secretlen != NULL)
+-            *secretlen = nlen;
+-    } else {
++    ret = RSA_public_encrypt((int)nlen, secret, out, prsactx->rsa,
++        RSA_NO_PADDING);
++    if (ret <= 0 || ret != (int)nlen) {
+         OPENSSL_cleanse(secret, nlen);
++        return 0;
+     }
+-    return ret;
++
++    if (outlen != NULL)
++        *outlen = nlen;
++    if (secretlen != NULL)
++        *secretlen = nlen;
++
++    return 1;
+ }
+ 
+ /**

--- a/specs/o/openssl/openssl.spec
+++ b/specs/o/openssl/openssl.spec
@@ -37,7 +37,7 @@ print(string.sub(hash, 0, 16))
 Summary: Utilities from the general purpose cryptography library with TLS implementation
 Name: openssl
 Version: 3.5.4
-Release: 4%{?dist}
+Release: 6%{?dist}
 Epoch: 1
 Source0: openssl-%{version}.tar.gz
 Source1: fips-hmacify.sh
@@ -120,6 +120,13 @@ Patch0069: 0069-CVE-2026-22795.patch
 Patch0070: 0070-CVE-2025-11187.patch
 Patch0071: 0071-Do-not-make-key-share-choice-in-tls1_set_groups.patch
 Patch0072: 0072-Fix-PPC-register-processing.patch
+Patch0073: 0073-CVE-2026-2673.patch
+Patch0074: 0074-CVE-2026-28387.patch
+Patch0075: 0075-CVE-2026-28388.patch
+Patch0076: 0076-CVE-2026-28389.patch
+Patch0077: 0077-CVE-2026-28390.patch
+Patch0078: 0078-CVE-2026-31789.patch
+Patch0079: 0079-CVE-2026-31790.patch
 
 
 License: Apache-2.0
@@ -492,6 +499,16 @@ ln -s /etc/crypto-policies/back-ends/openssl_fips.config $RPM_BUILD_ROOT%{_sysco
 %ldconfig_scriptlets libs
 
 %changelog
+* Mon Apr 20 2026 Pavol Žáčik <pzacik@redhat.com> - 1:3.5.4-3
+- Backport security patches from OpenSSL 3.5.6
+  Resolves: CVE-2026-2673
+  Resolves: CVE-2026-28387
+  Resolves: CVE-2026-28388
+  Resolves: CVE-2026-28389
+  Resolves: CVE-2026-28390
+  Resolves: CVE-2026-31789
+  Resolves: CVE-2026-31790
+
 * Tue Jan 27 2026 Dmitry Belyavskiy <dbelyavs@redhat.com> - 1:3.5.4-2
 - Resolves: CVE-2025-15467
 - Resolves: CVE-2025-15468


### PR DESCRIPTION
Pin openssl to Fedora f43 openssl-3.5.4-3 (commit 0990e54a) which backports security patches 0073-0079 from OpenSSL 3.5.6:

- **Critical:** CVE-2026-31789
- **High:** CVE-2026-28387, CVE-2026-31790, CVE-2026-2673, CVE-2026-28390, CVE-2026-28389, CVE-2026-28388

Fixes [AB#19971](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19971)