### PR TITLE
fix(vm-iso-installer): set efi_dir to azurelinux and add vim-minimal

### DIFF
--- a/base/images/vm-iso-installer/azurelinux.conf
+++ b/base/images/vm-iso-installer/azurelinux.conf
@@ -16,7 +16,7 @@ req_partition_sizes =
 default_on_boot = DEFAULT_ROUTE_DEVICE
 
 [Bootloader]
-efi_dir = fedora
+efi_dir = azurelinux
 
 [User Interface]
 hidden_spokes = NetworkSpoke

--- a/base/images/vm-iso-installer/post-bootloader.sh
+++ b/base/images/vm-iso-installer/post-bootloader.sh
@@ -65,10 +65,11 @@ done
 
 # --- Find or create EFI vendor directory ---
 EFI_VENDOR=""
-for d in "$SYSROOT/boot/efi/EFI/fedora" "$SYSROOT/boot/efi/EFI/azurelinux"; do
+for d in "$SYSROOT/boot/efi/EFI/azurelinux" "$SYSROOT/boot/efi/EFI/fedora"; do
     [ -d "$d" ] && { EFI_VENDOR="$d"; break; }
 done
-[ -z "$EFI_VENDOR" ] && { EFI_VENDOR="$SYSROOT/boot/efi/EFI/fedora"; mkdir -p "$EFI_VENDOR"; }
+[ -z "$EFI_VENDOR" ] && { EFI_VENDOR="$SYSROOT/boot/efi/EFI/azurelinux"; mkdir -p "$EFI_VENDOR"; }
+EFI_VENDOR_NAME=$(basename "$EFI_VENDOR")
 echo "EFI vendor dir: $EFI_VENDOR"
 ls -la "$EFI_VENDOR/" 2>/dev/null
 
@@ -143,14 +144,15 @@ if [ -n "$ESP_DEV" ]; then
 
     echo "=== Current UEFI boot entries ==="
     efibootmgr 2>/dev/null
-    for bootnum in $(efibootmgr 2>/dev/null | grep -i 'default\\\|anaconda\|fedora' | sed 's/Boot\([0-9A-Fa-f]*\).*/\1/'); do
+    for bootnum in $(efibootmgr 2>/dev/null | grep -i 'default\\\|anaconda\|fedora\|azurelinux' | sed 's/Boot\([0-9A-Fa-f]*\).*/\1/'); do
         echo "Removing stale entry Boot$bootnum"
         efibootmgr -b "$bootnum" -B 2>/dev/null || true
     done
 
+    EFI_NVRAM_PATH="\\EFI\\${EFI_VENDOR_NAME}\\${SHIM_EFI}"
     efibootmgr -c -d "$ESP_DISK" -p "$ESP_PART" \
-        -L "Azure Linux" -l "\\EFI\\fedora\\$SHIM_EFI" 2>/dev/null && \
-        echo "Created UEFI boot entry: Azure Linux -> \\EFI\\fedora\\$SHIM_EFI" || \
+        -L "Azure Linux" -l "$EFI_NVRAM_PATH" 2>/dev/null && \
+        echo "Created UEFI boot entry: Azure Linux -> $EFI_NVRAM_PATH" || \
         echo "WARNING: efibootmgr -c failed"
 
     echo "=== Updated UEFI boot entries ==="

--- a/base/images/vm-iso-installer/vm-iso-installer.kiwi
+++ b/base/images/vm-iso-installer/vm-iso-installer.kiwi
@@ -66,6 +66,7 @@
         <package name="systemd-resolved" />
         <package name="tar" />
         <package name="util-linux" />
+        <package name="vim-minimal" />
         <file
             name="20-wired-dhcp.network"
             target="/etc/systemd/network/20-wired-dhcp.network"


### PR DESCRIPTION
Change Anaconda override in azurelinux.conf from efi_dir = fedora to efi_dir = azurelinux so installer bootloader paths align with Azure Linux EFI vendor directory. Add vim-minimal to live iso for better user experience.