### PR TITLE
fix: `ptest` for gperftools

### DIFF
--- a/SPECS/gperftools/gperftools.spec
+++ b/SPECS/gperftools/gperftools.spec
@@ -89,7 +89,7 @@ TCMALLOC_SAMPLE_PARAMETER=128 && make check
 %{_libdir}/*.so.*
 
 %changelog
-* Mon May 25 2025 Akhila Guruju <v-guakhila@microsoft.com> - 2.12-3
+* Wed Jun 03 2026 Akhila Guruju <v-guakhila@microsoft.com> - 2.12-3
 - Added runtime library path in %check to fix ptests.
 
 * Wed Mar 13 2024 Himaja Kesari <himajakesari@microsoft.com> 

--- a/SPECS/gperftools/gperftools.spec
+++ b/SPECS/gperftools/gperftools.spec
@@ -83,6 +83,7 @@ TCMALLOC_SAMPLE_PARAMETER=128 && make check
 
 %files docs
 %{_docdir}/%{name}-%{version}/*
+%exclude %{_docdir}/%{name}-%{version}/COPYING
 %{_mandir}/man1/*
 
 %files libs
@@ -90,7 +91,8 @@ TCMALLOC_SAMPLE_PARAMETER=128 && make check
 
 %changelog
 * Wed Jun 03 2026 Akhila Guruju <v-guakhila@microsoft.com> - 2.12-3
-- Added runtime library path in %check to fix ptests.
+- Added runtime library path in %check to fix ptests
+- Fix license warning
 
 * Wed Mar 13 2024 Himaja Kesari <himajakesari@microsoft.com> 
 - Update build step from fedora and add libs package

--- a/SPECS/gperftools/gperftools.spec
+++ b/SPECS/gperftools/gperftools.spec
@@ -1,7 +1,7 @@
 Summary:        A fast malloc tool for threads
 Name:           gperftools
 Version:        2.12
-Release:        1%{?dist}
+Release:        3%{?dist}
 License:        BSD
 URL:            https://github.com/gperftools/gperftools
 Source0:        %{url}/releases/download/%{name}-%{version}/%{name}-%{version}.tar.gz
@@ -61,6 +61,7 @@ make DESTDIR=%{buildroot} install
 find %{buildroot} -name '*.la' -delete
 
 %check
+export LD_LIBRARY_PATH="$PWD/.libs:$PWD/src/.libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 TCMALLOC_SAMPLE_PARAMETER=128 && make check
 
 %ldconfig_scriptlets libs
@@ -88,6 +89,9 @@ TCMALLOC_SAMPLE_PARAMETER=128 && make check
 %{_libdir}/*.so.*
 
 %changelog
+* Mon May 25 2025 Akhila Guruju <v-guakhila@microsoft.com> - 2.12-3
+- Added runtime library path in %check to fix ptests.
+
 * Wed Mar 13 2024 Himaja Kesari <himajakesari@microsoft.com> 
 - Update build step from fedora and add libs package
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
fix ptest for gperftools by adding runtime library path in %check.

**Root Cause:**
- Test binaries cannot load freshly built shared libs during %check: `error while loading shared libraries: libtcmalloc*.so / libprofiler.so: cannot open shared object file`

**Fix Implemented:**
- The tests execute binaries from the build tree (including `.libs/lt-*` wrappers).
- Those binaries need the just-built libs in `.libs` before install.
- Without `LD_LIBRARY_PATH`, dynamic loader cannot find them, leading to widespread `exit 127`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified:   SPECS/gperftools/gperftools.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1125395&view=results)
