### PR TITLE
fix(gstreamer1-plugins-bad-free): drop openh264 subpackage

### DIFF
--- a/base/comps/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.comp.toml
+++ b/base/comps/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.comp.toml
@@ -8,8 +8,11 @@
 # -zbar subpackages. The dc1394 and onnx plugins are built independently
 # (their bconds default ON on Fedora) but only packaged inside %files
 # extras, so we must disable them too to avoid "unpackaged file" failures.
+# AZL does not ship openh264. Set openh264 bcond off to prevent building
+# gstreamer1-plugin-openh264 subpackage.
+
 [components.gstreamer1-plugins-bad-free]
-build.without = ["extras", "dc1394", "onnx"]
+build.without = ["extras", "dc1394", "onnx", "openh264"]
 
 # AZL does not ship opus — disable the opus parse plugin and remove its BR.
 

--- a/locks/gstreamer1-plugins-bad-free.lock
+++ b/locks/gstreamer1-plugins-bad-free.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'b5597ad939bb024c2ab32ef8cf17e2ba2b86ebe5'
 upstream-commit = 'b5597ad939bb024c2ab32ef8cf17e2ba2b86ebe5'
-input-fingerprint = 'sha256:7230b4ce8b1da8a96ee66bafede2e036a76d733c3b4214012352c903c013f058'
+input-fingerprint = 'sha256:740487c359da4297d4f7dd7ae104f79fb9f6f41697e83588fffac023cdb245c9'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.azl.macros
+++ b/specs/g/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.azl.macros
@@ -3,3 +3,4 @@
 %_without_dc1394 1
 %_without_extras 1
 %_without_onnx 1
+%_without_openh264 1

--- a/specs/g/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.spec
+++ b/specs/g/gstreamer1-plugins-bad-free/gstreamer1-plugins-bad-free.spec
@@ -36,7 +36,7 @@
 
 Name:           gstreamer1-plugins-bad-free
 Version:        1.26.10
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary:        GStreamer streaming media framework "bad" plugins
 
 # Automatically converted from old format: LGPLv2+ and LGPLv2 - review is highly recommended.


### PR DESCRIPTION
## Summary

AZL does not ship openh264. Force the `openh264` bcond off via a spec-search-replace overlay so the `gstreamer1-plugin-openh264` subpackage is not built.

## Changes

- Add overlay: `%bcond openh264 %{defined fedora}` → `%bcond openh264 0`
- All openh264 code is already guarded by `%if %{with openh264}` — no other changes needed

## Testing

- Built successfully — no `gstreamer1-plugin-openh264` subpackage in output
- Smoke-tested in mock: RPMs install, no openh264 files, `gst-inspect-1.0 --version` works