### PR TITLE
fix(python3.9): pin-forward to f43 for 3 CVEs

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -4439,7 +4439,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.'python3.11']
 [components.'python3.12']
 [components.'python3.6']
-[components.'python3.9']
 [components.pythoncapi-compat]
 [components.pythran]
 [components.pytz]

--- a/base/comps/python3.9/python3.9.comp.toml
+++ b/base/comps/python3.9/python3.9.comp.toml
@@ -1,0 +1,2 @@
+[components.'python3.9']
+spec = { type = "upstream", upstream-commit = "5607d49a61a595e35de21f3323bff2602e938bb6" }

--- a/locks/python3.9.lock
+++ b/locks/python3.9.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '077712bb7b3381bb151ef53be0072dd37d34aa67'
-upstream-commit = '077712bb7b3381bb151ef53be0072dd37d34aa67'
-input-fingerprint = 'sha256:406b49ae4f815d50b34ea270490945c74a11674efacd0eb4bc70e734f89a4f3b'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '5607d49a61a595e35de21f3323bff2602e938bb6'
+input-fingerprint = 'sha256:259dbf7e6004818e007d12e250aaa7f884fabc30aac4df842d3b6e9ca34c285d'
+resolution-input-hash = 'sha256:6f7a0fd728ef79faa585b62c785b4c86a2b350640eceda847c9beea441f7187d'

