### PR TITLE
fix(libgsasl): pin-forward to f43 for 1 CVEs

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -1776,7 +1776,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.libgnomekbd]
 [components.libgpg-error]
 [components.libgphoto2]
-[components.libgsasl]
 [components.libgsf]
 [components.libgta]
 [components.libgtop2]

--- a/base/comps/libgsasl/libgsasl.comp.toml
+++ b/base/comps/libgsasl/libgsasl.comp.toml
@@ -1,0 +1,2 @@
+[components.libgsasl]
+spec = { type = "upstream", upstream-commit = "6c70668f2134da6302a6d72445fd7b6df979e929" }

--- a/locks/libgsasl.lock
+++ b/locks/libgsasl.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '4a55cce28048b207bd2b41c3755024ef8f3a5675'
-upstream-commit = '4a55cce28048b207bd2b41c3755024ef8f3a5675'
-input-fingerprint = 'sha256:9bc824d1b94496acefc068749307f285616b034ef42d302a934758a950077804'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '6c70668f2134da6302a6d72445fd7b6df979e929'
+input-fingerprint = 'sha256:c80edc923471e4c10cc5756842f1579b6faa769803fa809142d9d0ac88a73649'
+resolution-input-hash = 'sha256:ecfc89d5443f9a835dba2551f037dc0934958a98cdddabcbc6385447719d8cc3'

--- a/specs/l/libgsasl/0001-fix-gssapi-server-oob.patch
+++ b/specs/l/libgsasl/0001-fix-gssapi-server-oob.patch
@@ -1,0 +1,26 @@
+From: Simon Josefsson <simon@josefsson.org>
+Date: Fri, 15 Jul 2022 16:23:58 +0200
+Subject: [PATCH] GSSAPI server: Boundary check gss_wrap token (read OOB).
+Origin: upstream, https://gitlab.com/gsasl/gsasl/-/commit/796e4197f696261c1f872d7576371232330bcc30
+
+---
+ lib/gssapi/server.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/gssapi/server.c b/lib/gssapi/server.c
+index 5410360b..4ebfda47 100644
+--- a/lib/gssapi/server.c
++++ b/lib/gssapi/server.c
+@@ -218,6 +218,9 @@ _gsasl_gssapi_server_step (Gsasl_session * sctx,
+          FALSE, and responds with the generated output_message.  The
+          client can then consider the server authenticated. */
+ 
++      if (bufdesc2.length < 4)
++	return GSASL_AUTHENTICATION_ERROR;
++
+       if ((((char *) bufdesc2.value)[0] & GSASL_QOP_AUTH) == 0)
+ 	{
+ 	  /* Integrity or privacy unsupported */
+-- 
+2.30.2
+

--- a/specs/l/libgsasl/libgsasl.spec
+++ b/specs/l/libgsasl/libgsasl.spec
@@ -3,13 +3,14 @@
 
 Name:           libgsasl
 Version:        1.10.0
-Release: 15%{?dist}
+Release: 17%{?dist}
 Summary:        GNU SASL library
 License:        LGPL-2.1-or-later
 URL:            https://www.gnu.org/software/gsasl/
 Source0:        https://ftp.gnu.org/gnu/gsasl/%{name}-%{version}.tar.gz
 Source1:        https://ftp.gnu.org/gnu/gsasl/%{name}-%{version}.tar.gz.sig
 Source2:        https://josefsson.org/54265e8c.txt
+Patch:          0001-fix-gssapi-server-oob.patch
 BuildRequires:  gcc
 # for %%gpgverify
 BuildRequires:  gnupg2
@@ -37,7 +38,7 @@ developing applications that use %{name}.
 
 %prep
 %{gpgverify} --keyring='%{SOURCE2}' --signature='%{SOURCE1}' --data='%{SOURCE0}'
-%autosetup
+%autosetup -p2
 
 %build
 %configure --disable-static --disable-rpath --with-gssapi-impl=mit
@@ -62,6 +63,9 @@ find %{buildroot} -name '*.la' -exec rm -f {} ';'
 %{_libdir}/pkgconfig/libgsasl.pc
 
 %changelog
+* Thu Mar 26 2026 Peter Lemenkov <lemenkov@gmail.com> - 1.10.0-15
+- Fix CVE-2022-2469
+
 * Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 1.10.0-14
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
 


### PR DESCRIPTION
## CVE Pin-Forward: libgsasl

Pins `libgsasl` to Fedora f43 HEAD (`6c70668`) to pick up
1 CVE patches added upstream.

### CVEs Resolved

| CVE | Severity | Status |
|-----|----------|--------|
| CVE-2022-2469 | High | Tracked |

### Fedora Spec Delta

Old commit: `4a55cce`
New commit: `6c70668`

New patches:
- `0001-fix-gssapi-server-oob.patch`
