### PR TITLE
docs: warn about manual release bump when modifying components

### DIFF
--- a/.github/instructions/comp-toml.instructions.md
+++ b/.github/instructions/comp-toml.instructions.md
@@ -232,6 +232,8 @@ value = "1%{?dist}"
 
 **When using `manual`:** You take ownership of bumping the Release value when needed (e.g., rebuild without a version change). The auto-calculator will not touch it.
 
+> **Pitfall — modifying a component with manual release:** Unlike `auto`/`static`/`autorelease` modes, `manual` release components do NOT get their Release bumped by the commit-render-amend cycle. When you change a manual-release component (add/remove build flags, modify overlays, etc.), you **must** also increment the release counter in the same change — typically an `azl_release` define in `[components.<name>.build.defines]` or the `value` in a `spec-set-tag` overlay for `Release`.
+
 ## Render Configuration
 
 The `render` section controls spec rendering behavior. Currently has one field:

--- a/.github/skills/skill-remove-component/SKILL.md
+++ b/.github/skills/skill-remove-component/SKILL.md
@@ -90,6 +90,7 @@ grep -rn "<name>" --include="*.kiwi" .                  # should return nothing
 ## Notes
 
 - **Check for reverse dependencies** before removing a component. If other components depend on it (via `BuildRequires` or `Requires`), removing it will break their builds.
+- **When modifying dependants, check their release calculation.** If you disable a feature or remove a `BuildRequires` from a dependant component that uses `release = { calculation = "manual" }`, you must also bump its release counter (e.g., increment the `azl_release` define). Components with automatic release calculation (`auto`, `static`, `autorelease`) handle this via the commit-render-amend cycle, but manual-release components do not.
 - **Publishing is component-scoped, exceptions are binary-scoped.** The `base-packages` group lists *component* names; the `exceptions-packages` group lists *binary RPM* names with `# srpm: <name>` comments. Always search by `# srpm:` comment rather than guessing suffix patterns.
 - **This is a metadata-only change.** No builds or tests are needed — the component is simply being dropped from the distro definition.
 - **When removing a component and its exclusive dependencies** (packages only needed by the component being removed), remove them all in the same change to keep the tree consistent.

--- a/.github/skills/skill-update-component/SKILL.md
+++ b/.github/skills/skill-update-component/SKILL.md
@@ -42,6 +42,8 @@ This applies to **every** commit that touches a component or its lock -- pin bum
 
 During iterative work (before any commit) the changelog/release fields are not expected to track the working tree. Only worry about the post-commit re-render once you're finalizing for a PR.
 
+> **Manual release components:** Keep the same post-commit re-render/amend workflow when finalizing, because rpmautospec-generated `%changelog` can still drift after you commit. The difference is that components with `release = { calculation = "manual" }` do **not** get their `Release:` value bumped automatically by that cycle. When modifying such a component, you must **manually increment** its release counter in the same change (for example via an `azl_release` define or a `spec-set-tag` overlay value). Check the component's `release.calculation` field before finalizing — if it's `manual`, do the re-render/amend step and bump the release counter yourself.
+
 ## Bumping an upstream commit pin
 
 Pin bumps follow the same rule as every other change: the changelog/release fields are derived from `git log`, so you need a post-commit re-render. The pin-bump variant just splits the work across two commits (lock first, then iterate, then amend), and adds an *extra* up-front `update` to move the pin.


### PR DESCRIPTION
Components with release = { calculation = "manual" } do not get their Release bumped by the commit-render-amend cycle. Document this pitfall in comp-toml.instructions.md, skill-update-component, and skill-remove-component so agents and contributors remember to increment the release counter (e.g. azl_release) when modifying such components.
