### PR TITLE
[Work Item #17159 & #17194] fix `ptest` for python-omegaconf

### DIFF
--- a/SPECS/python-omegaconf/python-omegaconf.spec
+++ b/SPECS/python-omegaconf/python-omegaconf.spec
@@ -54,7 +54,7 @@ PYTHONPATH=$PWD/.pytest-deps${PYTHONPATH:+:$PYTHONPATH} \
 %{python3_sitelib}/*
 
 %changelog
-* Mon May 18 2026 Akhila Guruju <v-guakhila@microsoft.com> - 2.3.0-2
+* Wed Jun 03 2026 Akhila Guruju <v-guakhila@microsoft.com> - 2.3.0-2
 - Added and fixed ptest.
 
 * Fri May 10 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 2.3.0-1

--- a/SPECS/python-omegaconf/python-omegaconf.spec
+++ b/SPECS/python-omegaconf/python-omegaconf.spec
@@ -1,13 +1,14 @@
 Summary:        A hierarchical configuration system
 Name:           python-omegaconf
 Version:        2.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          Development/Languages/Python
 URL:            https://pypi.org/project/omegaconf/
 Source0:        https://github.com/omry/omegaconf/archive/refs/tags/v%{version}.tar.gz#/%{name}-%version.tar.gz
+Patch0:         upstream-fix-for-ptests.patch
 %if 0%{?with_check}
 BuildRequires:  python3-pip
 %endif
@@ -28,7 +29,7 @@ OmegaConf is a hierarchical configuration system, with support for merging confi
 providing a consistent API regardless of hwo the configuration was created
 
 %prep
-%autosetup -n omegaconf-%{version}
+%autosetup -p1 -n omegaconf-%{version}
 
 %build
 %py3_build
@@ -37,14 +38,25 @@ providing a consistent API regardless of hwo the configuration was created
 %py3_install
 
 %check
-pip3 install mock wheel
-#%python3 setup.py test
+%{python3} -m pip install --disable-pip-version-check --no-cache-dir \
+    --target .pytest-deps \
+    -r requirements/base.txt \
+    "pytest<8" \
+    pytest-mock \
+    attrs \
+    pydevd
+
+PYTHONPATH=$PWD/.pytest-deps${PYTHONPATH:+:$PYTHONPATH} \
+    %{python3} -m pytest tests
 
 %files -n python3-omegaconf
 %license LICENSE
 %{python3_sitelib}/*
 
 %changelog
+* Mon May 18 2026 Akhila Guruju <v-guakhila@microsoft.com> - 2.3.0-2
+- Added and fixed ptest.
+
 * Fri May 10 2024 Alberto David Perez Guevara <aperezguevar@microsoft.com> - 2.3.0-1
 - Original version for Azure Linux.
 - license verified.

--- a/SPECS/python-omegaconf/upstream-fix-for-ptests.patch
+++ b/SPECS/python-omegaconf/upstream-fix-for-ptests.patch
@@ -1,0 +1,111 @@
+From ed7e24bdbf68c3b9f979fd5bdb46f6b6c5472549 Mon Sep 17 00:00:00 2001
+From: akhila-guruju <v-guakhila@microsoft.com>
+Date: Tue, 12 May 2026 11:59:39 +0000
+Subject: [PATCH] Upstream fix for ptests
+
+Upstream Patch reference: https://github.com/omry/omegaconf/commit/a656e85e44795d471c812d9f9c326967465cf788.patch
+PR: https://github.com/omry/omegaconf/pull/1225
+
+Modified to apply to Azure Linux.
+Only first 2 commit changes are relevant to the ptests.
+Combined commit changes: https://github.com/omry/omegaconf/pull/1225/changes/BASE..8cb50f64ea58c217f908d3f65cb09c0707633234
+---
+ pydevd_plugins/__init__.py            |  7 ++--
+ pydevd_plugins/extensions/__init__.py |  7 ++--
+ tests/test_nodes.py                   | 50 +++++++++++++++++++++++++--
+ 3 files changed, 52 insertions(+), 12 deletions(-)
+
+diff --git a/pydevd_plugins/__init__.py b/pydevd_plugins/__init__.py
+index e4abcfa..f77af49 100644
+--- a/pydevd_plugins/__init__.py
++++ b/pydevd_plugins/__init__.py
+@@ -1,6 +1,3 @@
+-try:
+-    __import__("pkg_resources").declare_namespace(__name__)
+-except ImportError:  # pragma: no cover
+-    import pkgutil
++import pkgutil
+ 
+-    __path__ = pkgutil.extend_path(__path__, __name__)
++__path__ = pkgutil.extend_path(__path__, __name__)
+diff --git a/pydevd_plugins/extensions/__init__.py b/pydevd_plugins/extensions/__init__.py
+index e4abcfa..f77af49 100644
+--- a/pydevd_plugins/extensions/__init__.py
++++ b/pydevd_plugins/extensions/__init__.py
+@@ -1,6 +1,3 @@
+-try:
+-    __import__("pkg_resources").declare_namespace(__name__)
+-except ImportError:  # pragma: no cover
+-    import pkgutil
++import pkgutil
+ 
+-    __path__ = pkgutil.extend_path(__path__, __name__)
++__path__ = pkgutil.extend_path(__path__, __name__)
+diff --git a/tests/test_nodes.py b/tests/test_nodes.py
+index af73670..8ef8e94 100644
+--- a/tests/test_nodes.py
++++ b/tests/test_nodes.py
+@@ -843,8 +843,11 @@ def test_eq(node: ValueNode, value: Any, expected: Any) -> None:
+     assert (value != node) != expected
+ 
+     # Check hash except for unhashable types (dict/list).
+-    if not isinstance(value, (dict, list)):
+-        assert (node.__hash__() == value.__hash__()) == expected
++    # Per Python's hash contract: if a == b, then hash(a) == hash(b)
++    # Note: if a != b, hashes may or may not be equal (collisions are allowed)
++    # E.g. Path('a') != 'a' but their hashes are equal as of Python 3.12
++    if not isinstance(value, (dict, list)) and expected:
++        assert node.__hash__() == value.__hash__()
+ 
+ 
+ @mark.parametrize(
+@@ -998,3 +1001,46 @@ def test_interpolation_result_readonly(flags: Any) -> None:
+     # If no value was provided for the "readonly" flag, it should be set.
+     if readonly is None:
+         assert node._get_node_flag("readonly")
++
++
++@mark.skipif(
++    sys.version_info < (3, 12),
++    reason="Hash collision between Path and str only exists in Python 3.12+",
++)
++def test_path_str_hash_collision_handling() -> None:
++    """
++    Regression test for Python 3.12+ hash collision between Path and str.
++
++    In Python 3.12+, Path('x') and 'x' have identical hashes but are not equal.
++    This test verifies that OmegaConf's containers handle this collision correctly.
++    """
++    from pathlib import Path
++
++    path_str = "hello.txt"
++    path_obj = Path(path_str)
++    assert hash(path_obj) == hash(path_str)
++    assert path_obj != path_str  # type: ignore[comparison-overlap]
++
++    # Test PathNode behavior with hash collision
++    path_node = PathNode(path_obj)
++    assert hash(path_node) == hash(path_str)
++    assert path_node != path_str
++
++    list_cfg1 = OmegaConf.create([path_obj])
++    assert path_obj in list_cfg1
++    assert path_str not in list_cfg1
++
++    list_cfg2 = OmegaConf.create([path_str])
++    assert path_obj not in list_cfg2
++    assert path_str in list_cfg2
++
++    # Test DictConfig with both types as values
++    dict_cfg = OmegaConf.create(
++        {
++            "by_path": {"file": path_obj},
++            "by_string": {"file": path_str},
++        }
++    )
++    assert dict_cfg.by_path.file == path_obj
++    assert dict_cfg.by_string.file == path_str
++    assert dict_cfg.by_path.file != dict_cfg.by_string.file
+-- 
+2.43.0
+


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add and fix ptest for python-omegaconf
- python-omegaconf of v2.3.0 does not provide support for python3.12([releases/tag/v2.3.0](https://github.com/omry/omegaconf/releases/tag/v2.3.0)).
- The ptests were fixed in the latest upstream branch.(https://github.com/omry/omegaconf/releases/tag/v2.4.0dev4)

Upstream Patch reference: https://github.com/omry/omegaconf/commit/a656e85e44795d471c812d9f9c326967465cf788.patch
PR: https://github.com/omry/omegaconf/pull/1225

Modified to apply to Azure Linux.
Only first 2 commit changes are relevant to the ptests.
Replace deprecated pkg_resources with pkgutil and fix failing test for Python 3.12+
Combined commit changes: https://github.com/omry/omegaconf/pull/1225/changes/BASE..8cb50f64ea58c217f908d3f65cb09c0707633234
The change made in `pyproject.toml` is already present in v2.3.0

No minor version upgrade can fix ptest failures.
disabled pip version check in %check section to fix the error caused during build.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified:   SPECS/python-omegaconf/python-omegaconf.spec
- new file:   SPECS/python-omegaconf/upstream-fix-for-ptests.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- For AMD: https://dev.azure.com/mariner-org/mariner/_workitems/edit/17159
- For ARM: https://dev.azure.com/mariner-org/mariner/_workitems/edit/17194

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
- Patch applies cleanly
<img width="341" height="150" alt="image" src="https://github.com/user-attachments/assets/2dc8e714-e907-480a-8ff4-e2f22eca79a6" />
<img width="691" height="153" alt="image" src="https://github.com/user-attachments/assets/ee07732b-6d6f-40b3-b51d-ec3cb99dc791" />

