### PR TITLE
[Medium] Patch etcd for CVE-2026-33814

### DIFF
--- a/SPECS/etcd/CVE-2026-33814.patch
+++ b/SPECS/etcd/CVE-2026-33814.patch
@@ -8,8 +8,7 @@ This CL backports https://go.dev/cl/761581 to x/net.
 Fixes golang/go#78476
 Fixes CVE-2026-33814
 
-Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
-Upstream-reference: AI Backport of https://github.com/golang/net/commit/1e71bd86e4a302b4e731bc06da6eb51679c7bd49.patch
+Upstream-reference: https://github.com/golang/net/commit/1e71bd86e4a302b4e731bc06da6eb51679c7bd49.patch
 ---
  vendor/golang.org/x/net/http2/transport.go | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)

--- a/SPECS/etcd/CVE-2026-33814.patch
+++ b/SPECS/etcd/CVE-2026-33814.patch
@@ -1,0 +1,43 @@
+From 7e9e82f8c3033974b16d93835521f6e133a7c9aa Mon Sep 17 00:00:00 2001
+From: AllSpark <allspark@microsoft.com>
+Date: Thu, 14 May 2026 09:00:37 +0000
+Subject: [PATCH] http2: prevent hanging Transport due to bad SETTINGS frame
+
+This CL backports https://go.dev/cl/761581 to x/net.
+
+Fixes golang/go#78476
+Fixes CVE-2026-33814
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: AI Backport of https://github.com/golang/net/commit/1e71bd86e4a302b4e731bc06da6eb51679c7bd49.patch
+---
+ vendor/golang.org/x/net/http2/transport.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index 8cf64b7..3b514a3 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -2865,6 +2865,9 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 
+ 	var seenMaxConcurrentStreams bool
+ 	err := f.ForeachSetting(func(s Setting) error {
++		if err := s.Valid(); err != nil {
++			return err
++		}
+ 		switch s.ID {
+ 		case SettingMaxFrameSize:
+ 			cc.maxFrameSize = s.Val
+@@ -2896,9 +2899,6 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			cc.henc.SetMaxDynamicTableSize(s.Val)
+ 			cc.peerMaxHeaderTableSize = s.Val
+ 		case SettingEnableConnectProtocol:
+-			if err := s.Valid(); err != nil {
+-				return err
+-			}
+ 			// If the peer wants to send us SETTINGS_ENABLE_CONNECT_PROTOCOL,
+ 			// we require that it do so in the first SETTINGS frame.
+ 			//
+-- 
+2.45.4
+

--- a/SPECS/etcd/etcd.spec
+++ b/SPECS/etcd/etcd.spec
@@ -3,7 +3,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.30
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -45,6 +45,7 @@ Source1:        etcd.service
 #             -cJf [tarball name] [folder to tar]
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2026-29181.patch
+Patch1:         CVE-2026-33814.patch
 BuildRequires:  golang >= 1.16
 
 %description
@@ -73,6 +74,7 @@ for component in server etcdctl etcdutl; do
     pushd $component
     tar --no-same-owner -xf %{_builddir}/%{name}-%{version}/vendor-$component.tar.gz
     patch -p1 -s --fuzz=0 --no-backup-if-mismatch -f --input=%{PATCH0}
+    patch -p1 -s --fuzz=0 --no-backup-if-mismatch -f --input=%{PATCH1}
     go build \
         -o %{ETCD_OUT_DIR} \
         -ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=v%{version}
@@ -86,6 +88,7 @@ mkdir -p %{ETCD_TOOLS_OUT_DIR}
 for component in etcd-dump-db etcd-dump-logs; do
     pushd tools/$component
     tar --no-same-owner -xf %{_builddir}/%{name}-%{version}/vendor-$component.tar.gz
+    patch -p1 -s --fuzz=0 --no-backup-if-mismatch -f --input=%{PATCH1}
     go build \
         -o %{ETCD_TOOLS_OUT_DIR}
     popd
@@ -147,6 +150,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Mon May 25 2026 Ratiranjan Behera <v-ratbehera@microsoft.com> - 3.5.30-2
+- Patch CVE-2026-33814
+
 * Tue May 19 2026 Akarsh Chaudhary <v-akarshc@microsoft.com> - 3.5.30-1
 - Upgrade to version 3.5.30 (fixes CVE-2026-44283).
 

--- a/SPECS/etcd/etcd.spec
+++ b/SPECS/etcd/etcd.spec
@@ -150,7 +150,7 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
-* Mon May 25 2026 Ratiranjan Behera <v-ratbehera@microsoft.com> - 3.5.30-2
+* Wed May 27 2026 Ratiranjan Behera <v-ratbehera@microsoft.com> - 3.5.30-2
 - Patch CVE-2026-33814
 
 * Tue May 19 2026 Akarsh Chaudhary <v-akarshc@microsoft.com> - 3.5.30-1


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Patch etcd for CVE-2026-33814

- The package `etcd` is affected by this CVE as it vendors `golang.org/x/net/http2`, and the vendored version in our source is `golang.org/x/net v0.51.0`, which falls within the affected range from 0 before `0.53.0`.
- The upstream patch has been backported manually.
- The patch matches with the upstream patch except the changes in test files are not included, as the corresponding test files are not present in our version of the source code.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/etcd/CVE-2026-33814.patch
- modified:   SPECS/etcd/etcd.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-33814

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.

<img width="792" height="251" alt="image" src="https://github.com/user-attachments/assets/28b9ca00-f200-4275-bf30-0af39f220eba" />

- Patch applies cleanly.
<img width="875" height="95" alt="image" src="https://github.com/user-attachments/assets/7b2a2a65-087c-4c70-8091-8bb24be21e74" />

- Check Installation:
<img width="696" height="80" alt="image" src="https://github.com/user-attachments/assets/7867b709-2317-4133-a0e8-5d90f9d69ef8" />

- Check Uninstallation:
<img width="314" height="58" alt="image" src="https://github.com/user-attachments/assets/7ca109e8-b806-4828-aba0-cd6727b9c7c6" />


<img width="202" height="23" alt="image" src="https://github.com/user-attachments/assets/108d643e-4fec-4272-b482-6ce8b58a48e3" />


