### PR TITLE
[High] Patch packer for CVE-2026-39833

### DIFF
--- a/SPECS/packer/CVE-2026-39832.patch
+++ b/SPECS/packer/CVE-2026-39832.patch
@@ -1,4 +1,4 @@
-From 1eef61582515828651c237498c609c356eaa3c7d Mon Sep 17 00:00:00 2001
+From a1ce0fee129597fdea8dfd58d71b6b607de6bdce Mon Sep 17 00:00:00 2001
 From: Nicola <nicola.murino@gmail.com>
 Date: Tue, 27 Jan 2026 12:15:18 +0100
 Subject: [PATCH] ssh/agent: preserve constraint extensions when adding keys
@@ -35,81 +35,13 @@ Reviewed-by: Neal Patel <nealpatel@google.com>
 Reviewed-by: Keith Randall <khr@google.com>
 Reviewed-by: David Chase <drchase@google.com>
 LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
-Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
-Upstream-reference: https://github.com/golang/crypto/commit/a1ce0fee129597fdea8dfd58d71b6b607de6bdce.patch
----
- internal/hcp/api/client_test.go               | 60 +++++++++++++++++++
- .../golang.org/x/crypto/ssh/agent/client.go   |  7 +++
- 2 files changed, 67 insertions(+)
 
-diff --git a/internal/hcp/api/client_test.go b/internal/hcp/api/client_test.go
-index 16d321b..a4a27a0 100644
---- a/internal/hcp/api/client_test.go
-+++ b/internal/hcp/api/client_test.go
-@@ -81,3 +81,63 @@ func TestGetOldestProject(t *testing.T) {
- 		})
- 	}
- }
-+
-+// capturingAgent records the AddedKey observed on the server side of the
-+// agent protocol. It forwards to a keyring with constraint fields stripped,
-+// so the keyring's own rejection of unsupported constraints does not
-+// interfere with what this test is measuring: the client-side wire
-+// serialization of ConstraintExtensions.
-+type capturingAgent struct {
-+	Agent
-+	lastAdd AddedKey
-+}
-+
-+func newCapturingAgent() *capturingAgent {
-+	return &capturingAgent{Agent: NewKeyring()}
-+}
-+
-+func (a *capturingAgent) Add(key AddedKey) error {
-+	a.lastAdd = key
-+	stripped := key
-+	stripped.ConstraintExtensions = nil
-+	stripped.ConfirmBeforeUse = false
-+	return a.Agent.Add(stripped)
-+}
-+
-+// TestAddConstraintExtensionsWireFormat verifies that client.Add serializes
-+// ConstraintExtensions into the SSH_AGENTC_ADD_IDENTITY payload and the
-+// server deserializes them back into the AddedKey delivered to the backend.
-+// Regressions in the client marshal loop (missing, swapped fields, wrong
-+// framing) would be invisible to a keyring-based rejection test, which
-+// signals only "extensions were present", not "the right ones arrived".
-+func TestAddConstraintExtensionsWireFormat(t *testing.T) {
-+	capturing := newCapturingAgent()
-+	client, cleanup := startAgent(t, capturing)
-+	defer cleanup()
-+
-+	constraints := []ConstraintExtension{
-+		{ExtensionName: "ext-one@example.com", ExtensionDetails: []byte("details-one")},
-+		{ExtensionName: "ext-two@example.com", ExtensionDetails: []byte("\x00\x01\x02\xff")},
-+	}
-+
-+	if err := client.Add(AddedKey{
-+		PrivateKey:           testPrivateKeys["rsa"],
-+		Comment:              "wire-format-test",
-+		ConstraintExtensions: constraints,
-+	}); err != nil {
-+		t.Fatalf("client.Add: %v", err)
-+	}
-+
-+	got := capturing.lastAdd.ConstraintExtensions
-+	if len(got) != len(constraints) {
-+		t.Fatalf("server received %d extensions, want %d", len(got), len(constraints))
-+	}
-+	for i, want := range constraints {
-+		if got[i].ExtensionName != want.ExtensionName {
-+			t.Errorf("extension[%d] name: got %q, want %q", i, got[i].ExtensionName, want.ExtensionName)
-+		}
-+		if !bytes.Equal(got[i].ExtensionDetails, want.ExtensionDetails) {
-+			t.Errorf("extension[%d] details: got %x, want %x", i, got[i].ExtensionDetails, want.ExtensionDetails)
-+		}
-+	}
-+}
+Upstream Patch reference: https://github.com/golang/crypto/commit/a1ce0fee129597fdea8dfd58d71b6b607de6bdce.patch & https://github.com/golang/crypto/commit/e3d1254f1e7e60baa086142c46174bf6d8d0fe50.patch
+---
+ vendor/golang.org/x/crypto/ssh/agent/client.go  |  7 +++++++
+ vendor/golang.org/x/crypto/ssh/agent/keyring.go | 12 +++++++++---
+ 2 files changed, 16 insertions(+), 3 deletions(-)
+
 diff --git a/vendor/golang.org/x/crypto/ssh/agent/client.go b/vendor/golang.org/x/crypto/ssh/agent/client.go
 index 31bd7e8..d879c40 100644
 --- a/vendor/golang.org/x/crypto/ssh/agent/client.go
