### PR TITLE
Upgrade azurelinux-image-tools to version 1.4.0 (fasttrack)

### DIFF
--- a/SPECS/azurelinux-image-tools/azurelinux-image-tools.signatures.json
+++ b/SPECS/azurelinux-image-tools/azurelinux-image-tools.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "azurelinux-image-tools-1.3.0-vendor.tar.gz": "0f8cde7b29cd24a5b8f695e9bf3f836f79d7d7ad2b02696de776843d071de291",
-  "azurelinux-image-tools-1.3.0.tar.gz": "a217ac57e88f07da52fe822d8423fa842901e5b9d9c1baaa2592198aa9b7a165"
+  "azurelinux-image-tools-1.4.0-vendor.tar.gz": "12beb8ddcf2b86cc3a3c5c8500997b22accff44601e95a9bf833ec6070489108",
+  "azurelinux-image-tools-1.4.0.tar.gz": "06103d884d98f4fc6e2807d244c38b798ad31f71097df0aa060e6ceab36ea86d"
  }
 }

--- a/SPECS/azurelinux-image-tools/azurelinux-image-tools.spec
+++ b/SPECS/azurelinux-image-tools/azurelinux-image-tools.spec
@@ -2,8 +2,8 @@
 
 Summary:        Azure Linux Image Tools
 Name:           azurelinux-image-tools
-Version:        1.3.0
-Release:        2%{?dist}
+Version:        1.4.0
+Release:        1%{?dist}
 License:        MIT
 URL:            https://github.com/microsoft/azure-linux-image-tools/
 Group:          Applications/System
@@ -113,6 +113,9 @@ go test -C toolkit/tools ./...
 %{_bindir}/osmodifier
 
 %changelog
+* Fri May 29 2026 Vince Perri <viperri@microsoft.com> - 1.4.0-1
+- Upgrade to version 1.4.0
+
 * Wed May 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.3.0-2
 - Patch for CVE-2026-39821
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -915,8 +915,8 @@
         "type": "other",
         "other": {
           "name": "azurelinux-image-tools",
-          "version": "1.3.0",
-          "downloadUrl": "https://github.com/microsoft/azure-linux-image-tools/archive/refs/tags/v1.3.0.tar.gz"
+          "version": "1.4.0",
+          "downloadUrl": "https://github.com/microsoft/azure-linux-image-tools/archive/refs/tags/v1.4.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
This PR updates the azurelinux-image-tools package to version 1.4.0 to reflect the new Image Customizer release.