### PR TITLE
fix(python3.6): pin-forward to f43 for 4 CVEs

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -4438,7 +4438,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.'python3.10']
 [components.'python3.11']
 [components.'python3.12']
-[components.'python3.6']
 [components.'python3.9']
 [components.pythoncapi-compat]
 [components.pythran]

--- a/base/comps/python3.6/python3.6.comp.toml
+++ b/base/comps/python3.6/python3.6.comp.toml
@@ -1,0 +1,2 @@
+[components.'python3.6']
+spec = { type = "upstream", upstream-commit = "0adc0163f65eacda8e17d2de6f0b3a529b3622d0" }

--- a/locks/python3.6.lock
+++ b/locks/python3.6.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '7166e1eb3cc76a647c8c64d2d1a2fd8c542685f4'
-upstream-commit = '7166e1eb3cc76a647c8c64d2d1a2fd8c542685f4'
-input-fingerprint = 'sha256:4414c033ef17d2e1b620ec12548d13ed0272945e777b72a6622d975636026dc2'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '0adc0163f65eacda8e17d2de6f0b3a529b3622d0'
+input-fingerprint = 'sha256:1afe692dc0bc96993b9232a9967d63970ef985353da086828e47a5e34d08e723'
+resolution-input-hash = 'sha256:b581364dd540149ac4fd67633162e93c40e152ecf51e5f8fa24f8ba5640a5ef0'

