### PR TITLE
chore(libkml): re-render spec

### DIFF
--- a/specs/l/libkml/libkml.spec
+++ b/specs/l/libkml/libkml.spec
@@ -17,7 +17,7 @@
 
 Name:           libkml
 Version:        1.3.0
-Release: 58%{?dist}
+Release: 59%{?dist}
 Summary:        Reference implementation of OGC KML 2.2
 
 License:        BSD-3-Clause


### PR DESCRIPTION
https://github.com/microsoft/azurelinux/pull/17276 missed rendering the spec after the lock file was updated