### PR TITLE
fix(corosync): pin-forward to f43 for 2 CVEs

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -273,7 +273,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.containerd]
 [components.containers-common]
 [components.convmv]
-[components.corosync]
 [components.corosync-qdevice]
 [components.cpp-httplib]
 [components.cppcheck]

--- a/base/comps/corosync/corosync.comp.toml
+++ b/base/comps/corosync/corosync.comp.toml
@@ -1,0 +1,2 @@
+[components.corosync]
+spec = { type = "upstream", upstream-commit = "63ea76e4bad12912d8e1202444b8fbc57b095903" }

--- a/locks/corosync.lock
+++ b/locks/corosync.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '2de47be2d1227827c642eeb38faf1938e11064d3'
-upstream-commit = '2de47be2d1227827c642eeb38faf1938e11064d3'
-input-fingerprint = 'sha256:4229ce9f4b035a2cd3acb7e89bfeffac57aff364b7192ec6badf4e3a89df03d9'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '63ea76e4bad12912d8e1202444b8fbc57b095903'
+input-fingerprint = 'sha256:dacb837121b914973d97eef7b923a88c963e67e64cd143c0da8d7e62e16f1f39'
+resolution-input-hash = 'sha256:e4f340f960364d1e07dd6b3036e68b09774aef9dfb22c5e5373528c5dd75822c'

--- a/specs/c/corosync/0001-totemsrp-Return-error-if-sanity-check-fails.patch
+++ b/specs/c/corosync/0001-totemsrp-Return-error-if-sanity-check-fails.patch
@@ -1,0 +1,46 @@
+From a16614accfdb3481264d7281843fadf439d9ab1b Mon Sep 17 00:00:00 2001
+From: Jan Friesse <jfriesse@redhat.com>
+Date: Thu, 2 Apr 2026 09:00:39 +0200
+Subject: [PATCH 1/2] totemsrp: Return error if sanity check fails
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Previously, the check_memb_commit_token_sanity function correctly
+checked the minimum message length. However, if the message was too
+short, it incorrectly returned a success code (0) instead of the
+expected failure code (-1).
+
+This commit ensures the appropriate error code is returned when the
+message length sanity check fails.
+
+Fixes: CVE-2026-35091
+
+Reported-by: Sebastián Alba Vives (@Sebasteuo / 0xS4bb1) <sebasjosue84@gmail.com>
+Signed-off-by: Jan Friesse <jfriesse@redhat.com>
+Also-proposed-by: nicholasyang <nicholas.yang@suse.com>
+Reviewed-by: Christine Caulfield <ccaulfie@redhat.com>
+---
+ exec/totemsrp.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/exec/totemsrp.c b/exec/totemsrp.c
+index a716ae9..372a96d 100644
+--- a/exec/totemsrp.c
++++ b/exec/totemsrp.c
+@@ -3811,10 +3811,10 @@ static int check_memb_commit_token_sanity(
+ 		log_printf (instance->totemsrp_log_level_security,
+ 		    "Received memb_commit_token message is too short...  ignoring.");
+ 
+-		return (0);
++		return (-1);
+ 	}
+ 
+-	addr_entries= mct_msg->addr_entries;
++	addr_entries = mct_msg->addr_entries;
+ 	if (endian_conversion_needed) {
+ 		addr_entries = swab32(addr_entries);
+ 	}
+-- 
+1.8.3.1
+