--- a/specs/p/python3.6/00471-cve-2025-12084.patch
+++ b/specs/p/python3.6/00471-cve-2025-12084.patch
@@ -1,0 +1,135 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lumir Balhar <lbalhar@redhat.com>
+Date: Tue, 6 Jan 2026 12:28:44 +0100
+Subject: 00471: CVE-2025-12084
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* gh-142145: Remove quadratic behavior in node ID cache clearing (GH-142146)
+* gh-142754: Ensure that Element & Attr instances have the ownerDocument attribute (GH-142794)
+(cherry picked from commit 1cc7551b3f9f71efbc88d96dce90f82de98b2454)
+(cherry picked from commit 08d8e18ad81cd45bc4a27d6da478b51ea49486e4)
+(cherry picked from commit 8d2d7bb2e754f8649a68ce4116271a4932f76907)
+
+Co-authored-by: Jacob Walls <38668450+jacobtylerwalls@users.noreply.github.com>
+Co-authored-by: Seth Michael Larson <seth@python.org>
+Co-authored-by: Petr Viktorin <encukou@gmail.com>
+Co-authored-by: Hugo van Kemenade <1324225+hugovk@users.noreply.github.com>
+Co-authored-by: Gregory P. Smith <68491+gpshead@users.noreply.github.com>
+Co-authored-by: Hugo van Kemenade <1324225+hugovk@users.noreply.github.com>
+Co-authored-by: Gregory P. Smith <68491+gpshead@users.noreply.github.com>
+Co-authored-by: Gregory P. Smith <greg@krypto.org>
+Co-authoded-by: Lumír Balhar <lbalhar@redhat.com>
+---
+ Lib/test/test_minidom.py                      | 32 ++++++++++++++++++-
+ Lib/xml/dom/minidom.py                        | 11 ++-----
+ ...-12-01-09-36-45.gh-issue-142145.tcAUhg.rst |  6 ++++
+ 3 files changed, 40 insertions(+), 9 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Security/2025-12-01-09-36-45.gh-issue-142145.tcAUhg.rst
+
+diff --git a/Lib/test/test_minidom.py b/Lib/test/test_minidom.py
+index 03fee2704e..accc7e98fd 100644
+--- a/Lib/test/test_minidom.py
++++ b/Lib/test/test_minidom.py
+@@ -8,7 +8,7 @@ import unittest
+ import pyexpat
+ import xml.dom.minidom
+ 
+-from xml.dom.minidom import parse, Node, Document, parseString
++from xml.dom.minidom import parse, Attr, Node, Document, Element, parseString
+ from xml.dom.minidom import getDOMImplementation
+ from xml.parsers.expat import ExpatError
+ 
+@@ -172,6 +172,36 @@ class MinidomTest(unittest.TestCase):
+         self.confirm(dom.documentElement.childNodes[-1].data == "Hello")
+         dom.unlink()
+ 
++    @support.requires_resource('cpu')
++    def testAppendChildNoQuadraticComplexity(self):
++        impl = getDOMImplementation()
++
++        newdoc = impl.createDocument(None, "some_tag", None)
++        top_element = newdoc.documentElement
++        children = [newdoc.createElement(f"child-{i}") for i in range(1, 2 ** 15 + 1)]
++        element = top_element
++
++        start = time.monotonic()
++        for child in children:
++            element.appendChild(child)
++            element = child
++        end = time.monotonic()
++
++        # This example used to take at least 30 seconds.
++        # Conservative assertion due to the wide variety of systems and
++        # build configs timing based tests wind up run under.
++        # A --with-address-sanitizer --with-pydebug build on a rpi5 still
++        # completes this loop in <0.5 seconds.
++        self.assertLess(end - start, 4)
++
++    def testSetAttributeNodeWithoutOwnerDocument(self):
++        # regression test for gh-142754
++        elem = Element("test")
++        attr = Attr("id")
++        attr.value = "test-id"
++        elem.setAttributeNode(attr)
++        self.assertEqual(elem.getAttribute("id"), "test-id")
++
+     def testAppendChildFragment(self):
+         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
+         dom.documentElement.appendChild(frag)
+diff --git a/Lib/xml/dom/minidom.py b/Lib/xml/dom/minidom.py
+index 24957ea14f..600bf0b781 100644
+--- a/Lib/xml/dom/minidom.py
++++ b/Lib/xml/dom/minidom.py
+@@ -291,13 +291,6 @@ def _append_child(self, node):
+     childNodes.append(node)
+     node.parentNode = self
+ 
+-def _in_document(node):
+-    # return True iff node is part of a document tree
+-    while node is not None:
+-        if node.nodeType == Node.DOCUMENT_NODE:
+-            return True
+-        node = node.parentNode
+-    return False
+ 
+ def _write_data(writer, data):
+     "Writes datachars to writer."
+@@ -354,6 +347,7 @@ class Attr(Node):
+     def __init__(self, qName, namespaceURI=EMPTY_NAMESPACE, localName=None,
+                  prefix=None):
+         self.ownerElement = None
++        self.ownerDocument = None
+         self._name = qName
+         self.namespaceURI = namespaceURI
+         self._prefix = prefix
+@@ -677,6 +671,7 @@ class Element(Node):
+ 
+     def __init__(self, tagName, namespaceURI=EMPTY_NAMESPACE, prefix=None,
+                  localName=None):
++        self.ownerDocument = None
+         self.parentNode = None
+         self.tagName = self.nodeName = tagName
+         self.prefix = prefix
+@@ -1512,7 +1507,7 @@ def _clear_id_cache(node):
+     if node.nodeType == Node.DOCUMENT_NODE:
+         node._id_cache.clear()
+         node._id_search_stack = None
+-    elif _in_document(node):
++    elif node.ownerDocument:
+         node.ownerDocument._id_cache.clear()
+         node.ownerDocument._id_search_stack= None
+ 
+diff --git a/Misc/NEWS.d/next/Security/2025-12-01-09-36-45.gh-issue-142145.tcAUhg.rst b/Misc/NEWS.d/next/Security/2025-12-01-09-36-45.gh-issue-142145.tcAUhg.rst
+new file mode 100644
+index 0000000000..05c7df35d1
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2025-12-01-09-36-45.gh-issue-142145.tcAUhg.rst
+@@ -0,0 +1,6 @@
++Remove quadratic behavior in ``xml.minidom`` node ID cache clearing.  In order
++to do this without breaking existing users, we also add the *ownerDocument*
++attribute to :mod:`xml.dom.minidom` elements and attributes created by directly
++instantiating the ``Element`` or ``Attr`` class. Note that this way of creating
++nodes is not supported; creator functions like
++:py:meth:`xml.dom.Document.documentElement` should be used instead.

