### PR TITLE
fix(python-pillow): pin-forward to f43 for 1 CVEs

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -4020,7 +4020,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.python-phonenumbers]
 [components.python-pickleshare]
 [components.python-pid]
-[components.python-pillow]
 [components.python-pint]
 [components.python-pip]
 [components.python-pip-requirements-parser]

--- a/base/comps/python-pillow/python-pillow.comp.toml
+++ b/base/comps/python-pillow/python-pillow.comp.toml
@@ -1,0 +1,2 @@
+[components.python-pillow]
+spec = { type = "upstream", upstream-commit = "c3200ba28e89e4ccedcd26be3d73d36fd04b5be2" }

--- a/locks/python-pillow.lock
+++ b/locks/python-pillow.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '2a9c1d28aced75a39840527937a32de21b01848c'
-upstream-commit = '2a9c1d28aced75a39840527937a32de21b01848c'
-input-fingerprint = 'sha256:5971e930e526d0be794a043e130e56d3c396ffbb2f5a81d11530e22c2f3e60f6'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = 'c3200ba28e89e4ccedcd26be3d73d36fd04b5be2'
+input-fingerprint = 'sha256:1a9846321d0f3a9cb89b6b9790bd628db047d84399203abb2303aa17d5375887'
+resolution-input-hash = 'sha256:2799b5d69e67b5035fb9eff70fcbc5baef447f14d51692de790feee4d4263480'

--- a/specs/p/python-pillow/3cb854e8b2bab43f40e342e665f9340d861aa628.patch
+++ b/specs/p/python-pillow/3cb854e8b2bab43f40e342e665f9340d861aa628.patch
@@ -1,0 +1,32 @@
+diff -rupN --no-dereference Pillow-11.3.0/src/PIL/FitsImagePlugin.py Pillow-11.3.0-new/src/PIL/FitsImagePlugin.py
+--- Pillow-11.3.0/src/PIL/FitsImagePlugin.py	2025-07-01 09:41:24.000000000 +0200
++++ Pillow-11.3.0-new/src/PIL/FitsImagePlugin.py	2026-04-18 08:15:14.428095481 +0200
+@@ -128,17 +128,18 @@ class FitsGzipDecoder(ImageFile.PyDecode
+ 
+     def decode(self, buffer: bytes | Image.SupportsArrayInterface) -> tuple[int, int]:
+         assert self.fd is not None
+-        value = gzip.decompress(self.fd.read())
++        with gzip.open(self.fd) as fp:
++            value = fp.read(self.state.xsize * self.state.ysize * 4)
+ 
+-        rows = []
+-        offset = 0
+-        number_of_bits = min(self.args[0] // 8, 4)
+-        for y in range(self.state.ysize):
+-            row = bytearray()
+-            for x in range(self.state.xsize):
+-                row += value[offset + (4 - number_of_bits) : offset + 4]
+-                offset += 4
+-            rows.append(row)
++            rows = []
++            offset = 0
++            number_of_bits = min(self.args[0] // 8, 4)
++            for y in range(self.state.ysize):
++                row = bytearray()
++                for x in range(self.state.xsize):
++                    row += value[offset + (4 - number_of_bits) : offset + 4]
++                    offset += 4
++                rows.append(row)
+         self.set_as_raw(bytes([pixel for row in rows[::-1] for pixel in row]))
+         return -1, 0
+ 

--- a/specs/p/python-pillow/python-pillow.spec
+++ b/specs/p/python-pillow/python-pillow.spec
@@ -24,7 +24,7 @@
 
 Name:           python-%{srcname}
 Version:        11.3.0
-Release: 9%{?dist}
+Release: 11%{?dist}
 Summary:        Python image processing library
 
 # License: see http://www.pythonware.com/products/pil/license.htm
@@ -37,6 +37,8 @@ Source9999: python-pillow.azl.macros
 Patch0:         pillow_mingw.patch
 # Backport fix for CVE-2026-25990
 Patch1:         https://github.com/python-pillow/Pillow/commit/9000313cc5d4a31bdcdd6d7f0781101abab553aa.patch
+# Backport fix for CVE-2026-40192
+Patch2:         https://github.com/python-pillow/Pillow/commit/3cb854e8b2bab43f40e342e665f9340d861aa628.patch
 
 BuildRequires:  freetype-devel
 BuildRequires:  gcc
@@ -315,6 +317,9 @@ popd
 
 
 %changelog
+* Sat Apr 18 2026 Sandro Mani <manisandro@gmail.com> - 11.3.0-8
+- Backport fix for CVE-2026-40192
+
 * Sat Feb 14 2026 Sandro Mani <manisandro@gmail.com> - 11.1.0-7
 - Backport fix for CVE-2026-25990
 


### PR DESCRIPTION
## CVE Pin-Forward: python-pillow

Pins `python-pillow` to Fedora f43 HEAD (`c3200ba`) to pick up
1 CVE patches added upstream.

### CVEs Resolved

| CVE | Severity | Status |
|-----|----------|--------|
| CVE-2026-40192 | High | Tracked |

### Fedora Spec Delta

Old commit: `2a9c1d2`
New commit: `c3200ba`

New patches:
- `https://github.com/python-pillow/Pillow/commit/3cb854e8b2bab43f40e342e665f9340d861aa628.patch`
