### PR TITLE
feat(annobin): bump release to fix distro triplet in installed paths

### DIFF
--- a/locks/annobin.lock
+++ b/locks/annobin.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '8bc321d24a8e1f4307d19a062bf857e5b88bd1b2'
 upstream-commit = '8bc321d24a8e1f4307d19a062bf857e5b88bd1b2'
-input-fingerprint = 'sha256:bb0ab89d8de4d544027eaef825f3c2d25a794276318d966e2b64481e172dc995'
+manual-bump = 1
+input-fingerprint = 'sha256:cac6d612c6e2e079f7846e6dd74563dff72ecb942f2d068baa4074f5e90babb3'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/a/annobin/annobin.spec
+++ b/specs/a/annobin/annobin.spec
@@ -5,7 +5,7 @@
 Name:    annobin
 Summary: Annotate and examine compiled binary files
 Version: 12.99
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: GPL-3.0-or-later AND LGPL-2.0-or-later AND (GPL-2.0-or-later WITH GCC-exception-2.0) AND (LGPL-2.0-or-later WITH GCC-exception-2.0) AND GFDL-1.3-or-later
 URL: https://sourceware.org/annobin/
 # Maintainer: nickc@redhat.com


### PR DESCRIPTION
## Problem

The current annobin build delivers plugin files to paths using the old distro triplet:

```
/usr/lib/gcc/x86_64-redhat-linux/15/
```

The LLVM triplet and distro have since changed to reflect `azurelinux` as the distro name. A simple rebuild is sufficient to fix this — the spec picks up the correct triplet from the build environment automatically.

## Fix

Bump the annobin release (12.99-2 → 12.99-3) using `azldev comp update --bump` to trigger a rebuild that will deliver files with the correct distro triplet.

## Verification

- Scratch build confirms the fix: https://20.114.86.47/koji/taskinfo?taskID=2521011
- Local build succeeds with all 13 RPMs produced (annocheck, gcc/clang/llvm plugins, libannocheck, docs)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>