### PR TITLE
Resolved `ptests` failure in `openvswitch` package

### DIFF
--- a/SPECS/openvswitch/openvswitch.spec
+++ b/SPECS/openvswitch/openvswitch.spec
@@ -20,7 +20,7 @@
 Summary:           Open vSwitch daemon/database/utilities
 Name:              openvswitch
 Version:           3.3.0
-Release:           3%{?dist}
+Release:           4%{?dist}
 License:           ASL 2.0 AND LGPLv2+ AND SISSL
 Vendor:            Microsoft Corporation
 Distribution:      Azure Linux
@@ -305,12 +305,17 @@ pushd $dir
 %if %{with check}
     touch resolv.conf
     export OVS_RESOLV_CONF=$(pwd)/resolv.conf
-    if make check TESTSUITEFLAGS='%{_smp_mflags}' ||
-       make check TESTSUITEFLAGS='--recheck' ||
-       make check TESTSUITEFLAGS='--recheck'; then :;
+    # Fast first pass; on retry raise OVS_CTL_TIMEOUT so timing-sensitive
+    # tests (notably PMD Auto Load Balance) tolerate CPU contention on CI.
+    if make check TESTSUITEFLAGS='%{_smp_mflags}'; then :;
     else
-        cat tests/testsuite.log
-        exit 1
+        export OVS_CTL_TIMEOUT=120
+        if make check TESTSUITEFLAGS='--recheck' ||
+           make check TESTSUITEFLAGS='--recheck'; then :;
+        else
+            cat tests/testsuite.log
+            exit 1
+        fi
     fi
 %endif
 %if %{with check_datapath_kernel}
@@ -506,6 +511,9 @@ fi
 %{_sysusersdir}/openvswitch.conf
 
 %changelog
+* Fri May 15 2026 Sumit Jena <sumitjena@microsoft.com> - 3.3.0-4
+- Make %check more tolerant to CI timing jitter.
+
 * Fri May 15 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 3.3.0-3
 - Patch for CVE-2026-34956
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
In the CI, 3 PMD Auto-Load-Balance tests (`alb.at:52/95/141`) fail on every retry: they advance simulated time via `ovs-appctl time/warp` and then wait 10s for the dummy-pmd thread to react. Locally the thread wakes in time (free CPU); in pipeline (2–4 vCPU, contended) it misses the deadline. Pure environmental flake, no upstream fix on any OVS branch. Proposed fix: bump `OVS_CTL_TIMEOUT=120` on the recheck path in the spec — keeps full test coverage, no source patch.
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/openvswitch/openvswitch.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1118877&view=results
