### PR TITLE
kernel: backport "net: gro: don't merge zcopy skbs" (CVE-pending)

### DIFF
--- a/SPECS/kernel/0002-net-gro-don-t-merge-zcopy-skbs.patch
+++ b/SPECS/kernel/0002-net-gro-don-t-merge-zcopy-skbs.patch
@@ -1,0 +1,42 @@
+From 4db79a322db8c97f7b73b8a347395ef4d685eb40 Mon Sep 17 00:00:00 2001
+From: Sabrina Dubroca <sd@queasysnail.net>
+Date: Wed, 20 May 2026 22:44:42 +0200
+Subject: [PATCH] net: gro: don't merge zcopy skbs
+
+skb_gro_receive() can currently copy frags between the source and GRO
+skb, without checking the zerocopy status, and in particular the
+SKBFL_MANAGED_FRAG_REFS flag.
+
+When SKBFL_MANAGED_FRAG_REFS is set, the skb doesn't hold a reference
+on the pages in shinfo->frags. Appending those frags to another skb's
+frags without fixing up the page refcount can lead to UAF.
+
+When either the last skb in the GRO chain (the one we would append
+frags to) or the source skb is zerocopy, don't merge the skbs.
+
+Fixes: 753f1ca4e1e5 ("net: introduce managed frags infrastructure")
+Reported-by: Huzaifa Sidhpurwala <huzaifas@redhat.com>
+Signed-off-by: Sabrina Dubroca <sd@queasysnail.net>
+Reviewed-by: Willem de Bruijn <willemb@google.com>
+Link: https://patch.msgid.link/c3b7f906bbfcbdfd7b4fa9d6c18a438870df85be.1779307748.git.sd@queasysnail.net
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ net/core/gro.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/net/core/gro.c b/net/core/gro.c
+index 9f8960789b2cf..a847539834679 100644
+--- a/net/core/gro.c
++++ b/net/core/gro.c
+@@ -109,6 +109,9 @@ int skb_gro_receive(struct sk_buff *p, struct sk_buff *skb)
+ 	if (p->pp_recycle != skb->pp_recycle)
+ 		return -ETOOMANYREFS;
+ 
++	if (skb_zcopy(p) || skb_zcopy(skb))
++		return -ETOOMANYREFS;
++
+ 	if (unlikely(p->len + len >= netif_get_gro_max_size(p->dev, p) ||
+ 		     NAPI_GRO_CB(skb)->flush))
+ 		return -E2BIG;
+-- 
+2.34.1

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -32,7 +32,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -46,6 +46,7 @@ Source4:        azurelinux-ca-20230216.pem
 Source5:        cpupower
 Source6:        cpupower.service
 Patch0:         0001-add-mstflint-kernel-%{mstflintver}.patch
+Patch1:         0002-net-gro-don-t-merge-zcopy-skbs.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -440,6 +441,10 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Fri May 23 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.139.1-2
+- Backport upstream fix 4db79a322db8 ("net: gro: don't merge zcopy skbs")
+- Prevents GRO managed-frag UAF that allows unprivileged LPE via io_uring SEND_ZC
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 


### PR DESCRIPTION
## Summary
Backports upstream commit [`4db79a322db8`](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=4db79a322db8c97f7b73b8a347395ef4d685eb40) ("net: gro: don't merge zcopy skbs") into the Azure Linux 3.0 `kernel-6.6.139.1` package. The fix prevents a UAF in `skb_gro_receive()` that allows unprivileged LPE via io_uring `SEND_ZC` + veth GRO.

## Why this matters for Azure Linux 3
- Pre-condition (`SKBFL_MANAGED_FRAG_REFS`, introduced upstream by `753f1ca4e1e5`) is present in 6.6 LTS → 6.6.139.1
- io_uring is enabled by default (`kernel.io_uring_disabled=0`)
- A public PoC achieves root LPE in ~4/5 trials on stock `6.6.139.1-1.azl3` (Azure D2as_v5 VM, F32s_v2 build VM)

## Change
- Adds `SPECS/kernel/0002-net-gro-don-t-merge-zcopy-skbs.patch` — 3-line addition to `net/core/gro.c`'s `skb_gro_receive()` returning `-ETOOMANYREFS` when either skb is zero-copy
- Spec uses `%autosetup -p1` so the patch auto-applies during `%prep`
- `Release` bumped to `2%{?dist}`; changelog entry added

## Empirical verification (Azure)
Built and booted `kernel-6.6.139.1-2.azl3.x86_64` (`6.6.139.1-grofix`) on an F32s_v2 VM:

| | unpatched `6.6.139.1-1.azl3` | patched `6.6.139.1-grofix` |
|---|---|---|
| Public PoC (`lcfr-eth/2566a5cef312c94a5ff8d62fa417955f`) over 5 trials | **4/5 root achieved** (`hax::0:0::/root:/bin/sh` injected into `/etc/passwd`) | **0/5** (UAF prevented; PTE extraction lands on poisoned page each trial — page-poison sentinel `0xdeadbeefdeadbeef` observed) |
| `tools/testing/selftests/net/gro.sh` | n/a | "All Tests Succeeded" |
| `skb_gro_receive` disasm — `skb_zcopy(p) || skb_zcopy(skb)` guard | absent | present (`testb $0x1,(%r8)` → `cmpq $0x0,0x28(%r8)` → branch to ETOOMANYREFS) |

## Test plan
- [x] Patch applies cleanly via `%autosetup` against `kernel-6.6.139.1-1.azl3` SRPM
- [x] Kernel builds without error (`make -j12 vmlinux bzImage modules`)
- [x] Kernel boots; gro selftest passes
- [x] Public PoC blocked across 5 trials
- [ ] CI / pipeline build (CLA-bot + build pipeline will run after PR open)

## References
- Upstream fix: `4db79a322db8c97f7b73b8a347395ef4d685eb40`
- Introduced by: `753f1ca4e1e5` ("net: introduce managed frags infrastructure")
- Author: Sabrina Dubroca `<sd@queasysnail.net>`
- Reported by: Huzaifa Sidhpurwala `<huzaifas@redhat.com>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)