### PR TITLE
fix(python-geographiclib): neutralize MinGW macros to avoid empty subshell

### DIFF
--- a/base/comps/python-geographiclib/python-geographiclib.comp.toml
+++ b/base/comps/python-geographiclib/python-geographiclib.comp.toml
@@ -50,36 +50,36 @@ tag = "BuildRequires"
 value = "mingw64-python3-build"
 
 [[components.python-geographiclib.overlays]]
-description = "Remove mingw32 wheel build step"
+description = "Neutralize mingw32 wheel build step (replace with bash no-op `:` to preserve subshell structure)"
 type = "spec-search-replace"
 section = "%build"
 regex = '^\%mingw32_py3_build_wheel$'
-replacement = ''
+replacement = ':'
 
 [[components.python-geographiclib.overlays]]
-description = "Remove mingw64 wheel build step"
+description = "Neutralize mingw64 wheel build step"
 type = "spec-search-replace"
 section = "%build"
 regex = '^\%mingw64_py3_build_wheel$'
-replacement = ''
+replacement = ':'
 
 [[components.python-geographiclib.overlays]]
-description = "Remove mingw32 wheel install step"
+description = "Neutralize mingw32 wheel install step — `:` keeps the upstream `( ... )` subshell non-empty so bash doesn't fail with `syntax error near unexpected token ')'`"
 type = "spec-search-replace"
 section = "%install"
 regex = '^\%mingw32_py3_install_wheel$'
-replacement = ''
+replacement = ':'
 
 [[components.python-geographiclib.overlays]]
-description = "Remove mingw64 wheel install step"
+description = "Neutralize mingw64 wheel install step"
 type = "spec-search-replace"
 section = "%install"
 regex = '^\%mingw64_py3_install_wheel$'
-replacement = ''
+replacement = ':'
 
 [[components.python-geographiclib.overlays]]
-description = "Remove mingw debug install post step"
+description = "Neutralize mingw debug install post step"
 type = "spec-search-replace"
 section = "%install"
 regex = '^\%mingw_debug_install_post$'
-replacement = ''
+replacement = ':'

--- a/locks/python-geographiclib.lock
+++ b/locks/python-geographiclib.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '9f0e5a5542506331cd5e68f6e57957e46d76bae1'
 upstream-commit = '9f0e5a5542506331cd5e68f6e57957e46d76bae1'
-input-fingerprint = 'sha256:81ac3e8a85301e74dd0e1623cee10000672cb47889fe9165fd75b8d824ddee67'
+input-fingerprint = 'sha256:bff6903fcfce14069fd32357e9ad05a263de42b4412125375a0e131e818d6a86'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/p/python-geographiclib/python-geographiclib.spec
+++ b/specs/p/python-geographiclib/python-geographiclib.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pkg_name}
 Version:        2.1
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary:        Python 3 implementation of geographiclib
 
 License:        MIT
@@ -43,8 +43,8 @@ A translation of the GeographicLib::Geodesic class to Python.
 # Native build
 %pyproject_wheel
 # MinGW build
-
-
+:
+:
 
 
 %install
@@ -53,10 +53,10 @@ A translation of the GeographicLib::Geodesic class to Python.
 %pyproject_save_files -l geographiclib
 # MinGW build
 (
-
-
+:
+:
 )
-
+:
 
 
 %check


### PR DESCRIPTION
The upstream Fedora spec wraps the MinGW install steps in a subshell:

    (
    %mingw32_py3_install_wheel
    %mingw64_py3_install_wheel
    )
    %mingw_debug_install_post

Azure Linux does not ship MinGW toolchains, so existing overlays replaced the MinGW macros inside the subshell with empty strings. That left an empty `( )` block, which bash rejects with `syntax error near unexpected token ')'` when %install runs, failing the build.

Change the MinGW `%build` and `%install` overlays to substitute the bash no-op `:` instead of an empty string. The subshell stays syntactically valid and the macros become true no-ops at runtime.

Fixes: [AB#20285](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20285)