### PR TITLE
feat(vm-base): add rootfiles package to image

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -141,6 +141,7 @@
         <package name="nvme-cli" />
         <package name="openssh-clients" />
         <package name="openssh-server" />
+        <package name="rootfiles" />
         <package name="rsync" />
         <package name="selinux-policy-targeted" />
         <package name="setup" />


### PR DESCRIPTION
The rootfiles package provides the default shell startup files
(.bashrc, .bash_profile, .bash_logout, .cshrc, .tcshrc) for the root
user's home directory. Without it, root's login shell falls back to
bare defaults with no sane PATH/prompt setup. Adding it brings the base
image in line with the expected out-of-box shell experience.

Fixes: [AB#20506](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20506)