### PR TITLE
fix(python-cbor2): pin-forward to f43 for 1 CVEs

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -3594,7 +3594,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.python-cairosvg]
 [components.python-capturer]
 [components.python-cattrs]
-[components.python-cbor2]
 [components.python-certifi]
 [components.python-cffi]
 [components.python-cffsubr]

--- a/base/comps/python-cbor2/python-cbor2.comp.toml
+++ b/base/comps/python-cbor2/python-cbor2.comp.toml
@@ -1,0 +1,2 @@
+[components.python-cbor2]
+spec = { type = "upstream", upstream-commit = "575d0ec8472e3a80f5d59b5eed00fc1c87ad99e0" }

--- a/locks/python-cbor2.lock
+++ b/locks/python-cbor2.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = 'c2b6a2de32bb5a357e3b0df3559e4f1d1c228376'
-upstream-commit = 'c2b6a2de32bb5a357e3b0df3559e4f1d1c228376'
-input-fingerprint = 'sha256:fa5a1db425769506eb25b1c541aa105f7f89c7637f39803cd4eecf0f1a73c324'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '575d0ec8472e3a80f5d59b5eed00fc1c87ad99e0'
+input-fingerprint = 'sha256:dd624c2a7e4120319cad1b01ed840b3b8c848589484497d5af8b3177f6fe8738'
+resolution-input-hash = 'sha256:a17016315a5a6e42f8869bf3dbba75d19f01ad210fa033242f0ee7204e0a10eb'

