### PR TITLE
kernel: backport RDMA/core route-entry loopback detection

### DIFF
--- a/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
+++ b/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
@@ -33,7 +33,7 @@
 Summary:        Linux Kernel
 Name:           kernel-ipe
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -460,6 +460,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Bump release to match kernel
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
+++ b/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
@@ -7,7 +7,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-64k-signed-%{buildarch}
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,6 +105,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Bump release to match kernel
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -145,6 +145,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Bump release to match kernel
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
+++ b/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed Unified Kernel Image for %{buildarch} systems
 Name:           kernel-uki-signed-%{buildarch}
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -68,6 +68,9 @@ popd
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Bump release to match kernel
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/SPECS/kernel-64k/kernel-64k.spec
+++ b/SPECS/kernel-64k/kernel-64k.spec
@@ -27,7 +27,7 @@
 Summary:        Linux Kernel
 Name:           kernel-64k
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -380,6 +380,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Bump release to match kernel
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +75,9 @@ done
 %endif
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Bump release to match kernel
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/SPECS/kernel/0001-RDMA-core-Use-route-entry-flag-to-decide-on-loopback.patch
+++ b/SPECS/kernel/0001-RDMA-core-Use-route-entry-flag-to-decide-on-loopback.patch
@@ -1,0 +1,131 @@
+From cf6b689997b039f1f274d588b7b7011be43e8fcd Mon Sep 17 00:00:00 2001
+From: Andreas Zaugg <azaugg@linkedin.com>
+Date: Tue, 26 May 2026 18:18:35 -0400
+Subject: [PATCH] RDMA/core: Use route entry flag to decide on loopback traffic
+
+addr_resolve() considers a destination to be local if the next-hop
+device of the resolved route for the destination is the loopback
+netdevice.
+
+This fails when the source and destination IP addresses belong to
+a netdev enslaved to a VRF netdev. In this case the next-hop device
+is the VRF itself:
+
+ $ ip link add name myvrf up type vrf table 100
+ $ ip link set ens2f0np0 master myvrf up
+ $ ip addr add 192.168.1.1/24 dev ens2f0np0
+ $ ip route get 192.168.1.1 oif myvrf
+ local 192.168.1.1 dev myvrf table 100 src 192.168.1.1 uid 0
+    cache <local>
+
+This results in packets being generated with an incorrect destination
+MAC of the VRF netdevice and ib_write_bw failing with timeout.
+
+Solve this by determining if a destination is local or not based on
+the resolved route's type rather than based on its next-hop netdevice
+loopback flag.
+
+This enables to resolve loopback traffic with and without VRF
+configurations in a uniform way.
+
+Backported from upstream commit c31e4038c97f (mainline) to 6.6 LTS.
+dst_rtable() helper is not available in 6.6, replaced with a direct
+cast to (const struct rtable *).
+
+Signed-off-by: Parav Pandit <parav@nvidia.com>
+Reviewed-by: Vlad Dumitrescu <vdumitrescu@nvidia.com>
+Signed-off-by: Edward Srouji <edwards@nvidia.com>
+Link: https://patch.msgid.link/20250916111103.84069-4-edwards@nvidia.com
+Signed-off-by: Leon Romanovsky <leon@kernel.org>
+---
+ drivers/infiniband/core/addr.c | 34 +++++++++++++++++++++-------------
+ 1 file changed, 21 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/infiniband/core/addr.c b/drivers/infiniband/core/addr.c
+index e95745710610..3895a7aa5ec0 100644
+--- a/drivers/infiniband/core/addr.c
++++ b/drivers/infiniband/core/addr.c
+@@ -439,19 +439,30 @@ static int addr6_resolve(struct sockaddr *src_sock,
+ }
+ #endif
+ 
++static bool is_dst_local(const struct dst_entry *dst)
++{
++	if (dst->ops->family == AF_INET)
++		return !!(((const struct rtable *)dst)->rt_type & RTN_LOCAL);
++	else if (dst->ops->family == AF_INET6)
++		return !!(dst_rt6_info(dst)->rt6i_flags & RTF_LOCAL);
++	else
++		return false;
++}
++
+ static int addr_resolve_neigh(const struct dst_entry *dst,
+ 			      const struct sockaddr *dst_in,
+ 			      struct rdma_dev_addr *addr,
+-			      unsigned int ndev_flags,
+ 			      u32 seq)
+ {
+-	int ret = 0;
+-
+-	if (ndev_flags & IFF_LOOPBACK)
++	if (is_dst_local(dst)) {
++		/* When the destination is local entry, source and destination
++		 * are same. Skip the neighbour lookup.
++		 */
+ 		memcpy(addr->dst_dev_addr, addr->src_dev_addr, MAX_ADDR_LEN);
+-	else
+-		ret = fetch_ha(dst, addr, dst_in, seq);
+-	return ret;
++		return 0;
++	}
++
++	return fetch_ha(dst, addr, dst_in, seq);
+ }
+ 
+ static int copy_src_l2_addr(struct rdma_dev_addr *dev_addr,
+@@ -483,15 +494,13 @@ static int copy_src_l2_addr(struct rdma_dev_addr *dev_addr,
+ }
+ 
+ static int rdma_set_src_addr_rcu(struct rdma_dev_addr *dev_addr,
+-				 unsigned int *ndev_flags,
+ 				 const struct sockaddr *dst_in,
+ 				 const struct dst_entry *dst)
+ {
+ 	struct net_device *ndev = READ_ONCE(dst->dev);
+ 
+-	*ndev_flags = ndev->flags;
+ 	/* A physical device must be the RDMA device to use */
+-	if (ndev->flags & IFF_LOOPBACK) {
++	if (is_dst_local(dst)) {
+ 		/*
+ 		 * RDMA (IB/RoCE, iWarp) doesn't run on lo interface or
+ 		 * loopback IP address. So if route is resolved to loopback
+@@ -540,7 +549,6 @@ static int addr_resolve(struct sockaddr *src_in,
+ 			u32 seq)
+ {
+ 	struct dst_entry *dst = NULL;
+-	unsigned int ndev_flags = 0;
+ 	struct rtable *rt = NULL;
+ 	int ret;
+ 
+@@ -577,7 +585,7 @@ static int addr_resolve(struct sockaddr *src_in,
+ 		rcu_read_unlock();
+ 		goto done;
+ 	}
+-	ret = rdma_set_src_addr_rcu(addr, &ndev_flags, dst_in, dst);
++	ret = rdma_set_src_addr_rcu(addr, dst_in, dst);
+ 	rcu_read_unlock();
+ 
+ 	/*
+@@ -585,7 +593,7 @@ static int addr_resolve(struct sockaddr *src_in,
+ 	 * only if src addr translation didn't fail.
+ 	 */
+ 	if (!ret && resolve_neigh)
+-		ret = addr_resolve_neigh(dst, dst_in, addr, ndev_flags, seq);
++		ret = addr_resolve_neigh(dst, dst_in, addr, seq);
+ 
+ 	if (src_in->sa_family == AF_INET)
+ 		ip_rt_put(rt);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kernel/kernel-uki.spec
+++ b/SPECS/kernel/kernel-uki.spec
@@ -13,7 +13,7 @@
 Summary:        Unified Kernel Image
 Name:           kernel-uki
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -70,6 +70,9 @@ cp %{buildroot}/boot/vmlinuz-uki-%{kernelver}.efi %{buildroot}/boot/efi/EFI/Linu
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Bump release to match kernel
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -32,7 +32,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.139.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -46,6 +46,7 @@ Source4:        azurelinux-ca-20230216.pem
 Source5:        cpupower
 Source6:        cpupower.service
 Patch0:         0001-add-mstflint-kernel-%{mstflintver}.patch
+Patch1:         0001-RDMA-core-Use-route-entry-flag-to-decide-on-loopback.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -440,6 +441,12 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed May 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.6.139.1-2
+- Backport upstream commit c31e4038c97f from mainline:
+  RDMA/core: Use route entry flag to decide on loopback traffic.
+  dst_rtable() helper is not available in 6.6, replaced with a direct
+  cast to (const struct rtable *).
+
 * Fri May 15 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.139.1-1
 - Auto-upgrade to 6.6.139.1
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
-kernel-headers-6.6.139.1-1.azl3.noarch.rpm
+kernel-headers-6.6.139.1-2.azl3.noarch.rpm
 glibc-2.38-19.azl3.aarch64.rpm
 glibc-devel-2.38-19.azl3.aarch64.rpm
 glibc-i18n-2.38-19.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
-kernel-headers-6.6.139.1-1.azl3.noarch.rpm
+kernel-headers-6.6.139.1-2.azl3.noarch.rpm
 glibc-2.38-19.azl3.x86_64.rpm
 glibc-devel-2.38-19.azl3.x86_64.rpm
 glibc-i18n-2.38-19.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.aarch64.rpm
 kbd-debuginfo-2.2.0-2.azl3.aarch64.rpm
-kernel-headers-6.6.139.1-1.azl3.noarch.rpm
+kernel-headers-6.6.139.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -165,8 +165,8 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.x86_64.rpm
 kbd-debuginfo-2.2.0-2.azl3.x86_64.rpm
-kernel-cross-headers-6.6.139.1-1.azl3.noarch.rpm
-kernel-headers-6.6.139.1-1.azl3.noarch.rpm
+kernel-cross-headers-6.6.139.1-2.azl3.noarch.rpm
+kernel-headers-6.6.139.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backport upstream commit c31e4038c97f ("RDMA/core: Use route entry flag to decide on loopback traffic") to the 6.6.139.1 AZL3 kernel.

In multi-NIC RoCE setups where the source and destination IPs live on netdevs enslaved to a VRF, addr_resolve() picks the VRF as the next-hop device. Because the VRF is not IFF_LOOPBACK, the existing loopback detection misses the local route and rdma_set_src_addr_rcu() leaves the RDMA destination MAC pointing at the VRF netdevice, causing ib_write_bw to time out. The upstream fix replaces the IFF_LOOPBACK check with a route-type (RTN_LOCAL / RTF_LOCAL) check so loopback is detected correctly with or without VRF.

Adjustments for 6.6:

- dst_rtable() is not present in v6.6 yet; replaced with a direct (const struct rtable *) cast (struct dst_entry is the first field of struct rtable, so it is equivalent to the upstream container_of).
- Verified that the patch applies cleanly to both v6.6.121 and v6.6.139 (drivers/infiniband/core/addr.c is byte-identical between them).

Spec/manifest changes (Release 1 -> 2, matching the BBR3 / IKCONFIG_PROC companion-bump pattern):

- SPECS/kernel/kernel.spec: add Patch1, bump Release
- SPECS/kernel/kernel-uki.spec: bump Release to match kernel
- SPECS/kernel-64k/kernel-64k.spec: bump Release to match kernel
- SPECS/kernel-headers/kernel-headers.spec: bump Release to match kernel
- SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec: bump Release to match kernel
- SPECS-SIGNED/kernel-signed/kernel-signed.spec: bump Release to match kernel
- SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec: bump Release to match kernel
- SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec: bump Release to match kernel
- toolkit/resources/manifests/package/{pkggen_core,toolchain}_{x86_64,aarch64}.txt: bump kernel-headers / kernel-cross-headers to -2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