--- a/specs/c/corosync/0002-totemsrp-Fix-integer-overflow-in-memb_join_sanity.patch
+++ b/specs/c/corosync/0002-totemsrp-Fix-integer-overflow-in-memb_join_sanity.patch
@@ -1,0 +1,56 @@
+From 4082294f5094a7591e4e00658c5a605f05d644f1 Mon Sep 17 00:00:00 2001
+From: Jan Friesse <jfriesse@redhat.com>
+Date: Thu, 2 Apr 2026 09:44:06 +0200
+Subject: [PATCH 2/2] totemsrp: Fix integer overflow in memb_join_sanity
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This commit addresses an integer overflow (wraparound) vulnerability
+in the check_memb_join_sanity function.
+
+Previously, the 32-bit unsigned network values proc_list_entries and
+failed_list_entries were added together before being promoted to
+size_t. This allowed the addition to wrap around in 32-bit arithmetic
+(e.g., 0x80000000 + 0x80000000 = 0), resulting in a required_len
+calculation that was incorrectly small.
+
+The solution is to cast the list entries to size_t and verify that
+neither exceeds the maximum allowed value before the addition occurs.
+
+Fixes: CVE-2026-35092
+
+Reported-by: Sebastián Alba Vives (@Sebasteuo / 0xS4bb1) <sebasjosue84@gmail.com>
+Signed-off-by: Jan Friesse <jfriesse@redhat.com>
+Also-proposed-by: nicholasyang <nicholas.yang@suse.com>
+Reviewed-by: Christine Caulfield <ccaulfie@redhat.com>
+---
+ exec/totemsrp.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/exec/totemsrp.c b/exec/totemsrp.c
+index 372a96d..6759691 100644
+--- a/exec/totemsrp.c
++++ b/exec/totemsrp.c
+@@ -3786,7 +3786,17 @@ static int check_memb_join_sanity(
+ 		failed_list_entries = swab32(failed_list_entries);
+ 	}
+ 
+-	required_len = sizeof(struct memb_join) + ((proc_list_entries + failed_list_entries) * sizeof(struct srp_addr));
++	if (proc_list_entries > PROCESSOR_COUNT_MAX ||
++	    failed_list_entries > PROCESSOR_COUNT_MAX) {
++		log_printf (instance->totemsrp_log_level_security,
++		    "Received memb_join message list_entries exceeds the maximum "
++		    "allowed value...  ignoring.");
++
++		return (-1);
++	}
++
++	required_len = sizeof(struct memb_join) +
++	  (((size_t)proc_list_entries + (size_t)failed_list_entries) * sizeof(struct srp_addr));
+ 	if (msg_len < required_len) {
+ 		log_printf (instance->totemsrp_log_level_security,
+ 		    "Received memb_join message is too short...  ignoring.");
+-- 
+1.8.3.1
+

--- a/specs/c/corosync/corosync.spec
+++ b/specs/c/corosync/corosync.spec
@@ -18,10 +18,13 @@
 Name: corosync
 Summary: The Corosync Cluster Engine and Application Programming Interfaces
 Version: 3.1.10
-Release: 2%{?dist}
+Release: 4%{?dist}
 License: BSD-3-Clause
 URL: http://corosync.github.io/corosync/
 Source0: https://github.com/%{name}/%{name}/releases/download/v%{version}/%{name}-%{version}%{?gittarver}.tar.gz
+
+Patch0: 0001-totemsrp-Return-error-if-sanity-check-fails.patch
+Patch1: 0002-totemsrp-Fix-integer-overflow-in-memb_join_sanity.patch
 
 # Runtime bits
 # The automatic dependency overridden in favor of explicit version lock
@@ -292,6 +295,21 @@ network splits)
 %endif
 
 %changelog
+* Thu Apr 02 2026 Jan Friesse <jfriesse@redhat.com> - 3.1.10-2
+- totemsrp: Return error if sanity check fails
+  (fixes CVE-2026-35091)
+- totemsrp: Fix integer overflow in memb_join_sanity
+  (fixes CVE-2026-35092)
+
+* Fri Jan 23 2026 Benjamin A. Beasley <code@musicinmybrain.net> - 3.1.10-4
+- Rebuilt for net-snmp 5.9.5.2
+
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 3.1.10-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 3.1.10-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
 * Sat Nov 15 2025 Jan Friesse <jfriesse@redhat.com> - 3.1.10-1
 - New upstream release
 


### PR DESCRIPTION
## CVE Pin-Forward: corosync

Pins `corosync` to Fedora f43 HEAD (`63ea76e`) to pick up
2 CVE patches added upstream.

### CVEs Resolved

| CVE | Severity | Status |
|-----|----------|--------|
| CVE-2026-35091 | High | Tracked |
| CVE-2026-35092 | High | Tracked |

### Fedora Spec Delta

Old commit: `2de47be`
New commit: `63ea76e`

New patches:
- `0001-totemsrp-Return-error-if-sanity-check-fails.patch`
- `0002-totemsrp-Fix-integer-overflow-in-memb_join_sanity.patch`
