### PR TITLE
ci: adopt lychee for docs validation

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,41 @@
+name: "Check docs"
+on:
+  push:
+    branches: [ 4.0 ]
+  pull_request:
+    branches: [ 4.0 ]
+  workflow_dispatch:
+  schedule:
+    # Run every night at 3:15am PST (11:15am UTC)
+    - cron: '15 11 * * *'
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+  CLICOLOR_FORCE: 1
+
+permissions:
+  contents: read
+
+# Cancel in-progress runs of this workflow if a new run is triggered.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Check links in docs
+  check-links:
+    name: "Check links"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check repo-local links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: ". --offline --verbose --include-verbatim --include-fragments --no-progress"
+          fail: true

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,4 @@
+exclude_path = [
+   # Exclude validation of links in rendered specs/content.
+   "(^|/)specs/" 
+]


### PR DESCRIPTION
Adopts [lychee](https://github.com/lycheeverse/lychee) for validation of links in .md files and similar. We choose to run in offline mode for now, and only validate *local* files. This is a more conservative option for that avoids trying to access arbitrary internet locations. It will still catch broken inter-.md links in docs, readmes, etc.

> NOTE: We also disable review of rendered content under `specs`.

A sample local run (without verbosity) looks like this:

<img width="1822" height="201" alt="image" src="https://github.com/user-attachments/assets/f168ec40-a7a9-4d82-8ede-c82362a6074c" />

For reference, `azldev` also uses `lychee` in CI workflows.