### PR TITLE
ci: declare workflow-level contents: read on 3 check workflows

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-check:
     name: Spec files check

--- a/.github/workflows/lint-specs.yml
+++ b/.github/workflows/lint-specs.yml
@@ -13,6 +13,9 @@ on:
       - '**.spec'
     branches: [main, dev, 1.0*, 2.0*, 3.0*, fasttrack/*]
 
+permissions:
+  contents: read
+
 jobs:
   spec-lint:
     name: Spec Linting


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.