### PR TITLE
[LOW] Patch expat for CVE-2026-41080 CVE-2026-45186

### DIFF
--- a/SPECS/expat/CVE-2026-41080.patch
+++ b/SPECS/expat/CVE-2026-41080.patch
@@ -1,0 +1,311 @@
+From 2ce1cae891d995481b913e16ea54870a34c0e009 Mon Sep 17 00:00:00 2001
+From: Sebastian Pipping <sebastian@pipping.org>
+Date: Wed, 8 Apr 2026 15:41:54 +0200
+Subject: [PATCH 01/13] lib: Inline function `get_hash_secret_salt`
+
+Upstream Patch Link: https://patch-diff.githubusercontent.com/raw/libexpat/libexpat/pull/1183.patch
+---
+ lib/expat.h    |  12 +++++
+ lib/internal.h |   2 +
+ lib/xmlparse.c | 123 ++++++++++++++++++++++++++++++++++---------------
+ 3 files changed, 100 insertions(+), 37 deletions(-)
+
+diff --git a/lib/expat.h b/lib/expat.h
+index df207e9..b356e00 100644
+--- a/lib/expat.h
++++ b/lib/expat.h
+@@ -44,6 +44,7 @@
+ #ifndef Expat_INCLUDED
+ #define Expat_INCLUDED 1
+ 
++#  include <stdint.h> // for uint8_t
+ #include <stdlib.h>
+ #include "expat_external.h"
+ 
+@@ -916,10 +917,21 @@ XML_SetParamEntityParsing(XML_Parser parser,
+    function behavior. This must be called before parsing is started.
+    Returns 1 if successful, 0 when called after parsing has started.
+    Note: If parser == NULL, the function will do nothing and return 0.
++   DEPRECATED since Expat 2.7.6.
+ */
+ XMLPARSEAPI(int)
+ XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt);
+ 
++/* Sets the hash salt to use for internal hash calculations.
++   Helps in preventing DoS attacks based on predicting hash function behavior.
++   This must be called before parsing is started.
++   Returns XML_TRUE if successful, XML_FALSE when called after parsing has
++   started or when parser is NULL.
++   Added in Expat 2.7.6.
++*/
++XMLPARSEAPI(XML_Bool)
++XML_SetHashSalt16Bytes(XML_Parser parser, const uint8_t entropy[16]);
++
+ /* If XML_Parse or XML_ParseBuffer have returned XML_STATUS_ERROR, then
+    XML_GetErrorCode returns information about the error.
+ */
+diff --git a/lib/internal.h b/lib/internal.h
+index 1b763ff..7aea199 100644
+--- a/lib/internal.h
++++ b/lib/internal.h
+@@ -112,6 +112,7 @@
+ #if defined(_WIN32)                                                            \
+     && (! defined(__USE_MINGW_ANSI_STDIO)                                      \
+         || (1 - __USE_MINGW_ANSI_STDIO - 1 == 0))
++#  define EXPAT_FMT_LLX(midpart) "%" midpart "I64x"
+ #  define EXPAT_FMT_ULL(midpart) "%" midpart "I64u"
+ #  if defined(_WIN64) // Note: modifiers "td" and "zu" do not work for MinGW
+ #    define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart "I64d"
+@@ -121,6 +122,7 @@
+ #    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "u"
+ #  endif
+ #else
++#  define EXPAT_FMT_LLX(midpart) "%" midpart "llx"
+ #  define EXPAT_FMT_ULL(midpart) "%" midpart "llu"
+ #  if ! defined(ULONG_MAX)
+ #    error Compiler did not define ULONG_MAX for us
+diff --git a/lib/xmlparse.c b/lib/xmlparse.c
+index 3cd8ff1..7d0de12 100644
+--- a/lib/xmlparse.c
++++ b/lib/xmlparse.c
+@@ -604,7 +604,7 @@ static ELEMENT_TYPE *getElementType(XML_Parser parser, const ENCODING *enc,
+ 
+ static XML_Char *copyString(const XML_Char *s, XML_Parser parser);
+ 
+-static unsigned long generate_hash_secret_salt(XML_Parser parser);
++static struct sipkey generate_hash_secret_salt(void);
+ static XML_Bool startParsing(XML_Parser parser);
+ 
+ static XML_Parser parserCreate(const XML_Char *encodingName,
+@@ -777,7 +777,8 @@ struct XML_ParserStruct {
+   XML_Bool m_useForeignDTD;
+   enum XML_ParamEntityParsing m_paramEntityParsing;
+ #endif
+-  unsigned long m_hash_secret_salt;
++  struct sipkey m_hash_secret_salt_128;
++  XML_Bool m_hash_secret_salt_set;
+ #if XML_GE == 1
+   ACCOUNTING m_accounting;
+   MALLOC_TRACKER m_alloc_tracker;
+@@ -1183,65 +1184,65 @@ gather_time_entropy(void) {
+ 
+ #endif /* ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM) */
+ 
+-static unsigned long
+-ENTROPY_DEBUG(const char *label, unsigned long entropy) {
++static struct sipkey
++ENTROPY_DEBUG(const char *label, struct sipkey entropy_128) {
+   if (getDebugLevel("EXPAT_ENTROPY_DEBUG", 0) >= 1u) {
+-    fprintf(stderr, "expat: Entropy: %s --> 0x%0*lx (%lu bytes)\n", label,
+-            (int)sizeof(entropy) * 2, entropy, (unsigned long)sizeof(entropy));
++    fprintf(stderr,
++            "expat: Entropy: %s --> [0x" EXPAT_FMT_LLX(
++                "016") ", 0x" EXPAT_FMT_LLX("016") "] (16 bytes)\n",
++            label, (unsigned long long)entropy_128.k[0],
++            (unsigned long long)entropy_128.k[1]);
+   }
+-  return entropy;
++  return entropy_128;
+ }
+ 
+-static unsigned long
+-generate_hash_secret_salt(XML_Parser parser) {
+-  unsigned long entropy;
+-  (void)parser;
++static struct sipkey
++generate_hash_secret_salt(void) {
++  struct sipkey entropy;
+ 
+   /* "Failproof" high quality providers: */
+ #if defined(HAVE_ARC4RANDOM_BUF)
+   arc4random_buf(&entropy, sizeof(entropy));
+   return ENTROPY_DEBUG("arc4random_buf", entropy);
+ #elif defined(HAVE_ARC4RANDOM)
+-  writeRandomBytes_arc4random((void *)&entropy, sizeof(entropy));
++  writeRandomBytes_arc4random(&entropy, sizeof(entropy));
+   return ENTROPY_DEBUG("arc4random", entropy);
+ #else
+   /* Try high quality providers first .. */
+ #  ifdef _WIN32
+-  if (writeRandomBytes_rand_s((void *)&entropy, sizeof(entropy))) {
++  if (writeRandomBytes_rand_s(&entropy, sizeof(entropy))) {
+     return ENTROPY_DEBUG("rand_s", entropy);
+   }
+ #  elif defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
+-  if (writeRandomBytes_getrandom_nonblock((void *)&entropy, sizeof(entropy))) {
++  if (writeRandomBytes_getrandom_nonblock(&entropy, sizeof(entropy))) {
+     return ENTROPY_DEBUG("getrandom", entropy);
+   }
+ #  endif
+ #  if ! defined(_WIN32) && defined(XML_DEV_URANDOM)
+-  if (writeRandomBytes_dev_urandom((void *)&entropy, sizeof(entropy))) {
++  if (writeRandomBytes_dev_urandom(&entropy, sizeof(entropy))) {
+     return ENTROPY_DEBUG("/dev/urandom", entropy);
+   }
+ #  endif /* ! defined(_WIN32) && defined(XML_DEV_URANDOM) */
+   /* .. and self-made low quality for backup: */
+ 
++  entropy.k[0] = 0;
++  entropy.k[1] = gather_time_entropy();
++#  if ! defined(__wasi__)
+   /* Process ID is 0 bits entropy if attacker has local access */
+-  entropy = gather_time_entropy() ^ getpid();
++  entropy.k[1] ^= getpid();
++#  endif
+ 
+   /* Factors are 2^31-1 and 2^61-1 (Mersenne primes M31 and M61) */
+   if (sizeof(unsigned long) == 4) {
+-    return ENTROPY_DEBUG("fallback(4)", entropy * 2147483647);
++    entropy.k[1] *= 2147483647;
++    return ENTROPY_DEBUG("fallback(4)", entropy);
+   } else {
+-    return ENTROPY_DEBUG("fallback(8)",
+-                         entropy * (unsigned long)2305843009213693951ULL);
++    entropy.k[1] *= 2305843009213693951ULL;
++    return ENTROPY_DEBUG("fallback(8)", entropy);
+   }
+ #endif
+ }
+ 
+-static unsigned long
+-get_hash_secret_salt(XML_Parser parser) {
+-  if (parser->m_parentParser != NULL)
+-    return get_hash_secret_salt(parser->m_parentParser);
+-  return parser->m_hash_secret_salt;
+-}
+-
+ static enum XML_Error
+ callProcessor(XML_Parser parser, const char *start, const char *end,
+               const char **endPtr) {
+@@ -1310,8 +1311,10 @@ callProcessor(XML_Parser parser, const char *start, const char *end,
+ static XML_Bool /* only valid for root parser */
+ startParsing(XML_Parser parser) {
+   /* hash functions must be initialized before setContext() is called */
+-  if (parser->m_hash_secret_salt == 0)
+-    parser->m_hash_secret_salt = generate_hash_secret_salt(parser);
++  if (parser->m_hash_secret_salt_set != XML_TRUE) {
++    parser->m_hash_secret_salt_128 = generate_hash_secret_salt();
++    parser->m_hash_secret_salt_set = XML_TRUE;
++  }
+   if (parser->m_ns) {
+     /* implicit context only set for root parser, since child
+        parsers (i.e. external entity parsers) will inherit it
+@@ -1598,7 +1601,9 @@ parserInit(XML_Parser parser, const XML_Char *encodingName) {
+   parser->m_useForeignDTD = XML_FALSE;
+   parser->m_paramEntityParsing = XML_PARAM_ENTITY_PARSING_NEVER;
+ #endif
+-  parser->m_hash_secret_salt = 0;
++  parser->m_hash_secret_salt_128.k[0] = 0;
++  parser->m_hash_secret_salt_128.k[1] = 0;
++  parser->m_hash_secret_salt_set = XML_FALSE;
+ 
+ #if XML_GE == 1
+   memset(&parser->m_accounting, 0, sizeof(ACCOUNTING));
+@@ -1765,7 +1770,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
+      from hash tables associated with either parser without us having
+      to worry which hash secrets each table has.
+   */
+-  unsigned long oldhash_secret_salt;
++  struct sipkey oldhash_secret_salt_128;
++  XML_Bool oldhash_secret_salt_set;
+   XML_Bool oldReparseDeferralEnabled;
+ 
+   /* Validate the oldParser parameter before we pull everything out of it */
+@@ -1811,7 +1817,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
+      from hash tables associated with either parser without us having
+      to worry which hash secrets each table has.
+   */
+-  oldhash_secret_salt = parser->m_hash_secret_salt;
++  oldhash_secret_salt_128 = parser->m_hash_secret_salt_128;
++  oldhash_secret_salt_set = parser->m_hash_secret_salt_set;
+   oldReparseDeferralEnabled = parser->m_reparseDeferralEnabled;
+ 
+ #ifdef XML_DTD
+@@ -1866,7 +1873,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
+     parser->m_externalEntityRefHandlerArg = oldExternalEntityRefHandlerArg;
+   parser->m_defaultExpandInternalEntities = oldDefaultExpandInternalEntities;
+   parser->m_ns_triplets = oldns_triplets;
+-  parser->m_hash_secret_salt = oldhash_secret_salt;
++  parser->m_hash_secret_salt_128 = oldhash_secret_salt_128;
++  parser->m_hash_secret_salt_set = oldhash_secret_salt_set;
+   parser->m_reparseDeferralEnabled = oldReparseDeferralEnabled;
+   parser->m_parentParser = oldParser;
+ #ifdef XML_DTD
+@@ -2310,19 +2318,58 @@ XML_SetParamEntityParsing(XML_Parser parser,
+ #endif
+ }
+ 
++// DEPRECATED since Expat 2.7.6.
+ int XMLCALL
+ XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
+   if (parser == NULL)
+     return 0;
+-  if (parser->m_parentParser)
+-    return XML_SetHashSalt(parser->m_parentParser, hash_salt);
++
++  const XML_Parser rootParser = getRootParserOf(parser, NULL);
++  assert(! rootParser->m_parentParser);
++
+   /* block after XML_Parse()/XML_ParseBuffer() has been called */
+   if (parserBusy(parser))
+     return 0;
+-  parser->m_hash_secret_salt = hash_salt;
++
++  rootParser->m_hash_secret_salt_128.k[0] = 0;
++  rootParser->m_hash_secret_salt_128.k[1] = hash_salt;
++
++  if (hash_salt != 0) { // to remain backwards compatible
++    rootParser->m_hash_secret_salt_set = XML_TRUE;
++
++    if (sizeof(unsigned long) == 4)
++      ENTROPY_DEBUG("explicit(4)", rootParser->m_hash_secret_salt_128);
++    else
++      ENTROPY_DEBUG("explicit(8)", rootParser->m_hash_secret_salt_128);
++  }
++
+   return 1;
+ }
+ 
++XML_Bool XMLCALL
++XML_SetHashSalt16Bytes(XML_Parser parser, const uint8_t entropy[16]) {
++  if (parser == NULL)
++    return XML_FALSE;
++
++  if (entropy == NULL)
++    return XML_FALSE;
++
++  const XML_Parser rootParser = getRootParserOf(parser, NULL);
++  assert(! rootParser->m_parentParser);
++
++  /* block after XML_Parse()/XML_ParseBuffer() has been called */
++  if (parserBusy(rootParser))
++    return XML_FALSE;
++
++  sip_tokey(&(rootParser->m_hash_secret_salt_128), entropy);
++
++  rootParser->m_hash_secret_salt_set = XML_TRUE;
++
++  ENTROPY_DEBUG("explicit(16)", rootParser->m_hash_secret_salt_128);
++
++  return XML_TRUE;
++}
++
+ enum XML_Status XMLCALL
+ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
+   if ((parser == NULL) || (len < 0) || ((s == NULL) && (len != 0))) {
+@@ -7825,8 +7872,10 @@ keylen(KEY s) {
+ 
+ static void
+ copy_salt_to_sipkey(XML_Parser parser, struct sipkey *key) {
+-  key->k[0] = 0;
+-  key->k[1] = get_hash_secret_salt(parser);
++  const XML_Parser rootParser = getRootParserOf(parser, NULL);
++  assert(! rootParser->m_parentParser);
++
++  *key = rootParser->m_hash_secret_salt_128;
+ }
+ 
+ static unsigned long FASTCALL
+-- 
+2.45.4
+

--- a/SPECS/expat/CVE-2026-41080.patch
+++ b/SPECS/expat/CVE-2026-41080.patch
@@ -7,8 +7,8 @@ Upstream Patch Link: https://patch-diff.githubusercontent.com/raw/libexpat/libex
 ---
  lib/expat.h    |  12 +++++
  lib/internal.h |   2 +
- lib/xmlparse.c | 123 ++++++++++++++++++++++++++++++++++---------------
- 3 files changed, 100 insertions(+), 37 deletions(-)
+ lib/xmlparse.c | 125 ++++++++++++++++++++++++++++++++++---------------
+ 3 files changed, 101 insertions(+), 38 deletions(-)
 
 diff --git a/lib/expat.h b/lib/expat.h
 index df207e9..b356e00 100644
@@ -65,7 +65,7 @@ index 1b763ff..7aea199 100644
  #  if ! defined(ULONG_MAX)
  #    error Compiler did not define ULONG_MAX for us
 diff --git a/lib/xmlparse.c b/lib/xmlparse.c
-index 3cd8ff1..7d0de12 100644
+index 3cd8ff1..50e15ed 100644
 --- a/lib/xmlparse.c
 +++ b/lib/xmlparse.c
 @@ -604,7 +604,7 @@ static ELEMENT_TYPE *getElementType(XML_Parser parser, const ENCODING *enc,
@@ -247,7 +247,8 @@ index 3cd8ff1..7d0de12 100644
 +  assert(! rootParser->m_parentParser);
 +
    /* block after XML_Parse()/XML_ParseBuffer() has been called */
-   if (parserBusy(parser))
+-  if (parserBusy(parser))
++  if (parserBusy(rootParser))
      return 0;
 -  parser->m_hash_secret_salt = hash_salt;
 +

--- a/SPECS/expat/CVE-2026-41080.patch
+++ b/SPECS/expat/CVE-2026-41080.patch
@@ -1,7 +1,7 @@
 From 2ce1cae891d995481b913e16ea54870a34c0e009 Mon Sep 17 00:00:00 2001
 From: Sebastian Pipping <sebastian@pipping.org>
 Date: Wed, 8 Apr 2026 15:41:54 +0200
-Subject: [PATCH 01/13] lib: Inline function `get_hash_secret_salt`
+Subject: [PATCH] lib: Inline function `get_hash_secret_salt`
 
 Upstream Patch Link: https://patch-diff.githubusercontent.com/raw/libexpat/libexpat/pull/1183.patch
 ---

--- a/SPECS/expat/CVE-2026-45186.patch
+++ b/SPECS/expat/CVE-2026-45186.patch
@@ -1,0 +1,122 @@
+From 0802a5892030610144b736dec6e2f63e8600fe85 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Berkay=20Eren=20=C3=9Cr=C3=BCn?= <berkay.ueruen@siemens.com>
+Date: Fri, 13 Mar 2026 13:26:45 +0100
+Subject: [PATCH] DoS due to attribute name collision checks
+
+Upstream Patch Link: https://github.com/libexpat/libexpat/pull/1216.patch
+---
+ lib/xmlparse.c | 34 +++++++++++++++++++++++++++++-----
+ 1 file changed, 29 insertions(+), 5 deletions(-)
+
+diff --git a/lib/xmlparse.c b/lib/xmlparse.c
+index 7d0de12..71615ec 100644
+--- a/lib/xmlparse.c
++++ b/lib/xmlparse.c
+@@ -388,6 +388,7 @@ typedef struct {
+   int nDefaultAtts;
+   int allocDefaultAtts;
+   DEFAULT_ATTRIBUTE *defaultAtts;
++  HASH_TABLE defaultAttsNames;
+ } ELEMENT_TYPE;
+ 
+ typedef struct {
+@@ -3884,6 +3885,8 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
+                                          sizeof(ELEMENT_TYPE));
+     if (! elementType)
+       return XML_ERROR_NO_MEMORY;
++    if (! elementType->defaultAttsNames.parser)
++      hashTableInit(&(elementType->defaultAttsNames), parser);
+     if (parser->m_ns && ! setElementTypePrefix(parser, elementType))
+       return XML_ERROR_NO_MEMORY;
+   }
+@@ -7215,10 +7218,10 @@ defineAttribute(ELEMENT_TYPE *type, ATTRIBUTE_ID *attId, XML_Bool isCdata,
+   if (value || isId) {
+     /* The handling of default attributes gets messed up if we have
+        a default which duplicates a non-default. */
+-    int i;
+-    for (i = 0; i < type->nDefaultAtts; i++)
+-      if (attId == type->defaultAtts[i].id)
+-        return 1;
++    NAMED *const nameFound
++        = (NAMED *)lookup(parser, &(type->defaultAttsNames), attId->name, 0);
++    if (nameFound)
++      return 1;
+     if (isId && ! type->idAtt && ! attId->xmlns)
+       type->idAtt = attId;
+   }
+@@ -7265,6 +7268,12 @@ defineAttribute(ELEMENT_TYPE *type, ATTRIBUTE_ID *attId, XML_Bool isCdata,
+   att->isCdata = isCdata;
+   if (! isCdata)
+     attId->maybeTokenized = XML_TRUE;
++
++  NAMED *const nameAddedOrFound = (NAMED *)lookup(
++      parser, &(type->defaultAttsNames), attId->name, sizeof(NAMED));
++  if (! nameAddedOrFound)
++    return 0;
++
+   type->nDefaultAtts += 1;
+   return 1;
+ }
+@@ -7590,6 +7599,7 @@ dtdReset(DTD *p, XML_Parser parser) {
+     ELEMENT_TYPE *e = (ELEMENT_TYPE *)hashTableIterNext(&iter);
+     if (! e)
+       break;
++    hashTableDestroy(&(e->defaultAttsNames));
+     if (e->allocDefaultAtts != 0)
+       FREE(parser, e->defaultAtts);
+   }
+@@ -7631,6 +7641,7 @@ dtdDestroy(DTD *p, XML_Bool isDocEntity, XML_Parser parser) {
+     ELEMENT_TYPE *e = (ELEMENT_TYPE *)hashTableIterNext(&iter);
+     if (! e)
+       break;
++    hashTableDestroy(&(e->defaultAttsNames));
+     if (e->allocDefaultAtts != 0)
+       FREE(parser, e->defaultAtts);
+   }
+@@ -7724,6 +7735,10 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
+                                   sizeof(ELEMENT_TYPE));
+     if (! newE)
+       return 0;
++
++    if (! newE->defaultAttsNames.parser)
++      hashTableInit(&(newE->defaultAttsNames), parser);
++
+     if (oldE->nDefaultAtts) {
+       /* Detect and prevent integer overflow.
+        * The preprocessor guard addresses the "always false" warning
+@@ -7749,8 +7764,9 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
+       newE->prefix = (PREFIX *)lookup(oldParser, &(newDtd->prefixes),
+                                       oldE->prefix->name, 0);
+     for (i = 0; i < newE->nDefaultAtts; i++) {
++      const XML_Char *const attributeName = oldE->defaultAtts[i].id->name;
+       newE->defaultAtts[i].id = (ATTRIBUTE_ID *)lookup(
+-          oldParser, &(newDtd->attributeIds), oldE->defaultAtts[i].id->name, 0);
++          oldParser, &(newDtd->attributeIds), attributeName, 0);
+       newE->defaultAtts[i].isCdata = oldE->defaultAtts[i].isCdata;
+       if (oldE->defaultAtts[i].value) {
+         newE->defaultAtts[i].value
+@@ -7759,6 +7775,12 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
+           return 0;
+       } else
+         newE->defaultAtts[i].value = NULL;
++
++      NAMED *const nameAddedOrFound = (NAMED *)lookup(
++          parser, &(newE->defaultAttsNames), attributeName, sizeof(NAMED));
++      if (! nameAddedOrFound) {
++        return 0;
++      }
+     }
+   }
+ 
+@@ -8502,6 +8524,8 @@ getElementType(XML_Parser parser, const ENCODING *enc, const char *ptr,
+                                sizeof(ELEMENT_TYPE));
+   if (! ret)
+     return NULL;
++  if (! ret->defaultAttsNames.parser)
++    hashTableInit(&(ret->defaultAttsNames), getRootParserOf(parser, NULL));
+   if (ret->name != name)
+     poolDiscard(&dtd->pool);
+   else {
+-- 
+2.45.4
+

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -2,7 +2,7 @@
 Summary:        An XML parser library
 Name:           expat
 Version:        2.6.4
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -17,6 +17,7 @@ Patch4:         Stop-updating-event-pointer-on-exit-for-reentry.patch
 Patch5:         CVE-2026-32776.patch
 Patch6:         CVE-2026-32777.patch
 Patch7:         CVE-2026-32778.patch
+Patch8:         CVE-2026-41080.patch
 Requires:       %{name}-libs = %{version}-%{release}
 
 %description
@@ -74,6 +75,9 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 %{_libdir}/libexpat.so.1*
 
 %changelog
+* Mon May 04 2026 Ratiranjan Behera <v-ratbehera@microsoft.com> - 2.6.4-7
+- Patch for CVE-2026-41080
+
 * Wed Apr 15 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.6.4-6
 - Patch for CVE-2026-32778, CVE-2026-32777, CVE-2026-32776
 

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -18,6 +18,7 @@ Patch5:         CVE-2026-32776.patch
 Patch6:         CVE-2026-32777.patch
 Patch7:         CVE-2026-32778.patch
 Patch8:         CVE-2026-41080.patch
+Patch9:         CVE-2026-45186.patch
 Requires:       %{name}-libs = %{version}-%{release}
 
 %description
@@ -75,8 +76,8 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 %{_libdir}/libexpat.so.1*
 
 %changelog
-* Mon May 04 2026 Ratiranjan Behera <v-ratbehera@microsoft.com> - 2.6.4-7
-- Patch for CVE-2026-41080
+* Tue May 12 2026 Ratiranjan Behera <v-ratbehera@microsoft.com> - 2.6.4-7
+- Patch for CVE-2026-41080 and CVE-2026-45186
 
 * Wed Apr 15 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.6.4-6
 - Patch for CVE-2026-32778, CVE-2026-32777, CVE-2026-32776

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -99,9 +99,9 @@ elfutils-libelf-0.189-6.azl3.aarch64.rpm
 elfutils-libelf-devel-0.189-6.azl3.aarch64.rpm
 elfutils-libelf-devel-static-0.189-6.azl3.aarch64.rpm
 elfutils-libelf-lang-0.189-6.azl3.aarch64.rpm
-expat-2.6.4-6.azl3.aarch64.rpm
-expat-devel-2.6.4-6.azl3.aarch64.rpm
-expat-libs-2.6.4-6.azl3.aarch64.rpm
+expat-2.6.4-7.azl3.aarch64.rpm
+expat-devel-2.6.4-7.azl3.aarch64.rpm
+expat-libs-2.6.4-7.azl3.aarch64.rpm
 libpipeline-1.5.7-1.azl3.aarch64.rpm
 libpipeline-devel-1.5.7-1.azl3.aarch64.rpm
 gdbm-1.23-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -99,9 +99,9 @@ elfutils-libelf-0.189-6.azl3.x86_64.rpm
 elfutils-libelf-devel-0.189-6.azl3.x86_64.rpm
 elfutils-libelf-devel-static-0.189-6.azl3.x86_64.rpm
 elfutils-libelf-lang-0.189-6.azl3.x86_64.rpm
-expat-2.6.4-6.azl3.x86_64.rpm
-expat-devel-2.6.4-6.azl3.x86_64.rpm
-expat-libs-2.6.4-6.azl3.x86_64.rpm
+expat-2.6.4-7.azl3.x86_64.rpm
+expat-devel-2.6.4-7.azl3.x86_64.rpm
+expat-libs-2.6.4-7.azl3.x86_64.rpm
 libpipeline-1.5.7-1.azl3.x86_64.rpm
 libpipeline-devel-1.5.7-1.azl3.x86_64.rpm
 gdbm-1.23-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -94,10 +94,10 @@ elfutils-libelf-0.189-6.azl3.aarch64.rpm
 elfutils-libelf-devel-0.189-6.azl3.aarch64.rpm
 elfutils-libelf-devel-static-0.189-6.azl3.aarch64.rpm
 elfutils-libelf-lang-0.189-6.azl3.aarch64.rpm
-expat-2.6.4-6.azl3.aarch64.rpm
-expat-debuginfo-2.6.4-6.azl3.aarch64.rpm
-expat-devel-2.6.4-6.azl3.aarch64.rpm
-expat-libs-2.6.4-6.azl3.aarch64.rpm
+expat-2.6.4-7.azl3.aarch64.rpm
+expat-debuginfo-2.6.4-7.azl3.aarch64.rpm
+expat-devel-2.6.4-7.azl3.aarch64.rpm
+expat-libs-2.6.4-7.azl3.aarch64.rpm
 file-5.45-1.azl3.aarch64.rpm
 file-debuginfo-5.45-1.azl3.aarch64.rpm
 file-devel-5.45-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -99,10 +99,10 @@ elfutils-libelf-0.189-6.azl3.x86_64.rpm
 elfutils-libelf-devel-0.189-6.azl3.x86_64.rpm
 elfutils-libelf-devel-static-0.189-6.azl3.x86_64.rpm
 elfutils-libelf-lang-0.189-6.azl3.x86_64.rpm
-expat-2.6.4-6.azl3.x86_64.rpm
-expat-debuginfo-2.6.4-6.azl3.x86_64.rpm
-expat-devel-2.6.4-6.azl3.x86_64.rpm
-expat-libs-2.6.4-6.azl3.x86_64.rpm
+expat-2.6.4-7.azl3.x86_64.rpm
+expat-debuginfo-2.6.4-7.azl3.x86_64.rpm
+expat-devel-2.6.4-7.azl3.x86_64.rpm
+expat-libs-2.6.4-7.azl3.x86_64.rpm
 file-5.45-1.azl3.x86_64.rpm
 file-debuginfo-5.45-1.azl3.x86_64.rpm
 file-devel-5.45-1.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch expat for CVE-2026-41080 CVE-2026-45186
Patch modified: Yes

- The `expat` package (version `2.6.4`) is affected by `CVE-2026-41080` and `CVE-2026-45186`, as the vulnerability impacts versions earlier than `2.8.0`.
CVE-2026-41080:
- This issue is caused by insufficient entropy used for hash salt generation, which can allow hash-flooding attacks via crafted XML input leading to denial-of-service.
- The upstream fix improves hash flooding protection by increasing entropy from 4–8 bytes to 16 bytes, leveraging full SipHash capabilities and enhancing randomness in hash salt generation. 
- The patch has been backported manually by applying only the required changes to source package (`xmlparse.c`, `internal.h`, and `expat.h`).
- Non-essential upstream changes (documentation updates, test additions, CI-related files, and symbol export files) have been excluded as they are not required for the CVE fix. Example: `doc/reference.html`,  `data/exported-symbols-unversioned.txt`, `exported-symbols-versioned-default.txt`, `lib/libexpat.map.in`, `tests/basic_tests.c` and `Changes` etc. 
- Replaced recursive parent parser delegation with using `getRootParserOf()` helper that fixes undeclared variable error and improves code consistency with upstream implementation.
- As in upstream, added platform-specific guard to skip PID entropy in WASI environments.

CVE-2026-45186:
-  Only the minimal necessary changes in the core library (`xmlparse.c`) have been included to address the CVE, while test and documentation changes have been intentionally excluded like the changes in `tests/basic_tests.c`, `tests/handlers.c`, `tests/handlers.h` and `Changes`. 

- Upstream Patch reference for CVE-2026-41080: https://[patch-diff.githubusercontent.com/raw/libexpat/libexpat/pull/1183.patch](https://patch-diff.githubusercontent.com/raw/libexpat/libexpat/pull/1183.patch)
- Upstream Patch reference for CVE-2026-45186: https://[patch-diff.githubusercontent.com/raw/libexpat/libexpat/pull/1216.patch](https://patch-diff.githubusercontent.com/raw/libexpat/libexpat/pull/1216.patch)


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/expat/CVE-2026-41080.patch
- modified:   SPECS/expat/expat.spec
- modified:   toolkit/resources/manifests/package/pkggen_core_aarch64.txt
- modified:   toolkit/resources/manifests/package/pkggen_core_x86_64.txt
- modified:   toolkit/resources/manifests/package/toolchain_aarch64.txt
- modified:   toolkit/resources/manifests/package/toolchain_x86_64.txt

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-41080

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful. 
<img width="325" height="356" alt="image" src="https://github.com/user-attachments/assets/b81ba1b5-6ddd-4736-996a-4348a654247b" />

- Patch applies cleanly.

<img width="648" height="23" alt="image" src="https://github.com/user-attachments/assets/21d4173b-340b-4e0f-885c-77177e8a7ea4" />

<img width="644" height="23" alt="image" src="https://github.com/user-attachments/assets/fae85704-9a04-41d4-b8d0-d19593c0bc7c" />


- Installation:
<img width="494" height="157" alt="image" src="https://github.com/user-attachments/assets/b8bcefa2-f86a-408a-882c-4a60b04af139" />
<img width="359" height="60" alt="image" src="https://github.com/user-attachments/assets/83780ce5-fd3c-470a-814a-581458bc90e8" />

- Uninstallation:
<img width="357" height="85" alt="image" src="https://github.com/user-attachments/assets/54f8b82a-d66a-4f5d-9e85-6ee04b66c2bc" />
