### PR TITLE
patch ofa_kernel to prepare for build-time dependency elimination for downstream GPU kmod

### DIFF
--- a/SPECS-SIGNED/mlnx-ofa_kernel-hwe-modules-signed/mlnx-ofa_kernel-hwe-modules-signed.spec
+++ b/SPECS-SIGNED/mlnx-ofa_kernel-hwe-modules-signed/mlnx-ofa_kernel-hwe-modules-signed.spec
@@ -46,7 +46,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 %{_name}-signed
 Version:	 25.07
-Release:	 8%{release_suffix}%{?dist}
+Release:	 9%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -237,6 +237,10 @@ fi
 %license %{_datadir}/licenses/%{_name}/copyright
 
 %changelog
+* Tue May 26 2026 Zheyu Shen <zheyushen@microsoft.com> - 25.07-9_6.12.57.1.6
+- Bump release to repackage signed modules against the GPL-export rebuild
+  of mlnx-ofa_kernel-hwe-25.07-9.
+
 * Fri Apr 10 2026 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 25.07-8_6.12.57.1.6
 - Tweak specs to use dynamic versioning for kernel
 

--- a/SPECS-SIGNED/mlnx-ofa_kernel-modules-signed/mlnx-ofa_kernel-modules-signed.spec
+++ b/SPECS-SIGNED/mlnx-ofa_kernel-modules-signed/mlnx-ofa_kernel-modules-signed.spec
@@ -43,7 +43,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 %{_name}-signed
 Version:	 25.07
-Release:	 2%{release_suffix}%{?dist}
+Release:	 3%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -198,6 +198,10 @@ fi
 %license %{_datadir}/licenses/%{_name}/copyright
 
 %changelog
+* Tue May 26 2026 Zheyu Shen <zheyushen@microsoft.com> - 25.07-3
+- Bump release to repackage signed modules against the GPL-export rebuild
+  of mlnx-ofa_kernel-25.07-3.
+
 * Fri Apr 10 2026 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 25.07-2
 - Tweak specs to use dynamic versioning for kernel versions.
 

