### PR TITLE
fix(curl): pin-forward to f43 for 5 CVEs

### DIFF
--- a/base/comps/curl/curl.comp.toml
+++ b/base/comps/curl/curl.comp.toml
@@ -1,4 +1,5 @@
 [components.curl]
+spec = { type = "upstream", upstream-commit = "1538b200c175eeb234abb749c0246c11ebc4f0d1" }
 
 [[components.curl.overlays]]
 description = "Drop python3-impacket BuildRequires (only used by Fedora-gated upstream test 1451; python-impacket is not packaged for Azure Linux due to RPM-signing issues)"

--- a/locks/curl.lock
+++ b/locks/curl.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '0e4af6147551051527b731925d55c37b164260d5'
-upstream-commit = '0e4af6147551051527b731925d55c37b164260d5'
-input-fingerprint = 'sha256:e12a3388d48de45bc572148ab3264d55cb991514bb820e37eada4fc3ee220650'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '1538b200c175eeb234abb749c0246c11ebc4f0d1'
+input-fingerprint = 'sha256:098b889aedbc59069630329662dc9b29a7216448156589a99c32e60e69421fa7'
+resolution-input-hash = 'sha256:d62815b3b1a73972e2bfd9d5d75c0c8f9270af57b76c2425aacd652b9a459f09'

