### PR TITLE
systemd: backport ukify merged-sections padding fix

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        27%{?dist}
+Release:        28%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -138,6 +138,10 @@ Patch0490:      use-none-scheduler.patch
 # NOTE: the patch was based on the fedora patch, but renamed to
 # 'azurelinux-...' and modified for our 'system-*' pam files
 Patch0491:      azurelinux-use-system-auth-in-pam-systemd-user.patch
+
+# ukify: fix insertion of padding in merged sections
+# Backport of upstream commit ec1d031f3de02f84beca89e2b402d085fba62be4
+Patch0492:      ukify-fix-insertion-of-padding-in-merged-sections.patch
 
 # Patches for Azure Linux
 Patch0900:      do-not-test-openssl-sm3.patch
@@ -1235,6 +1239,12 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Wed May 20 2026 Vince Perri <viperri@microsoft.com> - 255-28
+- Backport upstream ukify fix (ec1d031f3de02f84beca89e2b402d085fba62be4):
+  when merging into an existing PE section, padding was derived from the new
+  section size instead of the existing section size, which can leave
+  insufficient padding and corrupt the resulting UKI.
+
 * Thu Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
 - Fix pcrlock failure on Hyper-V/Azure VMs with vTPM by backporting upstream
   commit e90a255 from systemd v256 (PR #31429).

--- a/SPECS/systemd/ukify-fix-insertion-of-padding-in-merged-sections.patch
+++ b/SPECS/systemd/ukify-fix-insertion-of-padding-in-merged-sections.patch
@@ -1,0 +1,38 @@
+From ec1d031f3de02f84beca89e2b402d085fba62be4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Tue, 19 Aug 2025 11:02:44 +0200
+Subject: [PATCH] ukify: fix insertion of padding in merged sections
+
+The padding was done to expand the new section contents to the expected size of
+the new section. And this then would be used for the content in the existing
+section. The new section cannot be larger than the old section, but it can be
+smaller. If the new section was smaller, then we'd not write enough padding and
+the output file would be corrupted.
+
+This was observed in CI when the .sbat section in the stub was padded to 1k.
+The UKI with an .sbat section that was merged and was fairly short would hit
+this scenario and be corrupted.
+---
+ src/ukify/ukify.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/ukify/ukify.py b/src/ukify/ukify.py
+index 6d55abab35ec2..e3c427166d302 100755
+--- a/src/ukify/ukify.py
++++ b/src/ukify/ukify.py
+@@ -1050,14 +1050,13 @@ def pe_add_sections(opts: UkifyConfig, uki: UKI, output: str) -> None:
+                         f' (need {new_section.Misc_VirtualSize}, have {s.SizeOfRawData})'
+                     )
+ 
+-                padding = bytes(new_section.SizeOfRawData - new_section.Misc_VirtualSize)
++                padding = bytes(s.SizeOfRawData - new_section.Misc_VirtualSize)
+                 pe.__data__ = (
+                     pe.__data__[: s.PointerToRawData]
+                     + data
+                     + padding
+                     + pe.__data__[pe.sections[i + 1].PointerToRawData :]
+                 )
+-                s.SizeOfRawData = new_section.SizeOfRawData
+                 s.Misc_VirtualSize = new_section.Misc_VirtualSize
+                 break
+         else:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backports upstream ukify fix (ec1d031f3de02f84beca89e2b402d085fba62be4):
when merging into an existing PE section, padding was derived from the new
section size instead of the existing section size, which can leave
insufficient padding and corrupt the resulting UKI.

###### Change Log  <!-- REQUIRED -->
- Added SPECS/systemd/ukify-fix-insertion-of-padding-in-merged-sections.patch (upstream patch content).
- Added Patch0492 entry in SPECS/systemd/systemd.spec.
- Bumped Release from 27 to 28 and added a changelog entry.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