--- a/specs/p/python-cbor2/0001-Fix-bug-in-decode_definite_long_string-that-causes-incorrect-chunk-length-calculation-265.patch
+++ b/specs/p/python-cbor2/0001-Fix-bug-in-decode_definite_long_string-that-causes-incorrect-chunk-length-calculation-265.patch
@@ -1,0 +1,72 @@
+From ddc3993b96b7f7a8bad28c5ad7e250eb0037cd0b Mon Sep 17 00:00:00 2001
+From: Chenhao <24435007+tylzh97@users.noreply.github.com>
+Date: Wed, 22 Oct 2025 20:39:31 +0800
+Subject: [PATCH] Fix: bug in `decode_definite_long_string()` that causes
+ incorrect chunk length calculation (#265)
+
+(cherry picked from commit 2349197bea8ebd1bf57a68f4a6549d8fd7585e66)
+---
+ source/decoder.c      |  8 +++++++-
+ tests/test_decoder.py | 22 ++++++++++++++++++++++
+ 2 files changed, 29 insertions(+), 1 deletion(-)
+
+diff --git a/source/decoder.c b/source/decoder.c
+index fd4d70c..a39d6f7 100644
+--- a/source/decoder.c
++++ b/source/decoder.c
+@@ -758,7 +758,7 @@ decode_definite_long_string(CBORDecoderObject *self, Py_ssize_t length)
+     char *buffer = NULL;
+     while (left) {
+         // Read up to 65536 bytes of data from the stream
+-        Py_ssize_t chunk_length = 65536 - buffer_size;
++        Py_ssize_t chunk_length = 65536 - buffer_length;
+         if (left < chunk_length)
+             chunk_length = left;
+ 
+@@ -828,7 +828,13 @@ decode_definite_long_string(CBORDecoderObject *self, Py_ssize_t length)
+                 memcpy(buffer, bytes_buffer + consumed, unconsumed);
+             }
+             buffer_length = unconsumed;
++        } else {
++            // All bytes consumed, reset buffer_length
++            buffer_length = 0;
+         }
++
++        Py_DECREF(chunk);
++        chunk = NULL;
+     }
+ 
+     if (ret && string_namespace_add(self, ret, length) == -1)
+diff --git a/tests/test_decoder.py b/tests/test_decoder.py
+index 25e0c6b..2ef87a2 100644
+--- a/tests/test_decoder.py
++++ b/tests/test_decoder.py
+@@ -260,6 +260,28 @@ def test_string_oversized(impl) -> None:
+         (impl.loads(unhexlify("aeaeaeaeaeaeaeaeae0108c29843d90100d8249f0000aeaeffc26ca799")),)
+ 
+ 
++def test_string_issue_264_multiple_chunks_utf8_boundary(impl) -> None:
++    """Test for Issue #264: UTF-8 characters split across multiple 65536-byte chunk boundaries."""
++    import struct
++
++    # Construct: 65535 'a' + '€' (3 bytes) + 65533 'b' + '€' (3 bytes) + 100 'd'
++    # Total: 131174 bytes, which spans 3 chunks (65536 + 65536 + 102)
++    total_bytes = 65535 + 3 + 65533 + 3 + 100
++
++    payload = b"\x7a" + struct.pack(">I", total_bytes)  # major type 3, 4-byte length
++    payload += b"a" * 65535
++    payload += "€".encode()  # U+20AC: E2 82 AC
++    payload += b"b" * 65533
++    payload += "€".encode()
++    payload += b"d" * 100
++
++    expected = "a" * 65535 + "€" + "b" * 65533 + "€" + "d" * 100
++
++    result = impl.loads(payload)
++    assert result == expected
++    assert len(result) == 131170  # 65535 + 1 + 65533 + 1 + 100 characters
++
++
+ @pytest.mark.parametrize(
+     "payload, expected",
+     [

--- a/specs/p/python-cbor2/python-cbor2.spec
+++ b/specs/p/python-cbor2/python-cbor2.spec
@@ -1,69 +1,85 @@
 # This spec file has been modified by azldev to include build configuration overlays.
 # Do not edit manually; changes may be overwritten.
 
-%global pypi_name cbor2
-
-Name:           python-%{pypi_name}
+Name:           python-cbor2
 Version:        5.6.5
-Release: 8%{?dist}
+Release: 10%{?dist}
 Summary:        Python CBOR (de)serializer with extensive tag support
-
 License:        MIT
 URL:            https://github.com/agronholm/cbor2
-Source0:        %{pypi_source}
+Source:         %{pypi_source cbor2}
+# CVE-2025-64076
+# https://github.com/agronholm/cbor2/pull/265
+Patch:          0001-Fix-bug-in-decode_definite_long_string-that-causes-incorrect-chunk-length-calculation-265.patch
 
 BuildRequires:  gcc
 BuildRequires:  python3-devel
 
-%description
+%global _description %{expand:
 This library provides encoding and decoding for the Concise Binary Object
-Representation (CBOR) (RFC 7049) serialization format.
+Representation (CBOR) (RFC 7049) serialization format.}
 
-%package -n     python3-%{pypi_name}
+
+%description %_description
+
+
+%package -n     python3-cbor2
 Summary:        %{summary}
 
-%description -n python3-%{pypi_name}
-This library provides encoding and decoding for the Concise Binary Object
-Representation (CBOR) (RFC 7049) serialization format.
 
-%package -n python-%{pypi_name}-doc
+%description -n python3-cbor2 %_description
+
+
+%package -n python-cbor2-doc
 Summary:        cbor2 documentation
 BuildArch:      noarch
 BuildRequires:  python3dist(sphinx)
 BuildRequires:  python3dist(sphinx-rtd-theme)
 BuildRequires:  python3dist(sphinx-autodoc-typehints)
 
-%description -n python-%{pypi_name}-doc
+
+%description -n python-cbor2-doc
 Documentation for cbor2.
 
+
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -p 1 -n cbor2-%{version}
+
 
 %generate_buildrequires
 %pyproject_buildrequires -x test
 
+
 %build
 %pyproject_wheel
 
+
 %install
 %pyproject_install
-%pyproject_save_files %{pypi_name}
+%pyproject_save_files -l cbor2
 PYTHONPATH=${PWD} sphinx-build-3 docs html
 rm -rf html/.{doctrees,buildinfo}
+
 
 %check
 %pytest -v tests
 
-%files -n python3-%{pypi_name} -f %{pyproject_files}
-%doc README.rst
-%{python3_sitearch}/_%{pypi_name}%{python3_ext_suffix}
-%{_bindir}/%{pypi_name}
 
-%files -n python-%{pypi_name}-doc
+%files -n python3-cbor2 -f %{pyproject_files}
+%doc README.rst
+%{python3_sitearch}/_cbor2%{python3_ext_suffix}
+%{_bindir}/cbor2
+
+
+%files -n python-cbor2-doc
 %doc html
 %license LICENSE.txt
 
+
 %changelog
+* Fri Apr 10 2026 Carl George <carlwgeorge@fedoraproject.org> - 5.6.5-8
+- Backport upstream patch for CVE-2025-64076
+
 * Sat Jan 17 2026 Fedora Release Engineering <releng@fedoraproject.org> - 5.6.5-7
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
 


### PR DESCRIPTION
## CVE Pin-Forward: python-cbor2

Pins `python-cbor2` to Fedora f43 HEAD (`575d0ec`) to pick up
1 CVE patches added upstream.

### CVEs Resolved

| CVE | Severity | Status |
|-----|----------|--------|
| CVE-2025-64076 | High | Tracked |

### Fedora Spec Delta

Old commit: `c2b6a2d`
New commit: `575d0ec`

New patches:
- `0001-Fix-bug-in-decode_definite_long_string-that-causes-incorrect-chunk-length-calculation-265.patch`
