### PR TITLE
chore(libseccomp): pin to fedora 44, drop stale rawhide override

### DIFF
--- a/base/comps/libseccomp/libseccomp.comp.toml
+++ b/base/comps/libseccomp/libseccomp.comp.toml
@@ -1,3 +1,5 @@
 [components.libseccomp]
-# Need build fixes in rawhide
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "rawhide" } }
+# Pin to fedora 44 to minimize drift from what we're currently building
+# (the AZL4 default is fedora 43 @ snapshot, but rawhide -> f44 branched
+# at commit fa5ec89, which is what we have been shipping).
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "44" }, upstream-commit = "fa5ec89b71f49dbb6fb2136df5b74a6518f5f6d0" }

--- a/locks/libseccomp.lock
+++ b/locks/libseccomp.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-import-commit = 'fa5ec89b71f49dbb6fb2136df5b74a6518f5f6d0'
+import-commit = '9639e347a69b4ac9637dbaa6c7874910d93a1eb2'
 upstream-commit = 'fa5ec89b71f49dbb6fb2136df5b74a6518f5f6d0'
-input-fingerprint = 'sha256:6d8447b697b5551e507b1a8ce0c3139385f3168ac77f811ebb71cb27bc0585df'
-resolution-input-hash = 'sha256:7e5cd346f3310fd2d008e0c6be719cc36a2f15e36de889eb223aa254029a877f'
+input-fingerprint = 'sha256:a5884a6e23c8caefb31d71e5f155e48281f271062e0815b3074b6387a649430c'
+resolution-input-hash = 'sha256:c698c13355f5893180a1142ab20345b88b85b0c5c59c214578eed104fa8efd29'

--- a/specs/l/libseccomp/libseccomp.spec
+++ b/specs/l/libseccomp/libseccomp.spec
@@ -3,7 +3,7 @@
 
 Name:           libseccomp
 Version:        2.6.0
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary:        Enhanced seccomp library
 License:        LGPL-2.1-only
 URL:            https://github.com/seccomp/libseccomp


### PR DESCRIPTION
The 'Need build fixes in rawhide' rationale no longer describes real divergence. f44 (HEAD fa5ec89) is byte-identical to the rawhide commit we were previously pinned to. Switch the pin to fedora 44 to keep the spec stable against a real release branch while still matching exactly what we are currently shipping, and drop the obsolete rationale.

Fixes: [AB#19967](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/19967)