### PR TITLE
[High] Patch docker-buildx for CVE-2026-39833

### DIFF
--- a/SPECS/docker-buildx/CVE-2026-25680.patch
+++ b/SPECS/docker-buildx/CVE-2026-25680.patch
@@ -1,0 +1,105 @@
+From a41d5f6f770016cd9c9a05d51a9b4a578e64e3ba Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Tue, 12 May 2026 15:36:39 -0400
+Subject: [PATCH] html: improve Noah's Ark clause performance
+
+Instead of iterating over each element in the stack, and checking each
+attribute against each other attribute in a ~cubic fashion, sort the
+attributes and just use slices.Equal.
+
+Thanks to IPC Labs for reporting this issue.
+
+Fixes CVE-2026-25680
+
+Change-Id: Iec3513ba0b5da4f28f1359d24846401b9ab76ee3
+Reviewed-on: https://go-review.googlesource.com/c/net/+/781702
+TryBot-Bypass: Roland Shoemaker <roland@golang.org>
+Reviewed-by: Nicholas Husin <nsh@golang.org>
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Nicholas Husin <husin@google.com>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/golang/net/commit/08be507abce89191d78cd49da60f4501fc910472.patch
+---
+ vendor/golang.org/x/net/html/parse.go | 34 ++++++++++++++++-----------
+ 1 file changed, 20 insertions(+), 14 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/html/parse.go b/vendor/golang.org/x/net/html/parse.go
+index 3392845..4bd5e6d 100644
+--- a/vendor/golang.org/x/net/html/parse.go
++++ b/vendor/golang.org/x/net/html/parse.go
+@@ -5,9 +5,11 @@
+ package html
+ 
+ import (
++	"cmp"
+ 	"errors"
+ 	"fmt"
+ 	"io"
++	"slices"
+ 	"strings"
+ 
+ 	a "golang.org/x/net/html/atom"
+@@ -328,6 +330,14 @@ func (p *parser) addText(text string) {
+ 	})
+ }
+ 
++func attrCompare(a, b Attribute) int {
++	return cmp.Or(
++		cmp.Compare(a.Namespace, b.Namespace),
++		cmp.Compare(a.Key, b.Key),
++		cmp.Compare(a.Val, b.Val),
++	)
++}
++
+ // addElement adds a child element based on the current token.
+ func (p *parser) addElement() {
+ 	p.addChild(&Node{
+@@ -343,6 +353,10 @@ func (p *parser) addFormattingElement() {
+ 	tagAtom, attr := p.tok.DataAtom, p.tok.Attr
+ 	p.addElement()
+ 
++	// In order to optimize the search, we need the attributes to be sorted, so we
++	// can just use slices.Equal.
++	slices.SortFunc(attr, attrCompare)
++
+ 	// Implement the Noah's Ark clause, but with three per family instead of two.
+ 	identicalElements := 0
+ findIdenticalElements:
+@@ -360,19 +374,7 @@ findIdenticalElements:
+ 		if n.DataAtom != tagAtom {
+ 			continue
+ 		}
+-		if len(n.Attr) != len(attr) {
+-			continue
+-		}
+-	compareAttributes:
+-		for _, t0 := range n.Attr {
+-			for _, t1 := range attr {
+-				if t0.Key == t1.Key && t0.Namespace == t1.Namespace && t0.Val == t1.Val {
+-					// Found a match for this attribute, continue with the next attribute.
+-					continue compareAttributes
+-				}
+-			}
+-			// If we get here, there is no attribute that matches a.
+-			// Therefore the element is not identical to the new one.
++		if !slices.Equal(n.Attr, attr) {
+ 			continue findIdenticalElements
+ 		}
+ 
+@@ -382,7 +384,11 @@ findIdenticalElements:
+ 		}
+ 	}
+ 
+-	p.afe = append(p.afe, p.top())
++	// Sort the attributes to optimize future identical-element searches.
++	top := p.top()
++	slices.SortFunc(top.Attr, attrCompare)
++
++	p.afe = append(p.afe, top)
+ }
+ 
+ // Section 12.2.4.3.
+-- 
+2.45.4
+

--- a/SPECS/docker-buildx/CVE-2026-25681.patch
+++ b/SPECS/docker-buildx/CVE-2026-25681.patch
@@ -1,0 +1,113 @@
+From ad069ba0be8708962939d544ac5a30609ec70e1b Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Mon, 4 May 2026 11:47:15 -0700
+Subject: [PATCH] html: escape greater-than symbol in doctype identifiers
+
+During parsing, we unescape character references. When rendering, we
+re-escape certain characters in certain scenarios in order to avoid
+token content causing unexpected parser behavior.
+
+We appear to have not taken this into account when rendering DOCTYPE
+tokens, allowing ">" in PUBLIC/SYSTEM identifier strings, which trigger
+a abrupt-doctype-system-identifier parse error which immediately emits
+the current DOCTYPE token and then continues parsing in the data state.
+
+This may cause bypass in HTML santizers which use the html package for
+parsing.
+
+Thanks to ensy for reporting this issue.
+
+Fixes CVE-2026-25681
+
+Change-Id: I1d5be92129d17bfbf0917148db2672d57c224a18
+Reviewed-on: https://go-review.googlesource.com/c/net/+/781703
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Nicholas Husin <nsh@golang.org>
+TryBot-Bypass: Roland Shoemaker <roland@golang.org>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Reviewed-by: Nicholas Husin <husin@google.com>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/golang/net/commit/4ece7b612ad44ad6c4d5e0d5d4df9c18cc211905.patch
+---
+ vendor/golang.org/x/net/html/render.go        | 19 +++++++++++++------
+ .../html/testdata/go/doctype_named_entity.dat |  8 ++++++++
+ 2 files changed, 21 insertions(+), 6 deletions(-)
+ create mode 100644 vendor/golang.org/x/net/html/testdata/go/doctype_named_entity.dat
+
+diff --git a/vendor/golang.org/x/net/html/render.go b/vendor/golang.org/x/net/html/render.go
+index e8c1233..f3740cc 100644
+--- a/vendor/golang.org/x/net/html/render.go
++++ b/vendor/golang.org/x/net/html/render.go
+@@ -113,14 +113,14 @@ func render1(w writer, n *Node) error {
+ 				if _, err := w.WriteString(" PUBLIC "); err != nil {
+ 					return err
+ 				}
+-				if err := writeQuoted(w, p); err != nil {
++				if err := writeDoctypeQuoted(w, p); err != nil {
+ 					return err
+ 				}
+ 				if s != "" {
+ 					if err := w.WriteByte(' '); err != nil {
+ 						return err
+ 					}
+-					if err := writeQuoted(w, s); err != nil {
++					if err := writeDoctypeQuoted(w, s); err != nil {
+ 						return err
+ 					}
+ 				}
+@@ -128,7 +128,7 @@ func render1(w writer, n *Node) error {
+ 				if _, err := w.WriteString(" SYSTEM "); err != nil {
+ 					return err
+ 				}
+-				if err := writeQuoted(w, s); err != nil {
++				if err := writeDoctypeQuoted(w, s); err != nil {
+ 					return err
+ 				}
+ 			}
+@@ -251,19 +251,26 @@ func childTextNodesAreLiteral(n *Node) bool {
+ 	}
+ }
+ 
+-// writeQuoted writes s to w surrounded by quotes. Normally it will use double
++// writeDoctypeQuoted writes s to w surrounded by quotes. Normally it will use double
+ // quotes, but if s contains a double quote, it will use single quotes.
++// If s contains any '>' characters, they are replaced with &gt; in order
++// to prevent triggering an abrupt-doctype-system-identifier parse error.
+ // It is used for writing the identifiers in a doctype declaration.
+ // In valid HTML, they can't contain both types of quotes.
+-func writeQuoted(w writer, s string) error {
++func writeDoctypeQuoted(w writer, s string) error {
+ 	var q byte = '"'
+ 	if strings.Contains(s, `"`) {
++		// parseDoctype will never produce a Node with both quote types, but a user
++		// can construct their own Node that violates this assumption.
++		if strings.Contains(s, `'`) {
++			return errors.New("doctype contains both quote types, cannot be safely rendered")
++		}
+ 		q = '\''
+ 	}
+ 	if err := w.WriteByte(q); err != nil {
+ 		return err
+ 	}
+-	if _, err := w.WriteString(s); err != nil {
++	if _, err := w.WriteString(strings.ReplaceAll(s, ">", "&gt;")); err != nil {
+ 		return err
+ 	}
+ 	if err := w.WriteByte(q); err != nil {
+diff --git a/vendor/golang.org/x/net/html/testdata/go/doctype_named_entity.dat b/vendor/golang.org/x/net/html/testdata/go/doctype_named_entity.dat
+new file mode 100644
+index 0000000..a8bd963
+--- /dev/null
++++ b/vendor/golang.org/x/net/html/testdata/go/doctype_named_entity.dat
+@@ -0,0 +1,8 @@
++#data
++<!DOCTYPE &gt; PUBLIC "&gt;" "&gt;">
++#errors
++#document
++| <!DOCTYPE > ">" ">">
++| <html>
++|   <head>
++|   <body>
+-- 
+2.45.4
+

--- a/SPECS/docker-buildx/CVE-2026-39827.patch
+++ b/SPECS/docker-buildx/CVE-2026-39827.patch
@@ -1,0 +1,61 @@
+From dea4d512416306154b3fa843d1df540d61bace47 Mon Sep 17 00:00:00 2001
+From: Nicola Murino <nicola.murino@gmail.com>
+Date: Sun, 1 Mar 2026 11:49:28 +0100
+Subject: [PATCH] ssh: prevent memory leak when rejecting channels
+
+When a server rejects an incoming channel request via
+NewChannel.Reject, the channel is left in the multiplexer's
+channel list. Because the channel is never explicitly removed or
+closed, its internal buffers and sync primitives remain allocated
+for the lifetime of the SSH connection.
+
+A malicious client could exploit this behavior by repeatedly
+requesting to open channels that are destined to be rejected,
+causing unbounded memory growth and potentially leading to a
+Denial of Service (DoS) via resource exhaustion.
+
+This change fixes the leak by calling ch.mux.chanList.remove
+within the Reject method, removing the channel from the list and allowing the
+garbage collector to reclaim the associated memory immediately.
+
+Fixes golang/go#35127
+Fixes CVE-2026-3982
+
+Change-Id: Iaa177f5dfd151812dd404e528a4a1c77527a0e29
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/781320
+LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Reviewed-by: Nicholas Husin <nsh@golang.org>
+Reviewed-by: Nicholas Husin <husin@google.com>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/golang/crypto/commit/6c195c8a97ae3d91a366ebdd7787d5faa64bf42a.patch
+---
+ vendor/golang.org/x/crypto/ssh/channel.go | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/golang.org/x/crypto/ssh/channel.go b/vendor/golang.org/x/crypto/ssh/channel.go
+index 3967b65..77bac19 100644
+--- a/vendor/golang.org/x/crypto/ssh/channel.go
++++ b/vendor/golang.org/x/crypto/ssh/channel.go
+@@ -536,7 +536,17 @@ func (ch *channel) Reject(reason RejectionReason, message string) error {
+ 		Language: "en",
+ 	}
+ 	ch.decided = true
+-	return ch.sendMessage(reject)
++	err := ch.sendMessage(reject)
++
++	// Remove the channel from the mux to prevent memory leaks.
++	// Do not call ch.close() here: no goroutine holds a reference to a
++	// rejected channel's internal channels (msg, incomingRequests), so
++	// removing it from chanList is sufficient for GC. Calling close()
++	// would race with the mux loop goroutine (handlePacket or dropAll),
++	// causing a panic from closing an already-closed channel.
++	ch.mux.chanList.remove(ch.localId)
++
++	return err
+ }
+ 
+ func (ch *channel) Read(data []byte) (int, error) {
+-- 
+2.45.4
+

--- a/SPECS/docker-buildx/CVE-2026-39832.patch
+++ b/SPECS/docker-buildx/CVE-2026-39832.patch
@@ -1,45 +1,39 @@
-From e9da9a48632aecf8d45a351274dc2f36269140c2 Mon Sep 17 00:00:00 2001
+From e3d1254f1e7e60baa086142c46174bf6d8d0fe50 Mon Sep 17 00:00:00 2001
 From: Nicola <nicola.murino@gmail.com>
-Date: Tue, 27 Jan 2026 12:15:18 +0100
-Subject: [PATCH] ssh/agent: preserve constraint extensions when adding keys
+Date: Sun, 1 Feb 2026 14:55:12 +0100
+Subject: [PATCH] ssh/agent: don't accept keys with unsupported constraints
 
-The client Add method only serialized the lifetime and confirm
-constraints and silently dropped AddedKey.ConstraintExtensions before
-sending the SSH_AGENTC_ADD_IDENTITY request. As a result the remote
-agent always received the key with no extension constraints, regardless
-of what the caller requested.
+The in-memory keyring cannot enforce constraint extensions, so silently
+accepting a key that carries them gave callers a false sense of
+restriction. Refuse keys with constraint extensions instead: a key
+whose constraints cannot be enforced must not be loaded. This behavior
+is consistent with OpenSSH.
 
-Applications that add a key believing custom constraint extensions
-(such as restrict-destination-v00@openssh.com) would be enforced
-instead loaded a completely unrestricted key into the agent. For
-example, an administrator forwarding their agent into an untrusted jump
-host and trying to limit the forwarded key with restrict-destination
-never had that restriction reach the agent: any user or compromised
-process on that host could make the agent sign arbitrary challenges.
-
-Serialize each entry in key.ConstraintExtensions as an
-agentConstrainExtension constraint so the constraints reach the agent,
-and add a round-trip regression test that verifies the extensions
-survive client serialization and server parsing.
+This is a deliberate behavior change: keyring.Add previously accepted
+and ignored ConstraintExtensions and now returns an error.
 
 This issue was found during a security audit by NCC Group Cryptography
 Services, sponsored by Teleport.
 
-Updates CVE-2026-39832
-Updates golang/go#79435
+Fixes CVE-2026-39832
+Fixes golang/go#79435
 
-Change-Id: I14c5583b106cbf0d282d2ba01e000e0f586f08c7
-Reviewed-on: https://go-review.googlesource.com/c/crypto/+/778640
-Reviewed-by: Neal Patel <neal@golang.org>
-Reviewed-by: Neal Patel <nealpatel@google.com>
-Reviewed-by: Keith Randall <khr@google.com>
-Reviewed-by: David Chase <drchase@google.com>
+Change-Id: I6ca4f1c29f8edfabb287fe07299641f70896d5fe
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/778641
+Auto-Submit: Neal Patel <nealpatel@google.com>
 LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
-Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
-Upstream-reference: https://github.com/golang/crypto/commit/a1ce0fee129597fdea8dfd58d71b6b607de6bdce.patch
+Reviewed-by: Neal Patel <neal@golang.org>
+Reviewed-by: Dmitri Shuralyov <dmitshur@google.com>
+Reviewed-by: Neal Patel <nealpatel@google.com>
+
+This CVE needs 2 commits for the fix.
+Upstream Patch reference:
+1. https://github.com/golang/crypto/commit/e3d1254f1e7e60baa086142c46174bf6d8d0fe50.patch
+2. https://github.com/golang/crypto/commit/a1ce0fee129597fdea8dfd58d71b6b607de6bdce.patch
 ---
- vendor/golang.org/x/crypto/ssh/agent/client.go | 7 +++++++
- 1 file changed, 7 insertions(+)
+ vendor/golang.org/x/crypto/ssh/agent/client.go  |  7 +++++++
+ vendor/golang.org/x/crypto/ssh/agent/keyring.go | 12 +++++++++---
+ 2 files changed, 16 insertions(+), 3 deletions(-)
 
 diff --git a/vendor/golang.org/x/crypto/ssh/agent/client.go b/vendor/golang.org/x/crypto/ssh/agent/client.go
 index 6dc73e0..d9e7f73 100644
@@ -59,6 +53,35 @@ index 6dc73e0..d9e7f73 100644
  	cert := key.Certificate
  	if cert == nil {
  		return c.insertKey(key.PrivateKey, key.Comment, constraints)
+diff --git a/vendor/golang.org/x/crypto/ssh/agent/keyring.go b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+index 21bfa87..64bc105 100644
+--- a/vendor/golang.org/x/crypto/ssh/agent/keyring.go
++++ b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+@@ -143,15 +143,21 @@ func (r *keyring) List() ([]*Key, error) {
+ 	return ids, nil
+ }
+ 
+-// Insert adds a private key to the keyring. If a certificate
+-// is given, that certificate is added as public key. Note that
+-// any constraints given are ignored.
++// Add adds a private key to the keyring. If a certificate is given, that
++// certificate is added as public key.
++//
++// Add returns an error if key contains ConstraintExtensions.
+ func (r *keyring) Add(key AddedKey) error {
+ 	r.mu.Lock()
+ 	defer r.mu.Unlock()
+ 	if r.locked {
+ 		return errLocked
+ 	}
++
++	if len(key.ConstraintExtensions) > 0 {
++		return errors.New("agent: constraint extensions are present but not supported")
++	}
++
+ 	signer, err := ssh.NewSignerFromKey(key.PrivateKey)
+ 
+ 	if err != nil {
 -- 
-2.45.4
+2.43.0
 

--- a/SPECS/docker-buildx/CVE-2026-39833.patch
+++ b/SPECS/docker-buildx/CVE-2026-39833.patch
@@ -1,0 +1,83 @@
+From 0fb843a472225645e917c84f1f9744757f0bab14 Mon Sep 17 00:00:00 2001
+From: Nicola <nicola.murino@gmail.com>
+Date: Sun, 8 Feb 2026 15:28:56 +0100
+Subject: [PATCH] ssh/agent: reject keys with unsupported confirm constraint
+
+The in-memory keyring supports the "lifetime" constraint but does not
+implement the "confirm" constraint. Previously, keyring.Add silently
+ignored ConfirmBeforeUse: the key was stored, advertised through List,
+and used for signing without any interactive confirmation, potentially
+misleading callers into believing this security measure was enforced.
+
+Return an error when ConfirmBeforeUse is set instead of silently
+downgrading the caller's security expectations. Implementing real
+confirm-before-use in an in-memory library keyring is infeasible (there
+is no UI or confirmation callback), so failing closed is the correct
+behavior; adding actual confirm support would require an API addition
+and is out of scope.
+
+This is a deliberate behavior change: keyring.Add previously accepted
+and ignored ConfirmBeforeUse and now returns an error. This change also
+updates the keyring doc comments to document the supported constraints.
+
+This issue was found during a security audit by NCC Group Cryptography
+Services, sponsored by Teleport.
+
+Fixes CVE-2026-39833
+Updates golang/go#47533
+Fixes golang/go#79436
+
+Change-Id: I1b3a286f0c1e4a4e08ac37109f7e491692ca90ae
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/778642
+Reviewed-by: Dmitri Shuralyov <dmitshur@google.com>
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Neal Patel <neal@golang.org>
+Auto-Submit: Neal Patel <nealpatel@google.com>
+LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+
+Upstream Patch reference: https://github.com/golang/crypto/commit/0fb843a472225645e917c84f1f9744757f0bab14.patch
+---
+ vendor/golang.org/x/crypto/ssh/agent/keyring.go | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/vendor/golang.org/x/crypto/ssh/agent/keyring.go b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+index 64bc105..8d8cdb7 100644
+--- a/vendor/golang.org/x/crypto/ssh/agent/keyring.go
++++ b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+@@ -32,8 +32,10 @@ type keyring struct {
+ 
+ var errLocked = errors.New("agent: locked")
+ 
+-// NewKeyring returns an Agent that holds keys in memory.  It is safe
+-// for concurrent use by multiple goroutines.
++// NewKeyring returns an Agent that holds keys in memory.  It is safe for
++// concurrent use by multiple goroutines.
++//
++// The returned Agent only supports the "lifetime" constraint.
+ func NewKeyring() Agent {
+ 	return &keyring{}
+ }
+@@ -146,7 +148,8 @@ func (r *keyring) List() ([]*Key, error) {
+ // Add adds a private key to the keyring. If a certificate is given, that
+ // certificate is added as public key.
+ //
+-// Add returns an error if key contains ConstraintExtensions.
++// Add returns an error if key contains ConstraintExtensions or
++// ConfirmBeforeUse.
+ func (r *keyring) Add(key AddedKey) error {
+ 	r.mu.Lock()
+ 	defer r.mu.Unlock()
+@@ -154,6 +157,10 @@ func (r *keyring) Add(key AddedKey) error {
+ 		return errLocked
+ 	}
+ 
++	if key.ConfirmBeforeUse {
++		return errors.New("agent: confirm before use constraint is not supported")
++	}
++
+ 	if len(key.ConstraintExtensions) > 0 {
+ 		return errors.New("agent: constraint extensions are present but not supported")
+ 	}
+-- 
+2.43.0
+

--- a/SPECS/docker-buildx/CVE-2026-39835.patch
+++ b/SPECS/docker-buildx/CVE-2026-39835.patch
@@ -1,0 +1,57 @@
+From bdabc78062a16543b86cfa71d6b2b1a5ddf2153c Mon Sep 17 00:00:00 2001
+From: Nicola Murino <nicola.murino@gmail.com>
+Date: Sun, 25 Jan 2026 15:55:17 +0100
+Subject: [PATCH] ssh: fix panic when authority callbacks are nil
+
+Previously, if CertChecker.IsHostAuthority or CertChecker.IsUserAuthority
+were left unset, calling CheckHostKey or Authenticate would result in a
+nil pointer dereference panic.
+
+This change adds checks to ensure these callbacks are defined before
+invocation, returning an error instead of panicking.
+
+This issue was found during a security audit by NCC Group Cryptography
+Services, sponsored by Teleport.
+
+Fixes golang/go#79563
+Fixes CVE-2026-39835
+
+Change-Id: I2bd9c8d76646232e49f6aedc7b5334f3825918be
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/781660
+Commit-Queue: Neal Patel <nealpatel@google.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/golang/crypto/commit/ffd87b4878fa98ca2908ec534e1a410bf095a35e.patch
+---
+ vendor/golang.org/x/crypto/ssh/certs.go | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/vendor/golang.org/x/crypto/ssh/certs.go b/vendor/golang.org/x/crypto/ssh/certs.go
+index 27d0e14..2c442e4 100644
+--- a/vendor/golang.org/x/crypto/ssh/certs.go
++++ b/vendor/golang.org/x/crypto/ssh/certs.go
+@@ -342,6 +342,9 @@ func (c *CertChecker) CheckHostKey(addr string, remote net.Addr, key PublicKey)
+ 	if cert.CertType != HostCert {
+ 		return fmt.Errorf("ssh: certificate presented as a host key has type %d", cert.CertType)
+ 	}
++	if c.IsHostAuthority == nil {
++		return errors.New("ssh: cannot verify certificate, IsHostAuthority not set")
++	}
+ 	if !c.IsHostAuthority(cert.SignatureKey, addr) {
+ 		return fmt.Errorf("ssh: no authorities for hostname: %v", addr)
+ 	}
+@@ -369,6 +372,9 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
+ 	if cert.CertType != UserCert {
+ 		return nil, fmt.Errorf("ssh: cert has type %d", cert.CertType)
+ 	}
++	if c.IsUserAuthority == nil {
++		return nil, errors.New("ssh: cannot verify certificate, IsUserAuthority not set")
++	}
+ 	if !c.IsUserAuthority(cert.SignatureKey) {
+ 		return nil, fmt.Errorf("ssh: certificate signed by unrecognized authority")
+ 	}
+-- 
+2.45.4
+

--- a/SPECS/docker-buildx/CVE-2026-42502.patch
+++ b/SPECS/docker-buildx/CVE-2026-42502.patch
@@ -1,0 +1,64 @@
+From f745972753a602dac43f7e708e010ef0659bcdf0 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Mon, 4 May 2026 14:01:10 -0700
+Subject: [PATCH] html: properly render fostered elements in foreign content
+
+When we foster elements under another parent, there are complicated
+rules about which namespace may apply. This in particular affects
+childTextNodesAreLiteral, which checks if we should be emitting raw
+text, or escaped text.
+
+In childTextNodesAreLiteral, check if there is an ancestor which has a
+different namespace. If one is found, check if it's an HTML integration
+point. If not, treat the node as if it were in its parents namespace, if
+so, treat it as HTML.
+
+Thanks to Tristan Madani for reporting this issue.
+
+Fixes CVE-2026-42502
+
+Change-Id: I0ae1780dae335e5f719d7f176cefa83670cfea3d
+Reviewed-on: https://go-review.googlesource.com/c/net/+/781701
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Nicholas Husin <nsh@golang.org>
+TryBot-Bypass: Roland Shoemaker <roland@golang.org>
+Reviewed-by: Nicholas Husin <husin@google.com>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/golang/net/commit/a8fb2fe4f7378f816302b9f2f7b8290ce512e5dd.patch
+---
+ vendor/golang.org/x/net/html/render.go | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/vendor/golang.org/x/net/html/render.go b/vendor/golang.org/x/net/html/render.go
+index f3740cc..f2aa2ad 100644
+--- a/vendor/golang.org/x/net/html/render.go
++++ b/vendor/golang.org/x/net/html/render.go
+@@ -243,8 +243,24 @@ func childTextNodesAreLiteral(n *Node) bool {
+ 	if n.Namespace != "" {
+ 		return false
+ 	}
++
+ 	switch n.Data {
+ 	case "iframe", "noembed", "noframes", "noscript", "plaintext", "script", "style", "xmp":
++		// We need to check if n is a node that was fostered from a HTML namespace
++		// into a non-HTML namespace (in which case, different rules apply to it).
++		// We do this by walking up the tree until we find a node with a non-empty
++		// namespace. If we find such a node, we also have to check if it's
++		// an HTML integration point. If it isn't, then the node we're currently
++		// looking at is foster-parented and we should return false.
++		for p := n.Parent; p != nil; p = p.Parent {
++			if p.Namespace != "" {
++				if !htmlIntegrationPoint(p) {
++					return false
++				}
++				break
++			}
++		}
++
+ 		return true
+ 	default:
+ 		return false
+-- 
+2.45.4
+

--- a/SPECS/docker-buildx/CVE-2026-46598.patch
+++ b/SPECS/docker-buildx/CVE-2026-46598.patch
@@ -1,0 +1,51 @@
+From 2374f8faaaa689288a9214dbe380b1bbbddf7285 Mon Sep 17 00:00:00 2001
+From: Neal Patel <neal@golang.org>
+Date: Thu, 21 May 2026 10:29:46 -0400
+Subject: [PATCH] ssh/agent: prevent panic on pathological ed25519 inputs
+
+parseEd25519Key and parseEd25519Cert cast wire bytes
+to ed25519.PrivateKey without checking length; a short
+payload panics at priv[32:] in Public().
+
+Fixes CVE-2026-46598
+Fixes golang/go#46598
+
+Change-Id: I127bc6a22adff1c4beb4d54533062bebc388de47
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/781360
+LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Reviewed-by: Nicholas Husin <nsh@golang.org>
+Reviewed-by: Nicholas Husin <husin@google.com>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/golang/crypto/commit/e7c36ccb477ccdb9f0f9b77025a9384de23dcc9c.patch
+---
+ vendor/golang.org/x/crypto/ssh/agent/server.go | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/vendor/golang.org/x/crypto/ssh/agent/server.go b/vendor/golang.org/x/crypto/ssh/agent/server.go
+index e35ca7c..6ec03ef 100644
+--- a/vendor/golang.org/x/crypto/ssh/agent/server.go
++++ b/vendor/golang.org/x/crypto/ssh/agent/server.go
+@@ -267,6 +267,9 @@ func parseEd25519Key(req []byte) (*AddedKey, error) {
+ 	if err := ssh.Unmarshal(req, &k); err != nil {
+ 		return nil, err
+ 	}
++	if len(k.Priv) != ed25519.PrivateKeySize {
++		return nil, fmt.Errorf("agent: bad ED25519 key size: %d", len(k.Priv))
++	}
+ 	priv := ed25519.PrivateKey(k.Priv)
+ 
+ 	addedKey := &AddedKey{PrivateKey: &priv, Comment: k.Comments}
+@@ -333,6 +336,9 @@ func parseEd25519Cert(req []byte) (*AddedKey, error) {
+ 	if err != nil {
+ 		return nil, err
+ 	}
++	if len(k.Priv) != ed25519.PrivateKeySize {
++		return nil, fmt.Errorf("agent: bad ED25519 key size: %d", len(k.Priv))
++	}
+ 	priv := ed25519.PrivateKey(k.Priv)
+ 	cert, ok := pubKey.(*ssh.Certificate)
+ 	if !ok {
+-- 
+2.45.4
+

--- a/SPECS/docker-buildx/docker-buildx.spec
+++ b/SPECS/docker-buildx/docker-buildx.spec
@@ -4,7 +4,7 @@ Summary:        A Docker CLI plugin for extended build capabilities with BuildKi
 Name:           docker-buildx
 # update "commit_hash" above when upgrading version
 Version:        0.14.0
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        ASL 2.0
 Group:          Tools/Container
 Vendor:         Microsoft Corporation
@@ -30,6 +30,12 @@ Patch15:        CVE-2026-39834.patch
 Patch16:        CVE-2026-42506.patch
 Patch17:        CVE-2026-46597.patch
 Patch18:        CVE-2026-27136.patch
+Patch19:        CVE-2026-25680.patch
+Patch20:        CVE-2026-25681.patch
+Patch21:        CVE-2026-39827.patch
+Patch22:        CVE-2026-39835.patch
+Patch23:        CVE-2026-42502.patch
+Patch24:        CVE-2026-46598.patch
 
 BuildRequires: bash
 BuildRequires: golang < 1.25
@@ -63,6 +69,9 @@ install -m 755 buildx "%{buildroot}%{_libexecdir}/docker/cli-plugins/docker-buil
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Mon Jun 01 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.14.0-14
+- Patch for CVE-2026-46598, CVE-2026-42502, CVE-2026-39835, CVE-2026-39827, CVE-2026-25681, CVE-2026-25680
+
 * Wed May 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.14.0-13
 - Patch for CVE-2026-46597, CVE-2026-42506, CVE-2026-39834, CVE-2026-39832, CVE-2026-39830, CVE-2026-39829, CVE-2026-39821, CVE-2026-27136
 

--- a/SPECS/docker-buildx/docker-buildx.spec
+++ b/SPECS/docker-buildx/docker-buildx.spec
@@ -4,7 +4,7 @@ Summary:        A Docker CLI plugin for extended build capabilities with BuildKi
 Name:           docker-buildx
 # update "commit_hash" above when upgrading version
 Version:        0.14.0
-Release:        14%{?dist}
+Release:        15%{?dist}
 License:        ASL 2.0
 Group:          Tools/Container
 Vendor:         Microsoft Corporation
@@ -36,6 +36,7 @@ Patch21:        CVE-2026-39827.patch
 Patch22:        CVE-2026-39835.patch
 Patch23:        CVE-2026-42502.patch
 Patch24:        CVE-2026-46598.patch
+Patch25:        CVE-2026-39833.patch
 
 BuildRequires: bash
 BuildRequires: golang < 1.25
@@ -69,6 +70,9 @@ install -m 755 buildx "%{buildroot}%{_libexecdir}/docker/cli-plugins/docker-buil
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Mon Jun 01 2026 Akhila Guruju <v-guakhila@microsoft.com> - 0.14.0-15
+- Patch CVE-2026-39833 and fix patch for CVE-2026-39832
+
 * Mon Jun 01 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.14.0-14
 - Patch for CVE-2026-46598, CVE-2026-42502, CVE-2026-39835, CVE-2026-39827, CVE-2026-25681, CVE-2026-25680
 


### PR DESCRIPTION
**Summary**
- Patch docker-buildx for CVE-2026-39833
- Fix Patch for CVE-2026-39832

**Patch Analysis:**

For CVE-2026-39833:
Upstream Patch reference: [https://github.com/golang/crypto/commit/0fb843a472225645e917c84f1f9744757f0bab14.patch](https://github.com/golang/crypto/commit/0fb843a472225645e917c84f1f9744757f0bab14.patch)
the files `ssh/agent/keyring_test.go` and `ssh/test/agent_unix_test.go` are not available in azl source code.
Changes for `ssh/agent/keyring.go` cleanly applies.

For CVE-2026-39832:
Patch link mentioned in the Astrolabe is only a partial fix. The patch header states that it updates the CVE rather than fully resolving it. The `keyring.go` should also be patched with the commit [ssh/agent: don't accept keys with unsupported constraints · golang/crypto@e3d1254](https://github.com/golang/crypto/commit/e3d1254f1e7e60baa086142c46174bf6d8d0fe50), as the complete fix involves two commits.
 
fixes commit: [ssh/agent: don't accept keys with unsupported constraints · golang/crypto@e3d1254](https://github.com/golang/crypto/commit/e3d1254f1e7e60baa086142c46174bf6d8d0fe50)
updates commit: [ssh/agent: preserve constraint extensions when adding keys · golang/crypto@a1ce0fe](https://github.com/golang/crypto/commit/a1ce0fee129597fdea8dfd58d71b6b607de6bdce)

So updated the existing patch by adding another commit as a fix.

**Test Methodology**
[Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1130260&view=results)
Patch applies cleanly.
<img width="827" height="180" alt="image" src="https://github.com/user-attachments/assets/d5077d2a-580b-46b1-ae18-e621ac4d5c1c" />
