### PR TITLE
chore(bash): pin from rawhide to Fedora 44

### DIFF
--- a/base/comps/bash/bash.comp.toml
+++ b/base/comps/bash/bash.comp.toml
@@ -1,3 +1,4 @@
 [components.bash]
-# Need build fixes in rawhide
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "rawhide" } }
+# Pin to Fedora 44 dist-git head as of the AZL4 Public Preview cutoff.
+# F44 carries the build fixes we needed from rawhide; F43 does not.
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "44" }, upstream-commit = "a6bcc6767229199f4f02b781d1d39df0835d894b" }

--- a/locks/bash.lock
+++ b/locks/bash.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'a6bcc6767229199f4f02b781d1d39df0835d894b'
 upstream-commit = 'a6bcc6767229199f4f02b781d1d39df0835d894b'
-input-fingerprint = 'sha256:5da42a1ba96b29d4b926fac6c9689f10d74dc8c23b713d5f5c7bad47d53a4428'
-resolution-input-hash = 'sha256:7e5cd346f3310fd2d008e0c6be719cc36a2f15e36de889eb223aa254029a877f'
+input-fingerprint = 'sha256:8fb9363e5d04eb2b8085d3b1b7a0d45a89a8fc57f2b6d6d84750b5672145a278'
+resolution-input-hash = 'sha256:ef62403ea2e7c722631124b96c620ff6da2f4a997d8dd81d6d1a52454f74b1b2'

--- a/specs/b/bash/bash.spec
+++ b/specs/b/bash/bash.spec
@@ -9,7 +9,7 @@
 Version: %{baseversion}.%{patchlevel}
 Name: bash
 Summary: The GNU Bourne Again shell
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: GPL-3.0-or-later
 Url: https://www.gnu.org/software/bash
 Source0: https://ftp.gnu.org/gnu/bash/bash-%{baseversion}.tar.gz


### PR DESCRIPTION
bash was temporarily pinned to Fedora rawhide for build fixes that hadn't yet propagated to a stable Fedora branch. Those fixes are now available in Fedora 44 dist-git, so move the pin from the rawhide branch to the f44 branch and lock to an explicit upstream commit ('a6bcc67…') for deterministic resolution.

This keeps the dedicated bash.comp.toml in place so the description field can carry the rationale for the pin, and so the explicit upstream-commit travels with the package rather than the lock alone.

The resulting RPM is bash-5.3.9-5.azl4 (vs. -4.azl4 previously) — the upstream commit is unchanged, only the AZL Release counter bumps from the lock-fingerprint change.

Fixes: [AB#19413](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19413)