### PR TITLE
chore: remove reference to removed component

### DIFF
--- a/base/comps/components-publish-channels.toml
+++ b/base/comps/components-publish-channels.toml
@@ -733,7 +733,6 @@ components = [
     "koji-containerbuild",
     "koji-image-builder",
     "koji-osbuild",
-    "koji-tool",
     "krb5",
     "kronosnet",
     "ksc",


### PR DESCRIPTION
koji-tool was previously removed in commit 3243fffb9852a39905e2923572fa851adb819308, but ended up in a component group. At present this is ignored quietly, but we'd like to start turning on validation that would block this.