--- a/SPECS/mlnx-ofa_kernel-hwe/0001-peer_mem-export-symbols-as-GPL.patch
+++ b/SPECS/mlnx-ofa_kernel-hwe/0001-peer_mem-export-symbols-as-GPL.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zheyu Shen <zheyushen@microsoft.com>
+Date: Tue, 26 May 2026 00:00:00 +0000
+Subject: [PATCH] peer_mem: export IB peer memory API as GPL-only symbols
+
+The IB peer-memory API in drivers/infiniband/core/peer_mem.c was
+historically exported with EXPORT_SYMBOL. That dates back to a time when
+the consumer was the NVIDIA closed-source GPU driver, which could not
+link against EXPORT_SYMBOL_GPL symbols.
+
+Today the consumers are GPL kernel modules (NVIDIA open-source driver,
+AMDGPU + nvidia_peermem replacements, etc.). Exposing the peer-memory
+client registration API as EXPORT_SYMBOL_GPL more accurately reflects
+the GPL licensing of mlnx-ofa_kernel and matches the kernel's modern
+expectations around in-kernel API surfaces.
+
+In addition, switching to EXPORT_SYMBOL_GPL allows out-of-tree drivers
+(amdgpu, NVIDIA open-source GPU driver, AMD Vulcano NIC stack, ...) to
+discover the peer-memory client API via module symbol resolution at
+runtime instead of having to hard-link against the mlnx-ofa_kernel
+build, which is required to break the diamond build-time dependency
+between an OOT GPU driver and multiple OOT NIC drivers that all consume
+the same API.
+
+Signed-off-by: Zheyu Shen <zheyushen@microsoft.com>
+---
+ drivers/infiniband/core/peer_mem.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/infiniband/core/peer_mem.c b/drivers/infiniband/core/peer_mem.c
+--- a/drivers/infiniband/core/peer_mem.c
++++ b/drivers/infiniband/core/peer_mem.c
+@@ -86,7 +86,7 @@ void *ib_register_peer_memory_client(const struct peer_memory_client *peer_clien
+ 	mutex_unlock(&peer_memory_mutex);
+ 	return ib_peer_client;
+ }
+-EXPORT_SYMBOL(ib_register_peer_memory_client);
++EXPORT_SYMBOL_GPL(ib_register_peer_memory_client);
+ 
+ void ib_unregister_peer_memory_client(void *reg_handle)
+ {
+@@ -107,7 +107,7 @@ void ib_unregister_peer_memory_client(void *reg_handle)
+ 
+ 	kobject_put(&ib_peer_client->kobj);
+ }
+-EXPORT_SYMBOL(ib_unregister_peer_memory_client);
++EXPORT_SYMBOL_GPL(ib_unregister_peer_memory_client);
+ 
+ static struct ib_peer_memory_client *
+ ib_get_peer_client(unsigned long addr, size_t size,
+@@ -317,7 +317,7 @@ void ib_umem_activate_invalidation_notifier(struct ib_umem *umem,
+ 
+ 	/* At this point func can be called asynchronously */
+ }
+-EXPORT_SYMBOL(ib_umem_activate_invalidation_notifier);
++EXPORT_SYMBOL_GPL(ib_umem_activate_invalidation_notifier);
+ 
+ /*
+  * Caller has blocked DMA and will no longer be able to handle invalidate
+@@ -358,7 +358,7 @@ void ib_umem_stop_invalidation_notifier(struct ib_umem *umem)
+ 		ib_unmap_peer_client(umem_p, cur_state, UMEM_PEER_UNMAPPED);
+ 
+ }
+-EXPORT_SYMBOL(ib_umem_stop_invalidation_notifier);
++EXPORT_SYMBOL_GPL(ib_umem_stop_invalidation_notifier);
+ 
+ static void fix_peer_sgls(struct ib_umem_peer *umem_p,
+ 			  unsigned long peer_page_size)
+-- 
+2.43.0

--- a/SPECS/mlnx-ofa_kernel-hwe/0001-peer_mem-export-symbols-as-GPL.patch
+++ b/SPECS/mlnx-ofa_kernel-hwe/0001-peer_mem-export-symbols-as-GPL.patch
@@ -8,19 +8,21 @@ historically exported with EXPORT_SYMBOL. That dates back to a time when
 the consumer was the NVIDIA closed-source GPU driver, which could not
 link against EXPORT_SYMBOL_GPL symbols.
 
-Today the consumers are GPL kernel modules (NVIDIA open-source driver,
-AMDGPU + nvidia_peermem replacements, etc.). Exposing the peer-memory
-client registration API as EXPORT_SYMBOL_GPL more accurately reflects
-the GPL licensing of mlnx-ofa_kernel and matches the kernel's modern
-expectations around in-kernel API surfaces.
+Today the consumers are GPL kernel modules (AMDGPU, NVIDIA open-source
+driver). Exposing the peer-memory client registration API as
+EXPORT_SYMBOL_GPL more accurately reflects the GPL licensing of
+mlnx-ofa_kernel and matches the kernel's modern expectations around
+in-kernel API surfaces.
 
 In addition, switching to EXPORT_SYMBOL_GPL allows out-of-tree drivers
-(amdgpu, NVIDIA open-source GPU driver, AMD Vulcano NIC stack, ...) to
-discover the peer-memory client API via module symbol resolution at
-runtime instead of having to hard-link against the mlnx-ofa_kernel
-build, which is required to break the diamond build-time dependency
-between an OOT GPU driver and multiple OOT NIC drivers that all consume
-the same API.
+(AMDGPU, NVIDIA open-source GPU driver) to discover the peer-memory
+client API via module symbol resolution at runtime instead of having
+to hard-link against the mlnx-ofa_kernel build, which is required to
+break the diamond build-time dependency between an OOT GPU driver and
+multiple OOT NIC drivers that all consume the same API, which is the
+situation we are facing with AMD GPU (MI300X works with Mellanox while
+MI455X comes with Vulcano NIC, and we would like the same kmod to be
+able to work with both hardware).
 
 Signed-off-by: Zheyu Shen <zheyushen@microsoft.com>
 ---

--- a/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
+++ b/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
@@ -102,7 +102,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 mlnx-ofa_kernel-hwe
 Version:	 25.07
-Release:	 8%{release_suffix}%{?dist}
+Release:	 9%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -110,6 +110,14 @@ Group:		 System Environment/Base
 # This archive contains the SRPMs for each feature and each SRPM includes the source tarball and the SPEC file.
 # https://linux.mellanox.com/public/repo/doca/3.1.0/SOURCES/mlnx_ofed/MLNX_OFED_SRC-25.07-0.9.7.0.tgz
 Source0:         %{_distro_sources_url}/mlnx-ofa_kernel-%{_version}.tgz
+
+# Re-export the IB peer-memory client API as GPL-only symbols so that
+# GPL out-of-tree drivers (amdgpu, NVIDIA open-source GPU driver, ...)
+# can consume them at runtime via symbol resolution instead of needing
+# a build-time dependency on mlnx-ofa_kernel-hwe. This breaks the diamond
+# build-time dependency between an OOT GPU driver and multiple OOT NIC
+# drivers that all consume the same peermem API.
+Patch0:          0001-peer_mem-export-symbols-as-GPL.patch
 
 BuildRoot:	 /var/tmp/%{name}-%{version}-build
 Vendor:          Microsoft Corporation
@@ -283,6 +291,7 @@ The driver sources are located at: http://www.mellanox.com/downloads/ofed/
 
 %prep
 %setup -n mlnx-ofa_kernel-%{_version}
+%patch 0 -p1
 
 set -- *
 mkdir source
@@ -449,6 +458,11 @@ update-alternatives --remove \
 %{_prefix}/src/ofa_kernel/%{_arch}/[0-9]*
 
 %changelog
+* Tue May 26 2026 Zheyu Shen <zheyushen@microsoft.com> - 25.07-9_6.12.57.1.6
+- Re-export IB peer-memory client API as EXPORT_SYMBOL_GPL to allow OOT
+  GPU drivers (amdgpu, NVIDIA open-source) to resolve peermem symbols at
+  module load time, removing the build-time dependency on mlnx-ofa_kernel-hwe.
+
 * Fri Apr 10 2026 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 25.07-8_6.12.57.1.6
 - Tweak specs to use dynamic versioning for kernel
 

--- a/SPECS/mlnx-ofa_kernel/0001-peer_mem-export-symbols-as-GPL.patch
+++ b/SPECS/mlnx-ofa_kernel/0001-peer_mem-export-symbols-as-GPL.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zheyu Shen <zheyushen@microsoft.com>
+Date: Tue, 26 May 2026 00:00:00 +0000
+Subject: [PATCH] peer_mem: export IB peer memory API as GPL-only symbols
+
+The IB peer-memory API in drivers/infiniband/core/peer_mem.c was
+historically exported with EXPORT_SYMBOL. That dates back to a time when
+the consumer was the NVIDIA closed-source GPU driver, which could not
+link against EXPORT_SYMBOL_GPL symbols.
+
+Today the consumers are GPL kernel modules (NVIDIA open-source driver,
+AMDGPU + nvidia_peermem replacements, etc.). Exposing the peer-memory
+client registration API as EXPORT_SYMBOL_GPL more accurately reflects
+the GPL licensing of mlnx-ofa_kernel and matches the kernel's modern
+expectations around in-kernel API surfaces.
+
+In addition, switching to EXPORT_SYMBOL_GPL allows out-of-tree drivers
+(amdgpu, NVIDIA open-source GPU driver, AMD Vulcano NIC stack, ...) to
+discover the peer-memory client API via module symbol resolution at
+runtime instead of having to hard-link against the mlnx-ofa_kernel
+build, which is required to break the diamond build-time dependency
+between an OOT GPU driver and multiple OOT NIC drivers that all consume
+the same API.
+
+Signed-off-by: Zheyu Shen <zheyushen@microsoft.com>
+---
+ drivers/infiniband/core/peer_mem.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/infiniband/core/peer_mem.c b/drivers/infiniband/core/peer_mem.c
+--- a/drivers/infiniband/core/peer_mem.c
++++ b/drivers/infiniband/core/peer_mem.c
+@@ -86,7 +86,7 @@ void *ib_register_peer_memory_client(const struct peer_memory_client *peer_clien
+ 	mutex_unlock(&peer_memory_mutex);
+ 	return ib_peer_client;
+ }
+-EXPORT_SYMBOL(ib_register_peer_memory_client);
++EXPORT_SYMBOL_GPL(ib_register_peer_memory_client);
+ 
+ void ib_unregister_peer_memory_client(void *reg_handle)
+ {
+@@ -107,7 +107,7 @@ void ib_unregister_peer_memory_client(void *reg_handle)
+ 
+ 	kobject_put(&ib_peer_client->kobj);
+ }
+-EXPORT_SYMBOL(ib_unregister_peer_memory_client);
++EXPORT_SYMBOL_GPL(ib_unregister_peer_memory_client);
+ 
+ static struct ib_peer_memory_client *
+ ib_get_peer_client(unsigned long addr, size_t size,
+@@ -317,7 +317,7 @@ void ib_umem_activate_invalidation_notifier(struct ib_umem *umem,
+ 
+ 	/* At this point func can be called asynchronously */
+ }
+-EXPORT_SYMBOL(ib_umem_activate_invalidation_notifier);
++EXPORT_SYMBOL_GPL(ib_umem_activate_invalidation_notifier);
+ 
+ /*
+  * Caller has blocked DMA and will no longer be able to handle invalidate
+@@ -358,7 +358,7 @@ void ib_umem_stop_invalidation_notifier(struct ib_umem *umem)
+ 		ib_unmap_peer_client(umem_p, cur_state, UMEM_PEER_UNMAPPED);
+ 
+ }
+-EXPORT_SYMBOL(ib_umem_stop_invalidation_notifier);
++EXPORT_SYMBOL_GPL(ib_umem_stop_invalidation_notifier);
+ 
+ static void fix_peer_sgls(struct ib_umem_peer *umem_p,
+ 			  unsigned long peer_page_size)
+-- 
+2.43.0

--- a/SPECS/mlnx-ofa_kernel/0001-peer_mem-export-symbols-as-GPL.patch
+++ b/SPECS/mlnx-ofa_kernel/0001-peer_mem-export-symbols-as-GPL.patch
@@ -8,19 +8,21 @@ historically exported with EXPORT_SYMBOL. That dates back to a time when
 the consumer was the NVIDIA closed-source GPU driver, which could not
 link against EXPORT_SYMBOL_GPL symbols.
 
-Today the consumers are GPL kernel modules (NVIDIA open-source driver,
-AMDGPU + nvidia_peermem replacements, etc.). Exposing the peer-memory
-client registration API as EXPORT_SYMBOL_GPL more accurately reflects
-the GPL licensing of mlnx-ofa_kernel and matches the kernel's modern
-expectations around in-kernel API surfaces.
+Today the consumers are GPL kernel modules (AMDGPU, NVIDIA open-source
+driver). Exposing the peer-memory client registration API as
+EXPORT_SYMBOL_GPL more accurately reflects the GPL licensing of
+mlnx-ofa_kernel and matches the kernel's modern expectations around
+in-kernel API surfaces.
 
 In addition, switching to EXPORT_SYMBOL_GPL allows out-of-tree drivers
-(amdgpu, NVIDIA open-source GPU driver, AMD Vulcano NIC stack, ...) to
-discover the peer-memory client API via module symbol resolution at
-runtime instead of having to hard-link against the mlnx-ofa_kernel
-build, which is required to break the diamond build-time dependency
-between an OOT GPU driver and multiple OOT NIC drivers that all consume
-the same API.
+(AMDGPU, NVIDIA open-source GPU driver) to discover the peer-memory
+client API via module symbol resolution at runtime instead of having
+to hard-link against the mlnx-ofa_kernel build, which is required to
+break the diamond build-time dependency between an OOT GPU driver and
+multiple OOT NIC drivers that all consume the same API, which is the
+situation we are facing with AMD GPU (MI300X works with Mellanox while
+MI455X comes with Vulcano NIC, and we would like the same kmod to be
+able to work with both hardware).
 
 Signed-off-by: Zheyu Shen <zheyushen@microsoft.com>
 ---

--- a/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
+++ b/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
@@ -106,7 +106,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 mlnx-ofa_kernel
 Version:	 25.07
-Release:	 2%{release_suffix}%{?dist}
+Release:	 3%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -114,6 +114,14 @@ Group:		 System Environment/Base
 # This archive contains the SRPMs for each feature and each SRPM includes the source tarball and the SPEC file.
 # https://linux.mellanox.com/public/repo/doca/3.1.0/SOURCES/mlnx_ofed/MLNX_OFED_SRC-25.07-0.9.7.0.tgz
 Source0:         %{_distro_sources_url}/%{_name}-%{version}.tgz
+
+# Re-export the IB peer-memory client API as GPL-only symbols so that
+# GPL out-of-tree drivers (amdgpu, NVIDIA open-source GPU driver, ...)
+# can consume them at runtime via symbol resolution instead of needing
+# a build-time dependency on mlnx-ofa_kernel. This breaks the diamond
+# build-time dependency between an OOT GPU driver and multiple OOT NIC
+# drivers that all consume the same peermem API.
+Patch0:          0001-peer_mem-export-symbols-as-GPL.patch
 
 BuildRoot:	 /var/tmp/%{name}-%{version}-build
 Vendor:          Microsoft Corporation
@@ -302,6 +310,7 @@ drivers against it.
 
 %prep
 %setup -n %{_name}-%{version}
+%patch 0 -p1
 set -- *
 mkdir source
 mv "$@" source/
@@ -765,6 +774,11 @@ update-alternatives --remove \
 %{_prefix}/src/mlnx-ofa_kernel-%version
 
 %changelog
+* Tue May 26 2026 Zheyu Shen <zheyushen@microsoft.com> - 25.07-3
+- Re-export IB peer-memory client API as EXPORT_SYMBOL_GPL to allow OOT
+  GPU drivers (amdgpu, NVIDIA open-source) to resolve peermem symbols at
+  module load time, removing the build-time dependency on mlnx-ofa_kernel.
+
 * Fri Apr 10 2026 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 25.07-2
 - Tweak specs to use dynamic versioning for kernel.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The IB peer-memory API in drivers/infiniband/core/peer_mem.c was
historically exported with EXPORT_SYMBOL. That dates back to a time when
the consumer was the NVIDIA closed-source GPU driver, which could not
link against EXPORT_SYMBOL_GPL symbols.

Today the consumers are GPL kernel modules (AMDGPU, NVIDIA open-source
driver). Exposing the peer-memory client registration API as
EXPORT_SYMBOL_GPL more accurately reflects the GPL licensing of
mlnx-ofa_kernel and matches the kernel's modern expectations around
in-kernel API surfaces.

In addition, switching to EXPORT_SYMBOL_GPL allows out-of-tree drivers
(AMDGPU, NVIDIA open-source GPU driver) to discover the peer-memory
client API via module symbol resolution at runtime instead of having
to hard-link against the mlnx-ofa_kernel build, which is required to
break the diamond build-time dependency between an OOT GPU driver and
multiple OOT NIC drivers that all consume the same API, which is the
situation we are facing with AMD GPU (MI300X works with Mellanox while
MI455X comes with Vulcano NIC, and we would like the same kmod to be
able to work with both hardware).

###### Change Log  <!-- REQUIRED -->
- patch mlnx-ofa_kernel and mlnx-ofa_kernel-hwe to export symbols via GPL
###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Test Methodology
tested locally with adjusted ofa_kernel and amdgpu-with-eliminated-build-time-dependency:
```
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong  
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)          
           8             2     float     sum      -1   225.21    0.00    0.00       0   210.65    0.00    0.00       0
          16             4     float     sum      -1   211.26    0.00    0.00       0   210.56    0.00    0.00       0
          32             8     float     sum      -1   209.27    0.00    0.00       0   209.02    0.00    0.00       0
          64            16     float     sum      -1   211.89    0.00    0.00       0   207.27    0.00    0.00       0
         128            32     float     sum      -1   211.60    0.00    0.00       0   213.49    0.00    0.00       0
         256            64     float     sum      -1   217.10    0.00    0.00       0   209.60    0.00    0.00       0
         512           128     float     sum      -1   209.81    0.00    0.00       0   213.69    0.00    0.00       0
        1024           256     float     sum      -1    46.25    0.02    0.04       0    46.74    0.02    0.04       0
        2048           512     float     sum      -1    46.06    0.04    0.08       0    45.87    0.04    0.08       0
        4096          1024     float     sum      -1    46.98    0.09    0.15       0    47.50    0.09    0.15       0
        8192          2048     float     sum      -1    45.81    0.18    0.31       0    46.92    0.17    0.31       0
       16384          4096     float     sum      -1    46.63    0.35    0.61       0    47.08    0.35    0.61       0
       32768          8192     float     sum      -1    47.27    0.69    1.21       0    48.38    0.68    1.19       0
       65536         16384     float     sum      -1    48.55    1.35    2.36       0    45.69    1.43    2.51       0
      131072         32768     float     sum      -1    57.07    2.30    4.02       0    59.30    2.21    3.87       0
      262144         65536     float     sum      -1    58.84    4.46    7.80       0    58.82    4.46    7.80       0
      524288        131072     float     sum      -1    59.95    8.75   15.31       0    58.81    8.91   15.60       0
     1048576        262144     float     sum      -1    56.75   18.48   32.33       0    58.52   17.92   31.36       0
     2097152        524288     float     sum      -1    60.47   34.68   60.69       0    61.16   34.29   60.01       0
     4194304       1048576     float     sum      -1    59.93   69.99  122.48       0    60.92   68.85  120.49       0
     8388608       2097152     float     sum      -1    85.52   98.08  171.65       0    88.54   94.75  165.81       0
    16777216       4194304     float     sum      -1   150.49  111.48  195.09       0   157.18  106.74  186.79       0
    33554432       8388608     float     sum      -1   427.23   78.54  137.44       0   429.57   78.11  136.69       0
    67108864      16777216     float     sum      -1   586.83  114.36  200.13       0   592.84  113.20  198.10       0
   134217728      33554432     float     sum      -1   953.67  140.74  246.29       0   951.04  141.13  246.97       0
   268435456      67108864     float     sum      -1  1686.36  159.18  278.57       0  1692.94  158.56  277.48       0
   536870912     134217728     float     sum      -1  3158.38  169.98  297.47       0  3176.69  169.00  295.76       0
  1073741824     268435456     float     sum      -1  6078.79  176.64  309.12       0  6078.00  176.66  309.16       0
  2147483648     536870912     float     sum      -1  11948.3  179.73  314.53       0  11954.7  179.63  314.36       0
  4294967296    1073741824     float     sum      -1  23719.2  181.08  316.88       0  23749.6  180.84  316.48       0
  8589934592    2147483648     float     sum      -1  47344.4  181.43  317.51       0  47400.8  181.22  317.13       0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 97.4325 
#
# Collective test concluded: all_reduce_perf
#

hpcuser@compu13f0000001 [ ~/azurelinux ]$ sudo dmesg | grep PeerDirect
[   15.958353] amdgpu: PeerDirect support was initialized successfully
hpcuser@compu13f0000001 [ ~/azurelinux ]$ 
```