### PR TITLE
revert(51c1d56, grub2): re-enable os-prober by default

### DIFF
--- a/base/comps/grub2/grub2.comp.toml
+++ b/base/comps/grub2/grub2.comp.toml
@@ -16,36 +16,3 @@ type = "file-search-replace"
 file = "grub.macros"
 regex = '%global with_xen_pvh_arch 1'
 replacement = '%global with_xen_pvh_arch 0'
-
-# Drop the two Fedora revert patches that re-enable the os-prober-by-default
-# behavior in grub-mkconfig. os-prober has been disabled by default for security
-# reason in grub2 (2.06+), and previous versions of Azure Linux have
-# historically followed suite.
-#
-# `patch-remove` can't be used: grub2.spec pulls its patch list from
-# `grub.patches` via `%include %{SOURCE11}`, and azldev only scans inline
-# `PatchN:` / `%patchlist` tags. Edit `grub.patches` and delete the files
-# directly instead.
-[[components.grub2.overlays]]
-description = "Drop Fedora os-prober revert (properly disable) from grub.patches"
-type = "file-search-replace"
-file = "grub.patches"
-regex = 'Patch0002: 0002-Revert-templates-Properly-disable-the-os-prober-by-d\.patch\n'
-replacement = ""
-
-[[components.grub2.overlays]]
-description = "Drop Fedora os-prober revert (disable by default) from grub.patches"
-type = "file-search-replace"
-file = "grub.patches"
-regex = 'Patch0003: 0003-Revert-templates-Disable-the-os-prober-by-default\.patch\n'
-replacement = ""
-
-[[components.grub2.overlays]]
-description = "Remove Fedora os-prober revert patch file (properly disable)"
-type = "file-remove"
-file = "0002-Revert-templates-Properly-disable-the-os-prober-by-d.patch"
-
-[[components.grub2.overlays]]
-description = "Remove Fedora os-prober revert patch file (disable by default)"
-type = "file-remove"
-file = "0003-Revert-templates-Disable-the-os-prober-by-default.patch"

--- a/locks/grub2.lock
+++ b/locks/grub2.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '354c77b195316a4aa09979793a73ea4485217769'
 upstream-commit = '354c77b195316a4aa09979793a73ea4485217769'
