### PR TITLE
Resolved `ptests` failure in `runc` package

### DIFF
--- a/SPECS/runc/runc.spec
+++ b/SPECS/runc/runc.spec
@@ -31,10 +31,14 @@ export CGO_ENABLED=1
 make %{?_smp_mflags} BUILDTAGS="seccomp" COMMIT="%{commit_hash}" man runc
 
 %check
-mount -t cgroup2 none /sys/fs/cgroup
-trap 'umount -l /sys/fs/cgroup' EXIT
-go test -tags "seccomp cgo" -timeout 3m -v \
+unshare -m --propagation unchanged sh <<'EOF'
+if ! mountpoint -q /sys/fs/cgroup; then
+    mount -t cgroup2 none /sys/fs/cgroup
+    trap 'umount -l /sys/fs/cgroup' EXIT
+fi
+go test -tags "seccomp cgo" -timeout 10m \
     $(go list ./... | grep -vE '/libcontainer/(integration|nsenter)$')
+EOF
 
 %install
 make install DESTDIR=%{buildroot} PREFIX=%{_prefix} BINDIR=%{_bindir}

--- a/SPECS/runc/runc.spec
+++ b/SPECS/runc/runc.spec
@@ -33,8 +33,9 @@ make %{?_smp_mflags} BUILDTAGS="seccomp" COMMIT="%{commit_hash}" man runc
 %check
 unshare -m --propagation unchanged sh <<'EOF'
 if ! mountpoint -q /sys/fs/cgroup; then
-    mount -t cgroup2 none /sys/fs/cgroup || exit 1
-    trap 'umount -l /sys/fs/cgroup' EXIT
+    if mount -t cgroup2 none /sys/fs/cgroup; then
+        trap 'umount -l /sys/fs/cgroup' EXIT
+    fi
 fi
 go test -tags "seccomp cgo" -timeout 10m \
     $(go list ./... | grep -vE '/libcontainer/(integration|nsenter)$')

--- a/SPECS/runc/runc.spec
+++ b/SPECS/runc/runc.spec
@@ -3,7 +3,7 @@ Summary:        CLI tool for spawning and running containers per OCI spec.
 Name:           runc
 # update "commit_hash" above when upgrading version
 Version:        1.3.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -31,7 +31,10 @@ export CGO_ENABLED=1
 make %{?_smp_mflags} BUILDTAGS="seccomp" COMMIT="%{commit_hash}" man runc
 
 %check
-make %{?_smp_mflags} COMMIT="%{commit_hash}" localunittest
+mount -t cgroup2 none /sys/fs/cgroup
+trap 'umount -l /sys/fs/cgroup' EXIT
+go test -tags "seccomp cgo" -timeout 3m -v \
+    $(go list ./... | grep -vE '/libcontainer/(integration|nsenter)$')
 
 %install
 make install DESTDIR=%{buildroot} PREFIX=%{_prefix} BINDIR=%{_bindir}
@@ -43,6 +46,9 @@ make install-man DESTDIR=%{buildroot} PREFIX=%{_prefix}
 %{_mandir}/*
 
 %changelog
+* Fri May 15 2026 Sumit Jena <sumitjena@microsoft.com> - 1.3.3-2
+- Fixed ptests failure
+
 * Wed Nov 05 2025 Nan Liu <liunan@microsoft.com> - 1.3.3-1
 - Upgrade to 1.3.3
 - BR golang < 1.25

--- a/SPECS/runc/runc.spec
+++ b/SPECS/runc/runc.spec
@@ -33,7 +33,7 @@ make %{?_smp_mflags} BUILDTAGS="seccomp" COMMIT="%{commit_hash}" man runc
 %check
 unshare -m --propagation unchanged sh <<'EOF'
 if ! mountpoint -q /sys/fs/cgroup; then
-    mount -t cgroup2 none /sys/fs/cgroup
+    mount -t cgroup2 none /sys/fs/cgroup || exit 1
     trap 'umount -l /sys/fs/cgroup' EXIT
 fi
 go test -tags "seccomp cgo" -timeout 10m \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This pull request updates the `runc` package spec to address ptests failures and improve the test process. The main changes are focused on fixing test execution and updating the package release.

**Test improvements:**
* Changed the `%check` section to explicitly mount `cgroup2` and run Go tests with appropriate tags, replacing the previous `make localunittest` command. This helps ensure tests run in the correct environment and excludes integration/nsenter tests.
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/runc/runc.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1119442&view=results
