### PR TITLE
refactor: adjust azurelinux macro (major version only)

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -373,7 +373,7 @@ cat >> %{buildroot}%{_rpmconfigdir}/macros.d/macros.dist << EOF
 # dist macros.
 
 %%__bootstrap         ~bootstrap
-%%azurelinux          %{dist_version}
+%%azurelinux          %{dist_version_major}
 %%azl4                1
 %%fedora              %{upstream_fedora_version}
 %%distcore            .azl%{dist_version_major}
@@ -476,6 +476,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Thu May 14 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-17
+- Redefine azurelinux macro as major version.
+
 * Tue May 12 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-16
 - Add 50-permit-root-login.conf to explicitly set PermitRootLogin no
 

--- a/base/comps/openssl/openssl.comp.toml
+++ b/base/comps/openssl/openssl.comp.toml
@@ -5,20 +5,21 @@
 # Fedora commit: https://src.fedoraproject.org/rpms/openssl/c/0990e54a2f6b6b8e4f3e238175382505fff8be51
 spec = { type = "upstream", upstream-commit = "0990e54a2f6b6b8e4f3e238175382505fff8be51" }
 
-# AZL4 does not ship fips.so. Extend the existing RHEL fips.so-deletion
-# path to cover AZL4 so the module and its config are excluded from the package.
+# Azure Linux does not ship fips.so. Extend the existing RHEL fips.so-deletion
+# path to cover Azure Linux so the module and its config are excluded from the
+# package.
 [[components.openssl.overlays]]
 type = "spec-search-replace"
 regex = '%if \( %\{defined rhel\} && \(! %\{defined centos\}\) && \(! %\{defined eln\}\) \)'
-replacement = '%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || 0%{?azl4}'
-description = "Remove fips.so from openssl on AZL4 (not supported for public preview)"
+replacement = '%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || %{defined azurelinux}'
+description = "Remove fips.so from openssl on Azure Linux (not supported for public preview)"
 
 # The above replacement also hits the Requires: openssl-fips-provider guard.
-# Suppress that dependency on AZL4 — openssl-fips-provider is not shipped for
-# public preview.
+# Suppress that dependency on Azure Linux — openssl-fips-provider is not
+# shipped for public preview.
 [[components.openssl.overlays]]
 type = "spec-remove-tag"
 tag = "Requires"
 value = "openssl-fips-provider"
 package = "libs"
-description = "Don't require openssl-fips-provider on AZL4"
+description = "Don't require openssl-fips-provider on Azure Linux"

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:77dbc8826997e5ae080299968a4fec582eb39ae26f6933c7516714d26be32753'
+input-fingerprint = 'sha256:124623b2ce048aa85c9d4af46ea9f151155be5cb62cdf4c8814c82af8c0064f7'

--- a/locks/openssl.lock
+++ b/locks/openssl.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '8e2fde9ae8b83393b6d58c62492106751e52a696'
 upstream-commit = '0990e54a2f6b6b8e4f3e238175382505fff8be51'
-input-fingerprint = 'sha256:e32077b5155981d98a2f48e92da88f8ef676ab311ffc3dc5dbabf8eea97a67c6'
+input-fingerprint = 'sha256:c3005ddb1be362e7d6627f19ba5a93f57b88525a0acd2ae2f560d208a0a00588'
 resolution-input-hash = 'sha256:888b19e73f615d9932deea30309a22436c3d0f059c9f14437204e2e1887dc692'

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -376,7 +376,7 @@ cat >> %{buildroot}%{_rpmconfigdir}/macros.d/macros.dist << EOF
 # dist macros.
 
 %%__bootstrap         ~bootstrap
-%%azurelinux          %{dist_version}
+%%azurelinux          %{dist_version_major}
 %%azl4                1
 %%fedora              %{upstream_fedora_version}
 %%distcore            .azl%{dist_version_major}
@@ -479,6 +479,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Thu May 14 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-17
+- Redefine azurelinux macro as major version.
+
 * Tue May 12 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-16
 - Add 50-permit-root-login.conf to explicitly set PermitRootLogin no
 

--- a/specs/o/openssl/openssl.spec
+++ b/specs/o/openssl/openssl.spec
@@ -37,7 +37,7 @@ print(string.sub(hash, 0, 16))
 Summary: Utilities from the general purpose cryptography library with TLS implementation
 Name: openssl
 Version: 3.5.4
-Release: 6%{?dist}
+Release: 7%{?dist}
 Epoch: 1
 Source0: openssl-%{version}.tar.gz
 Source1: fips-hmacify.sh
@@ -98,7 +98,7 @@ Patch0049: 0049-FIPS-fix-disallowed-digests-tests.patch
 Patch0050: 0050-Make-openssl-speed-run-in-FIPS-mode.patch
 Patch0051: 0051-Backport-upstream-27483-for-PKCS11-needs.patch
 Patch0052: 0052-Red-Hat-9-FIPS-indicator-defines.patch
-%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || 0%{?azl4}
+%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || %{defined azurelinux}
 Patch0053: 0053-Allow-hybrid-MLKEM-in-FIPS-mode.patch
 %endif
 Patch0054: 0054-Temporarily-disable-SLH-DSA-FIPS-self-tests.patch
@@ -158,7 +158,7 @@ Summary: A general purpose cryptography library with TLS implementation
 Requires: ca-certificates >= 2008-5
 Requires: crypto-policies >= 20180730
 Recommends: pkcs11-provider%{?_isa}
-%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || 0%{?azl4}
+%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || %{defined azurelinux}
 %endif
 
 %description libs
@@ -342,7 +342,7 @@ make test HARNESS_JOBS=8
 # Add generation of HMAC checksum of the final stripped library
 # We manually copy standard definition of __spec_install_post
 # and add hmac calculation/embedding to fips.so
-%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || 0%{?azl4}
+%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || %{defined azurelinux}
 %define __spec_install_post \
     rm -rf $RPM_BUILD_ROOT/%{_libdir}/ossl-modules/fips.so \
     %{?__debug_package:%{__debug_install_post}} \


### PR DESCRIPTION
For consistency with other distros' macros, we:

* Change the definition of the azurelinux macro only to include major version (i.e. 4).
* Remove the azl4 macro; we should use the azurelinux macro instead.

A compensating change is made to openssl.

--
Fixes: [AB#19815](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19815)