-input-fingerprint = 'sha256:e457a7afd4e6150cf6133f8a1b739ade7d97eb714e39af09abd248c4bad5c2af'
+manual-bump = 1
+input-fingerprint = 'sha256:218bb17939644ac159ceee0573390edcbf722424a674b8a95182f580bc99dbbb'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/grub2/0002-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/specs/g/grub2/0002-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Fri, 11 Jun 2021 12:10:54 +0200
+Subject: [PATCH] Revert "templates: Properly disable the os-prober by default"
+
+This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
+---
+ util/grub-mkconfig.in       | 5 +----
+ util/grub.d/30_os-prober.in | 8 ++++----
+ 2 files changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index 32c480daeb2..7516a015be0 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -140,9 +140,6 @@ GRUB_DEVICE_PARTUUID="`${grub_probe} --device ${GRUB_DEVICE} --target=partuuid 2
+ GRUB_DEVICE_BOOT="`${grub_probe} --target=device /boot`"
+ GRUB_DEVICE_BOOT_UUID="`${grub_probe} --device ${GRUB_DEVICE_BOOT} --target=fs_uuid 2> /dev/null`" || true
+ 
+-# Disable os-prober by default due to security reasons.
+-GRUB_DISABLE_OS_PROBER="true"
+-
+ # Filesystem for the device containing our userland.  Used for stuff like
+ # choosing Hurd filesystem module.
+ GRUB_FS="`${grub_probe} --device ${GRUB_DEVICE} --target=fs 2> /dev/null || echo unknown`"
+@@ -204,7 +201,6 @@ export GRUB_DEVICE \
+   GRUB_DEVICE_PARTUUID \
+   GRUB_DEVICE_BOOT \
+   GRUB_DEVICE_BOOT_UUID \
+-  GRUB_DISABLE_OS_PROBER \
+   GRUB_FS \
+   GRUB_FONT \
+   GRUB_PRELOAD_MODULES \
+@@ -250,6 +246,7 @@ export GRUB_DEFAULT \
+   GRUB_BACKGROUND \
+   GRUB_THEME \
+   GRUB_GFXPAYLOAD_LINUX \
++  GRUB_DISABLE_OS_PROBER \
+   GRUB_INIT_TUNE \
+   GRUB_SAVEDEFAULT \
+   GRUB_ENABLE_CRYPTODISK \
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index 376ca47efe4..30f27f15b83 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,8 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
+-  grub_warn "$(gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.")"
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
++  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
+   exit 0
+ fi
+ 
+@@ -36,12 +36,12 @@ if ! command -v os-prober > /dev/null || ! command -v linux-boot-prober > /dev/n
+   exit 0
+ fi
+ 
+-grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+-
+ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
++else
++  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {

--- a/specs/g/grub2/0003-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/specs/g/grub2/0003-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Fri, 11 Jun 2021 12:10:58 +0200
+Subject: [PATCH] Revert "templates: Disable the os-prober by default"
+
+This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
+---
+ docs/grub.texi              | 18 ++++++++----------
+ util/grub.d/30_os-prober.in |  5 +----
+ 2 files changed, 9 insertions(+), 14 deletions(-)
+
+diff --git a/docs/grub.texi b/docs/grub.texi
+index a225f9a88d2..974bc0ddb07 100644
+--- a/docs/grub.texi
++++ b/docs/grub.texi
+@@ -1552,13 +1552,10 @@ boot sequence.  If you have problems, set this option to @samp{text} and
+ GRUB will tell Linux to boot in normal text mode.
+ 
+ @item GRUB_DISABLE_OS_PROBER
+-The @command{grub-mkconfig} has a feature to use the external
+-@command{os-prober} program to discover other operating systems installed on
+-the same machine and generate appropriate menu entries for them. It is disabled
+-by default since automatic and silent execution of @command{os-prober}, and
+-creating boot entries based on that data, is a potential attack vector. Set
+-this option to @samp{false} to enable this feature in the
+-@command{grub-mkconfig} command.
++Normally, @command{grub-mkconfig} will try to use the external
++@command{os-prober} program, if installed, to discover other operating
++systems installed on the same system and generate appropriate menu entries
++for them.  Set this option to @samp{true} to disable this.
+ 
+ @item GRUB_OS_PROBER_SKIP_LIST
+ List of space-separated FS UUIDs of filesystems to be ignored from os-prober
+@@ -1889,9 +1886,10 @@ than zero; otherwise 0.
+ @section Multi-boot manual config
+ 
+ Currently autogenerating config files for multi-boot environments depends on
+-os-prober and has several shortcomings. Due to that it is disabled by default.
+-It is advised to use the power of GRUB syntax and do it yourself. A possible
+-configuration is detailed here, feel free to adjust to your needs.
++os-prober and has several shortcomings. While fixing it is scheduled for the
++next release, meanwhile you can make use of the power of GRUB syntax and do it
++yourself. A possible configuration is detailed here, feel free to adjust to your
++needs.
+ 
+ First create a separate GRUB partition, big enough to hold GRUB. Some of the
+ following entries show how to load OS installer images from this same partition,
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index 30f27f15b83..f300e46fc6a 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,8 +26,7 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
+-  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
+   exit 0
+ fi
+ 
+@@ -40,8 +39,6 @@ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
+-else
+-  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {

--- a/specs/g/grub2/grub.patches
+++ b/specs/g/grub2/grub.patches
@@ -1,4 +1,6 @@
 Patch0001: 0001-Revert-templates-Fix-user-facing-typo-with-an-incorr.patch
+Patch0002: 0002-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+Patch0003: 0003-Revert-templates-Disable-the-os-prober-by-default.patch
 Patch0004: 0004-Rework-linux-command.patch
 Patch0005: 0005-Rework-linux16-command.patch
 Patch0006: 0006-re-write-.gitignore.patch

--- a/specs/g/grub2/grub2.spec
+++ b/specs/g/grub2/grub2.spec
@@ -20,7 +20,7 @@
 Name:		grub2
 Epoch:		1
 Version:	2.12
-Release: 43%{?dist}
+Release: 44%{?dist}
 Summary:	Bootloader with support for Linux, Multiboot and more
 License:	GPL-3.0-or-later
 URL:		http://www.gnu.org/software/grub/


### PR DESCRIPTION
This reverts commit 51c1d561aa8cabba2da7577dd7a86a56dfbe34cd.

The change broke the build with the following error during %prep:

    /builddir/build/SOURCES/0382-Set-correctly-the-memory-attributes-for-the-kernel-P.patch
    error: patch failed: docs/grub.texi:1552
    error: docs/grub.texi: patch does not apply
    Applying: Revert "templates: Fix user-facing typo with an incorrect use of "it's""
    Applying: Rework linux command
    Applying: Rework linux16 command
    Applying: re-write .gitignore
    Applying: IBM client architecture (CAS) reboot support
    Applying: for ppc, reset console display attr when clear screen
    Applying: Disable GRUB video support for IBM power machines
    Applying: Move bash completion script (#922997)
    Applying: Allow "fallback" to include entries by title, not just number.
    Applying: Make "exit" take a return code.
    Applying: Make efi machines load an env block from a variable
    Applying: Migrate PPC from Yaboot to Grub2
    Applying: Add fw_path variable (revised)
    Applying: Pass "\x[[:hex:]][[:hex:]]" straight through unmolested.
    Applying: blscfg: add blscfg module to parse Boot Loader Specification snippets
    Applying: Add devicetree loading
    Applying: Enable pager by default. (#985860)
    Applying: Don't say "GNU/Linux" in generated menus.
    Applying: Add .eh_frame to list of relocations stripped
    Applying: Don't require a password to boot entries generated by grub-mkconfig.
    Applying: use fw_path prefix when fallback searching for grub config
    Applying: Try mac/guid/etc before grub.cfg on tftp config files.
    Applying: Generate OS and CLASS in 10_linux from /etc/os-release
    Applying: Try $prefix if $fw_path doesn't work.
    Applying: Make grub2-mkconfig construct titles that look like the ones we want elsewhere.
    Applying: Add friendly grub2 password config tool (#985962)
    Applying: tcp: add window scaling support
    Applying: efinet and bootp: add support for dhcpv6
    Applying: bootp: New net_bootp6 command
    Applying: Add grub-get-kernel-settings and use it in 10_linux
    Applying: Make grub_fatal() also backtrace.
    Applying: Make our info pages say "grub2" where appropriate.
    Patch failed at 0032 Make our info pages say "grub2" where appropriate.
    hint: Use 'git am --show-current-patch=diff' to see the failed patch
    hint: When you have resolved this problem, run "git am --continue".
    hint: If you prefer to skip this patch, run "git am --skip" instead.
    hint: To restore the original branch and stop patching, run "git am --abort".
    hint: Disable this message with "git config set advice.mergeConflict false"
    error: Bad exit status from /var/tmp/rpm-tmp.7SswhI (%prep)
    RPM build errors:
        %changelog not in descending chronological order
        Bad exit status from /var/tmp/rpm-tmp.7SswhI (%prep)
    Child return code was: 1

Fixes: [AB#20278](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20278)