### PR TITLE
fix(repoclosure): promote python-gmpy2 to base channel

### DIFF
--- a/base/comps/components-publish-channels.toml
+++ b/base/comps/components-publish-channels.toml
@@ -1926,6 +1926,7 @@ components = [
     "python-fuse",
     "python-genshi",
     "python-gitdb",
+    "python-gmpy2",
     "python-google-auth",
     "python-googleapis-common-protos",
     "python-greenlet",


### PR DESCRIPTION
The `python3-mpmath+gmpy` package (in base) has a runtime dependency on `python3.14dist(gmpy2) >= 2.1~a4`, but no package in `base` previously satisfied this requirement, causing a repoclosure failure.

This change promotes `python-gmpy2` from `sdk` to `base` to provide the missing `gmpy2` module. The promoted package introduces no additional runtime requirements beyond what is already available in `base`. The package provides a Python module for multiple-precision arithmetic.

(We also separate evaluated whether removal of `python3-mpmath` was feasible, but it's included in the dependency chains of some popular Python packages, such as `python3-networkx`, `python3-onnxruntime` , and `python3-torch`.)