@@ -128,6 +60,35 @@ index 31bd7e8..d879c40 100644
  	cert := key.Certificate
  	if cert == nil {
  		return c.insertKey(key.PrivateKey, key.Comment, constraints)
+diff --git a/vendor/golang.org/x/crypto/ssh/agent/keyring.go b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+index c1b4361..53bfcd8 100644
+--- a/vendor/golang.org/x/crypto/ssh/agent/keyring.go
++++ b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+@@ -143,15 +143,21 @@ func (r *keyring) List() ([]*Key, error) {
+ 	return ids, nil
+ }
+ 
+-// Insert adds a private key to the keyring. If a certificate
+-// is given, that certificate is added as public key. Note that
+-// any constraints given are ignored.
++// Add adds a private key to the keyring. If a certificate is given, that
++// certificate is added as public key.
++//
++// Add returns an error if key contains ConstraintExtensions.
+ func (r *keyring) Add(key AddedKey) error {
+ 	r.mu.Lock()
+ 	defer r.mu.Unlock()
+ 	if r.locked {
+ 		return errLocked
+ 	}
++
++	if len(key.ConstraintExtensions) > 0 {
++		return errors.New("agent: constraint extensions are present but not supported")
++	}
++
+ 	signer, err := ssh.NewSignerFromKey(key.PrivateKey)
+ 
+ 	if err != nil {
 -- 
-2.45.4
+2.43.0
 

--- a/SPECS/packer/CVE-2026-39833.patch
+++ b/SPECS/packer/CVE-2026-39833.patch
@@ -1,0 +1,83 @@
+From 0fb843a472225645e917c84f1f9744757f0bab14 Mon Sep 17 00:00:00 2001
+From: Nicola <nicola.murino@gmail.com>
+Date: Sun, 8 Feb 2026 15:28:56 +0100
+Subject: [PATCH] ssh/agent: reject keys with unsupported confirm constraint
+
+The in-memory keyring supports the "lifetime" constraint but does not
+implement the "confirm" constraint. Previously, keyring.Add silently
+ignored ConfirmBeforeUse: the key was stored, advertised through List,
+and used for signing without any interactive confirmation, potentially
+misleading callers into believing this security measure was enforced.
+
+Return an error when ConfirmBeforeUse is set instead of silently
+downgrading the caller's security expectations. Implementing real
+confirm-before-use in an in-memory library keyring is infeasible (there
+is no UI or confirmation callback), so failing closed is the correct
+behavior; adding actual confirm support would require an API addition
+and is out of scope.
+
+This is a deliberate behavior change: keyring.Add previously accepted
+and ignored ConfirmBeforeUse and now returns an error. This change also
+updates the keyring doc comments to document the supported constraints.
+
+This issue was found during a security audit by NCC Group Cryptography
+Services, sponsored by Teleport.
+
+Fixes CVE-2026-39833
+Updates golang/go#47533
+Fixes golang/go#79436
+
+Change-Id: I1b3a286f0c1e4a4e08ac37109f7e491692ca90ae
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/778642
+Reviewed-by: Dmitri Shuralyov <dmitshur@google.com>
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Neal Patel <neal@golang.org>
+Auto-Submit: Neal Patel <nealpatel@google.com>
+LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+
+Upstream Patch reference: https://github.com/golang/crypto/commit/0fb843a472225645e917c84f1f9744757f0bab14.patch
+---
+ vendor/golang.org/x/crypto/ssh/agent/keyring.go | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/vendor/golang.org/x/crypto/ssh/agent/keyring.go b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+index 53bfcd8..b7db9b4 100644
+--- a/vendor/golang.org/x/crypto/ssh/agent/keyring.go
++++ b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+@@ -32,8 +32,10 @@ type keyring struct {
+ 
+ var errLocked = errors.New("agent: locked")
+ 
+-// NewKeyring returns an Agent that holds keys in memory.  It is safe
+-// for concurrent use by multiple goroutines.
++// NewKeyring returns an Agent that holds keys in memory.  It is safe for
++// concurrent use by multiple goroutines.
++//
++// The returned Agent only supports the "lifetime" constraint.
+ func NewKeyring() Agent {
+ 	return &keyring{}
+ }
+@@ -146,7 +148,8 @@ func (r *keyring) List() ([]*Key, error) {
+ // Add adds a private key to the keyring. If a certificate is given, that
+ // certificate is added as public key.
+ //
+-// Add returns an error if key contains ConstraintExtensions.
++// Add returns an error if key contains ConstraintExtensions or
++// ConfirmBeforeUse.
+ func (r *keyring) Add(key AddedKey) error {
+ 	r.mu.Lock()
+ 	defer r.mu.Unlock()
+@@ -154,6 +157,10 @@ func (r *keyring) Add(key AddedKey) error {
+ 		return errLocked
+ 	}
+ 
++	if key.ConfirmBeforeUse {
++		return errors.New("agent: confirm before use constraint is not supported")
++	}
++
+ 	if len(key.ConstraintExtensions) > 0 {
+ 		return errors.New("agent: constraint extensions are present but not supported")
+ 	}
+-- 
+2.43.0
+

--- a/SPECS/packer/packer.spec
+++ b/SPECS/packer/packer.spec
@@ -4,7 +4,7 @@
 Summary:        Tool for creating identical machine images for multiple platforms from a single source configuration.
 Name:           packer
 Version:        1.9.5
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -65,6 +65,7 @@ Patch30:        CVE-2026-39835.patch
 Patch31:        CVE-2026-42502.patch
 Patch32:        CVE-2026-46598.patch
 Patch33:        CVE-2026-33814.patch
+Patch34:        CVE-2026-39833.patch
 
 BuildRequires:  golang >= 1.21
 BuildRequires:  kernel-headers
@@ -96,6 +97,9 @@ go test -mod=vendor
 %{_bindir}/packer
 
 %changelog
+* Mon Jun 08 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.9.5-16
+- Patch for CVE-2026-39833
+
 * Fri May 29 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.9.5-15
 - Patch for CVE-2026-33814
 

--- a/SPECS/packer/packer.spec
+++ b/SPECS/packer/packer.spec
@@ -98,6 +98,7 @@ go test -mod=vendor
 
 %changelog
 * Mon Jun 08 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.9.5-16
+- Fix patch for CVE-2026-39832
 - Patch for CVE-2026-39833
 
 * Fri May 29 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.9.5-15


### PR DESCRIPTION
Summary:
- Patch packer for CVE-2026-39833
   - `ssh/agent/keyring_test.go` and `ssh/test/agent_unix_test.go` files are not present in our source code, so patch could not be applied for those two files.
- Modified CVE-2026-39832 
   - `ssh/agent/keyring_test.go` and `ssh/agent/client_test.go` files are not preset in our source code, so patch could not be applied for those two files.

Change Log:
- modified:   ../SPECS/packer/CVE-2026-39832.patch
- new file:   ../SPECS/packer/CVE-2026-39833.patch
- modified:   ../SPECS/packer/packer.spec

Test Methodology
Local Build:
[packer-1.9.5-15.azl3.src.rpm.log](https://github.com/user-attachments/files/28460263/packer-1.9.5-15.azl3.src.rpm.log)
[packer-1.9.5-15.azl3.src.rpm.test.log](https://github.com/user-attachments/files/28460265/packer-1.9.5-15.azl3.src.rpm.test.log)
Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1130253&view=results 
