### PR TITLE
fix(container-base): remove explicit user="root" from containerconfig

### DIFF
--- a/base/images/container-base/container-base.kiwi
+++ b/base/images/container-base/container-base.kiwi
@@ -58,7 +58,6 @@
                 name="microsoft/azurelinux/base/core"
                 tag="4.0"
                 additionalnames=":latest"
-                user="root"
                 workingdir="/">
                 <subcommand execute="/bin/bash"/>
             </containerconfig>
@@ -69,7 +68,6 @@
             <containerconfig
                 name="microsoft/azurelinux/base/core"
                 tag="4.0-dev"
-                user="root"
                 workingdir="/">
                 <subcommand execute="/bin/bash"/>
             </containerconfig>
@@ -81,7 +79,6 @@
                 name="microsoft/azurelinux/distroless/minimal"
                 tag="4.0"
                 additionalnames=":latest"
-                user="root"
                 workingdir="/">
                 <subcommand clear="true"/>
             </containerconfig>
@@ -93,7 +90,6 @@
                 name="microsoft/azurelinux/distroless/base"
                 tag="4.0"
                 additionalnames=":latest"
-                user="root"
                 workingdir="/">
                 <subcommand clear="true"/>
             </containerconfig>
@@ -105,7 +101,6 @@
                 name="microsoft/azurelinux/distroless/debug"
                 tag="4.0"
                 additionalnames=":latest"
-                user="root"
                 workingdir="/">
                 <subcommand clear="true"/>
             </containerconfig>


### PR DESCRIPTION
## Summary

All five `<containerconfig>` blocks in `base/images/container-base/container-base.kiwi` (core, core-dev, distroless-minimal, distroless-base, distroless-debug) declare `user="root"`, which kiwi maps to OCI `Config.User="root"` in the published image manifest.

This diverges from Azure Linux 3.0 (`Config.User=null`) and from every mainstream distro base image (Debian, Ubuntu, Alpine, UBI, Fedora), which all leave `Config.User` unset.

## Why this matters

The OCI runtime default for an unset User is uid 0, so removing the attribute does **not** change effective runtime behavior — the containers still run as root unless overridden by a downstream image.

## Repro

```
$ oras manifest fetch-config --platform linux/amd64 \
    mcr.microsoft.com/azurelinux/base/core:3.0 | jq -c '.config.User'
null

$ oras manifest fetch-config --platform linux/amd64 \
    mcr.microsoft.com/azurelinux-beta/base/core:4.0 | jq -c '.config.User'
"root"
```

After this change, the 4.0 manifest will report `null`, matching 3.0 and peer distros.

Fixes: [AB#20607](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20607)