--- a/specs/p/python3.9/00478-cve-2026-4519.patch
+++ b/specs/p/python3.9/00478-cve-2026-4519.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: tomcruiseqi <tom33qi@gmail.com>
+Date: Wed, 25 Mar 2026 02:23:45 +0800
+Subject: 00478: CVE-2026-4519
+
+Reject leading dashes in webbrowser URLs (GH-143931) (GH-146359)
+
+Cherry-picked from Python 3.10: ad4d5ba32af4d80b0dfa2ba9d8203bfb219e60a5
+
+(cherry picked from commit 82a24a4442312bdcfc4c799885e8b3e00990f02b)
+
+Co-authored-by: Seth Michael Larson <seth@python.org>
+---
+ Lib/test/test_webbrowser.py                        |  5 +++++
+ Lib/webbrowser.py                                  | 14 ++++++++++++++
+ .../2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst |  1 +
+ 3 files changed, 20 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+
+diff --git a/Lib/test/test_webbrowser.py b/Lib/test/test_webbrowser.py
+index 519a9432ab..f8e9234db8 100644
+--- a/Lib/test/test_webbrowser.py
++++ b/Lib/test/test_webbrowser.py
+@@ -55,6 +55,11 @@ class GenericBrowserCommandTest(CommandTestMixin, unittest.TestCase):
+                    options=[],
+                    arguments=[URL])
+ 
++    def test_reject_dash_prefixes(self):
++        browser = self.browser_class(name=CMD_NAME)
++        with self.assertRaises(ValueError):
++            browser.open(f"--key=val {URL}")
++
+ 
+ class BackgroundBrowserCommandTest(CommandTestMixin, unittest.TestCase):
+ 
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index 6023c1e138..f5349dbce5 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -154,6 +154,12 @@ class BaseBrowser(object):
+     def open_new_tab(self, url):
+         return self.open(url, 2)
+ 
++    @staticmethod
++    def _check_url(url):
++        """Ensures that the URL is safe to pass to subprocesses as a parameter"""
++        if url and url.lstrip().startswith("-"):
++            raise ValueError(f"Invalid URL: {url}")
++
+ 
+ class GenericBrowser(BaseBrowser):
+     """Class for all browsers started with a command
+@@ -171,6 +177,7 @@ class GenericBrowser(BaseBrowser):
+ 
+     def open(self, url, new=0, autoraise=True):
+         sys.audit("webbrowser.open", url)
++        self._check_url(url)
+         cmdline = [self.name] + [arg.replace("%s", url)
+                                  for arg in self.args]
+         try:
+@@ -191,6 +198,7 @@ class BackgroundBrowser(GenericBrowser):
+         cmdline = [self.name] + [arg.replace("%s", url)
+                                  for arg in self.args]
+         sys.audit("webbrowser.open", url)
++        self._check_url(url)
+         try:
+             if sys.platform[:3] == 'win':
+                 p = subprocess.Popen(cmdline)
+@@ -256,6 +264,7 @@ class UnixBrowser(BaseBrowser):
+ 
+     def open(self, url, new=0, autoraise=True):
+         sys.audit("webbrowser.open", url)
++        self._check_url(url)
+         if new == 0:
+             action = self.remote_action
+         elif new == 1:
+@@ -357,6 +366,7 @@ class Konqueror(BaseBrowser):
+ 
+     def open(self, url, new=0, autoraise=True):
+         sys.audit("webbrowser.open", url)
++        self._check_url(url)
+         # XXX Currently I know no way to prevent KFM from opening a new win.
+         if new == 2:
+             action = "newTab"
+@@ -441,6 +451,7 @@ class Grail(BaseBrowser):
+ 
+     def open(self, url, new=0, autoraise=True):
+         sys.audit("webbrowser.open", url)
++        self._check_url(url)
+         if new:
+             ok = self._remote("LOADNEW " + url)
+         else:
+@@ -599,6 +610,7 @@ if sys.platform[:3] == "win":
+     class WindowsDefault(BaseBrowser):
+         def open(self, url, new=0, autoraise=True):
+             sys.audit("webbrowser.open", url)
++            self._check_url(url)
+             try:
+                 os.startfile(url)
+             except OSError:
+@@ -629,6 +641,7 @@ if sys.platform == 'darwin':
+ 
+         def open(self, url, new=0, autoraise=True):
+             sys.audit("webbrowser.open", url)
++            self._check_url(url)
+             assert "'" not in url
+             # hack for local urls
+             if not ':' in url:
+@@ -666,6 +679,7 @@ if sys.platform == 'darwin':
+             self._name = name
+ 
+         def open(self, url, new=0, autoraise=True):
++            self._check_url(url)
+             if self._name == 'default':
+                 script = 'open location "%s"' % url.replace('"', '%22') # opens in default browser
+             else:
+diff --git a/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst b/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+new file mode 100644
+index 0000000000..0f27eae99a
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+@@ -0,0 +1 @@
++Reject leading dashes in URLs passed to :func:`webbrowser.open`

--- a/specs/p/python3.9/00480-cve-2026-4786.patch
+++ b/specs/p/python3.9/00480-cve-2026-4786.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stan Ulbrych <stan@python.org>
+Date: Mon, 13 Apr 2026 22:41:53 +0100
+Subject: 00480: CVE-2026-4786
+
+Fix webbrowser `%action` substitution bypass of dash-prefix check
+---
+ Lib/test/test_webbrowser.py                               | 8 ++++++++
+ Lib/webbrowser.py                                         | 5 +++--
+ .../2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst        | 2 ++
+ 3 files changed, 13 insertions(+), 2 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst
+
+diff --git a/Lib/test/test_webbrowser.py b/Lib/test/test_webbrowser.py
+index f8e9234db8..9156ceec60 100644
+--- a/Lib/test/test_webbrowser.py
++++ b/Lib/test/test_webbrowser.py
+@@ -95,6 +95,14 @@ class ChromeCommandTest(CommandTestMixin, unittest.TestCase):
+                    options=[],
+                    arguments=[URL])
+ 
++    def test_reject_action_dash_prefixes(self):
++        browser = self.browser_class(name=CMD_NAME)
++        with self.assertRaises(ValueError):
++            browser.open('%action--incognito')
++        # new=1: action is "--new-window", so "%action" itself expands to
++        # a dash-prefixed flag even with no dash in the original URL.
++        with self.assertRaises(ValueError):
++            browser.open('%action', new=1)
+ 
+ class MozillaCommandTest(CommandTestMixin, unittest.TestCase):
+ 
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index f5349dbce5..43ccddf330 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -264,7 +264,6 @@ class UnixBrowser(BaseBrowser):
+ 
+     def open(self, url, new=0, autoraise=True):
+         sys.audit("webbrowser.open", url)
+-        self._check_url(url)
+         if new == 0:
+             action = self.remote_action
+         elif new == 1:
+@@ -278,7 +277,9 @@ class UnixBrowser(BaseBrowser):
+             raise Error("Bad 'new' parameter to open(); " +
+                         "expected 0, 1, or 2, got %s" % new)
+ 
+-        args = [arg.replace("%s", url).replace("%action", action)
++        self._check_url(url.replace("%action", action))
++
++        args = [arg.replace("%action", action).replace("%s", url)
+                 for arg in self.remote_args]
+         args = [arg for arg in args if arg]
+         success = self._invoke(args, True, autoraise, url)
+diff --git a/Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst b/Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst
+new file mode 100644
+index 0000000000..45cdeebe1b
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst
+@@ -0,0 +1,2 @@
++A bypass in :mod:`webbrowser` allowed URLs prefixed with ``%action`` to pass
++the dash-prefix safety check.

--- a/specs/p/python3.9/00482-cve-2026-6100.patch
+++ b/specs/p/python3.9/00482-cve-2026-6100.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stan Ulbrych <stan@python.org>
+Date: Mon, 13 Apr 2026 22:42:24 +0100
+Subject: 00482: CVE-2026-6100
+
+Fix a possible UAF in {LZMA,BZ2,_Zlib}Decompressor
+---
+ .../Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst  | 5 +++++
+ Modules/_bz2module.c                                         | 1 +
+ Modules/_lzmamodule.c                                        | 1 +
+ 3 files changed, 7 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+
+diff --git a/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst b/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+new file mode 100644
+index 0000000000..b095329bd9
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+@@ -0,0 +1,5 @@
++Fix a dangling input pointer in :class:`lzma.LZMADecompressor`,
++:class:`bz2.BZ2Decompressor`
++when memory allocation fails with :exc:`MemoryError`, which could let a
++subsequent :meth:`!decompress` call read or write through a stale pointer to
++the already-released caller buffer.
+diff --git a/Modules/_bz2module.c b/Modules/_bz2module.c
+index 880632c623..9b17341e49 100644
+--- a/Modules/_bz2module.c
++++ b/Modules/_bz2module.c
+@@ -559,6 +559,7 @@ decompress(BZ2Decompressor *d, char *data, size_t len, Py_ssize_t max_length)
+     return result;
+ 
+ error:
++    bzs->next_in = NULL;
+     Py_XDECREF(result);
+     return NULL;
+ }
+diff --git a/Modules/_lzmamodule.c b/Modules/_lzmamodule.c
+index 2a62a68356..dde81238ef 100644
+--- a/Modules/_lzmamodule.c
++++ b/Modules/_lzmamodule.c
+@@ -1039,6 +1039,7 @@ decompress(Decompressor *d, uint8_t *data, size_t len, Py_ssize_t max_length)
+     return result;
+ 
+ error:
++    lzs->next_in = NULL;
+     Py_XDECREF(result);
+     return NULL;
+ }

--- a/specs/p/python3.9/python3.9.spec
+++ b/specs/p/python3.9/python3.9.spec
@@ -20,8 +20,8 @@ URL: https://www.python.org/
 #global prerel ...
 %global upstream_version %{general_version}%{?prerel}
 Version: %{general_version}%{?prerel:~%{prerel}}
-Release: 7%{?dist}
-License: Python
+Release: 11%{?dist}
+License: Python-2.0.1
 
 
 # ==================================
@@ -222,8 +222,7 @@ BuildRequires: bluez-libs-devel
 BuildRequires: bzip2
 BuildRequires: bzip2-devel
 BuildRequires: desktop-file-utils
-# See the runtime requirement in the -libs subpackage
-BuildRequires: expat-devel >= 2.6
+BuildRequires: expat-devel
 
 BuildRequires: findutils
 BuildRequires: gcc-c++
@@ -246,7 +245,6 @@ BuildRequires: libX11-devel
 BuildRequires: make
 BuildRequires: ncurses-devel
 
-BuildRequires: openssl-devel
 BuildRequires: pkgconfig
 BuildRequires: readline-devel
 BuildRequires: redhat-rpm-config >= 127
@@ -258,6 +256,10 @@ BuildRequires: tcl-devel < 1:9
 BuildRequires: tix-devel
 BuildRequires: tk-devel < 1:9
 BuildRequires: tzdata
+
+# Support for OpenSSL 4 only landed in Python 3.15 for now
+# https://github.com/python/cpython/issues/146207
+BuildRequires: (openssl-devel < 1:4 or openssl3-devel)
 
 %if %{with valgrind}
 BuildRequires: valgrind-devel
@@ -444,6 +446,26 @@ Patch475: 00475-cve-2025-15367.patch
 # gh-144125: email: verify headers are sound in BytesGenerator
 Patch476: 00476-cve-2026-1299.patch
 
+# 00478 # 88bb1e37c971fd1d6bda82a68b5ad873ed099f08
+# CVE-2026-4519
+#
+# Reject leading dashes in webbrowser URLs (GH-143931) (GH-146359)
+#
+# Cherry-picked from Python 3.10: ad4d5ba32af4d80b0dfa2ba9d8203bfb219e60a5
+Patch478: 00478-cve-2026-4519.patch
+
+# 00480 # 9f4b1483ecfbc8c08117133c239fba544fcb42e7
+# CVE-2026-4786
+#
+# Fix webbrowser `%%action` substitution bypass of dash-prefix check
+Patch480: 00480-cve-2026-4786.patch
+
+# 00482 # 51e25e8a804257b707e2021655037d07dcfa9cd6
+# CVE-2026-6100
+#
+# Fix a possible UAF in {LZMA,BZ2,_Zlib}Decompressor
+Patch482: 00482-cve-2026-6100.patch
+
 # (New patches go here ^^^)
 #
 # When adding new patches to "python" and "python3" in Fedora, EL, etc.,
@@ -618,14 +640,6 @@ Recommends: (%{pkgname}-tkinter%{?_isa} = %{version}-%{release} if tk%{?_isa})
 
 # The zoneinfo module needs tzdata
 Requires: tzdata
-
-# The requirement on libexpat is generated, but we need to version it.
-# When built with expat >= 2.6, but installed with older expat, we get:
-#   ImportError: /usr/lib64/python3.X/lib-dynload/pyexpat.cpython-....so:
-#   undefined symbol: XML_SetReparseDeferralEnabled
-# This breaks many things, including python -m venv.
-# Other subpackages (like -debug) also need this, but they all depend on -libs.
-Requires: expat >= 2.6
 
 # https://fedoraproject.org/wiki/Changes/Move_usr_bin_python_into_separate_package
 # In Fedora 31, several "unversioned" files like /usr/bin/pydoc and all the
@@ -828,14 +842,6 @@ Provides: bundled(libmpdec) = %{libmpdec_version}
 
 # The zoneinfo module needs tzdata
 Requires: tzdata
-
-# The requirement on libexpat is generated, but we need to version it.
-# When built with expat >= 2.6, but installed with older expat, we get:
-#   ImportError: /usr/lib64/python3.X/lib-dynload/pyexpat.cpython-....so:
-#   undefined symbol: XML_SetReparseDeferralEnabled
-# This breaks many things, including python -m venv.
-# Other subpackages (like -debug) also need this, but they all depend on -libs.
-Requires: expat >= 2.6
 
 # Provides of the subpackages contained in flatpackage
 Provides: %{pkgname}-libs = %{version}-%{release}
@@ -1933,6 +1939,16 @@ CheckPython optimized
 # ======================================================
 
 %changelog
+* Fri Apr 17 2026 Charalampos Stratakis <cstratak@redhat.com> - 3.9.25-9
+- Security fixes for CVE-2026-4786 and CVE-2026-6100
+Resolves: rhbz#2458019, rhbz#2458227
+
+* Sat Apr 11 2026 Miro Hrončok <mhroncok@redhat.com> - 3.9.25-8
+- Explicitly build with OpenSSL 3
+
+* Thu Mar 26 2026 Lumír Balhar <lbalhar@redhat.com> - 3.9.25-7
+- Security fix for CVE-2026-4519 (rhbz#2449735)
+
 * Tue Feb 10 2026 Tomáš Hrnčiar <thrnciar@redhat.com> - 3.9.25-6
 - Security fix for CVE-2026-1299
 


### PR DESCRIPTION
## CVE Pin-Forward: python3.9

Pins `python3.9` to Fedora f43 HEAD (`5607d49`) to pick up
3 CVE patches added upstream.

### CVEs Resolved

| CVE | Severity | Status |
|-----|----------|--------|
| CVE-2026-4519 | High | Tracked |
| CVE-2026-4786 | — | Additional |
| CVE-2026-6100 | — | Additional |

### Fedora Spec Delta

Old commit: `077712b`
New commit: `5607d49`

New patches:
- `00478-cve-2026-4519.patch`
- `00480-cve-2026-4786.patch`
- `00482-cve-2026-6100.patch`
