### PR TITLE
feat(grubby): provide the /etc/sysconfig/kernel file

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -1107,7 +1107,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.grep]
 [components.groff]
 [components.grpc]
-[components.grubby]
 [components.gsettings-desktop-schemas]
 [components.gsl]
 [components.gsm]

--- a/base/comps/grubby/grubby.comp.toml
+++ b/base/comps/grubby/grubby.comp.toml
@@ -1,0 +1,30 @@
+[components.grubby]
+
+[[components.grubby.overlays]]
+description = "Provide /etc/sysconfig/kernel file"
+type = "file-add"
+file = "kernel.sysconfig"
+source = "kernel.sysconfig"
+
+[[components.grubby.overlays]]
+description = "Provide /etc/sysconfig/kernel file"
+type = "spec-add-tag"
+tag = "Source999"
+value = "kernel.sysconfig"
+
+[[components.grubby.overlays]]
+description = "Provide /etc/sysconfig/kernel file"
+type = "spec-append-lines"
+section = "%install"
+lines = [
+  "mkdir -p %{buildroot}%{_sysconfdir}/sysconfig",
+  "install -m 0644 %{SOURCE999} %{buildroot}%{_sysconfdir}/sysconfig/kernel",
+]
+
+[[components.grubby.overlays]]
+description = "Provide /etc/sysconfig/kernel file"
+type = "spec-append-lines"
+section = "%files"
+lines = [
+  "%config(noreplace) %{_sysconfdir}/sysconfig/kernel",
+]

--- a/base/comps/grubby/kernel.sysconfig
+++ b/base/comps/grubby/kernel.sysconfig
@@ -1,0 +1,6 @@
+# UPDATEDEFAULT specifies if kernel-install should make
+# new kernels the default
+UPDATEDEFAULT=yes
+
+# DEFAULTKERNEL specifies the default kernel package type
+DEFAULTKERNEL=kernel-core

--- a/locks/grubby.lock
+++ b/locks/grubby.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '6095bc576b3aa216400f1cc133ade107d4830ea7'
 upstream-commit = '6095bc576b3aa216400f1cc133ade107d4830ea7'
-input-fingerprint = 'sha256:b671086c622372cdbe19f56c5b93a8cf2e9c9011cda4ef5ca095be17b87fd3d1'
+input-fingerprint = 'sha256:4e4d6eadfa7a610b2590ae529250234d165b48bfbaa2ad7d4d1d2627a82b78f6'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/grubby/grubby.spec
+++ b/specs/g/grubby/grubby.spec
@@ -6,7 +6,7 @@
 
 Name: grubby
 Version: 8.40
-Release: 86%{?dist}
+Release: 87%{?dist}
 Summary: Command line tool for updating bootloader configs
 License: GPL-2.0-or-later
 Source1: grubby-bls
@@ -40,6 +40,7 @@ Conflicts:	uboot-tools < 2021.01-0.1.rc2
 Obsoletes:	%{name}-bls < %{version}-%{release}
 Obsoletes:	%{name}-deprecated < %{version}-%{release}
 
+Source999: kernel.sysconfig
 %description
 This package provides a grubby compatibility script that manages
 BootLoaderSpec files and is meant to be backward compatible with
@@ -62,6 +63,8 @@ install -D -m 0755 -t %{buildroot}%{_prefix}/lib/kernel/install.d/ %{SOURCE6}
 mkdir -p %{buildroot}%{_mandir}/man8
 install -m 0644 %{SOURCE7} %{buildroot}%{_mandir}/man8/
 
+mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
+install -m 0644 %{SOURCE999} %{buildroot}%{_sysconfdir}/sysconfig/kernel
 %post
 if [ "$1" = 2 ]; then
     arch=$(uname -m)
@@ -76,6 +79,7 @@ fi
 %attr(0755,root,root) %{_prefix}/lib/kernel/install.d/95-kernel-hooks.install
 %{_mandir}/man8/grubby.8*
 
+%config(noreplace) %{_sysconfdir}/sysconfig/kernel
 %changelog
 * Wed Jul 30 2025 Leo Sandoval <lsandova@redhat.com> - 8.40-85
 - Update cfg when setting a default kernel

--- a/specs/g/grubby/kernel.sysconfig
+++ b/specs/g/grubby/kernel.sysconfig
@@ -1,0 +1,6 @@
+# UPDATEDEFAULT specifies if kernel-install should make
+# new kernels the default
+UPDATEDEFAULT=yes
+
+# DEFAULTKERNEL specifies the default kernel package type
+DEFAULTKERNEL=kernel-core


### PR DESCRIPTION
This file has a setting, UPDATEDEFAULT=, which is used by the kernel-install (aka installkernel) program to determine if the default kernel should be updated to use the newly installed kernel.

This sets UPDATEDEFAULT=yes, so a newly installed kernel will be set as the default kernel (on the next boot); without this, the default kernel will remain set to the current kernel.

Taken from upstream:
https://src.fedoraproject.org/rpms/grubby/c/482a2825c47c4fd28a18beb279a3e826461bf878

Fixes: [AB#20392](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20392)