--- a/specs/p/python3.6/00478-cve-2026-4519.patch
+++ b/specs/p/python3.6/00478-cve-2026-4519.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: tomcruiseqi <tom33qi@gmail.com>
+Date: Wed, 25 Mar 2026 02:23:45 +0800
+Subject: 00478: CVE-2026-4519
+
+Reject leading dashes in webbrowser URLs (GH-143931) (GH-146359)
+
+(cherry picked from commit 82a24a4442312bdcfc4c799885e8b3e00990f02b)
+
+Backported from Python 3.10: ad4d5ba32af4d80b0dfa2ba9d8203bfb219e60a5
+
+Co-authored-by: Seth Michael Larson <seth@python.org>
+---
+ Lib/test/test_webbrowser.py                        |  5 +++++
+ Lib/webbrowser.py                                  | 14 ++++++++++++++
+ .../2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst |  1 +
+ 3 files changed, 20 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+
+diff --git a/Lib/test/test_webbrowser.py b/Lib/test/test_webbrowser.py
+index 7cbb8d0a29..ec4ba2f7ac 100644
+--- a/Lib/test/test_webbrowser.py
++++ b/Lib/test/test_webbrowser.py
+@@ -53,6 +53,11 @@ class GenericBrowserCommandTest(CommandTestMixin, unittest.TestCase):
+                    options=[],
+                    arguments=[URL])
+ 
++    def test_reject_dash_prefixes(self):
++        browser = self.browser_class(name=CMD_NAME)
++        with self.assertRaises(ValueError):
++            browser.open(f"--key=val {URL}")
++
+ 
+ class BackgroundBrowserCommandTest(CommandTestMixin, unittest.TestCase):
+ 
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index 1a553f0e65..f00f1a712a 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -120,6 +120,12 @@ class BaseBrowser(object):
+     def open_new_tab(self, url):
+         return self.open(url, 2)
+ 
++    @staticmethod
++    def _check_url(url):
++        """Ensures that the URL is safe to pass to subprocesses as a parameter"""
++        if url and url.lstrip().startswith("-"):
++            raise ValueError(f"Invalid URL: {url}")
++
+ 
+ class GenericBrowser(BaseBrowser):
+     """Class for all browsers started with a command
+@@ -136,6 +142,7 @@ class GenericBrowser(BaseBrowser):
+         self.basename = os.path.basename(self.name)
+ 
+     def open(self, url, new=0, autoraise=True):
++        self._check_url(url)
+         cmdline = [self.name] + [arg.replace("%s", url)
+                                  for arg in self.args]
+         try:
+@@ -153,6 +160,7 @@ class BackgroundBrowser(GenericBrowser):
+        background."""
+ 
+     def open(self, url, new=0, autoraise=True):
++        self._check_url(url)
+         cmdline = [self.name] + [arg.replace("%s", url)
+                                  for arg in self.args]
+         try:
+@@ -219,6 +227,7 @@ class UnixBrowser(BaseBrowser):
+             return not p.wait()
+ 
+     def open(self, url, new=0, autoraise=True):
++        self._check_url(url)
+         if new == 0:
+             action = self.remote_action
+         elif new == 1:
+@@ -319,6 +328,7 @@ class Konqueror(BaseBrowser):
+     """
+ 
+     def open(self, url, new=0, autoraise=True):
++        self._check_url(url)
+         # XXX Currently I know no way to prevent KFM from opening a new win.
+         if new == 2:
+             action = "newTab"
+@@ -402,6 +412,7 @@ class Grail(BaseBrowser):
+         return 1
+ 
+     def open(self, url, new=0, autoraise=True):
++        self._check_url(url)
+         if new:
+             ok = self._remote("LOADNEW " + url)
+         else:
+@@ -508,6 +519,7 @@ if os.environ.get("TERM"):
+ if sys.platform[:3] == "win":
+     class WindowsDefault(BaseBrowser):
+         def open(self, url, new=0, autoraise=True):
++            self._check_url(url)
+             try:
+                 os.startfile(url)
+             except OSError:
+@@ -551,6 +563,7 @@ if sys.platform == 'darwin':
+             self.name = name
+ 
+         def open(self, url, new=0, autoraise=True):
++            self._check_url(url)
+             assert "'" not in url
+             # hack for local urls
+             if not ':' in url:
+@@ -588,6 +601,7 @@ if sys.platform == 'darwin':
+             self._name = name
+ 
+         def open(self, url, new=0, autoraise=True):
++            self._check_url(url)
+             if self._name == 'default':
+                 script = 'open location "%s"' % url.replace('"', '%22') # opens in default browser
+             else:
+diff --git a/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst b/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+new file mode 100644
+index 0000000000..0f27eae99a
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2026-01-16-12-04-49.gh-issue-143930.zYC5x3.rst
+@@ -0,0 +1 @@
++Reject leading dashes in URLs passed to :func:`webbrowser.open`

--- a/specs/p/python3.6/00480-cve-2026-4786.patch
+++ b/specs/p/python3.6/00480-cve-2026-4786.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stan Ulbrych <stan@python.org>
+Date: Mon, 13 Apr 2026 22:41:53 +0100
+Subject: 00480: CVE-2026-4786
+
+Fix webbrowser `%action` substitution bypass of dash-prefix check
+
+Backported from Python 3.10
+---
+ Lib/test/test_webbrowser.py                               | 8 ++++++++
+ Lib/webbrowser.py                                         | 5 +++--
+ .../2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst        | 2 ++
+ 3 files changed, 13 insertions(+), 2 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst
+
+diff --git a/Lib/test/test_webbrowser.py b/Lib/test/test_webbrowser.py
+index ec4ba2f7ac..362572e312 100644
+--- a/Lib/test/test_webbrowser.py
++++ b/Lib/test/test_webbrowser.py
+@@ -93,6 +93,14 @@ class ChromeCommandTest(CommandTestMixin, unittest.TestCase):
+                    options=[],
+                    arguments=[URL])
+ 
++    def test_reject_action_dash_prefixes(self):
++        browser = self.browser_class(name=CMD_NAME)
++        with self.assertRaises(ValueError):
++            browser.open('%action--incognito')
++        # new=1: action is "--new-window", so "%action" itself expands to
++        # a dash-prefixed flag even with no dash in the original URL.
++        with self.assertRaises(ValueError):
++            browser.open('%action', new=1)
+ 
+ class MozillaCommandTest(CommandTestMixin, unittest.TestCase):
+ 
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index f00f1a712a..9345f785e0 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -227,7 +227,6 @@ class UnixBrowser(BaseBrowser):
+             return not p.wait()
+ 
+     def open(self, url, new=0, autoraise=True):
+-        self._check_url(url)
+         if new == 0:
+             action = self.remote_action
+         elif new == 1:
+@@ -241,7 +240,9 @@ class UnixBrowser(BaseBrowser):
+             raise Error("Bad 'new' parameter to open(); " +
+                         "expected 0, 1, or 2, got %s" % new)
+ 
+-        args = [arg.replace("%s", url).replace("%action", action)
++        self._check_url(url.replace("%action", action))
++
++        args = [arg.replace("%action", action).replace("%s", url)
+                 for arg in self.remote_args]
+         args = [arg for arg in args if arg]
+         success = self._invoke(args, True, autoraise)
+diff --git a/Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst b/Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst
+new file mode 100644
+index 0000000000..45cdeebe1b
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2026-03-31-09-15-51.gh-issue-148169.EZJzz2.rst
+@@ -0,0 +1,2 @@
++A bypass in :mod:`webbrowser` allowed URLs prefixed with ``%action`` to pass
++the dash-prefix safety check.

--- a/specs/p/python3.6/00482-cve-2026-6100.patch
+++ b/specs/p/python3.6/00482-cve-2026-6100.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stan Ulbrych <stan@python.org>
+Date: Mon, 13 Apr 2026 22:42:24 +0100
+Subject: 00482: CVE-2026-6100
+
+Fix a possible UAF in {LZMA,BZ2,_Zlib}Decompressor
+
+Backported from Python 3.10
+---
+ .../Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst  | 5 +++++
+ Modules/_bz2module.c                                         | 1 +
+ Modules/_lzmamodule.c                                        | 1 +
+ 3 files changed, 7 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+
+diff --git a/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst b/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+new file mode 100644
+index 0000000000..b095329bd9
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2026-04-10-16-28-21.gh-issue-148395.kfzm0G.rst
+@@ -0,0 +1,5 @@
++Fix a dangling input pointer in :class:`lzma.LZMADecompressor`,
++:class:`bz2.BZ2Decompressor`
++when memory allocation fails with :exc:`MemoryError`, which could let a
++subsequent :meth:`!decompress` call read or write through a stale pointer to
++the already-released caller buffer.
+diff --git a/Modules/_bz2module.c b/Modules/_bz2module.c
+index fe06953ec4..394ed22540 100644
+--- a/Modules/_bz2module.c
++++ b/Modules/_bz2module.c
+@@ -587,6 +587,7 @@ decompress(BZ2Decompressor *d, char *data, size_t len, Py_ssize_t max_length)
+     return result;
+ 
+ error:
++    bzs->next_in = NULL;
+     Py_XDECREF(result);
+     return NULL;
+ }
+diff --git a/Modules/_lzmamodule.c b/Modules/_lzmamodule.c
+index 3d3645af92..0157dce83a 100644
+--- a/Modules/_lzmamodule.c
++++ b/Modules/_lzmamodule.c
+@@ -1053,6 +1053,7 @@ decompress(Decompressor *d, uint8_t *data, size_t len, Py_ssize_t max_length)
+     return result;
+ 
+ error:
++    lzs->next_in = NULL;
+     Py_XDECREF(result);
+     return NULL;
+ }

--- a/specs/p/python3.6/python3.6.spec
+++ b/specs/p/python3.6/python3.6.spec
@@ -20,7 +20,7 @@ URL: https://www.python.org/
 #global prerel ...
 %global upstream_version %{general_version}%{?prerel}
 Version: %{general_version}%{?prerel:~%{prerel}}
-Release: 53%{?dist}
+Release: 59%{?dist}
 # Python is Python
 # pip MIT is and bundles:
 #   appdirs: MIT
@@ -292,12 +292,14 @@ BuildRequires: redhat-rpm-config >= 127
 BuildRequires: sqlite-devel
 BuildRequires: gdb
 
-BuildRequires: openssl-devel
-
 BuildRequires: tar
 BuildRequires: tcl-devel < 1:9
 BuildRequires: tix-devel
 BuildRequires: tk-devel < 1:9
+
+# Support for OpenSSL 4 only landed in Python 3.15 for now
+# https://github.com/python/cpython/issues/146207
+BuildRequires: (openssl-devel < 1:4 or openssl3-devel)
 
 %if %{with valgrind}
 BuildRequires: valgrind-devel
@@ -909,6 +911,40 @@ Patch475: 00475-cve-2025-15367.patch
 #
 # (cherry-picked from commit 45b2f8893c1b7ab3b3981a966f82e42beea82106)
 Patch476: 00476-cve-2026-1299.patch
+
+# 00471 # e3d4476ede73ee3ebef54cc1afd6177689762ac4
+# CVE-2025-12084
+#
+# * gh-142145: Remove quadratic behavior in node ID cache clearing (GH-142146)
+# * gh-142754: Ensure that Element & Attr instances have the ownerDocument attribute (GH-142794)
+#
+# Co-authoded-by: Lumír Balhar <lbalhar@redhat.com>
+Patch471: 00471-cve-2025-12084.patch
+
+# 00478 # 0093ea5b062f01b1078f43655d6378f0096b479f
+# CVE-2026-4519
+#
+# Reject leading dashes in webbrowser URLs (GH-143931) (GH-146359)
+#
+#
+# Backported from Python 3.10: ad4d5ba32af4d80b0dfa2ba9d8203bfb219e60a5
+Patch478: 00478-cve-2026-4519.patch
+
+# 00480 # 2fdcb1ee7535bec67f807eb9a1ea1477cccbb86d
+# CVE-2026-4786
+#
+# Fix webbrowser `%%action` substitution bypass of dash-prefix check
+#
+# Backported from Python 3.10
+Patch480: 00480-cve-2026-4786.patch
+
+# 00482 # 51e25e8a804257b707e2021655037d07dcfa9cd6
+# CVE-2026-6100
+#
+# Fix a possible UAF in {LZMA,BZ2,_Zlib}Decompressor
+#
+# Backported from Python 3.10
+Patch482: 00482-cve-2026-6100.patch
 
 # (New patches go here ^^^)
 #
@@ -2211,6 +2247,22 @@ CheckPython optimized
 # ======================================================
 
 %changelog
+* Fri Apr 17 2026 Charalampos Stratakis <cstratak@redhat.com> - 3.6.15-57
+- Security fixes for CVE-2026-4786, CVE-2026-6100
+Resolves: rhbz#2458018, rhbz#2458226
+
+* Sat Apr 11 2026 Miro Hrončok <mhroncok@redhat.com> - 3.6.15-56
+- Explicitly build with OpenSSL 3
+
+* Thu Mar 26 2026 Lumír Balhar <lbalhar@redhat.com> - 3.6.15-55
+- Security fix for CVE-2026-4519 (rhbz#2449733)
+
+* Thu Mar 12 2026 Miro Hrončok <mhroncok@redhat.com> - 3.6.15-54
+- Rebuilt for improvements of %%python_wheel_inject_sbom in python-rpm-macros-3.14-11
+
+* Thu Feb 26 2026 Lumír Balhar <lbalhar@redhat.com> - 3.6.15-53
+- Security fix for CVE-2025-12084
+
 * Thu Jan 29 2026 Lumír Balhar <lbalhar@redhat.com> - 3.6.15-52
 - Security fixes for CVE-2026-0865, CVE-2025-15366, CVE-2025-15367, CVE-2026-1299
 


### PR DESCRIPTION
## CVE Pin-Forward: python3.6

Pins `python3.6` to Fedora f43 HEAD (`0adc016`) to pick up
4 CVE patches added upstream.

### CVEs Resolved

| CVE | Severity | Status |
|-----|----------|--------|
| CVE-2026-4519 | High | Tracked |
| CVE-2025-12084 | — | Additional |
| CVE-2026-4786 | — | Additional |
| CVE-2026-6100 | — | Additional |

### Fedora Spec Delta

Old commit: `7166e1e`
New commit: `0adc016`

New patches:
- `00471-cve-2025-12084.patch`
- `00478-cve-2026-4519.patch`
- `00480-cve-2026-4786.patch`
- `00482-cve-2026-6100.patch`