--- a/specs/c/curl/0003-curl-8.15.0-CVE-2026-1965.patch
+++ b/specs/c/curl/0003-curl-8.15.0-CVE-2026-1965.patch
@@ -1,0 +1,166 @@
+From 3dcb1b4ea3505ac7368843feb0401d9b1076465c Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 5 Feb 2026 08:34:21 +0100
+Subject: [PATCH 1/4] CVE-2026-1965
+
+url: fix reuse of connections using HTTP Negotiate
+
+Assume Negotiate means connection-based
+
+Reported-by: Zhicheng Chen
+Closes #20534
+
+(cherry picked from commit 34fa034d9a390c4bd65e2d05262755ec8646ac12)
+
+sws: prevent "connection monitor" to say disconnect twice
+
+(cherry picked from commit 510fdad64df7f91f605b19ffdb0c4c67891f1518)
+
+url: fix copy and paste url_match_auth_nego mistake
+
+Follow-up to 34fa034
+Reported-by: dahmono on github
+Closes #20662
+
+(cherry picked from commit f1a39f221d57354990e3eeeddc3404aede2aff70)
+---
+ lib/url.c          | 87 +++++++++++++++++++++++++++++++++++++++++++---
+ tests/server/sws.c |  1 +
+ 2 files changed, 83 insertions(+), 5 deletions(-)
+
+diff --git a/lib/url.c b/lib/url.c
+index e4f250f54a..9d109f2005 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -820,6 +820,8 @@ struct url_conn_match {
+   BIT(may_multiplex);
+   BIT(want_ntlm_http);
+   BIT(want_proxy_ntlm_http);
++  BIT(want_nego_http);
++  BIT(want_proxy_nego_http);
+ 
+   BIT(wait_pipe);
+   BIT(force_reuse);
+@@ -1242,6 +1244,63 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
+ #define url_match_auth_ntlm(c,m)    ((void)c, (void)m, TRUE)
+ #endif
+ 
++#ifdef USE_SPNEGO
++static bool url_match_auth_nego(struct connectdata *conn,
++                                struct url_conn_match *m)
++{
++  /* If we are looking for an HTTP+Negotiate connection, check if this is
++     already authenticating with the right credentials. If not, keep looking
++     so that we can reuse Negotiate connections if possible. */
++  if(m->want_nego_http) {
++    if(Curl_timestrcmp(m->needle->user, conn->user) ||
++       Curl_timestrcmp(m->needle->passwd, conn->passwd))
++      return FALSE;
++  }
++  else if(conn->http_negotiate_state != GSS_AUTHNONE) {
++    /* Connection is using Negotiate auth but we do not want Negotiate */
++    return FALSE;
++  }
++
++#ifndef CURL_DISABLE_PROXY
++  /* Same for Proxy Negotiate authentication */
++  if(m->want_proxy_nego_http) {
++    /* Both conn->http_proxy.user and conn->http_proxy.passwd can be
++     * NULL */
++    if(!conn->http_proxy.user || !conn->http_proxy.passwd)
++      return FALSE;
++
++    if(Curl_timestrcmp(m->needle->http_proxy.user,
++                       conn->http_proxy.user) ||
++       Curl_timestrcmp(m->needle->http_proxy.passwd,
++                       conn->http_proxy.passwd))
++      return FALSE;
++  }
++  else if(conn->proxy_negotiate_state != GSS_AUTHNONE) {
++    /* Proxy connection is using Negotiate auth but we do not want Negotiate */
++    return FALSE;
++  }
++#endif
++  if(m->want_nego_http || m->want_proxy_nego_http) {
++    /* Credentials are already checked, we may use this connection. We MUST
++     * use a connection where it has already been fully negotiated. If it has
++     * not, we keep on looking for a better one. */
++    m->found = conn;
++    if((m->want_nego_http &&
++        (conn->http_negotiate_state != GSS_AUTHNONE)) ||
++       (m->want_proxy_nego_http &&
++        (conn->proxy_negotiate_state != GSS_AUTHNONE))) {
++      /* We must use this connection, no other */
++      m->force_reuse = TRUE;
++      return TRUE;
++    }
++    return FALSE; /* get another */
++  }
++  return TRUE;
++}
++#else
++#define url_match_auth_nego(c, m) ((void)c, (void)m, TRUE)
++#endif
++
+ static bool url_match_conn(struct connectdata *conn, void *userdata)
+ {
+   struct url_conn_match *m = userdata;
+@@ -1284,6 +1343,11 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
+   else if(m->force_reuse)
+     return TRUE;
+ 
++  if(!url_match_auth_nego(conn, m))
++    return FALSE;
++  else if(m->force_reuse)
++    return TRUE;
++
+   if(!url_match_multiplex_limits(conn, m))
+     return FALSE;
+ 
+@@ -1350,13 +1414,26 @@ ConnectionExists(struct Curl_easy *data,
+   match.may_multiplex = xfer_may_multiplex(data, needle);
+ 
+ #ifdef USE_NTLM
+-  match.want_ntlm_http = ((data->state.authhost.want & CURLAUTH_NTLM) &&
+-                          (needle->handler->protocol & PROTO_FAMILY_HTTP));
++  match.want_ntlm_http =
++    (data->state.authhost.want & CURLAUTH_NTLM) &&
++    (needle->handler->protocol & PROTO_FAMILY_HTTP);
+ #ifndef CURL_DISABLE_PROXY
+   match.want_proxy_ntlm_http =
+-    (needle->bits.proxy_user_passwd &&
+-     (data->state.authproxy.want & CURLAUTH_NTLM) &&
+-     (needle->handler->protocol & PROTO_FAMILY_HTTP));
++    needle->bits.proxy_user_passwd &&
++    (data->state.authproxy.want & CURLAUTH_NTLM) &&
++    (needle->handler->protocol & PROTO_FAMILY_HTTP);
++#endif
++#endif
++
++#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
++  match.want_nego_http =
++    (data->state.authhost.want & CURLAUTH_NEGOTIATE) &&
++    (needle->handler->protocol & PROTO_FAMILY_HTTP);
++#ifndef CURL_DISABLE_PROXY
++  match.want_proxy_nego_http =
++    needle->bits.proxy_user_passwd &&
++    (data->state.authproxy.want & CURLAUTH_NEGOTIATE) &&
++    (needle->handler->protocol & PROTO_FAMILY_HTTP);
+ #endif
+ #endif
+ 
+diff --git a/tests/server/sws.c b/tests/server/sws.c
+index 7b90e510b4..4f3d71b4a6 100644
+--- a/tests/server/sws.c
++++ b/tests/server/sws.c
+@@ -2394,6 +2394,7 @@ static int test_sws(int argc, char *argv[])
+             if(req->connmon) {
+               const char *keepopen = "[DISCONNECT]\n";
+               sws_storerequest(keepopen, strlen(keepopen));
++              req->connmon = FALSE;
+             }
+ 
+             if(!req->open)
+-- 
+2.53.0
+

--- a/specs/c/curl/0004-curl-8.15.0-CVE-2026-3783.patch
+++ b/specs/c/curl/0004-curl-8.15.0-CVE-2026-3783.patch
@@ -1,0 +1,151 @@
+From cd43259865e8ecb48383cc0533768f9ba640a6ed Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 6 Mar 2026 23:13:07 +0100
+Subject: [PATCH 2/4] CVE-2026-3783
+
+http: only send bearer if auth is allowed
+
+Verify with test 2006
+
+Closes #20843
+
+(cherry picked from commit e3d7401a32a46516c9e5ee877e613e62ed35bddc)
+---
+ lib/http.c             |  1 +
+ tests/data/Makefile.am |  2 +-
+ tests/data/test2006    | 98 ++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 100 insertions(+), 1 deletion(-)
+ create mode 100644 tests/data/test2006
+
+diff --git a/lib/http.c b/lib/http.c
+index e5a0696274..5feb99ef4b 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -697,6 +697,7 @@ output_auth_headers(struct Curl_easy *data,
+   if(authstatus->picked == CURLAUTH_BEARER) {
+     /* Bearer */
+     if((!proxy && data->set.str[STRING_BEARER] &&
++        Curl_auth_allowed_to_host(data) &&
+         !Curl_checkheaders(data, STRCONST("Authorization")))) {
+       auth = "Bearer";
+       result = http_output_bearer(data);
+diff --git a/tests/data/Makefile.am b/tests/data/Makefile.am
+index 7d8e8c7fc5..46b97e2913 100644
+--- a/tests/data/Makefile.am
++++ b/tests/data/Makefile.am
+@@ -240,7 +240,7 @@ test1955 test1956 test1957 test1958 test1959 test1960 test1964 \
+ test1970 test1971 test1972 test1973 test1974 test1975 test1976 test1977 \
+ test1978 test1979 test1980 \
+ \
+-test2000 test2001 test2002 test2003 test2004 test2005 \
++test2000 test2001 test2002 test2003 test2004 test2005 test2006 \
+ \
+                                                                test2023 \
+ test2024 test2025 test2026 test2027 test2028 test2029 test2030 test2031 \
+diff --git a/tests/data/test2006 b/tests/data/test2006
+new file mode 100644
+index 0000000000..200d30a7ce
+--- /dev/null
++++ b/tests/data/test2006
+@@ -0,0 +1,98 @@
++<?xml version="1.0" encoding="US-ASCII"?>
++<testcase>
++<info>
++<keywords>
++netrc
++HTTP
++</keywords>
++</info>
++# Server-side
++<reply>
++<data crlf="yes">
++HTTP/1.1 301 Follow this you fool
++Date: Tue, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
++ETag: "21025-dc7-39462498"
++Accept-Ranges: bytes
++Content-Length: 6
++Connection: close
++Location: http://b.com/%TESTNUMBER0002
++
++-foo-
++</data>
++
++<data2 crlf="yes">
++HTTP/1.1 200 OK
++Date: Tue, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
++ETag: "21025-dc7-39462498"
++Accept-Ranges: bytes
++Content-Length: 7
++Connection: close
++
++target
++</data2>
++
++<datacheck crlf="yes">
++HTTP/1.1 301 Follow this you fool
++Date: Tue, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
++ETag: "21025-dc7-39462498"
++Accept-Ranges: bytes
++Content-Length: 6
++Connection: close
++Location: http://b.com/%TESTNUMBER0002
++
++HTTP/1.1 200 OK
++Date: Tue, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
++ETag: "21025-dc7-39462498"
++Accept-Ranges: bytes
++Content-Length: 7
++Connection: close
++
++target
++</datacheck>
++</reply>
++
++# Client-side
++<client>
++<server>
++http
++</server>
++<features>
++proxy
++</features>
++<name>
++.netrc default with redirect plus oauth2-bearer
++</name>
++<command>
++--netrc --netrc-file %LOGDIR/netrc%TESTNUMBER --oauth2-bearer SECRET_TOKEN -L -x http://%HOSTIP:%HTTPPORT/ http://a.com/
++</command>
++<file name="%LOGDIR/netrc%TESTNUMBER" >
++default login testuser password testpass
++</file>
++</client>
++
++<verify>
++<protocol crlf="yes">
++GET http://a.com/ HTTP/1.1
++Host: a.com
++Authorization: Bearer SECRET_TOKEN
++User-Agent: curl/%VERSION
++Accept: */*
++Proxy-Connection: Keep-Alive
++
++GET http://b.com/%TESTNUMBER0002 HTTP/1.1
++Host: b.com
++User-Agent: curl/%VERSION
++Accept: */*
++Proxy-Connection: Keep-Alive
++
++</protocol>
++</verify>
++</testcase>
+-- 
+2.53.0
+

--- a/specs/c/curl/0005-curl-8.15.0-CVE-2026-3784.patch
+++ b/specs/c/curl/0005-curl-8.15.0-CVE-2026-3784.patch
@@ -1,0 +1,170 @@
+From 9c7160641607813c799d42ea0c2ea1f7bb1a5b8c Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Fri, 6 Mar 2026 14:54:09 +0100
+Subject: [PATCH 3/4] CVE-2026-3784
+
+proxy-auth: additional tests
+
+Also eliminate the special handling for socks proxy match.
+
+Closes #20837
+
+(cherry picked from commit 5f13a7645e565c5c1a06f3ef86e97afb856fb364)
+---
+ lib/url.c                        | 34 +++++++-------------------------
+ tests/http/test_13_proxy_auth.py | 20 +++++++++++++++++++
+ tests/http/testenv/curl.py       | 18 ++++++++++++++---
+ 3 files changed, 42 insertions(+), 30 deletions(-)
+
+diff --git a/lib/url.c b/lib/url.c
+index 9d109f2005..fd3bb575c7 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -643,34 +643,15 @@ proxy_info_matches(const struct proxy_info *data,
+ {
+   if((data->proxytype == needle->proxytype) &&
+      (data->port == needle->port) &&
+-     curl_strequal(data->host.name, needle->host.name))
+-    return TRUE;
++     curl_strequal(data->host.name, needle->host.name)) {
+ 
++    if(Curl_timestrcmp(data->user, needle->user) ||
++       Curl_timestrcmp(data->passwd, needle->passwd))
++      return FALSE;
++    return TRUE;
++  }
+   return FALSE;
+ }
+-
+-static bool
+-socks_proxy_info_matches(const struct proxy_info *data,
+-                         const struct proxy_info *needle)
+-{
+-  if(!proxy_info_matches(data, needle))
+-    return FALSE;
+-
+-  /* the user information is case-sensitive
+-     or at least it is not defined as case-insensitive
+-     see https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1 */
+-
+-  /* curl_strequal does a case insensitive comparison,
+-     so do not use it here! */
+-  if(Curl_timestrcmp(data->user, needle->user) ||
+-     Curl_timestrcmp(data->passwd, needle->passwd))
+-    return FALSE;
+-  return TRUE;
+-}
+-#else
+-/* disabled, will not get called */
+-#define proxy_info_matches(x,y) FALSE
+-#define socks_proxy_info_matches(x,y) FALSE
+ #endif
+ 
+ /* A connection has to have been idle for less than 'conn_max_idle_ms'
+@@ -985,8 +966,7 @@ static bool url_match_proxy_use(struct connectdata *conn,
+     return FALSE;
+ 
+   if(m->needle->bits.socksproxy &&
+-    !socks_proxy_info_matches(&m->needle->socks_proxy,
+-                              &conn->socks_proxy))
++     !proxy_info_matches(&m->needle->socks_proxy, &conn->socks_proxy))
+     return FALSE;
+ 
+   if(m->needle->bits.httpproxy) {
+diff --git a/tests/http/test_13_proxy_auth.py b/tests/http/test_13_proxy_auth.py
+index 6a9a7e6a84..727557a682 100644
+--- a/tests/http/test_13_proxy_auth.py
++++ b/tests/http/test_13_proxy_auth.py
+@@ -167,3 +167,23 @@ class TestProxyAuth:
+             '--negotiate', '--proxy-user', 'proxy:proxy'
+         ])
+         r1.check_response(count=1, http_status=200)
++
++    def test_13_10_tunnels_mixed_auth(self, env: Env, httpd, configures_httpd):
++        self.httpd_configure(env, httpd)
++        curl = CurlClient(env=env)
++        url1 = f'http://localhost:{env.http_port}/data.json?1'
++        url2 = f'http://localhost:{env.http_port}/data.json?2'
++        url3 = f'http://localhost:{env.http_port}/data.json?3'
++        xargs1 = curl.get_proxy_args(proxys=False, tunnel=True)
++        xargs1.extend(['--proxy-user', 'proxy:proxy']) # good auth
++        xargs2 = curl.get_proxy_args(proxys=False, tunnel=True)
++        xargs2.extend(['--proxy-user', 'ungood:ungood']) # bad auth
++        xargs3 = curl.get_proxy_args(proxys=False, tunnel=True)
++        # no auth
++        r = curl.http_download(urls=[url1, url2, url3], alpn_proto='http/1.1', with_stats=True,
++                               url_options={url1: xargs1, url2: xargs2, url3: xargs3})
++        # only url1 succeeds, others fail, no connection reuse
++        assert r.stats[0]['http_code'] == 200, f'{r.dump_logs()}'
++        assert r.stats[1]['http_code'] == 0, f'{r.dump_logs()}'
++        assert r.stats[2]['http_code'] == 0, f'{r.dump_logs()}'
++        assert r.total_connects == 3, f'{r.dump_logs()}'
+diff --git a/tests/http/testenv/curl.py b/tests/http/testenv/curl.py
+index fb28cd7fa7..4ea67e6a1d 100644
+--- a/tests/http/testenv/curl.py
++++ b/tests/http/testenv/curl.py
+@@ -580,7 +580,8 @@ class CurlClient:
+                       with_profile: bool = False,
+                       with_tcpdump: bool = False,
+                       no_save: bool = False,
+-                      extra_args: Optional[List[str]] = None):
++                      extra_args: Optional[List[str]] = None,
++                      url_options: Optional[Dict[str,List[str]]] = None):
+         if extra_args is None:
+             extra_args = []
+         if no_save:
+@@ -600,6 +601,7 @@ class CurlClient:
+             ])
+         return self._raw(urls, alpn_proto=alpn_proto, options=extra_args,
+                          with_stats=with_stats,
++                         url_options=url_options,
+                          with_headers=with_headers,
+                          with_profile=with_profile,
+                          with_tcpdump=with_tcpdump)
+@@ -870,6 +872,7 @@ class CurlClient:
+ 
+     def _raw(self, urls, intext='', timeout=None, options=None, insecure=False,
+              alpn_proto: Optional[str] = None,
++             url_options=None,
+              force_resolve=True,
+              with_stats=False,
+              with_headers=True,
+@@ -879,7 +882,8 @@ class CurlClient:
+         args = self._complete_args(
+             urls=urls, timeout=timeout, options=options, insecure=insecure,
+             alpn_proto=alpn_proto, force_resolve=force_resolve,
+-            with_headers=with_headers, def_tracing=def_tracing)
++            with_headers=with_headers, def_tracing=def_tracing,
++            url_options=url_options)
+         r = self._run(args, intext=intext, with_stats=with_stats,
+                       with_profile=with_profile, with_tcpdump=with_tcpdump)
+         if r.exit_code == 0 and with_headers:
+@@ -889,8 +893,10 @@ class CurlClient:
+     def _complete_args(self, urls, timeout=None, options=None,
+                        insecure=False, force_resolve=True,
+                        alpn_proto: Optional[str] = None,
++                       url_options=None,
+                        with_headers: bool = True,
+                        def_tracing: bool = True):
++        url_sep = []
+         if not isinstance(urls, list):
+             urls = [urls]
+ 
+@@ -910,7 +916,13 @@ class CurlClient:
+             active_options = options[options.index('--next') + 1:]
+ 
+         for url in urls:
+-            u = urlparse(urls[0])
++            args.extend(url_sep)
++            if url_options is not None:
++                url_sep = ['--next']
++
++            u = urlparse(url)
++            if url_options is not None and url in url_options:
++                args.extend(url_options[url])
+             if options:
+                 args.extend(options)
+             if alpn_proto is not None:
+-- 
+2.53.0
+

--- a/specs/c/curl/0006-curl-8.15.0-CVE-2026-3805.patch
+++ b/specs/c/curl/0006-curl-8.15.0-CVE-2026-3805.patch
@@ -1,0 +1,1856 @@
+From 1db75fdaff8af5f9b0feac43e6c3990782af120f Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Sun, 21 Dec 2025 16:19:52 +0100
+Subject: [PATCH 4/4] CVE-2026-3805
+
+lib: reorder protocol functions to avoid forward declarations (misc)
+
+For protocols: dict, file, gopher, tftp, http, mqtt, smb.
+
+Move protocol hander table to the end of sources, rearrange static
+functions is reverse dependency order as necessary.
+
+Closes #20274
+
+(cherry picked from commit 07926b59828936117a7c6662f850bc09edb14357)
+
+smb: free the path in the request struct properly
+
+Closes #20854
+
+(cherry picked from commit e090be9f73a7a71459ef678c7cc4b1f75e3ea883)
+
+test1850: verify the SMB request path use for two transfers
+
+(cherry picked from commit 1f8cfa049d7a0ea595863abf0230198972873ad6)
+---
+ lib/dict.c             |  64 ++--
+ lib/file.c             |  98 +++---
+ lib/gopher.c           | 125 ++++---
+ lib/http.c             | 203 ++++++------
+ lib/mqtt.c             |  72 ++--
+ lib/smb.c              | 217 ++++++------
+ lib/tftp.c             | 727 ++++++++++++++++++++---------------------
+ tests/data/Makefile.am |   2 +-
+ tests/data/test1850    |  39 +++
+ 9 files changed, 754 insertions(+), 793 deletions(-)
+ create mode 100644 tests/data/test1850
+
+diff --git a/lib/dict.c b/lib/dict.c
+index 7f13e6f7ea..12198f0770 100644
+--- a/lib/dict.c
++++ b/lib/dict.c
+@@ -73,41 +73,6 @@
+ #define DICT_DEFINE3 "/LOOKUP:"
+ 
+ 
+-/*
+- * Forward declarations.
+- */
+-
+-static CURLcode dict_do(struct Curl_easy *data, bool *done);
+-
+-/*
+- * DICT protocol handler.
+- */
+-
+-const struct Curl_handler Curl_handler_dict = {
+-  "dict",                               /* scheme */
+-  ZERO_NULL,                            /* setup_connection */
+-  dict_do,                              /* do_it */
+-  ZERO_NULL,                            /* done */
+-  ZERO_NULL,                            /* do_more */
+-  ZERO_NULL,                            /* connect_it */
+-  ZERO_NULL,                            /* connecting */
+-  ZERO_NULL,                            /* doing */
+-  ZERO_NULL,                            /* proto_getsock */
+-  ZERO_NULL,                            /* doing_getsock */
+-  ZERO_NULL,                            /* domore_getsock */
+-  ZERO_NULL,                            /* perform_getsock */
+-  ZERO_NULL,                            /* disconnect */
+-  ZERO_NULL,                            /* write_resp */
+-  ZERO_NULL,                            /* write_resp_hd */
+-  ZERO_NULL,                            /* connection_check */
+-  ZERO_NULL,                            /* attach connection */
+-  ZERO_NULL,                            /* follow */
+-  PORT_DICT,                            /* defport */
+-  CURLPROTO_DICT,                       /* protocol */
+-  CURLPROTO_DICT,                       /* family */
+-  PROTOPT_NONE | PROTOPT_NOURLQUERY     /* flags */
+-};
+-
+ #define DYN_DICT_WORD 10000
+ static char *unescape_word(const char *input)
+ {
+@@ -314,4 +279,33 @@ error:
+   free(path);
+   return result;
+ }
++
++/*
++ * DICT protocol handler.
++ */
++const struct Curl_handler Curl_handler_dict = {
++  "dict",                               /* scheme */
++  ZERO_NULL,                            /* setup_connection */
++  dict_do,                              /* do_it */
++  ZERO_NULL,                            /* done */
++  ZERO_NULL,                            /* do_more */
++  ZERO_NULL,                            /* connect_it */
++  ZERO_NULL,                            /* connecting */
++  ZERO_NULL,                            /* doing */
++  ZERO_NULL,                            /* proto_getsock */
++  ZERO_NULL,                            /* doing_getsock */
++  ZERO_NULL,                            /* domore_getsock */
++  ZERO_NULL,                            /* perform_getsock */
++  ZERO_NULL,                            /* disconnect */
++  ZERO_NULL,                            /* write_resp */
++  ZERO_NULL,                            /* write_resp_hd */
++  ZERO_NULL,                            /* connection_check */
++  ZERO_NULL,                            /* attach connection */
++  ZERO_NULL,                            /* follow */
++  PORT_DICT,                            /* defport */
++  CURLPROTO_DICT,                       /* protocol */
++  CURLPROTO_DICT,                       /* family */
++  PROTOPT_NONE | PROTOPT_NOURLQUERY     /* flags */
++};
++
+ #endif /* CURL_DISABLE_DICT */
+diff --git a/lib/file.c b/lib/file.c
+index b88f612305..c8e0e50c9a 100644
+--- a/lib/file.c
++++ b/lib/file.c
+@@ -93,50 +93,6 @@ struct FILEPROTO {
+   int fd;     /* open file descriptor to read from! */
+ };
+ 
+-/*
+- * Forward declarations.
+- */
+-
+-static CURLcode file_do(struct Curl_easy *data, bool *done);
+-static CURLcode file_done(struct Curl_easy *data,
+-                          CURLcode status, bool premature);
+-static CURLcode file_connect(struct Curl_easy *data, bool *done);
+-static CURLcode file_disconnect(struct Curl_easy *data,
+-                                struct connectdata *conn,
+-                                bool dead_connection);
+-static CURLcode file_setup_connection(struct Curl_easy *data,
+-                                      struct connectdata *conn);
+-
+-/*
+- * FILE scheme handler.
+- */
+-
+-const struct Curl_handler Curl_handler_file = {
+-  "file",                               /* scheme */
+-  file_setup_connection,                /* setup_connection */
+-  file_do,                              /* do_it */
+-  file_done,                            /* done */
+-  ZERO_NULL,                            /* do_more */
+-  file_connect,                         /* connect_it */
+-  ZERO_NULL,                            /* connecting */
+-  ZERO_NULL,                            /* doing */
+-  ZERO_NULL,                            /* proto_getsock */
+-  ZERO_NULL,                            /* doing_getsock */
+-  ZERO_NULL,                            /* domore_getsock */
+-  ZERO_NULL,                            /* perform_getsock */
+-  file_disconnect,                      /* disconnect */
+-  ZERO_NULL,                            /* write_resp */
+-  ZERO_NULL,                            /* write_resp_hd */
+-  ZERO_NULL,                            /* connection_check */
+-  ZERO_NULL,                            /* attach connection */
+-  ZERO_NULL,                            /* follow */
+-  0,                                    /* defport */
+-  CURLPROTO_FILE,                       /* protocol */
+-  CURLPROTO_FILE,                       /* family */
+-  PROTOPT_NONETWORK | PROTOPT_NOURLQUERY /* flags */
+-};
+-
+-
+ static void file_cleanup(struct FILEPROTO *file)
+ {
+   Curl_safefree(file->freepath);
+@@ -170,6 +126,19 @@ static CURLcode file_setup_connection(struct Curl_easy *data,
+   return CURLE_OK;
+ }
+ 
++static CURLcode file_done(struct Curl_easy *data,
++                          CURLcode status, bool premature)
++{
++  struct FILEPROTO *file = Curl_meta_get(data, CURL_META_FILE_EASY);
++  (void)status;
++  (void)premature;
++
++  if(file)
++    file_cleanup(file);
++
++  return CURLE_OK;
++}
++
+ /*
+  * file_connect() gets called from Curl_protocol_connect() to allow us to
+  * do protocol-specific actions at connect-time. We emulate a
+@@ -288,19 +257,6 @@ static CURLcode file_connect(struct Curl_easy *data, bool *done)
+   return CURLE_OK;
+ }
+ 
+-static CURLcode file_done(struct Curl_easy *data,
+-                          CURLcode status, bool premature)
+-{
+-  struct FILEPROTO *file = Curl_meta_get(data, CURL_META_FILE_EASY);
+-  (void)status; /* not used */
+-  (void)premature; /* not used */
+-
+-  if(file)
+-    file_cleanup(file);
+-
+-  return CURLE_OK;
+-}
+-
+ static CURLcode file_disconnect(struct Curl_easy *data,
+                                 struct connectdata *conn,
+                                 bool dead_connection)
+@@ -667,4 +623,32 @@ out:
+   return result;
+ }
+ 
++/*
++ * FILE scheme handler.
++ */
++const struct Curl_handler Curl_handler_file = {
++  "file",                               /* scheme */
++  file_setup_connection,                /* setup_connection */
++  file_do,                              /* do_it */
++  file_done,                            /* done */
++  ZERO_NULL,                            /* do_more */
++  file_connect,                         /* connect_it */
++  ZERO_NULL,                            /* connecting */
++  ZERO_NULL,                            /* doing */
++  ZERO_NULL,                            /* proto_getsock */
++  ZERO_NULL,                            /* doing_getsock */
++  ZERO_NULL,                            /* domore_getsock */
++  ZERO_NULL,                            /* perform_getsock */
++  file_disconnect,                      /* disconnect */
++  ZERO_NULL,                            /* write_resp */
++  ZERO_NULL,                            /* write_resp_hd */
++  ZERO_NULL,                            /* connection_check */
++  ZERO_NULL,                            /* attach connection */
++  ZERO_NULL,                            /* follow */
++  0,                                    /* defport */
++  CURLPROTO_FILE,                       /* protocol */
++  CURLPROTO_FILE,                       /* family */
++  PROTOPT_NONETWORK | PROTOPT_NOURLQUERY /* flags */
++};
++
+ #endif
+diff --git a/lib/gopher.c b/lib/gopher.c
+index 68ccb59e40..b0ee51be55 100644
+--- a/lib/gopher.c
++++ b/lib/gopher.c
+@@ -45,73 +45,7 @@
+ /* The last #include file should be: */
+ #include "memdebug.h"
+ 
+-/*
+- * Forward declarations.
+- */
+-
+-static CURLcode gopher_do(struct Curl_easy *data, bool *done);
+ #ifdef USE_SSL
+-static CURLcode gopher_connect(struct Curl_easy *data, bool *done);
+-static CURLcode gopher_connecting(struct Curl_easy *data, bool *done);
+-#endif
+-
+-/*
+- * Gopher protocol handler.
+- * This is also a nice simple template to build off for simple
+- * connect-command-download protocols.
+- */
+-
+-const struct Curl_handler Curl_handler_gopher = {
+-  "gopher",                             /* scheme */
+-  ZERO_NULL,                            /* setup_connection */
+-  gopher_do,                            /* do_it */
+-  ZERO_NULL,                            /* done */
+-  ZERO_NULL,                            /* do_more */
+-  ZERO_NULL,                            /* connect_it */
+-  ZERO_NULL,                            /* connecting */
+-  ZERO_NULL,                            /* doing */
+-  ZERO_NULL,                            /* proto_getsock */
+-  ZERO_NULL,                            /* doing_getsock */
+-  ZERO_NULL,                            /* domore_getsock */
+-  ZERO_NULL,                            /* perform_getsock */
+-  ZERO_NULL,                            /* disconnect */
+-  ZERO_NULL,                            /* write_resp */
+-  ZERO_NULL,                            /* write_resp_hd */
+-  ZERO_NULL,                            /* connection_check */
+-  ZERO_NULL,                            /* attach connection */
+-  ZERO_NULL,                            /* follow */
+-  PORT_GOPHER,                          /* defport */
+-  CURLPROTO_GOPHER,                     /* protocol */
+-  CURLPROTO_GOPHER,                     /* family */
+-  PROTOPT_NONE                          /* flags */
+-};
+-
+-#ifdef USE_SSL
+-const struct Curl_handler Curl_handler_gophers = {
+-  "gophers",                            /* scheme */
+-  ZERO_NULL,                            /* setup_connection */
+-  gopher_do,                            /* do_it */
+-  ZERO_NULL,                            /* done */
+-  ZERO_NULL,                            /* do_more */
+-  gopher_connect,                       /* connect_it */
+-  gopher_connecting,                    /* connecting */
+-  ZERO_NULL,                            /* doing */
+-  ZERO_NULL,                            /* proto_getsock */
+-  ZERO_NULL,                            /* doing_getsock */
+-  ZERO_NULL,                            /* domore_getsock */
+-  ZERO_NULL,                            /* perform_getsock */
+-  ZERO_NULL,                            /* disconnect */
+-  ZERO_NULL,                            /* write_resp */
+-  ZERO_NULL,                            /* write_resp_hd */
+-  ZERO_NULL,                            /* connection_check */
+-  ZERO_NULL,                            /* attach connection */
+-  ZERO_NULL,                            /* follow */
+-  PORT_GOPHER,                          /* defport */
+-  CURLPROTO_GOPHERS,                    /* protocol */
+-  CURLPROTO_GOPHER,                     /* family */
+-  PROTOPT_SSL                           /* flags */
+-};
+-
+ static CURLcode gopher_connect(struct Curl_easy *data, bool *done)
+ {
+   (void)data;
+@@ -243,4 +177,63 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
+   Curl_xfer_setup1(data, CURL_XFER_RECV, -1, FALSE);
+   return CURLE_OK;
+ }
++
++/*
++ * Gopher protocol handler.
++ * This is also a nice simple template to build off for simple
++ * connect-command-download protocols.
++ */
++
++const struct Curl_handler Curl_handler_gopher = {
++  "gopher",                             /* scheme */
++  ZERO_NULL,                            /* setup_connection */
++  gopher_do,                            /* do_it */
++  ZERO_NULL,                            /* done */
++  ZERO_NULL,                            /* do_more */
++  ZERO_NULL,                            /* connect_it */
++  ZERO_NULL,                            /* connecting */
++  ZERO_NULL,                            /* doing */
++  ZERO_NULL,                            /* proto_getsock */
++  ZERO_NULL,                            /* doing_getsock */
++  ZERO_NULL,                            /* domore_getsock */
++  ZERO_NULL,                            /* perform_getsock */
++  ZERO_NULL,                            /* disconnect */
++  ZERO_NULL,                            /* write_resp */
++  ZERO_NULL,                            /* write_resp_hd */
++  ZERO_NULL,                            /* connection_check */
++  ZERO_NULL,                            /* attach connection */
++  ZERO_NULL,                            /* follow */
++  PORT_GOPHER,                          /* defport */
++  CURLPROTO_GOPHER,                     /* protocol */
++  CURLPROTO_GOPHER,                     /* family */
++  PROTOPT_NONE                          /* flags */
++};
++
++#ifdef USE_SSL
++const struct Curl_handler Curl_handler_gophers = {
++  "gophers",                            /* scheme */
++  ZERO_NULL,                            /* setup_connection */
++  gopher_do,                            /* do_it */
++  ZERO_NULL,                            /* done */
++  ZERO_NULL,                            /* do_more */
++  gopher_connect,                       /* connect_it */
++  gopher_connecting,                    /* connecting */
++  ZERO_NULL,                            /* doing */
++  ZERO_NULL,                            /* proto_getsock */
++  ZERO_NULL,                            /* doing_getsock */
++  ZERO_NULL,                            /* domore_getsock */
++  ZERO_NULL,                            /* perform_getsock */
++  ZERO_NULL,                            /* disconnect */
++  ZERO_NULL,                            /* write_resp */
++  ZERO_NULL,                            /* write_resp_hd */
++  ZERO_NULL,                            /* connection_check */
++  ZERO_NULL,                            /* attach connection */
++  ZERO_NULL,                            /* follow */
++  PORT_GOPHER,                          /* defport */
++  CURLPROTO_GOPHERS,                    /* protocol */
++  CURLPROTO_GOPHER,                     /* family */
++  PROTOPT_SSL                           /* flags */
++};
++#endif
++
+ #endif /* CURL_DISABLE_GOPHER */
+diff --git a/lib/http.c b/lib/http.c
+index 5feb99ef4b..77f1fd6d41 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -519,13 +519,83 @@ static CURLcode http_perhapsrewind(struct Curl_easy *data,
+   return CURLE_OK;
+ }
+ 
++/**
++ * http_should_fail() determines whether an HTTP response code has gotten us
++ * into an error state or not.
++ *
++ * @retval FALSE communications should continue
++ *
++ * @retval TRUE communications should not continue
++ */
++static bool http_should_fail(struct Curl_easy *data, int httpcode)
++{
++  DEBUGASSERT(data);
++  DEBUGASSERT(data->conn);
++
++  /*
++  ** If we have not been asked to fail on error,
++  ** do not fail.
++  */
++  if(!data->set.http_fail_on_error)
++    return FALSE;
++
++  /*
++  ** Any code < 400 is never terminal.
++  */
++  if(httpcode < 400)
++    return FALSE;
++
++  /*
++  ** A 416 response to a resume request is presumably because the file is
++  ** already completely downloaded and thus not actually a fail.
++  */
++  if(data->state.resume_from && data->state.httpreq == HTTPREQ_GET &&
++     httpcode == 416)
++    return FALSE;
++
++  /*
++  ** Any code >= 400 that is not 401 or 407 is always
++  ** a terminal error
++  */
++  if((httpcode != 401) && (httpcode != 407))
++    return TRUE;
++
++  /*
++  ** All we have left to deal with is 401 and 407
++  */
++  DEBUGASSERT((httpcode == 401) || (httpcode == 407));
++
++  /*
++  ** Examine the current authentication state to see if this is an error. The
++  ** idea is for this function to get called after processing all the headers
++  ** in a response message. So, if we have been to asked to authenticate a
++  ** particular stage, and we have done it, we are OK. If we are already
++  ** completely authenticated, it is not OK to get another 401 or 407.
++  **
++  ** It is possible for authentication to go stale such that the client needs
++  ** to reauthenticate. Once that info is available, use it here.
++  */
++
++  /*
++  ** Either we are not authenticating, or we are supposed to be authenticating
++  ** something else. This is an error.
++  */
++  if((httpcode == 401) && !data->state.aptr.user)
++    return TRUE;
++#ifndef CURL_DISABLE_PROXY
++  if((httpcode == 407) && !data->conn->bits.proxy_user_passwd)
++    return TRUE;
++#endif
++
++  return data->state.authproblem;
++}
++
+ /*
+  * Curl_http_auth_act() gets called when all HTTP headers have been received
+  * and it checks what authentication methods that are available and decides
+  * which one (if any) to use. It will set 'newurl' if an auth method was
+  * picked.
+  */
+-
+ CURLcode Curl_http_auth_act(struct Curl_easy *data)
+ {
+   struct connectdata *conn = data->conn;
+@@ -1084,77 +1154,6 @@ CURLcode Curl_http_input_auth(struct Curl_easy *data, bool proxy,
+ #endif
+ }
+ 
+-/**
+- * http_should_fail() determines whether an HTTP response code has gotten us
+- * into an error state or not.
+- *
+- * @retval FALSE communications should continue
+- *
+- * @retval TRUE communications should not continue
+- */
+-static bool http_should_fail(struct Curl_easy *data, int httpcode)
+-{
+-  DEBUGASSERT(data);
+-  DEBUGASSERT(data->conn);
+-
+-  /*
+-  ** If we have not been asked to fail on error,
+-  ** do not fail.
+-  */
+-  if(!data->set.http_fail_on_error)
+-    return FALSE;
+-
+-  /*
+-  ** Any code < 400 is never terminal.
+-  */
+-  if(httpcode < 400)
+-    return FALSE;
+-
+-  /*
+-  ** A 416 response to a resume request is presumably because the file is
+-  ** already completely downloaded and thus not actually a fail.
+-  */
+-  if(data->state.resume_from && data->state.httpreq == HTTPREQ_GET &&
+-     httpcode == 416)
+-    return FALSE;
+-
+-  /*
+-  ** Any code >= 400 that is not 401 or 407 is always
+-  ** a terminal error
+-  */
+-  if((httpcode != 401) && (httpcode != 407))
+-    return TRUE;
+-
+-  /*
+-  ** All we have left to deal with is 401 and 407
+-  */
+-  DEBUGASSERT((httpcode == 401) || (httpcode == 407));
+-
+-  /*
+-  ** Examine the current authentication state to see if this is an error. The
+-  ** idea is for this function to get called after processing all the headers
+-  ** in a response message. So, if we have been to asked to authenticate a
+-  ** particular stage, and we have done it, we are OK. If we are already
+-  ** completely authenticated, it is not OK to get another 401 or 407.
+-  **
+-  ** It is possible for authentication to go stale such that the client needs
+-  ** to reauthenticate. Once that info is available, use it here.
+-  */
+-
+-  /*
+-  ** Either we are not authenticating, or we are supposed to be authenticating
+-  ** something else. This is an error.
+-  */
+-  if((httpcode == 401) && !data->state.aptr.user)
+-    return TRUE;
+-#ifndef CURL_DISABLE_PROXY
+-  if((httpcode == 407) && !data->conn->bits.proxy_user_passwd)
+-    return TRUE;
+-#endif
+-
+-  return data->state.authproblem;
+-}
+-
+ static void http_switch_to_get(struct Curl_easy *data, int code)
+ {
+   const char *req = data->set.str[STRING_CUSTOMREQUEST];
+@@ -1533,6 +1532,33 @@ int Curl_http_getsock_do(struct Curl_easy *data,
+   return GETSOCK_WRITESOCK(0);
+ }
+ 
++static CURLcode http_write_header(struct Curl_easy *data,
++                                  const char *hd, size_t hdlen)
++{
++  CURLcode result;
++  int writetype;
++
++  /* now, only output this if the header AND body are requested:
++   */
++  Curl_debug(data, CURLINFO_HEADER_IN, hd, hdlen);
++
++  writetype = CLIENTWRITE_HEADER |
++    ((data->req.httpcode / 100 == 1) ? CLIENTWRITE_1XX : 0);
++
++  result = Curl_client_write(data, writetype, hd, hdlen);
++  if(result)
++    return result;
++
++  result = Curl_bump_headersize(data, hdlen, FALSE);
++  if(result)
++    return result;
++
++  data->req.deductheadercount = (100 <= data->req.httpcode &&
++                                 199 >= data->req.httpcode) ?
++    data->req.headerbytecount : 0;
++  return result;
++}
++
+ /*
+  * Curl_http_done() gets called after a single HTTP request has been
+  * performed.
+@@ -3660,33 +3686,6 @@ CURLcode Curl_bump_headersize(struct Curl_easy *data,
+   return CURLE_OK;
+ }
+ 
+-static CURLcode http_write_header(struct Curl_easy *data,
+-                                  const char *hd, size_t hdlen)
+-{
+-  CURLcode result;
+-  int writetype;
+-
+-  /* now, only output this if the header AND body are requested:
+-   */
+-  Curl_debug(data, CURLINFO_HEADER_IN, hd, hdlen);
+-
+-  writetype = CLIENTWRITE_HEADER |
+-    ((data->req.httpcode/100 == 1) ? CLIENTWRITE_1XX : 0);
+-
+-  result = Curl_client_write(data, writetype, hd, hdlen);
+-  if(result)
+-    return result;
+-
+-  result = Curl_bump_headersize(data, hdlen, FALSE);
+-  if(result)
+-    return result;
+-
+-  data->req.deductheadercount = (100 <= data->req.httpcode &&
+-                                 199 >= data->req.httpcode) ?
+-    data->req.headerbytecount : 0;
+-  return result;
+-}
+-
+ static CURLcode http_on_response(struct Curl_easy *data,
+                                  const char *last_hd, size_t last_hd_len,
+                                  const char *buf, size_t blen,
+diff --git a/lib/mqtt.c b/lib/mqtt.c
+index 90f857dca5..20cafb62bf 100644
+--- a/lib/mqtt.c
++++ b/lib/mqtt.c
+@@ -98,49 +98,6 @@ struct MQTT {
+   BIT(pingsent); /* 1 while we wait for ping response */
+ };
+ 
+-
+-/*
+- * Forward declarations.
+- */
+-
+-static CURLcode mqtt_do(struct Curl_easy *data, bool *done);
+-static CURLcode mqtt_done(struct Curl_easy *data,
+-                          CURLcode status, bool premature);
+-static CURLcode mqtt_doing(struct Curl_easy *data, bool *done);
+-static int mqtt_getsock(struct Curl_easy *data, struct connectdata *conn,
+-                        curl_socket_t *sock);
+-static CURLcode mqtt_setup_conn(struct Curl_easy *data,
+-                                struct connectdata *conn);
+-
+-/*
+- * MQTT protocol handler.
+- */
+-
+-const struct Curl_handler Curl_handler_mqtt = {
+-  "mqtt",                             /* scheme */
+-  mqtt_setup_conn,                    /* setup_connection */
+-  mqtt_do,                            /* do_it */
+-  mqtt_done,                          /* done */
+-  ZERO_NULL,                          /* do_more */
+-  ZERO_NULL,                          /* connect_it */
+-  ZERO_NULL,                          /* connecting */
+-  mqtt_doing,                         /* doing */
+-  ZERO_NULL,                          /* proto_getsock */
+-  mqtt_getsock,                       /* doing_getsock */
+-  ZERO_NULL,                          /* domore_getsock */
+-  ZERO_NULL,                          /* perform_getsock */
+-  ZERO_NULL,                          /* disconnect */
+-  ZERO_NULL,                          /* write_resp */
+-  ZERO_NULL,                          /* write_resp_hd */
+-  ZERO_NULL,                          /* connection_check */
+-  ZERO_NULL,                          /* attach connection */
+-  ZERO_NULL,                          /* follow */
+-  PORT_MQTT,                          /* defport */
+-  CURLPROTO_MQTT,                     /* protocol */
+-  CURLPROTO_MQTT,                     /* family */
+-  PROTOPT_NONE                        /* flags */
+-};
+-
+ static void mqtt_easy_dtor(void *key, size_t klen, void *entry)
+ {
+   struct MQTT *mq = entry;
+@@ -982,4 +939,33 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
+   return result;
+ }
+ 
++/*
++ * MQTT protocol handler.
++ */
++
++const struct Curl_handler Curl_handler_mqtt = {
++  "mqtt",                             /* scheme */
++  mqtt_setup_conn,                    /* setup_connection */
++  mqtt_do,                            /* do_it */
++  mqtt_done,                          /* done */
++  ZERO_NULL,                          /* do_more */
++  ZERO_NULL,                          /* connect_it */
++  ZERO_NULL,                          /* connecting */
++  mqtt_doing,                         /* doing */
++  ZERO_NULL,                          /* proto_getsock */
++  mqtt_getsock,                       /* doing_getsock */
++  ZERO_NULL,                          /* domore_getsock */
++  ZERO_NULL,                          /* perform_getsock */
++  ZERO_NULL,                          /* disconnect */
++  ZERO_NULL,                          /* write_resp */
++  ZERO_NULL,                          /* write_resp_hd */
++  ZERO_NULL,                          /* connection_check */
++  ZERO_NULL,                          /* attach connection */
++  ZERO_NULL,                          /* follow */
++  PORT_MQTT,                          /* defport */
++  CURLPROTO_MQTT,                     /* protocol */
++  CURLPROTO_MQTT,                     /* family */
++  PROTOPT_NONE                        /* flags */
++};
++
+ #endif /* CURL_DISABLE_MQTT */
+diff --git a/lib/smb.c b/lib/smb.c
+index 3eee16468d..23afb51b22 100644
+--- a/lib/smb.c
++++ b/lib/smb.c
+@@ -291,77 +291,6 @@ struct smb_tree_disconnect {
+ #  pragma pack(pop)
+ #endif
+ 
+-/* Local API functions */
+-static CURLcode smb_setup_connection(struct Curl_easy *data,
+-                                     struct connectdata *conn);
+-static CURLcode smb_connect(struct Curl_easy *data, bool *done);
+-static CURLcode smb_connection_state(struct Curl_easy *data, bool *done);
+-static CURLcode smb_do(struct Curl_easy *data, bool *done);
+-static CURLcode smb_request_state(struct Curl_easy *data, bool *done);
+-static int smb_getsock(struct Curl_easy *data, struct connectdata *conn,
+-                       curl_socket_t *socks);
+-static CURLcode smb_parse_url_path(struct Curl_easy *data,
+-                                   struct smb_conn *smbc,
+-                                   struct smb_request *req);
+-
+-/*
+- * SMB handler interface
+- */
+-const struct Curl_handler Curl_handler_smb = {
+-  "smb",                                /* scheme */
+-  smb_setup_connection,                 /* setup_connection */
+-  smb_do,                               /* do_it */
+-  ZERO_NULL,                            /* done */
+-  ZERO_NULL,                            /* do_more */
+-  smb_connect,                          /* connect_it */
+-  smb_connection_state,                 /* connecting */
+-  smb_request_state,                    /* doing */
+-  smb_getsock,                          /* proto_getsock */
+-  smb_getsock,                          /* doing_getsock */
+-  ZERO_NULL,                            /* domore_getsock */
+-  ZERO_NULL,                            /* perform_getsock */
+-  ZERO_NULL,                            /* disconnect */
+-  ZERO_NULL,                            /* write_resp */
+-  ZERO_NULL,                            /* write_resp_hd */
+-  ZERO_NULL,                            /* connection_check */
+-  ZERO_NULL,                            /* attach connection */
+-  ZERO_NULL,                            /* follow */
+-  PORT_SMB,                             /* defport */
+-  CURLPROTO_SMB,                        /* protocol */
+-  CURLPROTO_SMB,                        /* family */
+-  PROTOPT_NONE                          /* flags */
+-};
+-
+-#ifdef USE_SSL
+-/*
+- * SMBS handler interface
+- */
+-const struct Curl_handler Curl_handler_smbs = {
+-  "smbs",                               /* scheme */
+-  smb_setup_connection,                 /* setup_connection */
+-  smb_do,                               /* do_it */
+-  ZERO_NULL,                            /* done */
+-  ZERO_NULL,                            /* do_more */
+-  smb_connect,                          /* connect_it */
+-  smb_connection_state,                 /* connecting */
+-  smb_request_state,                    /* doing */
+-  smb_getsock,                          /* proto_getsock */
+-  smb_getsock,                          /* doing_getsock */
+-  ZERO_NULL,                            /* domore_getsock */
+-  ZERO_NULL,                            /* perform_getsock */
+-  ZERO_NULL,                            /* disconnect */
+-  ZERO_NULL,                            /* write_resp */
+-  ZERO_NULL,                            /* write_resp_hd */
+-  ZERO_NULL,                            /* connection_check */
+-  ZERO_NULL,                            /* attach connection */
+-  ZERO_NULL,                            /* follow */
+-  PORT_SMBS,                            /* defport */
+-  CURLPROTO_SMBS,                       /* protocol */
+-  CURLPROTO_SMB,                        /* family */
+-  PROTOPT_SSL                           /* flags */
+-};
+-#endif
+-
+ #define MAX_PAYLOAD_SIZE  0x8000
+ #define MAX_MESSAGE_SIZE  (MAX_PAYLOAD_SIZE + 0x1000)
+ #define CLIENTNAME        "curl"
+@@ -448,9 +377,7 @@ static void smb_easy_dtor(void *key, size_t klen, void *entry)
+   struct smb_request *req = entry;
+   (void)key;
+   (void)klen;
+-  /* `req->path` points to somewhere in `struct smb_conn` which is
+-   * kept at the connection meta. If the connection is destroyed first,
+-   * req->path points to free'd memory. */
++  Curl_safefree(req->path);
+   free(req);
+ }
+ 
+@@ -466,6 +393,52 @@ static void smb_conn_dtor(void *key, size_t klen, void *entry)
+   free(smbc);
+ }
+ 
++static CURLcode smb_parse_url_path(struct Curl_easy *data,
++                                   struct smb_conn *smbc,
++                                   struct smb_request *req)
++{
++  char *path;
++  char *slash, *s;
++  CURLcode result;
++
++  /* URL decode the path */
++  result = Curl_urldecode(data->state.up.path, 0, &path, NULL, REJECT_CTRL);
++  if(result)
++    return result;
++
++  /* Parse the path for the share */
++  Curl_safefree(smbc->share);
++  smbc->share = strdup((*path == '/' || *path == '\\') ? path + 1 : path);
++  free(path);
++  if(!smbc->share)
++    return CURLE_OUT_OF_MEMORY;
++
++  slash = strchr(smbc->share, '/');
++  if(!slash)
++    slash = strchr(smbc->share, '\\');
++
++  /* The share must be present */
++  if(!slash) {
++    Curl_safefree(smbc->share);
++    failf(data, "missing share in URL path for SMB");
++    return CURLE_URL_MALFORMAT;
++  }
++
++  /* Parse the path for the file path converting any forward slashes into
++     backslashes */
++  *slash++ = 0;
++  for(s = slash; *s; s++) {
++    if(*s == '/')
++      *s = '\\';
++  }
++  /* keep a copy at easy struct to not share this with connection state */
++  req->path = strdup(slash);
++  if(!req->path)
++    return CURLE_OUT_OF_MEMORY;
++
++  return CURLE_OK;
++}
++
+ /* this should setup things in the connection, not in the easy
+    handle */
+ static CURLcode smb_setup_connection(struct Curl_easy *data,
+@@ -1225,47 +1198,63 @@ static CURLcode smb_do(struct Curl_easy *data, bool *done)
+   return CURLE_URL_MALFORMAT;
+ }
+ 
+-static CURLcode smb_parse_url_path(struct Curl_easy *data,
+-                                   struct smb_conn *smbc,
+-                                   struct smb_request *req)
+-{
+-  char *path;
+-  char *slash;
+-  CURLcode result;
+-
+-  /* URL decode the path */
+-  result = Curl_urldecode(data->state.up.path, 0, &path, NULL, REJECT_CTRL);
+-  if(result)
+-    return result;
+-
+-  /* Parse the path for the share */
+-  smbc->share = strdup((*path == '/' || *path == '\\') ? path + 1 : path);
+-  free(path);
+-  if(!smbc->share)
+-    return CURLE_OUT_OF_MEMORY;
+-
+-  slash = strchr(smbc->share, '/');
+-  if(!slash)
+-    slash = strchr(smbc->share, '\\');
+-
+-  /* The share must be present */
+-  if(!slash) {
+-    Curl_safefree(smbc->share);
+-    failf(data, "missing share in URL path for SMB");
+-    return CURLE_URL_MALFORMAT;
+-  }
+-
+-  /* Parse the path for the file path converting any forward slashes into
+-     backslashes */
+-  *slash++ = 0;
+-  req->path = slash;
++/*
++ * SMB handler interface
++ */
++const struct Curl_handler Curl_handler_smb = {
++  "smb",                                /* scheme */
++  smb_setup_connection,                 /* setup_connection */
++  smb_do,                               /* do_it */
++  ZERO_NULL,                            /* done */
++  ZERO_NULL,                            /* do_more */
++  smb_connect,                          /* connect_it */
++  smb_connection_state,                 /* connecting */
++  smb_request_state,                    /* doing */
++  smb_getsock,                          /* proto_getsock */
++  smb_getsock,                          /* doing_getsock */
++  ZERO_NULL,                            /* domore_getsock */
++  ZERO_NULL,                            /* perform_getsock */
++  ZERO_NULL,                            /* disconnect */
++  ZERO_NULL,                            /* write_resp */
++  ZERO_NULL,                            /* write_resp_hd */
++  ZERO_NULL,                            /* connection_check */
++  ZERO_NULL,                            /* attach connection */
++  ZERO_NULL,                            /* follow */
++  PORT_SMB,                             /* defport */
++  CURLPROTO_SMB,                        /* protocol */
++  CURLPROTO_SMB,                        /* family */
++  PROTOPT_NONE                          /* flags */
++};
+ 
+-  for(; *slash; slash++) {
+-    if(*slash == '/')
+-      *slash = '\\';
+-  }
+-  return CURLE_OK;
+-}
++#ifdef USE_SSL
++/*
++ * SMBS handler interface
++ */
++const struct Curl_handler Curl_handler_smbs = {
++  "smbs",                               /* scheme */
++  smb_setup_connection,                 /* setup_connection */
++  smb_do,                               /* do_it */
++  ZERO_NULL,                            /* done */
++  ZERO_NULL,                            /* do_more */
++  smb_connect,                          /* connect_it */
++  smb_connection_state,                 /* connecting */
++  smb_request_state,                    /* doing */
++  smb_getsock,                          /* proto_getsock */
++  smb_getsock,                          /* doing_getsock */
++  ZERO_NULL,                            /* domore_getsock */
++  ZERO_NULL,                            /* perform_getsock */
++  ZERO_NULL,                            /* disconnect */
++  ZERO_NULL,                            /* write_resp */
++  ZERO_NULL,                            /* write_resp_hd */
++  ZERO_NULL,                            /* connection_check */
++  ZERO_NULL,                            /* attach connection */
++  ZERO_NULL,                            /* follow */
++  PORT_SMBS,                            /* defport */
++  CURLPROTO_SMBS,                       /* protocol */
++  CURLPROTO_SMB,                        /* family */
++  PROTOPT_SSL                           /* flags */
++};
++#endif
+ 
+ #endif /* CURL_DISABLE_SMB && USE_CURL_NTLM_CORE &&
+           SIZEOF_CURL_OFF_T > 4 */
+diff --git a/lib/tftp.c b/lib/tftp.c
+index 5ea986dbb4..0fecd93645 100644
+--- a/lib/tftp.c
++++ b/lib/tftp.c
+@@ -148,52 +148,6 @@ struct tftp_conn {
+   struct tftp_packet spacket;
+ };
+ 
+-
+-/* Forward declarations */
+-static CURLcode tftp_rx(struct tftp_conn *state, tftp_event_t event);
+-static CURLcode tftp_tx(struct tftp_conn *state, tftp_event_t event);
+-static CURLcode tftp_connect(struct Curl_easy *data, bool *done);
+-static CURLcode tftp_do(struct Curl_easy *data, bool *done);
+-static CURLcode tftp_done(struct Curl_easy *data,
+-                          CURLcode, bool premature);
+-static CURLcode tftp_setup_connection(struct Curl_easy *data,
+-                                      struct connectdata *conn);
+-static CURLcode tftp_multi_statemach(struct Curl_easy *data, bool *done);
+-static CURLcode tftp_doing(struct Curl_easy *data, bool *dophase_done);
+-static int tftp_getsock(struct Curl_easy *data, struct connectdata *conn,
+-                        curl_socket_t *socks);
+-static CURLcode tftp_translate_code(tftp_error_t error);
+-
+-
+-/*
+- * TFTP protocol handler.
+- */
+-
+-const struct Curl_handler Curl_handler_tftp = {
+-  "tftp",                               /* scheme */
+-  tftp_setup_connection,                /* setup_connection */
+-  tftp_do,                              /* do_it */
+-  tftp_done,                            /* done */
+-  ZERO_NULL,                            /* do_more */
+-  tftp_connect,                         /* connect_it */
+-  tftp_multi_statemach,                 /* connecting */
+-  tftp_doing,                           /* doing */
+-  tftp_getsock,                         /* proto_getsock */
+-  tftp_getsock,                         /* doing_getsock */
+-  ZERO_NULL,                            /* domore_getsock */
+-  ZERO_NULL,                            /* perform_getsock */
+-  ZERO_NULL,                            /* disconnect */
+-  ZERO_NULL,                            /* write_resp */
+-  ZERO_NULL,                            /* write_resp_hd */
+-  ZERO_NULL,                            /* connection_check */
+-  ZERO_NULL,                            /* attach connection */
+-  ZERO_NULL,                            /* follow */
+-  PORT_TFTP,                            /* defport */
+-  CURLPROTO_TFTP,                       /* protocol */
+-  CURLPROTO_TFTP,                       /* family */
+-  PROTOPT_NOTCPPROXY | PROTOPT_NOURLQUERY /* flags */
+-};
+-
+ /**********************************************************
+  *
+  * tftp_set_timeouts -
+@@ -390,190 +344,175 @@ static CURLcode tftp_option_add(struct tftp_conn *state, size_t *csize,
+   return CURLE_OK;
+ }
+ 
+-static CURLcode tftp_connect_for_tx(struct tftp_conn *state,
+-                                    tftp_event_t event)
+-{
+-  CURLcode result;
+-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+-  struct Curl_easy *data = state->data;
+-
+-  infof(data, "%s", "Connected for transmit");
+-#endif
+-  state->state = TFTP_STATE_TX;
+-  result = tftp_set_timeouts(state);
+-  if(result)
+-    return result;
+-  return tftp_tx(state, event);
+-}
+-
+-static CURLcode tftp_connect_for_rx(struct tftp_conn *state,
+-                                    tftp_event_t event)
+-{
+-  CURLcode result;
+-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+-  struct Curl_easy *data = state->data;
+-
+-  infof(data, "%s", "Connected for receive");
+-#endif
+-  state->state = TFTP_STATE_RX;
+-  result = tftp_set_timeouts(state);
+-  if(result)
+-    return result;
+-  return tftp_rx(state, event);
+-}
++/* the next blocknum is x + 1 but it needs to wrap at an unsigned 16bit
++   boundary */
++#define NEXT_BLOCKNUM(x) (((x) + 1) & 0xffff)
+ 
+-static CURLcode tftp_send_first(struct tftp_conn *state,
+-                                tftp_event_t event)
++/**********************************************************
++ *
++ * tftp_tx
++ *
++ * Event handler for the TX state
++ *
++ **********************************************************/
++static CURLcode tftp_tx(struct tftp_conn *state, tftp_event_t event)
+ {
+-  size_t sbytes;
+-  ssize_t senddata;
+-  const char *mode = "octet";
+-  char *filename;
+   struct Curl_easy *data = state->data;
+-  const struct Curl_sockaddr_ex *remote_addr = NULL;
++  ssize_t sbytes;
+   CURLcode result = CURLE_OK;
+-
+-  /* Set ASCII mode if -B flag was used */
+-  if(data->state.prefer_ascii)
+-    mode = "netascii";
++  struct SingleRequest *k = &data->req;
++  size_t cb; /* Bytes currently read */
++  char buffer[STRERROR_LEN];
++  char *bufptr;
++  bool eos;
+ 
+   switch(event) {
+ 
+-  case TFTP_EVENT_INIT:    /* Send the first packet out */
+-  case TFTP_EVENT_TIMEOUT: /* Resend the first packet out */
+-    /* Increment the retry counter, quit if over the limit */
+-    state->retries++;
+-    if(state->retries > state->retry_max) {
+-      state->error = TFTP_ERR_NORESPONSE;
+-      state->state = TFTP_STATE_FIN;
+-      return result;
+-    }
++  case TFTP_EVENT_ACK:
++  case TFTP_EVENT_OACK:
++    if(event == TFTP_EVENT_ACK) {
++      /* Ack the packet */
++      int rblock = getrpacketblock(&state->rpacket);
+ 
+-    if(data->state.upload) {
+-      /* If we are uploading, send an WRQ */
+-      setpacketevent(&state->spacket, TFTP_EVENT_WRQ);
+-      if(data->state.infilesize != -1)
+-        Curl_pgrsSetUploadSize(data, data->state.infilesize);
+-    }
+-    else {
+-      /* If we are downloading, send an RRQ */
+-      setpacketevent(&state->spacket, TFTP_EVENT_RRQ);
+-    }
+-    /* As RFC3617 describes the separator slash is not actually part of the
+-       filename so we skip the always-present first letter of the path
+-       string. */
+-    result = Curl_urldecode(&state->data->state.up.path[1], 0,
+-                            &filename, NULL, REJECT_ZERO);
+-    if(result)
+-      return result;
++      if(rblock != state->block &&
++         /* There is a bug in tftpd-hpa that causes it to send us an ack for
++          * 65535 when the block number wraps to 0. So when we are expecting
++          * 0, also accept 65535. See
++          * https://www.syslinux.org/archives/2010-September/015612.html
++          * */
++         !(state->block == 0 && rblock == 65535)) {
++        /* This is not the expected block. Log it and up the retry counter */
++        infof(data, "Received ACK for block %d, expecting %d",
++              rblock, state->block);
++        state->retries++;
++        /* Bail out if over the maximum */
++        if(state->retries > state->retry_max) {
++          failf(data, "tftp_tx: giving up waiting for block %d ack",
++                state->block);
++          result = CURLE_SEND_ERROR;
++        }
++        else {
++          /* Re-send the data packet */
++          sbytes = sendto(state->sockfd, (void *)state->spacket.data,
++                          4 + (SEND_TYPE_ARG3)state->sbytes, SEND_4TH_ARG,
++                          (struct sockaddr *)&state->remote_addr,
++                          state->remote_addrlen);
++          /* Check all sbytes were sent */
++          if(sbytes < 0) {
++            failf(data, "%s",
++                  Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++            result = CURLE_SEND_ERROR;
++          }
++        }
+ 
+-    if(strlen(filename) > (state->blksize - strlen(mode) - 4)) {
+-      failf(data, "TFTP filename too long");
+-      free(filename);
+-      return CURLE_TFTP_ILLEGAL; /* too long filename field */
++        return result;
++      }
++      /* This is the expected packet. Reset the counters and send the next
++         block */
++      state->rx_time = time(NULL);
++      state->block++;
+     }
++    else
++      state->block = 1; /* first data block is 1 when using OACK */
+ 
+-    msnprintf((char *)state->spacket.data + 2,
+-              state->blksize,
+-              "%s%c%s%c", filename, '\0',  mode, '\0');
+-    sbytes = 4 + strlen(filename) + strlen(mode);
+-
+-    /* optional addition of TFTP options */
+-    if(!data->set.tftp_no_options) {
+-      char buf[64];
+-      /* add tsize option */
+-      msnprintf(buf, sizeof(buf), "%" FMT_OFF_T,
+-                data->state.upload && (data->state.infilesize != -1) ?
+-                data->state.infilesize : 0);
+-
+-      result = tftp_option_add(state, &sbytes,
+-                               (char *)state->spacket.data + sbytes,
+-                               TFTP_OPTION_TSIZE);
+-      if(result == CURLE_OK)
+-        result = tftp_option_add(state, &sbytes,
+-                                 (char *)state->spacket.data + sbytes, buf);
+-
+-      /* add blksize option */
+-      msnprintf(buf, sizeof(buf), "%d", state->requested_blksize);
+-      if(result == CURLE_OK)
+-        result = tftp_option_add(state, &sbytes,
+-                                 (char *)state->spacket.data + sbytes,
+-                                 TFTP_OPTION_BLKSIZE);
+-      if(result == CURLE_OK)
+-        result = tftp_option_add(state, &sbytes,
+-                                 (char *)state->spacket.data + sbytes, buf);
+-
+-      /* add timeout option */
+-      msnprintf(buf, sizeof(buf), "%d", state->retry_time);
+-      if(result == CURLE_OK)
+-        result = tftp_option_add(state, &sbytes,
+-                                 (char *)state->spacket.data + sbytes,
+-                                 TFTP_OPTION_INTERVAL);
+-      if(result == CURLE_OK)
+-        result = tftp_option_add(state, &sbytes,
+-                                 (char *)state->spacket.data + sbytes, buf);
+-
+-      if(result != CURLE_OK) {
+-        failf(data, "TFTP buffer too small for options");
+-        free(filename);
+-        return CURLE_TFTP_ILLEGAL;
+-      }
++    state->retries = 0;
++    setpacketevent(&state->spacket, TFTP_EVENT_DATA);
++    setpacketblock(&state->spacket, state->block);
++    if(state->block > 1 && state->sbytes < state->blksize) {
++      state->state = TFTP_STATE_FIN;
++      return CURLE_OK;
+     }
+ 
+-    /* the typecase for the 3rd argument is mostly for systems that do
+-       not have a size_t argument, like older unixes that want an 'int' */
+-#ifdef __AMIGA__
+-#define CURL_SENDTO_ARG5(x) CURL_UNCONST(x)
+-#else
+-#define CURL_SENDTO_ARG5(x) (x)
+-#endif
+-    remote_addr = Curl_conn_get_remote_addr(data, FIRSTSOCKET);
+-    if(!remote_addr)
+-      return CURLE_FAILED_INIT;
++    /* TFTP considers data block size < 512 bytes as an end of session. So
++     * in some cases we must wait for additional data to build full (512 bytes)
++     * data block.
++     * */
++    state->sbytes = 0;
++    bufptr = (char *)state->spacket.data + 4;
++    do {
++      result = Curl_client_read(data, bufptr, state->blksize - state->sbytes,
++                                &cb, &eos);
++      if(result)
++        return result;
++      state->sbytes += cb;
++      bufptr += cb;
++    } while(state->sbytes < state->blksize && cb);
+ 
+-    senddata = sendto(state->sockfd, (void *)state->spacket.data,
+-                      (SEND_TYPE_ARG3)sbytes, 0,
+-                      CURL_SENDTO_ARG5(&remote_addr->curl_sa_addr),
+-                      (curl_socklen_t)remote_addr->addrlen);
+-    if(senddata != (ssize_t)sbytes) {
+-      char buffer[STRERROR_LEN];
+-      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++    sbytes = sendto(state->sockfd, (void *)state->spacket.data,
++                    4 + (SEND_TYPE_ARG3)state->sbytes, SEND_4TH_ARG,
++                    (struct sockaddr *)&state->remote_addr,
++                    state->remote_addrlen);
++    /* Check all sbytes were sent */
++    if(sbytes < 0) {
++      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++      return CURLE_SEND_ERROR;
+     }
+-    free(filename);
++    /* Update the progress meter */
++    k->writebytecount += state->sbytes;
++    Curl_pgrsSetUploadCounter(data, k->writebytecount);
+     break;
+ 
+-  case TFTP_EVENT_OACK:
+-    if(data->state.upload) {
+-      result = tftp_connect_for_tx(state, event);
++  case TFTP_EVENT_TIMEOUT:
++    /* Increment the retry counter and log the timeout */
++    state->retries++;
++    infof(data, "Timeout waiting for block %d ACK. "
++          " Retries = %d", NEXT_BLOCKNUM(state->block), state->retries);
++    /* Decide if we have had enough */
++    if(state->retries > state->retry_max) {
++      state->error = TFTP_ERR_TIMEOUT;
++      state->state = TFTP_STATE_FIN;
+     }
+     else {
+-      result = tftp_connect_for_rx(state, event);
++      /* Re-send the data packet */
++      sbytes = sendto(state->sockfd, (void *)state->spacket.data,
++                      4 + (SEND_TYPE_ARG3)state->sbytes, SEND_4TH_ARG,
++                      (struct sockaddr *)&state->remote_addr,
++                      state->remote_addrlen);
++      /* Check all sbytes were sent */
++      if(sbytes < 0) {
++        failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++        return CURLE_SEND_ERROR;
++      }
++      /* since this was a re-send, we remain at the still byte position */
++      Curl_pgrsSetUploadCounter(data, k->writebytecount);
+     }
+     break;
+ 
+-  case TFTP_EVENT_ACK: /* Connected for transmit */
+-    result = tftp_connect_for_tx(state, event);
+-    break;
+-
+-  case TFTP_EVENT_DATA: /* Connected for receive */
+-    result = tftp_connect_for_rx(state, event);
+-    break;
+-
+   case TFTP_EVENT_ERROR:
+     state->state = TFTP_STATE_FIN;
++    setpacketevent(&state->spacket, TFTP_EVENT_ERROR);
++    setpacketblock(&state->spacket, state->block);
++    (void)sendto(state->sockfd, (void *)state->spacket.data, 4, SEND_4TH_ARG,
++                 (struct sockaddr *)&state->remote_addr,
++                 state->remote_addrlen);
++    /* do not bother with the return code, but if the socket is still up we
++     * should be a good TFTP client and let the server know we are done */
++    state->state = TFTP_STATE_FIN;
+     break;
+ 
+   default:
+-    failf(state->data, "tftp_send_first: internal error");
++    failf(data, "tftp_tx: internal error, event: %i", (int)(event));
+     break;
+   }
+ 
+   return result;
+ }
+ 
+-/* the next blocknum is x + 1 but it needs to wrap at an unsigned 16bit
+-   boundary */
+-#define NEXT_BLOCKNUM(x) (((x) + 1)&0xffff)
++static CURLcode tftp_connect_for_tx(struct tftp_conn *state,
++                                    tftp_event_t event)
++{
++  CURLcode result;
++#ifndef CURL_DISABLE_VERBOSE_STRINGS
++  struct Curl_easy *data = state->data;
++
++  infof(data, "%s", "Connected for transmit");
++#endif
++  state->state = TFTP_STATE_TX;
++  result = tftp_set_timeouts(state);
++  if(result)
++    return result;
++  return tftp_tx(state, event);
++}
+ 
+ /**********************************************************
+  *
+@@ -620,7 +559,7 @@ static CURLcode tftp_rx(struct tftp_conn *state, tftp_event_t event)
+                     (struct sockaddr *)&state->remote_addr,
+                     state->remote_addrlen);
+     if(sbytes < 0) {
+-      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
+       return CURLE_SEND_ERROR;
+     }
+ 
+@@ -629,209 +568,59 @@ static CURLcode tftp_rx(struct tftp_conn *state, tftp_event_t event)
+       state->state = TFTP_STATE_FIN;
+     }
+     else {
+-      state->state = TFTP_STATE_RX;
+-    }
+-    state->rx_time = time(NULL);
+-    break;
+-
+-  case TFTP_EVENT_OACK:
+-    /* ACK option acknowledgement so we can move on to data */
+-    state->block = 0;
+-    state->retries = 0;
+-    setpacketevent(&state->spacket, TFTP_EVENT_ACK);
+-    setpacketblock(&state->spacket, state->block);
+-    sbytes = sendto(state->sockfd, (void *)state->spacket.data,
+-                    4, SEND_4TH_ARG,
+-                    (struct sockaddr *)&state->remote_addr,
+-                    state->remote_addrlen);
+-    if(sbytes < 0) {
+-      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
+-      return CURLE_SEND_ERROR;
+-    }
+-
+-    /* we are ready to RX data */
+-    state->state = TFTP_STATE_RX;
+-    state->rx_time = time(NULL);
+-    break;
+-
+-  case TFTP_EVENT_TIMEOUT:
+-    /* Increment the retry count and fail if over the limit */
+-    state->retries++;
+-    infof(data,
+-          "Timeout waiting for block %d ACK. Retries = %d",
+-          NEXT_BLOCKNUM(state->block), state->retries);
+-    if(state->retries > state->retry_max) {
+-      state->error = TFTP_ERR_TIMEOUT;
+-      state->state = TFTP_STATE_FIN;
+-    }
+-    else {
+-      /* Resend the previous ACK */
+-      sbytes = sendto(state->sockfd, (void *)state->spacket.data,
+-                      4, SEND_4TH_ARG,
+-                      (struct sockaddr *)&state->remote_addr,
+-                      state->remote_addrlen);
+-      if(sbytes < 0) {
+-        failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
+-        return CURLE_SEND_ERROR;
+-      }
+-    }
+-    break;
+-
+-  case TFTP_EVENT_ERROR:
+-    setpacketevent(&state->spacket, TFTP_EVENT_ERROR);
+-    setpacketblock(&state->spacket, state->block);
+-    (void)sendto(state->sockfd, (void *)state->spacket.data,
+-                 4, SEND_4TH_ARG,
+-                 (struct sockaddr *)&state->remote_addr,
+-                 state->remote_addrlen);
+-    /* do not bother with the return code, but if the socket is still up we
+-     * should be a good TFTP client and let the server know we are done */
+-    state->state = TFTP_STATE_FIN;
+-    break;
+-
+-  default:
+-    failf(data, "%s", "tftp_rx: internal error");
+-    return CURLE_TFTP_ILLEGAL; /* not really the perfect return code for
+-                                  this */
+-  }
+-  return CURLE_OK;
+-}
+-
+-/**********************************************************
+- *
+- * tftp_tx
+- *
+- * Event handler for the TX state
+- *
+- **********************************************************/
+-static CURLcode tftp_tx(struct tftp_conn *state, tftp_event_t event)
+-{
+-  struct Curl_easy *data = state->data;
+-  ssize_t sbytes;
+-  CURLcode result = CURLE_OK;
+-  struct SingleRequest *k = &data->req;
+-  size_t cb; /* Bytes currently read */
+-  char buffer[STRERROR_LEN];
+-  char *bufptr;
+-  bool eos;
+-
+-  switch(event) {
+-
+-  case TFTP_EVENT_ACK:
+-  case TFTP_EVENT_OACK:
+-    if(event == TFTP_EVENT_ACK) {
+-      /* Ack the packet */
+-      int rblock = getrpacketblock(&state->rpacket);
+-
+-      if(rblock != state->block &&
+-         /* There is a bug in tftpd-hpa that causes it to send us an ack for
+-          * 65535 when the block number wraps to 0. So when we are expecting
+-          * 0, also accept 65535. See
+-          * https://www.syslinux.org/archives/2010-September/015612.html
+-          * */
+-         !(state->block == 0 && rblock == 65535)) {
+-        /* This is not the expected block. Log it and up the retry counter */
+-        infof(data, "Received ACK for block %d, expecting %d",
+-              rblock, state->block);
+-        state->retries++;
+-        /* Bail out if over the maximum */
+-        if(state->retries > state->retry_max) {
+-          failf(data, "tftp_tx: giving up waiting for block %d ack",
+-                state->block);
+-          result = CURLE_SEND_ERROR;
+-        }
+-        else {
+-          /* Re-send the data packet */
+-          sbytes = sendto(state->sockfd, (void *)state->spacket.data,
+-                          4 + (SEND_TYPE_ARG3)state->sbytes, SEND_4TH_ARG,
+-                          (struct sockaddr *)&state->remote_addr,
+-                          state->remote_addrlen);
+-          /* Check all sbytes were sent */
+-          if(sbytes < 0) {
+-            failf(data, "%s", Curl_strerror(SOCKERRNO,
+-                                            buffer, sizeof(buffer)));
+-            result = CURLE_SEND_ERROR;
+-          }
+-        }
+-
+-        return result;
+-      }
+-      /* This is the expected packet. Reset the counters and send the next
+-         block */
+-      state->rx_time = time(NULL);
+-      state->block++;
++      state->state = TFTP_STATE_RX;
+     }
+-    else
+-      state->block = 1; /* first data block is 1 when using OACK */
++    state->rx_time = time(NULL);
++    break;
+ 
++  case TFTP_EVENT_OACK:
++    /* ACK option acknowledgement so we can move on to data */
++    state->block = 0;
+     state->retries = 0;
+-    setpacketevent(&state->spacket, TFTP_EVENT_DATA);
++    setpacketevent(&state->spacket, TFTP_EVENT_ACK);
+     setpacketblock(&state->spacket, state->block);
+-    if(state->block > 1 && state->sbytes < state->blksize) {
+-      state->state = TFTP_STATE_FIN;
+-      return CURLE_OK;
+-    }
+-
+-    /* TFTP considers data block size < 512 bytes as an end of session. So
+-     * in some cases we must wait for additional data to build full (512 bytes)
+-     * data block.
+-     * */
+-    state->sbytes = 0;
+-    bufptr = (char *)state->spacket.data + 4;
+-    do {
+-      result = Curl_client_read(data, bufptr, state->blksize - state->sbytes,
+-                                &cb, &eos);
+-      if(result)
+-        return result;
+-      state->sbytes += cb;
+-      bufptr += cb;
+-    } while(state->sbytes < state->blksize && cb);
+-
+-    sbytes = sendto(state->sockfd, (void *) state->spacket.data,
+-                    4 + (SEND_TYPE_ARG3)state->sbytes, SEND_4TH_ARG,
++    sbytes = sendto(state->sockfd, (void *)state->spacket.data,
++                    4, SEND_4TH_ARG,
+                     (struct sockaddr *)&state->remote_addr,
+                     state->remote_addrlen);
+-    /* Check all sbytes were sent */
+     if(sbytes < 0) {
+-      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
+       return CURLE_SEND_ERROR;
+     }
+-    /* Update the progress meter */
+-    k->writebytecount += state->sbytes;
+-    Curl_pgrsSetUploadCounter(data, k->writebytecount);
++
++    /* we are ready to RX data */
++    state->state = TFTP_STATE_RX;
++    state->rx_time = time(NULL);
+     break;
+ 
+   case TFTP_EVENT_TIMEOUT:
+-    /* Increment the retry counter and log the timeout */
++    /* Increment the retry count and fail if over the limit */
+     state->retries++;
+-    infof(data, "Timeout waiting for block %d ACK. "
+-          " Retries = %d", NEXT_BLOCKNUM(state->block), state->retries);
+-    /* Decide if we have had enough */
++    infof(data,
++          "Timeout waiting for block %d ACK. Retries = %d",
++          NEXT_BLOCKNUM(state->block), state->retries);
+     if(state->retries > state->retry_max) {
+       state->error = TFTP_ERR_TIMEOUT;
+       state->state = TFTP_STATE_FIN;
+     }
+     else {
+-      /* Re-send the data packet */
++      /* Resend the previous ACK */
+       sbytes = sendto(state->sockfd, (void *)state->spacket.data,
+-                      4 + (SEND_TYPE_ARG3)state->sbytes, SEND_4TH_ARG,
++                      4, SEND_4TH_ARG,
+                       (struct sockaddr *)&state->remote_addr,
+                       state->remote_addrlen);
+-      /* Check all sbytes were sent */
+       if(sbytes < 0) {
+-        failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++        failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
+         return CURLE_SEND_ERROR;
+       }
+-      /* since this was a re-send, we remain at the still byte position */
+-      Curl_pgrsSetUploadCounter(data, k->writebytecount);
+     }
+     break;
+ 
+   case TFTP_EVENT_ERROR:
+-    state->state = TFTP_STATE_FIN;
+     setpacketevent(&state->spacket, TFTP_EVENT_ERROR);
+     setpacketblock(&state->spacket, state->block);
+-    (void)sendto(state->sockfd, (void *)state->spacket.data, 4, SEND_4TH_ARG,
++    (void)sendto(state->sockfd, (void *)state->spacket.data,
++                 4, SEND_4TH_ARG,
+                  (struct sockaddr *)&state->remote_addr,
+                  state->remote_addrlen);
+     /* do not bother with the return code, but if the socket is still up we
+@@ -840,7 +629,172 @@ static CURLcode tftp_tx(struct tftp_conn *state, tftp_event_t event)
+     break;
+ 
+   default:
+-    failf(data, "tftp_tx: internal error, event: %i", (int)(event));
++    failf(data, "%s", "tftp_rx: internal error");
++    return CURLE_TFTP_ILLEGAL; /* not really the perfect return code for
++                                  this */
++  }
++  return CURLE_OK;
++}
++
++static CURLcode tftp_connect_for_rx(struct tftp_conn *state,
++                                    tftp_event_t event)
++{
++  CURLcode result;
++#ifndef CURL_DISABLE_VERBOSE_STRINGS
++  struct Curl_easy *data = state->data;
++
++  infof(data, "%s", "Connected for receive");
++#endif
++  state->state = TFTP_STATE_RX;
++  result = tftp_set_timeouts(state);
++  if(result)
++    return result;
++  return tftp_rx(state, event);
++}
++
++static CURLcode tftp_send_first(struct tftp_conn *state,
++                                tftp_event_t event)
++{
++  size_t sbytes;
++  ssize_t senddata;
++  const char *mode = "octet";
++  char *filename;
++  struct Curl_easy *data = state->data;
++  const struct Curl_sockaddr_ex *remote_addr = NULL;
++  CURLcode result = CURLE_OK;
++
++  /* Set ASCII mode if -B flag was used */
++  if(data->state.prefer_ascii)
++    mode = "netascii";
++
++  switch(event) {
++
++  case TFTP_EVENT_INIT:    /* Send the first packet out */
++  case TFTP_EVENT_TIMEOUT: /* Resend the first packet out */
++    /* Increment the retry counter, quit if over the limit */
++    state->retries++;
++    if(state->retries > state->retry_max) {
++      state->error = TFTP_ERR_NORESPONSE;
++      state->state = TFTP_STATE_FIN;
++      return result;
++    }
++
++    if(data->state.upload) {
++      /* If we are uploading, send an WRQ */
++      setpacketevent(&state->spacket, TFTP_EVENT_WRQ);
++      if(data->state.infilesize != -1)
++        Curl_pgrsSetUploadSize(data, data->state.infilesize);
++    }
++    else {
++      /* If we are downloading, send an RRQ */
++      setpacketevent(&state->spacket, TFTP_EVENT_RRQ);
++    }
++    /* As RFC3617 describes the separator slash is not actually part of the
++       filename so we skip the always-present first letter of the path
++       string. */
++    result = Curl_urldecode(&state->data->state.up.path[1], 0,
++                            &filename, NULL, REJECT_ZERO);
++    if(result)
++      return result;
++
++    if(strlen(filename) > (state->blksize - strlen(mode) - 4)) {
++      failf(data, "TFTP filename too long");
++      free(filename);
++      return CURLE_TFTP_ILLEGAL; /* too long filename field */
++    }
++
++    msnprintf((char *)state->spacket.data + 2,
++              state->blksize,
++              "%s%c%s%c", filename, '\0',  mode, '\0');
++    sbytes = 4 + strlen(filename) + strlen(mode);
++
++    /* optional addition of TFTP options */
++    if(!data->set.tftp_no_options) {
++      char buf[64];
++      /* add tsize option */
++      msnprintf(buf, sizeof(buf), "%" FMT_OFF_T,
++                data->state.upload && (data->state.infilesize != -1) ?
++                data->state.infilesize : 0);
++
++      result = tftp_option_add(state, &sbytes,
++                               (char *)state->spacket.data + sbytes,
++                               TFTP_OPTION_TSIZE);
++      if(result == CURLE_OK)
++        result = tftp_option_add(state, &sbytes,
++                                 (char *)state->spacket.data + sbytes, buf);
++
++      /* add blksize option */
++      msnprintf(buf, sizeof(buf), "%d", state->requested_blksize);
++      if(result == CURLE_OK)
++        result = tftp_option_add(state, &sbytes,
++                                 (char *)state->spacket.data + sbytes,
++                                 TFTP_OPTION_BLKSIZE);
++      if(result == CURLE_OK)
++        result = tftp_option_add(state, &sbytes,
++                                 (char *)state->spacket.data + sbytes, buf);
++
++      /* add timeout option */
++      msnprintf(buf, sizeof(buf), "%d", state->retry_time);
++      if(result == CURLE_OK)
++        result = tftp_option_add(state, &sbytes,
++                                 (char *)state->spacket.data + sbytes,
++                                 TFTP_OPTION_INTERVAL);
++      if(result == CURLE_OK)
++        result = tftp_option_add(state, &sbytes,
++                                 (char *)state->spacket.data + sbytes, buf);
++
++      if(result != CURLE_OK) {
++        failf(data, "TFTP buffer too small for options");
++        free(filename);
++        return CURLE_TFTP_ILLEGAL;
++      }
++    }
++
++    /* the typecase for the 3rd argument is mostly for systems that do
++       not have a size_t argument, like older unixes that want an 'int' */
++#ifdef __AMIGA__
++#define CURL_SENDTO_ARG5(x) CURL_UNCONST(x)
++#else
++#define CURL_SENDTO_ARG5(x) (x)
++#endif
++    remote_addr = Curl_conn_get_remote_addr(data, FIRSTSOCKET);
++    if(!remote_addr)
++      return CURLE_FAILED_INIT;
++
++    senddata = sendto(state->sockfd, (void *)state->spacket.data,
++                      (SEND_TYPE_ARG3)sbytes, 0,
++                      CURL_SENDTO_ARG5(&remote_addr->curl_sa_addr),
++                      (curl_socklen_t)remote_addr->addrlen);
++    if(senddata != (ssize_t)sbytes) {
++      char buffer[STRERROR_LEN];
++      failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
++    }
++    free(filename);
++    break;
++
++  case TFTP_EVENT_OACK:
++    if(data->state.upload) {
++      result = tftp_connect_for_tx(state, event);
++    }
++    else {
++      result = tftp_connect_for_rx(state, event);
++    }
++    break;
++
++  case TFTP_EVENT_ACK: /* Connected for transmit */
++    result = tftp_connect_for_tx(state, event);
++    break;
++
++  case TFTP_EVENT_DATA: /* Connected for receive */
++    result = tftp_connect_for_rx(state, event);
++    break;
++
++  case TFTP_EVENT_ERROR:
++    state->state = TFTP_STATE_FIN;
++    break;
++
++  default:
++    failf(state->data, "tftp_send_first: internal error");
+     break;
+   }
+ 
+@@ -1400,4 +1354,33 @@ static CURLcode tftp_setup_connection(struct Curl_easy *data,
+ 
+   return CURLE_OK;
+ }
++
++/*
++ * TFTP protocol handler.
++ */
++const struct Curl_handler Curl_handler_tftp = {
++  "tftp",                               /* scheme */
++  tftp_setup_connection,                /* setup_connection */
++  tftp_do,                              /* do_it */
++  tftp_done,                            /* done */
++  ZERO_NULL,                            /* do_more */
++  tftp_connect,                         /* connect_it */
++  tftp_multi_statemach,                 /* connecting */
++  tftp_doing,                           /* doing */
++  tftp_getsock,                         /* proto_getsock */
++  tftp_getsock,                         /* doing_getsock */
++  ZERO_NULL,                            /* domore_getsock */
++  ZERO_NULL,                            /* perform_getsock */
++  ZERO_NULL,                            /* disconnect */
++  ZERO_NULL,                            /* write_resp */
++  ZERO_NULL,                            /* write_resp_hd */
++  ZERO_NULL,                            /* connection_check */
++  ZERO_NULL,                            /* attach connection */
++  ZERO_NULL,                            /* follow */
++  PORT_TFTP,                            /* defport */
++  CURLPROTO_TFTP,                       /* protocol */
++  CURLPROTO_TFTP,                       /* family */
++  PROTOPT_NOTCPPROXY | PROTOPT_NOURLQUERY /* flags */
++};
++
+ #endif
+diff --git a/tests/data/Makefile.am b/tests/data/Makefile.am
+index 46b97e2913..ca1a0c52f8 100644
+--- a/tests/data/Makefile.am
++++ b/tests/data/Makefile.am
+@@ -228,7 +228,7 @@ test1680 test1681 test1682 test1683 \
+ test1700 test1701 test1702 test1703 test1704 test1705 test1706 test1707 \
+ test1708 test1709 test1710 \
+ \
+-test1800 test1801 \
++test1800 test1801 test1850 \
+ \
+ test1900 test1901          test1903 test1904 test1905 test1906 test1907 \
+ test1908 test1909 test1910 test1911 test1912 test1913 test1914 test1915 \
+diff --git a/tests/data/test1850 b/tests/data/test1850
+new file mode 100644
+index 0000000000..6a3e4d409b
+--- /dev/null
++++ b/tests/data/test1850
+@@ -0,0 +1,39 @@
++<?xml version="1.0" encoding="US-ASCII"?>
++<testcase>
++<info>
++<keywords>
++SMB
++</keywords>
++</info>
++
++# Server-side
++<reply>
++<data nocheck="yes">
++Basic SMB test complete
++</data>
++</reply>
++
++# Client-side
++<client>
++<server>
++smb
++</server>
++<features>
++smb
++</features>
++<name>
++Two SMB requests in the same command line
++</name>
++<command>
++-u 'curltest:curltest' smb://%HOSTIP:%SMBPORT/TESTS/%TESTNUMBER smb://%HOSTIP:%SMBPORT/TESTS/%TESTNUMBER
++</command>
++</client>
++
++# Verify data after the test has been "shot"
++<verify>
++<stdout>
++Basic SMB test complete
++Basic SMB test complete
++</stdout>
++</verify>
++</testcase>
+-- 
+2.53.0
+

--- a/specs/c/curl/0007-curl-8.15.0-CVE-2025-9086.patch
+++ b/specs/c/curl/0007-curl-8.15.0-CVE-2025-9086.patch
@@ -1,0 +1,56 @@
+From a8daa4ae31442a5ee932409a711fd65dc052c1eb Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 11 Aug 2025 20:23:05 +0200
+Subject: [PATCH] cookie: don't treat the leading slash as trailing
+
+If there is only a leading slash in the path, keep that. Also add an
+assert to make sure the path is never blank.
+
+Reported-by: Google Big Sleep
+Closes #18266
+
+(cherry picked from commit c6ae07c6a541e0e96d0040afb62b45dd37711300)
+---
+ lib/cookie.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/lib/cookie.c b/lib/cookie.c
+index 9221871e4b..2a1e59d9c6 100644
+--- a/lib/cookie.c
++++ b/lib/cookie.c
+@@ -296,9 +296,9 @@ static char *sanitize_cookie_path(const char *cookie_path)
+     /* Let cookie-path be the default-path. */
+     return strdup("/");
+ 
+-  /* remove trailing slash */
++  /* remove trailing slash when path is non-empty */
+   /* convert /hoge/ to /hoge */
+-  if(len && cookie_path[len - 1] == '/')
++  if(len > 1 && cookie_path[len - 1] == '/')
+     len--;
+ 
+   return Curl_memdup0(cookie_path, len);
+@@ -965,7 +965,7 @@ replace_existing(struct Curl_easy *data,
+          clist->spath && co->spath && /* both have paths */
+          clist->secure && !co->secure && !secure) {
+         size_t cllen;
+-        const char *sep;
++        const char *sep = NULL;
+ 
+         /*
+          * A non-secure cookie may not overlay an existing secure cookie.
+@@ -974,8 +974,9 @@ replace_existing(struct Curl_easy *data,
+          * "/loginhelper" is ok.
+          */
+ 
+-        sep = strchr(clist->spath + 1, '/');
+-
++        DEBUGASSERT(clist->spath[0]);
++        if(clist->spath[0])
++          sep = strchr(clist->spath + 1, '/');
+         if(sep)
+           cllen = sep - clist->spath;
+         else
+-- 
+2.54.0
+

--- a/specs/c/curl/curl.spec
+++ b/specs/c/curl/curl.spec
@@ -10,7 +10,7 @@
 Summary: A utility for getting files from remote servers (FTP, HTTP, and others)
 Name: curl
 Version: 8.15.0
-Release: 7%{?dist}
+Release: 10%{?dist}
 License: curl
 Source0: https://curl.se/download/%{name}-%{version_no_tilde}.tar.xz
 Source1: https://curl.se/download/%{name}-%{version_no_tilde}.tar.xz.asc
@@ -24,6 +24,21 @@ Patch001: 0001-curl-8.15.0-curl-tool_read_cb-fix-of-segfault.patch
 
 # fix broken TLS options for threaded LDAPS (CVE-2025-14017)
 Patch002: 0002-curl-8.15.0-CVE-2025-14017.patch
+
+# fix bad reuse of HTTP Negotiate connection (CVE-2026-1965)
+Patch003: 0003-curl-8.15.0-CVE-2026-1965.patch
+
+# fix token leak with redirect and netrc (CVE-2026-3783)
+Patch004: 0004-curl-8.15.0-CVE-2026-3783.patch
+
+# fix wrong proxy connection reuse with credentials (CVE-2026-3784)
+Patch005: 0005-curl-8.15.0-CVE-2026-3784.patch
+
+# fix use after free in SMB connection reuse (CVE-2026-3805)
+Patch006: 0006-curl-8.15.0-CVE-2026-3805.patch
+
+# fix Out of bounds read for cookie path (CVE-2025-9086)
+Patch007: 0007-curl-8.15.0-CVE-2025-9086.patch
 
 # patch making libcurl multilib ready
 Patch101: 0101-curl-7.32.0-multilib.patch
@@ -423,6 +438,15 @@ rm -f ${RPM_BUILD_ROOT}%{_mandir}/man1/wcurl.1*
 %{_libdir}/libcurl.so.4.[0-9].[0-9].minimal
 
 %changelog
+* Mon May 11 2026 Jan Macku <jamacku@redhat.com> - 8.15.0-7
+- fix Out of bounds read for cookie path (CVE-2025-9086)
+
+* Mon Apr 13 2026 Jan Macku <jamacku@redhat.com> - 8.15.0-6
+- fix bad reuse of HTTP Negotiate connection (CVE-2026-1965)
+- fix token leak with redirect and netrc (CVE-2026-3783)
+- fix wrong proxy connection reuse with credentials (CVE-2026-3784)
+- fix use after free in SMB connection reuse (CVE-2026-3805)
+
 * Mon Jan 19 2026 Jan Macku <jamacku@redhat.com> - 8.15.0-5
 - fix broken TLS options for threaded LDAPS (CVE-2025-14017)
 


### PR DESCRIPTION
## CVE Pin-Forward: curl

Pins `curl` to Fedora f43 HEAD (`1538b20`) to pick up
5 CVE patches added upstream.

### CVEs Resolved

| CVE | Severity | Status |
|-----|----------|--------|
| CVE-2025-9086 | High | Tracked |
| CVE-2026-3805 | High | Tracked |
| CVE-2026-1965 | — | Additional |
| CVE-2026-3783 | — | Additional |
| CVE-2026-3784 | — | Additional |

### Fedora Spec Delta

Old commit: `0e4af61`
New commit: `1538b20`

New patches:
- `0003-curl-8.15.0-CVE-2026-1965.patch`
- `0004-curl-8.15.0-CVE-2026-3783.patch`
- `0005-curl-8.15.0-CVE-2026-3784.patch`
- `0006-curl-8.15.0-CVE-2026-3805.patch`
- `0007-curl-8.15.0-CVE-2025-9086.patch`
