### PR TITLE
Patch kernel: backport Bluetooth L2CAP UAF fix in l2cap_sock_cleanup_listen() (torvalds/linux@ab1513597c6c)

### DIFF
--- a/SPECS/kernel/ab1513597c6c-l2cap-fix-uaf-cleanup-listen.patch
+++ b/SPECS/kernel/ab1513597c6c-l2cap-fix-uaf-cleanup-listen.patch
@@ -1,0 +1,157 @@
+diff --git a/net/bluetooth/af_bluetooth.c b/net/bluetooth/af_bluetooth.c
+index aebef5c..0910cc3 100644
+--- a/net/bluetooth/af_bluetooth.c
++++ b/net/bluetooth/af_bluetooth.c
+@@ -243,8 +243,10 @@ restart:
+ 			goto restart;
+ 		}
+ 
+-		/* sk is safely in the parent list so reduce reference count */
+-		sock_put(sk);
++		/* Keep the early sock_hold() ref live across release_sock();
++		 * a concurrent l2cap_conn_del() -> l2cap_sock_kill() cannot
++		 * free sk under the caller. Every caller does sock_put().
++		 */
+ 
+ 		/* FIXME: Is this check still needed */
+ 		if (sk->sk_state == BT_CLOSED) {
+diff --git a/net/bluetooth/l2cap_sock.c b/net/bluetooth/l2cap_sock.c
+index 8e2e6d1..d209f26 100644
+--- a/net/bluetooth/l2cap_sock.c
++++ b/net/bluetooth/l2cap_sock.c
+@@ -366,8 +366,13 @@ static int l2cap_sock_accept(struct socket *sock, struct socket *newsock,
+ 		}
+ 
+ 		nsk = bt_accept_dequeue(sk, newsock);
+-		if (nsk)
++		if (nsk) {
++			/* Drop the bridging ref from bt_accept_dequeue();
++			 * the grafted socket keeps nsk alive from here.
++			 */
++			sock_put(nsk);
+ 			break;
++		}
+ 
+ 		if (!timeo) {
+ 			err = -EAGAIN;
+@@ -1444,22 +1449,54 @@ static void l2cap_sock_cleanup_listen(struct sock *parent)
+ 	BT_DBG("parent %p state %s", parent,
+ 	       state_to_string(parent->sk_state));
+ 
+-	/* Close not yet accepted channels */
++	/* Close not yet accepted channels.
++	 *
++	 * bt_accept_dequeue() now returns sk with an extra reference held
++	 * (taken while sk was still locked) so a concurrent l2cap_conn_del()
++	 * -> l2cap_sock_kill() cannot free sk under us.
++	 *
++	 * cleanup_listen() runs under the parent sk lock, so unlike
++	 * l2cap_sock_shutdown() we must NOT take conn->lock here: that would
++	 * establish sk_lock -> conn->lock and invert the established
++	 * conn->lock -> chan->lock -> sk_lock order (lockdep deadlock).
++	 *
++	 * Instead, briefly take the child sk lock to fetch and pin its chan.
++	 * l2cap_conn_del() reaches the chan free only via
++	 * l2cap_chan_del() -> l2cap_sock_teardown_cb(), which itself takes
++	 * the child sk lock; holding it across l2cap_chan_hold_unless_zero()
++	 * therefore guarantees the chan cannot be freed while we read and
++	 * pin it (hold_unless_zero() additionally skips a chan already past
++	 * its last reference).  We then drop the sk lock before taking
++	 * chan->lock, so sk and chan locks are never held together.
++	 */
+ 	while ((sk = bt_accept_dequeue(parent, NULL))) {
+-		struct l2cap_chan *chan = l2cap_pi(sk)->chan;
++		struct l2cap_chan *chan;
++
++		lock_sock_nested(sk, L2CAP_NESTING_NORMAL);
++		chan = l2cap_chan_hold_unless_zero(l2cap_pi(sk)->chan);
++		release_sock(sk);
++		if (!chan) {
++			/* l2cap_conn_del() already tearing this child down */
++			sock_put(sk);
++			continue;
++		}
+ 
+ 		BT_DBG("child chan %p state %s", chan,
+ 		       state_to_string(chan->state));
+ 
+-		l2cap_chan_hold(chan);
+ 		l2cap_chan_lock(chan);
+-
+ 		__clear_chan_timer(chan);
+ 		l2cap_chan_close(chan, ECONNRESET);
+-		l2cap_sock_kill(sk);
+-
++		/* l2cap_conn_del() may already have killed this socket
++		 * (it sets SOCK_DEAD); skip the duplicate to avoid a
++		 * double sock_put()/l2cap_chan_put().
++		 */
++		if (!sock_flag(sk, SOCK_DEAD))
++			l2cap_sock_kill(sk);
+ 		l2cap_chan_unlock(chan);
++
+ 		l2cap_chan_put(chan);
++		sock_put(sk);
+ 	}
+ }
+ 
+diff --git a/net/bluetooth/rfcomm/sock.c b/net/bluetooth/rfcomm/sock.c
+index d1f2c93..933a91c 100644
+--- a/net/bluetooth/rfcomm/sock.c
++++ b/net/bluetooth/rfcomm/sock.c
+@@ -180,6 +180,10 @@ static void rfcomm_sock_cleanup_listen(struct sock *parent)
+ 	while ((sk = bt_accept_dequeue(parent, NULL))) {
+ 		rfcomm_sock_close(sk);
+ 		rfcomm_sock_kill(sk);
++		/* Drop the bridging ref from bt_accept_dequeue();
++		 * rfcomm_sock_kill() has detached sk from the rfcomm list.
++		 */
++		sock_put(sk);
+ 	}
+ 
+ 	parent->sk_state  = BT_CLOSED;
+@@ -503,8 +507,13 @@ static int rfcomm_sock_accept(struct socket *sock, struct socket *newsock, int f
+ 		}
+ 
+ 		nsk = bt_accept_dequeue(sk, newsock);
+-		if (nsk)
++		if (nsk) {
++			/* Drop the bridging ref from bt_accept_dequeue();
++			 * the grafted socket keeps nsk alive from here.
++			 */
++			sock_put(nsk);
+ 			break;
++		}
+ 
+ 		if (!timeo) {
+ 			err = -EAGAIN;
+diff --git a/net/bluetooth/sco.c b/net/bluetooth/sco.c
+index d98648b..c183cae 100644
+--- a/net/bluetooth/sco.c
++++ b/net/bluetooth/sco.c
+@@ -390,6 +390,10 @@ static void sco_sock_cleanup_listen(struct sock *parent)
+ 	while ((sk = bt_accept_dequeue(parent, NULL))) {
+ 		sco_sock_close(sk);
+ 		sco_sock_kill(sk);
++		/* Drop the bridging ref from bt_accept_dequeue();
++		 * sco_sock_kill() has detached sk from the sco list.
++		 */
++		sock_put(sk);
+ 	}
+ 
+ 	parent->sk_state  = BT_CLOSED;
+@@ -683,8 +687,13 @@ static int sco_sock_accept(struct socket *sock, struct socket *newsock,
+ 		}
+ 
+ 		ch = bt_accept_dequeue(sk, newsock);
+-		if (ch)
++		if (ch) {
++			/* Drop the bridging ref from bt_accept_dequeue();
++			 * the grafted socket keeps ch alive from here.
++			 */
++			sock_put(ch);
+ 			break;
++		}
+ 
+ 		if (!timeo) {
+ 			err = -EAGAIN;

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -1,9 +1,10 @@
 {
   "Signatures": {
+    "ab1513597c6c-l2cap-fix-uaf-cleanup-listen.patch": "9fa2dd72c435aadf7b96beaa9aaa0218d006d49cb0a95b32773d0ea86ffd7fd2",
     "cbl-mariner-ca-20211013-20230216.pem": "228046d92ccb7d268cf4f195425c0f990afa00a968cc940fb1df4629fb7a6765",
     "config": "2c72d5eb716de25bccbb65c7d38a14d285e309f6d328f3475d2385019f5ecfff",
     "config_aarch64": "7f94b2221de7195b2f2b35332f080c56371fcbd31fbc65b1683cf2a75ee90c78",
-    "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f",
-    "kernel-5.15.202.1.tar.gz": "7c3540ec0dd00ef161076195e50c3b5d0d52799795c36e0701c76d3456f7f704"
+    "kernel-5.15.202.1.tar.gz": "7c3540ec0dd00ef161076195e50c3b5d0d52799795c36e0701c76d3456f7f704",
+    "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f"
   }
 }

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -28,7 +28,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.15.202.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -40,6 +40,7 @@ Source2:        config_aarch64
 Source3:        sha512hmac-openssl.sh
 Source4:        cbl-mariner-ca-20211013-20230216.pem
 Patch0:         nvme_multipath_default_false.patch
+Patch1:         ab1513597c6c-l2cap-fix-uaf-cleanup-listen.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -163,6 +164,7 @@ manipulation of eBPF programs and maps.
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-2-%{version}
 %patch0 -p1
+%patch1 -p1
 
 make mrproper
 
@@ -426,6 +428,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon May 25 2026 omkhar <omkhar@linkedin.com> - 5.15.202.1-2
+- Backport UAF fix in l2cap_sock_cleanup_listen() vs l2cap_conn_del() (custom 5.15 backport, drops iso.c hunk, contextual rewrite for already-absorbed CVE-2025-39860 base).
+
 * Fri Mar 27 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.202.1-1
 - Auto-upgrade to 5.15.202.1
 


### PR DESCRIPTION
Backport upstream Bluetooth L2CAP UAF fix from torvalds/linux@ab1513597c6cf17cd1ad2a21e3b045421b48e022.

**Upstream:** Author Safa Karakuş; Reported-by/Reviewed-by Siwei Zhang; Signed-off-by chain Safa → Luiz Augusto von Dentz. Cc: stable@vger.kernel.org. Fixes: 15f02b910562.

**Backport type:** CUSTOM 5.15 backport. Upstream commit touches 5 files including net/bluetooth/iso.c (added v6.0, doesn't exist on 5.15). af_bluetooth.c hunk needed contextual rewrite because 5.15 already absorbed the CVE-2025-39860 base fix (47f6090bcf75) which introduced an early sock_hold(sk). Backport is 4 files +60/-7.

**Code-correctness:** l2cap_sock_cleanup_listen function grew 332→501 bytes (+51%). l2cap_chan_hold_unless_zero already exported; now called from cleanup_listen per patch design.

**LTP regression:** Mariner 2.0 LTP-net (net.features/net.ipv6/net.multicast/net.tcp_cmds/net_stress.interface; 118 tests). 0 patch-induced regressions.

**Mariner 2.0 caveat:** AKS EOL 2025-11-30; PR for non-AKS consumers.