### PR TITLE
Add ukify-fix-insertion-of-padding-in-merged-sections patch to systemd

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Wed May 20 2026 Vince Perri <viperri@microsoft.com> - 255-28
+- Bump release to match systemd spec
+
 * Thu Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
 - Bump release to match systemd spec
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        27%{?dist}
+Release:        28%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -138,6 +138,10 @@ Patch0490:      use-none-scheduler.patch
 # NOTE: the patch was based on the fedora patch, but renamed to
 # 'azurelinux-...' and modified for our 'system-*' pam files
 Patch0491:      azurelinux-use-system-auth-in-pam-systemd-user.patch
+
+# ukify: fix insertion of padding in merged sections
+# Backport of upstream commit ec1d031f3de02f84beca89e2b402d085fba62be4
+Patch0492:      ukify-fix-insertion-of-padding-in-merged-sections.patch
 
 # Patches for Azure Linux
 Patch0900:      do-not-test-openssl-sm3.patch
@@ -1235,6 +1239,12 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Wed May 20 2026 Vince Perri <viperri@microsoft.com> - 255-28
+- Backport upstream ukify fix (ec1d031f3de02f84beca89e2b402d085fba62be4):
+  when merging into an existing PE section, padding was derived from the new
+  section size instead of the existing section size, which can leave
+  insufficient padding and corrupt the resulting UKI.
+
 * Thu Mar 26 2026 Lanze Liu <lanzeliu@microsoft.com> - 255-27
 - Fix pcrlock failure on Hyper-V/Azure VMs with vTPM by backporting upstream
   commit e90a255 from systemd v256 (PR #31429).

--- a/SPECS/systemd/ukify-fix-insertion-of-padding-in-merged-sections.patch
+++ b/SPECS/systemd/ukify-fix-insertion-of-padding-in-merged-sections.patch
@@ -1,0 +1,34 @@
+From ec1d031f3de02f84beca89e2b402d085fba62be4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Tue, 19 Aug 2025 11:02:44 +0200
+Subject: [PATCH] ukify: fix insertion of padding in merged sections
+
+The padding was done to expand the new section contents to the expected size of
+the new section. And this then would be used for the content in the existing
+section. The new section cannot be larger than the old section, but it can be
+smaller. If the new section was smaller, then we'd not write enough padding and
+the output file would be corrupted.
+
+This was observed in CI when the .sbat section in the stub was padded to 1k.
+The UKI with an .sbat section that was merged and was fairly short would hit
+this scenario and be corrupted.
+
+[Rebased onto systemd v255 by Vince Perri <viperri@microsoft.com>]
+---
+ src/ukify/ukify.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/ukify/ukify.py b/src/ukify/ukify.py
+--- a/src/ukify/ukify.py
++++ b/src/ukify/ukify.py
+@@ -618,9 +618,8 @@ def pe_add_sections(uki: UKI, output: str):
+                 if new_section.Misc_VirtualSize > s.SizeOfRawData:
+                     raise PEError(f'Not enough space in existing section {section.name} to append new data.')
+ 
+-                padding = bytes(new_section.SizeOfRawData - new_section.Misc_VirtualSize)
++                padding = bytes(s.SizeOfRawData - new_section.Misc_VirtualSize)
+                 pe.__data__ = pe.__data__[:s.PointerToRawData] + data + padding + pe.__data__[pe.sections[i+1].PointerToRawData:]
+-                s.SizeOfRawData = new_section.SizeOfRawData
+                 s.Misc_VirtualSize = new_section.Misc_VirtualSize
+                 break
+         else:


### PR DESCRIPTION
Backports upstream ukify fix ([`ec1d031f`](https://github.com/systemd/systemd/commit/ec1d031f3de02f84beca89e2b402d085fba62be4)):
when merging into an existing PE section, padding was derived from the new
section size instead of the existing section size, which can leave
insufficient padding and corrupt the resulting UKI.