### PR TITLE
[High] Patch rust for CVE-2026-40034, CVE-2026-5222, CVE-2026-5223

### DIFF
--- a/SPECS-EXTENDED/rust-cbindgen/rust-cbindgen.spec
+++ b/SPECS-EXTENDED/rust-cbindgen/rust-cbindgen.spec
@@ -2,7 +2,7 @@
 Summary:        Tool for generating C bindings to Rust code
 Name:           rust-cbindgen
 Version:        0.24.3
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -96,6 +96,9 @@ RUSTFLAGS=%{rustflags} cargo test --release
 %endif
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.24.3-11
+- Bump release to rebuild with rust
+
 * Tue Apr 07 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.24.3-10
 - Bump release to rebuild with rust
 

--- a/SPECS-EXTENDED/tardev-snapshotter/tardev-snapshotter.spec
+++ b/SPECS-EXTENDED/tardev-snapshotter/tardev-snapshotter.spec
@@ -3,7 +3,7 @@
 Summary: Tardev Snapshotter for containerd
 Name: tardev-snapshotter
 Version: 3.2.0.tardev1
-Release: 8%{?dist}
+Release: 9%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 Vendor: Microsoft Corporation
@@ -67,6 +67,9 @@ fi
 %config(noreplace) %{_unitdir}/%{name}.service
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.2.0.tardev1-9
+- Bump release to rebuild with rust
+
 * Tue Apr 07 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.2.0.tardev1-8
 - Bump release to rebuild with rust
 

--- a/SPECS/clamav/clamav.spec
+++ b/SPECS/clamav/clamav.spec
@@ -1,7 +1,7 @@
 Summary:        Open source antivirus engine
 Name:           clamav
 Version:        1.5.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0 AND BSD AND bzip2-1.0.4 AND GPLv2 AND LGPLv2+ AND MIT AND Public Domain AND UnRar
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -152,6 +152,9 @@ fi
 %dir %attr(-,clamav,clamav) %{_sharedstatedir}/clamav
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.5.2-3
+- Bump release to rebuild with rust
+
 * Mon Apr 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.5.2-2
 - Patch for CVE-2026-33056, CVE-2026-33055
 

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -5,7 +5,7 @@
 Name:           cloud-hypervisor
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of the KVM hypervisor and the Microsoft Hypervisor (MSHV).
 Version:        51.1.101
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -137,6 +137,9 @@ cargo build --release --target=%{rust_musl_target} %{cargo_pkg_feature_opts} %{c
 %license LICENSES/CC-BY-4.0.txt
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 51.1.101-2
+- Bump release to rebuild with rust
+
 * Mon Jun 01 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 51.1.101-1
 - Auto-upgrade to 51.1.101
 

--- a/SPECS/flux/flux.spec
+++ b/SPECS/flux/flux.spec
@@ -22,7 +22,7 @@
 Summary:        Influx data language
 Name:           flux
 Version:        0.194.5
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -146,6 +146,9 @@ RUSTFLAGS=%{rustflags} cargo test --release
 %{_includedir}/influxdata/flux.h
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.194.5-10
+- Bump release to rebuild with rust
+
 * Tue Apr 07 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.194.5-9
 - Bump release to rebuild with rust
 

--- a/SPECS/influxdb/influxdb.spec
+++ b/SPECS/influxdb/influxdb.spec
@@ -18,7 +18,7 @@
 Summary:        Scalable datastore for metrics, events, and real-time analytics
 Name:           influxdb
 Version:        2.7.5
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -169,6 +169,9 @@ go test ./...
 %{_tmpfilesdir}/influxdb.conf
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2.7.5-18
+- Bump release to rebuild with rust
+
 * Wed May 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.7.5-17
 - Patch for CVE-2026-42506, CVE-2026-39821, CVE-2026-27136, CVE-2026-42502, CVE-2026-25681, CVE-2026-25680
 

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -3,7 +3,7 @@
 
 Name:         kata-containers-cc
 Version:      3.15.0.aks0
-Release:      12%{?dist}
+Release:      13%{?dist}
 Summary:      Kata Confidential Containers package developed for Confidential Containers on AKS
 License:      ASL 2.0
 URL:          https://github.com/microsoft/kata-containers
@@ -153,6 +153,9 @@ fi
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.15.0-aks0-13
+- Bump release to rebuild with rust
+
 * Fri May 29 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 3.15.0.aks0-12
 - Patch for CVE-2026-33814
 

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -2,7 +2,7 @@
 
 Name:           kata-containers
 Version:        3.19.1.kata3
-Release:        4%{?dist}
+Release:        5%{?dist}
 
 Summary:        Kata Containers package developed for Pod Sandboxing on AKS
 License:        ASL 2.0
@@ -119,6 +119,9 @@ popd
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.19.1.kata3-5
+- Bump release to rebuild with rust
+
 * Fri May 29 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 3.19.1.kata3-4
 - Patch for CVE-2026-33814
 

--- a/SPECS/librsvg2/librsvg2.spec
+++ b/SPECS/librsvg2/librsvg2.spec
@@ -8,7 +8,7 @@
 Summary:        An SVG library based on cairo
 Name:           librsvg2
 Version:        2.58.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -125,6 +125,9 @@ rm -vrf %{buildroot}%{_docdir}
 %{_bindir}/rsvg-convert
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2.58.1-8
+- Bump release to rebuild with rust
+
 * Tue Apr 07 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2.58.1-7
 - Bump release to rebuild with rust
 

--- a/SPECS/mesa/mesa.spec
+++ b/SPECS/mesa/mesa.spec
@@ -67,7 +67,7 @@
 Name:           mesa
 Summary:        Mesa graphics libraries
 Version:        24.0.1
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -741,6 +741,9 @@ popd
 %endif
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 24.0.1-9
+- Bump release to rebuild with rust
+
 * Mon Apr 13 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 24.0.1-8
 - Patch for CVE-2026-40393
 

--- a/SPECS/netavark/netavark.spec
+++ b/SPECS/netavark/netavark.spec
@@ -11,7 +11,7 @@
 
 Name:          netavark
 Version:       1.10.3
-Release:       8%{?dist}
+Release:       9%{?dist}
 Summary:       OCI network stack
 License:       ASL 2.0 and BSD and MIT
 Vendor:        Microsoft Corporation
@@ -225,6 +225,9 @@ popd
 %{_unitdir}/%{name}-firewalld-reload.service
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.10.3-9
+- Bump release to rebuild with rust
+
 * Tue Apr 07 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.10.3-8
 - Bump release to rebuild with rust
 

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,7 +1,7 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
 Version:        2024.4
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -182,6 +182,9 @@ make check
 %{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
+* Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2024.4-11
+- Bump release to rebuild with rust
+
 * Tue Apr 21 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2024.4-10
 - Patch for CVE-2026-33056, CVE-2026-33055
 

--- a/SPECS/rust/CVE-2026-40034.patch
+++ b/SPECS/rust/CVE-2026-40034.patch
@@ -1,0 +1,104 @@
+From e3ca1e64b0bcd627c7c5d3620f891cc22d1d03c7 Mon Sep 17 00:00:00 2001
+From: Sebastian Thiel <sebastian.thiel@icloud.com>
+Date: Thu, 23 Apr 2026 16:45:43 +0800
+Subject: [PATCH] fix(gix-submodule): make sure that `update` commands won't be
+ from `.gitmodules` files
+
+This is a proper fix for what previously was also already attempted,
+but wasn't correctly implemented.
+
+Upstream Patch reference: https://github.com/GitoxideLabs/gitoxide/commit/e3ca1e64b0bcd627c7c5d3620f891cc22d1d03c7.patch
+---
+ vendor/gix-submodule-0.17.0/.cargo-checksum.json |  2 +-
+ vendor/gix-submodule-0.17.0/src/access.rs        | 16 +++++++---------
+ vendor/gix-submodule-0.20.0/.cargo-checksum.json |  2 +-
+ vendor/gix-submodule-0.20.0/src/access.rs        | 16 +++++++---------
+ 4 files changed, 16 insertions(+), 20 deletions(-)
+
+diff --git a/vendor/gix-submodule-0.17.0/.cargo-checksum.json b/vendor/gix-submodule-0.17.0/.cargo-checksum.json
+index a0208d753..491cbd99d 100644
+--- a/vendor/gix-submodule-0.17.0/.cargo-checksum.json
++++ b/vendor/gix-submodule-0.17.0/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"ab3ec1abaf6a9268e93545baf49803608a05d0b6d91b07e5ebc1350c97a268c7","Cargo.toml":"ed2807eec51202824aada3584dae26df93dc08b4f63ec83101b5a3eacf7f77ff","Cargo.toml.orig":"9b2c32c1baec946ba0053804d85ec8798795b8a5ac05a9a1749239c4f04f89c7","LICENSE-APACHE":"ee54e469a7971f7c331e03e5530db15c897417116e2ee4f1b802a02f683f5dba","LICENSE-MIT":"f9c4c77baa3828004ee54b8a4f2db2e88ed44a6237a493965bf551fac0fcb62d","src/access.rs":"0d8dc84318f7f40e83bddf2c385b164398a034be4d499597275c6d06ee4198e4","src/config.rs":"c79da16fabb8b9a9420324c680fefb43a45a2f91f7bd013e8a162bea9a2661c3","src/is_active_platform.rs":"f557a1b194b4e332f64dab6877cf2950eae14c482452975cd1e17b6ca98a8db1","src/lib.rs":"8a97de59b418727e22e194761faf6ffa0c40956ca301285e8ec51771c795c78c"},"package":"74972fe8d46ac8a09490ae1e843b4caf221c5b157c5ac17057e8e1c38417a3ac"}
+\ No newline at end of file
++{"files":{".cargo_vcs_info.json":"ab3ec1abaf6a9268e93545baf49803608a05d0b6d91b07e5ebc1350c97a268c7","Cargo.toml":"ed2807eec51202824aada3584dae26df93dc08b4f63ec83101b5a3eacf7f77ff","Cargo.toml.orig":"9b2c32c1baec946ba0053804d85ec8798795b8a5ac05a9a1749239c4f04f89c7","LICENSE-APACHE":"ee54e469a7971f7c331e03e5530db15c897417116e2ee4f1b802a02f683f5dba","LICENSE-MIT":"f9c4c77baa3828004ee54b8a4f2db2e88ed44a6237a493965bf551fac0fcb62d","src/access.rs":"f08153ebfc3f19899966f189fd6d558649df0f024774d5279d407e995337dbe3","src/config.rs":"c79da16fabb8b9a9420324c680fefb43a45a2f91f7bd013e8a162bea9a2661c3","src/is_active_platform.rs":"f557a1b194b4e332f64dab6877cf2950eae14c482452975cd1e17b6ca98a8db1","src/lib.rs":"8a97de59b418727e22e194761faf6ffa0c40956ca301285e8ec51771c795c78c"},"package":"74972fe8d46ac8a09490ae1e843b4caf221c5b157c5ac17057e8e1c38417a3ac"}
+diff --git a/vendor/gix-submodule-0.17.0/src/access.rs b/vendor/gix-submodule-0.17.0/src/access.rs
+index deba9a140..cd3e9ec3d 100644
+--- a/vendor/gix-submodule-0.17.0/src/access.rs
++++ b/vendor/gix-submodule-0.17.0/src/access.rs
+@@ -166,7 +166,12 @@ impl File {
+ 
+     /// Retrieve the `update` field of the submodule named `name`, if present.
+     pub fn update(&self, name: &BStr) -> Result<Option<Update>, config::update::Error> {
+-        let value: Update = match self.config.string(format!("submodule.{name}.update")) {
++        let mut value_is_from_modules_file = None;
++        let our_meta = self.config.meta();
++        let value: Update = match self.config.string_filter(&format!("submodule.{name}.update"), |meta| {
++            value_is_from_modules_file = Some(std::ptr::eq(meta, our_meta));
++            true
++        }) {
+             Some(v) => v.as_ref().try_into().map_err(|()| config::update::Error::Invalid {
+                 submodule: name.to_owned(),
+                 actual: v.into_owned(),
+@@ -175,14 +180,7 @@ impl File {
+         };
+ 
+         if let Update::Command(cmd) = &value {
+-            let ours = self.config.meta();
+-            let has_value_from_foreign_section = self
+-                .config
+-                .sections_by_name("submodule")
+-                .into_iter()
+-                .flatten()
+-                .any(|s| (s.header().subsection_name() == Some(name) && s.meta() as *const _ != ours as *const _));
+-            if !has_value_from_foreign_section {
++            if value_is_from_modules_file.unwrap_or_default() {
+                 return Err(config::update::Error::CommandForbiddenInModulesConfiguration {
+                     submodule: name.to_owned(),
+                     actual: cmd.to_owned(),
+diff --git a/vendor/gix-submodule-0.20.0/.cargo-checksum.json b/vendor/gix-submodule-0.20.0/.cargo-checksum.json
+index 121ede370..0bdae38d7 100644
+--- a/vendor/gix-submodule-0.20.0/.cargo-checksum.json
++++ b/vendor/gix-submodule-0.20.0/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"e5bf5de8bdb21a0b2b614540a4663716c6d478ca0f6b98bee0f4b74c1131ae47","Cargo.lock":"6153c19206300561c1ccb850eb55d74da9c47e4d3379182dff477b3b95356d52","Cargo.toml":"c8cfcb2e1dc52ec08aac03b624ccb8bebfbfa9466281aad5cf8ac40a05df00b4","Cargo.toml.orig":"ce89fc89563f177913bd57e0880d6913374e776f94c9b8b331ecdd580991568a","LICENSE-APACHE":"0d542e0c8804e39aa7f37eb00da5a762149dc682d7829451287e11b938e94594","LICENSE-MIT":"f9c4c77baa3828004ee54b8a4f2db2e88ed44a6237a493965bf551fac0fcb62d","src/access.rs":"d62e97f0b3809cf215934484b43997fd5e5539d93e1623ac5bdd8c592b465858","src/config.rs":"c79da16fabb8b9a9420324c680fefb43a45a2f91f7bd013e8a162bea9a2661c3","src/is_active_platform.rs":"ee956af6a52f418b0ef2ef8533f06877f08d7f38b73f1728465eff90a0a8b2c1","src/lib.rs":"8a97de59b418727e22e194761faf6ffa0c40956ca301285e8ec51771c795c78c"},"package":"657cc5dd43cbc7a14d9c5aaf02cfbe9c2a15d077cded3f304adb30ef78852d3e"}
+\ No newline at end of file
++{"files":{".cargo_vcs_info.json":"e5bf5de8bdb21a0b2b614540a4663716c6d478ca0f6b98bee0f4b74c1131ae47","Cargo.lock":"6153c19206300561c1ccb850eb55d74da9c47e4d3379182dff477b3b95356d52","Cargo.toml":"c8cfcb2e1dc52ec08aac03b624ccb8bebfbfa9466281aad5cf8ac40a05df00b4","Cargo.toml.orig":"ce89fc89563f177913bd57e0880d6913374e776f94c9b8b331ecdd580991568a","LICENSE-APACHE":"0d542e0c8804e39aa7f37eb00da5a762149dc682d7829451287e11b938e94594","LICENSE-MIT":"f9c4c77baa3828004ee54b8a4f2db2e88ed44a6237a493965bf551fac0fcb62d","src/access.rs":"f08153ebfc3f19899966f189fd6d558649df0f024774d5279d407e995337dbe3","src/config.rs":"c79da16fabb8b9a9420324c680fefb43a45a2f91f7bd013e8a162bea9a2661c3","src/is_active_platform.rs":"ee956af6a52f418b0ef2ef8533f06877f08d7f38b73f1728465eff90a0a8b2c1","src/lib.rs":"8a97de59b418727e22e194761faf6ffa0c40956ca301285e8ec51771c795c78c"},"package":"657cc5dd43cbc7a14d9c5aaf02cfbe9c2a15d077cded3f304adb30ef78852d3e"}
+diff --git a/vendor/gix-submodule-0.20.0/src/access.rs b/vendor/gix-submodule-0.20.0/src/access.rs
+index 2d52705c2..cd3e9ec3d 100644
+--- a/vendor/gix-submodule-0.20.0/src/access.rs
++++ b/vendor/gix-submodule-0.20.0/src/access.rs
+@@ -166,7 +166,12 @@ impl File {
+ 
+     /// Retrieve the `update` field of the submodule named `name`, if present.
+     pub fn update(&self, name: &BStr) -> Result<Option<Update>, config::update::Error> {
+-        let value: Update = match self.config.string(format!("submodule.{name}.update")) {
++        let mut value_is_from_modules_file = None;
++        let our_meta = self.config.meta();
++        let value: Update = match self.config.string_filter(&format!("submodule.{name}.update"), |meta| {
++            value_is_from_modules_file = Some(std::ptr::eq(meta, our_meta));
++            true
++        }) {
+             Some(v) => v.as_ref().try_into().map_err(|()| config::update::Error::Invalid {
+                 submodule: name.to_owned(),
+                 actual: v.into_owned(),
+@@ -175,14 +180,7 @@ impl File {
+         };
+ 
+         if let Update::Command(cmd) = &value {
+-            let ours = self.config.meta();
+-            let has_value_from_foreign_section = self
+-                .config
+-                .sections_by_name("submodule")
+-                .into_iter()
+-                .flatten()
+-                .any(|s| (s.header().subsection_name() == Some(name) && !std::ptr::eq(s.meta(), ours)));
+-            if !has_value_from_foreign_section {
++            if value_is_from_modules_file.unwrap_or_default() {
+                 return Err(config::update::Error::CommandForbiddenInModulesConfiguration {
+                     submodule: name.to_owned(),
+                     actual: cmd.to_owned(),
+-- 
+2.43.0
+

--- a/SPECS/rust/CVE-2026-40034_1.75.patch
+++ b/SPECS/rust/CVE-2026-40034_1.75.patch
@@ -1,60 +1,64 @@
-From e3ca1e64b0bcd627c7c5d3620f891cc22d1d03c7 Mon Sep 17 00:00:00 2001
-From: Sebastian Thiel <sebastian.thiel@icloud.com>
-Date: Thu, 23 Apr 2026 16:45:43 +0800
-Subject: [PATCH] fix(gix-submodule): make sure that `update` commands won't be
- from `.gitmodules` files
+From c7d64874b50b759030ec27557a19e6f826b31fa5 Mon Sep 17 00:00:00 2001
+From: Kavya Sree Kaitepalli <kkaitepalli@microsoft.com>
+Date: Mon, 8 Jun 2026 06:38:14 +0000
+Subject: [PATCH] Backport CVE-2026-40034
 
-This is a proper fix for what previously was also already attempted,
-but wasn't correctly implemented.
+fix(gix-submodule): prevent `!command` values in `update` from being
+executed when sourced from the untrusted `.gitmodules` file.
+
+The original check looked for any foreign (non-.gitmodules) config section
+for the submodule to decide the command was safe, but never verified that
+the foreign section actually had an `update` key — allowing a bypass.
+
+This backport adds `s.body().contains_key("update")` to the check, so a
+foreign section is only treated as a safe override if it actually provides
+an `update` value.
+
+The upstream fix (gitoxide e3ca1e6) uses the `string_filter` API with
+`impl FnMut`, but the vendored gix-config in Rust 1.75 uses `&mut
+MetadataFilter` (`dyn FnMut + 'static`), which does not allow closures
+capturing local variables. This approach avoids that constraint entirely.
 
 Upstream Patch reference: https://github.com/GitoxideLabs/gitoxide/commit/e3ca1e64b0bcd627c7c5d3620f891cc22d1d03c7.patch
 ---
  vendor/gix-submodule/.cargo-checksum.json |  2 +-
- vendor/gix-submodule/src/access.rs        | 16 +++++++---------
- 2 files changed, 8 insertions(+), 10 deletions(-)
+ vendor/gix-submodule/src/access.rs        | 10 +++++++---
+ 2 files changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/vendor/gix-submodule/.cargo-checksum.json b/vendor/gix-submodule/.cargo-checksum.json
-index 72c1e3993..b3d5afae3 100644
+index 72c1e3993..ca0666c4c 100644
 --- a/vendor/gix-submodule/.cargo-checksum.json
 +++ b/vendor/gix-submodule/.cargo-checksum.json
 @@ -1 +1 @@
 -{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"162ad231287795c40681f47eb516b91c706215687ea7ed7d7a98b762feb46d8c","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
 \ No newline at end of file
-+{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"d925507ea2e4474fa0a0e372865b49c94f852c61013b2af994b6953d61fc5034","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
++{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"6c42379c1767a7d273cb74ee2501e9c2b8c20d69a4c9ef8dba781d383ae5091a","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
+\ No newline at end of file
 diff --git a/vendor/gix-submodule/src/access.rs b/vendor/gix-submodule/src/access.rs
-index 4def2f42f..c17228ccf 100644
+index 4def2f42f..847b06d01 100644
 --- a/vendor/gix-submodule/src/access.rs
 +++ b/vendor/gix-submodule/src/access.rs
-@@ -166,7 +166,12 @@ impl File {
- 
-     /// Retrieve the `update` field of the submodule named `name`, if present.
-     pub fn update(&self, name: &BStr) -> Result<Option<Update>, config::update::Error> {
--        let value: Update = match self.config.string("submodule", Some(name), "update") {
-+        let mut value_is_from_modules_file = None;
-+        let our_meta = self.config.meta();
-+        let value: Update = match self.config.string_filter("submodule", Some(name), "update", &mut |meta| {
-+            value_is_from_modules_file = Some(std::ptr::eq(meta, our_meta));
-+            true
-+        }) {
-             Some(v) => v.as_ref().try_into().map_err(|()| config::update::Error::Invalid {
-                 submodule: name.to_owned(),
-                 actual: v.into_owned(),
-@@ -175,14 +180,7 @@ impl File {
-         };
+@@ -176,13 +176,17 @@ impl File {
  
          if let Update::Command(cmd) = &value {
--            let ours = self.config.meta();
+             let ours = self.config.meta();
 -            let has_value_from_foreign_section = self
--                .config
--                .sections_by_name("submodule")
--                .into_iter()
--                .flatten()
++            let value_is_from_modules_file = !self
+                 .config
+                 .sections_by_name("submodule")
+                 .into_iter()
+                 .flatten()
 -                .any(|s| (s.header().subsection_name() == Some(name) && s.meta() as *const _ != ours as *const _));
 -            if !has_value_from_foreign_section {
-+            if value_is_from_modules_file.unwrap_or_default() {
++                .any(|s| {
++                    s.header().subsection_name() == Some(name)
++                        && (s.meta() as *const _ != ours as *const _)
++                        && s.body().contains_key("update")
++                });
++            if value_is_from_modules_file {
                  return Err(config::update::Error::CommandForbiddenInModulesConfiguration {
                      submodule: name.to_owned(),
                      actual: cmd.to_owned(),
 -- 
-2.43.0
+2.45.4
 

--- a/SPECS/rust/CVE-2026-40034_1.75.patch
+++ b/SPECS/rust/CVE-2026-40034_1.75.patch
@@ -1,0 +1,60 @@
+From e3ca1e64b0bcd627c7c5d3620f891cc22d1d03c7 Mon Sep 17 00:00:00 2001
+From: Sebastian Thiel <sebastian.thiel@icloud.com>
+Date: Thu, 23 Apr 2026 16:45:43 +0800
+Subject: [PATCH] fix(gix-submodule): make sure that `update` commands won't be
+ from `.gitmodules` files
+
+This is a proper fix for what previously was also already attempted,
+but wasn't correctly implemented.
+
+Upstream Patch reference: https://github.com/GitoxideLabs/gitoxide/commit/e3ca1e64b0bcd627c7c5d3620f891cc22d1d03c7.patch
+---
+ vendor/gix-submodule/.cargo-checksum.json |  2 +-
+ vendor/gix-submodule/src/access.rs        | 16 +++++++---------
+ 2 files changed, 8 insertions(+), 10 deletions(-)
+
+diff --git a/vendor/gix-submodule/.cargo-checksum.json b/vendor/gix-submodule/.cargo-checksum.json
+index 72c1e3993..122d81a5b 100644
+--- a/vendor/gix-submodule/.cargo-checksum.json
++++ b/vendor/gix-submodule/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"162ad231287795c40681f47eb516b91c706215687ea7ed7d7a98b762feb46d8c","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"08e45bad70f3e63e06673d398e0dd97daf063afdc3a484a2a2aa8c46243ee5de","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
+diff --git a/vendor/gix-submodule/src/access.rs b/vendor/gix-submodule/src/access.rs
+index 4def2f42f..703f779eb 100644
+--- a/vendor/gix-submodule/src/access.rs
++++ b/vendor/gix-submodule/src/access.rs
+@@ -166,7 +166,12 @@ impl File {
+ 
+     /// Retrieve the `update` field of the submodule named `name`, if present.
+     pub fn update(&self, name: &BStr) -> Result<Option<Update>, config::update::Error> {
+-        let value: Update = match self.config.string("submodule", Some(name), "update") {
++        let mut value_is_from_modules_file = None;
++        let our_meta = self.config.meta();
++        let value: Update = match self.config.string_filter(&format!("submodule.{name}.update"), |meta| {
++            value_is_from_modules_file = Some(std::ptr::eq(meta, our_meta));
++            true
++        }) {
+             Some(v) => v.as_ref().try_into().map_err(|()| config::update::Error::Invalid {
+                 submodule: name.to_owned(),
+                 actual: v.into_owned(),
+@@ -175,14 +180,7 @@ impl File {
+         };
+ 
+         if let Update::Command(cmd) = &value {
+-            let ours = self.config.meta();
+-            let has_value_from_foreign_section = self
+-                .config
+-                .sections_by_name("submodule")
+-                .into_iter()
+-                .flatten()
+-                .any(|s| (s.header().subsection_name() == Some(name) && s.meta() as *const _ != ours as *const _));
+-            if !has_value_from_foreign_section {
++            if value_is_from_modules_file.unwrap_or_default() {
+                 return Err(config::update::Error::CommandForbiddenInModulesConfiguration {
+                     submodule: name.to_owned(),
+                     actual: cmd.to_owned(),
+-- 
+2.43.0
+

--- a/SPECS/rust/CVE-2026-40034_1.75.patch
+++ b/SPECS/rust/CVE-2026-40034_1.75.patch
@@ -14,15 +14,15 @@ Upstream Patch reference: https://github.com/GitoxideLabs/gitoxide/commit/e3ca1e
  2 files changed, 8 insertions(+), 10 deletions(-)
 
 diff --git a/vendor/gix-submodule/.cargo-checksum.json b/vendor/gix-submodule/.cargo-checksum.json
-index 72c1e3993..122d81a5b 100644
+index 72c1e3993..b3d5afae3 100644
 --- a/vendor/gix-submodule/.cargo-checksum.json
 +++ b/vendor/gix-submodule/.cargo-checksum.json
 @@ -1 +1 @@
 -{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"162ad231287795c40681f47eb516b91c706215687ea7ed7d7a98b762feb46d8c","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
 \ No newline at end of file
-+{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"08e45bad70f3e63e06673d398e0dd97daf063afdc3a484a2a2aa8c46243ee5de","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
++{"files":{"CHANGELOG.md":"d0e4158ec6a71783e7e2b37449b2fcc873610eb58715a44bd473eeb901da8e22","Cargo.toml":"b7d40e0d304ddf3e001ebf490a5a9a217de9daf08d99be2306f65faa02e12830","LICENSE-APACHE":"cb4780590812826851ba250f90bed0ed19506ec98f6865a0e2e20bbf62391ff9","LICENSE-MIT":"49df47913ab2beafe8dc45607877ae64198bf0eee64aaad3e82ed9e4d27424e8","src/access.rs":"d925507ea2e4474fa0a0e372865b49c94f852c61013b2af994b6953d61fc5034","src/config.rs":"2062c34f82e42517ac0d8d2d564643883249f6f44b5e8cc49f00f085ce66b31d","src/is_active_platform.rs":"fa89ba25ae7cde8f0b04bb032a27ad22919aeea7d285c003355cd9ea0d980157","src/lib.rs":"a896e4f0188322673835674b49be1b013f4aefa997fe25f34ad8d4fcc9c8d850","tests/file/baseline.rs":"8d80db5bdfcb0625153617c39fdada700921487a083391822dec4363c33fadb4","tests/file/mod.rs":"aa7b943bf8518e79df663e0de32b0266ac00bae2aa9f9c7653cf6745031a14a1","tests/fixtures/basic.sh":"22a14fd8fac3377b9a7653f60348ba0906777b2ecc23405c4b604c4834e7eec4","tests/fixtures/generated-archives/basic.tar.xz":"f1213af1023577c8c59e1a065530785e28ee10e4e04f731597aebc6a63e3dc86","tests/submodule.rs":"e42d1f34b35a3230f29ae4f04524c113b5059aa5753bbee1818e245888457ddd"},"package":"bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"}
 diff --git a/vendor/gix-submodule/src/access.rs b/vendor/gix-submodule/src/access.rs
-index 4def2f42f..703f779eb 100644
+index 4def2f42f..c17228ccf 100644
 --- a/vendor/gix-submodule/src/access.rs
 +++ b/vendor/gix-submodule/src/access.rs
 @@ -166,7 +166,12 @@ impl File {
@@ -32,7 +32,7 @@ index 4def2f42f..703f779eb 100644
 -        let value: Update = match self.config.string("submodule", Some(name), "update") {
 +        let mut value_is_from_modules_file = None;
 +        let our_meta = self.config.meta();
-+        let value: Update = match self.config.string_filter(&format!("submodule.{name}.update"), |meta| {
++        let value: Update = match self.config.string_filter("submodule", Some(name), "update", &mut |meta| {
 +            value_is_from_modules_file = Some(std::ptr::eq(meta, our_meta));
 +            true
 +        }) {

--- a/SPECS/rust/CVE-2026-5222.patch
+++ b/SPECS/rust/CVE-2026-5222.patch
@@ -1,0 +1,184 @@
+From c4d63a44234de22dc745231c416b80ed848d997f Mon Sep 17 00:00:00 2001
+From: Arlo Siemsen <arkixml@gmail.com>
+Date: Mon, 25 May 2026 09:49:43 +0200
+Subject: [PATCH] CVE-2026-5222: avoid stripping .git suffix when for non git
+ registries
+
+Upstream Patch reference: https://github.com/rust-lang/cargo/commit/c4d63a44234de22dc745231c416b80ed848d997f.patch
+---
+ .../cargo/src/cargo/sources/git/source.rs     |  7 +++
+ .../cargo/src/cargo/util/canonical_url.rs     | 44 ++++++++++---------
+ .../src/cargo/sources/git/source.rs           |  7 +++
+ .../src/cargo/util/canonical_url.rs           | 44 ++++++++++---------
+ .../cargo/src/cargo/sources/git/source.rs     |  7 +++
+ 5 files changed, 69 insertions(+), 40 deletions(-)
+
+diff --git a/src/tools/cargo/src/cargo/sources/git/source.rs b/src/tools/cargo/src/cargo/sources/git/source.rs
+index 2459b87b9..2d3ea0327 100644
+--- a/src/tools/cargo/src/cargo/sources/git/source.rs
++++ b/src/tools/cargo/src/cargo/sources/git/source.rs
+@@ -455,6 +455,13 @@ mod test {
+         assert_eq!(ident1, ident2);
+     }
+ 
++    #[test]
++    fn test_canonicalize_idents_does_not_strip_dot_git_for_sparse() {
++        let ident1 = ident(&src("sparse+https://crates.io/fake-registry"));
++        let ident2 = ident(&src("sparse+https://crates.io/fake-registry.git"));
++        assert_ne!(ident1, ident2);
++    }
++
+     fn src(s: &str) -> SourceId {
+         SourceId::for_git(&s.into_url().unwrap(), GitReference::DefaultBranch).unwrap()
+     }
+diff --git a/src/tools/cargo/src/cargo/util/canonical_url.rs b/src/tools/cargo/src/cargo/util/canonical_url.rs
+index 7516e0356..2716d2d4f 100644
+--- a/src/tools/cargo/src/cargo/util/canonical_url.rs
++++ b/src/tools/cargo/src/cargo/util/canonical_url.rs
+@@ -33,27 +33,31 @@ impl CanonicalUrl {
+             url.path_segments_mut().unwrap().pop_if_empty();
+         }
+ 
+-        // For GitHub URLs specifically, just lower-case everything. GitHub
+-        // treats both the same, but they hash differently, and we're gonna be
+-        // hashing them. This wants a more general solution, and also we're
+-        // almost certainly not using the same case conversion rules that GitHub
+-        // does. (See issue #84)
+-        if url.host_str() == Some("github.com") {
+-            url = format!("https{}", &url[url::Position::AfterScheme..])
+-                .parse()
+-                .unwrap();
+-            let path = url.path().to_lowercase();
+-            url.set_path(&path);
+-        }
++        // Perform further canonicalization specific to git registries, which
++        // do not contain a `+` specifier.
++        if !url.scheme().contains('+') {
++            // For GitHub URLs specifically, just lower-case everything. GitHub
++            // treats both the same, but they hash differently, and we're gonna be
++            // hashing them. This wants a more general solution, and also we're
++            // almost certainly not using the same case conversion rules that GitHub
++            // does. (See issue #84)
++            if url.host_str() == Some("github.com") {
++                url = format!("https{}", &url[url::Position::AfterScheme..])
++                    .parse()
++                    .unwrap();
++                let path = url.path().to_lowercase();
++                url.set_path(&path);
++            }
+ 
+-        // Repos can generally be accessed with or without `.git` extension.
+-        let needs_chopping = url.path().ends_with(".git");
+-        if needs_chopping {
+-            let last = {
+-                let last = url.path_segments().unwrap().next_back().unwrap();
+-                last[..last.len() - 4].to_owned()
+-            };
+-            url.path_segments_mut().unwrap().pop().push(&last);
++            // Repos can generally be accessed with or without `.git` extension.
++            let needs_chopping = url.path().ends_with(".git");
++            if needs_chopping {
++                let last = {
++                    let last = url.path_segments().unwrap().next_back().unwrap();
++                    last[..last.len() - 4].to_owned()
++                };
++                url.path_segments_mut().unwrap().pop().push(&last);
++            }
+         }
+ 
+         Ok(CanonicalUrl(url))
+diff --git a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/git/source.rs b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/git/source.rs
+index 1c1dc4cd7..c1299b961 100644
+--- a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/git/source.rs
++++ b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/git/source.rs
+@@ -450,6 +450,13 @@ mod test {
+         assert_eq!(ident1, ident2);
+     }
+ 
++    #[test]
++    fn test_canonicalize_idents_does_not_strip_dot_git_for_sparse() {
++        let ident1 = ident(&src("sparse+https://crates.io/fake-registry"));
++        let ident2 = ident(&src("sparse+https://crates.io/fake-registry.git"));
++        assert_ne!(ident1, ident2);
++    }
++
+     fn src(s: &str) -> SourceId {
+         SourceId::for_git(&s.into_url().unwrap(), GitReference::DefaultBranch).unwrap()
+     }
+diff --git a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/util/canonical_url.rs b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/util/canonical_url.rs
+index 7516e0356..2716d2d4f 100644
+--- a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/util/canonical_url.rs
++++ b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/util/canonical_url.rs
+@@ -33,27 +33,31 @@ impl CanonicalUrl {
+             url.path_segments_mut().unwrap().pop_if_empty();
+         }
+ 
+-        // For GitHub URLs specifically, just lower-case everything. GitHub
+-        // treats both the same, but they hash differently, and we're gonna be
+-        // hashing them. This wants a more general solution, and also we're
+-        // almost certainly not using the same case conversion rules that GitHub
+-        // does. (See issue #84)
+-        if url.host_str() == Some("github.com") {
+-            url = format!("https{}", &url[url::Position::AfterScheme..])
+-                .parse()
+-                .unwrap();
+-            let path = url.path().to_lowercase();
+-            url.set_path(&path);
+-        }
++        // Perform further canonicalization specific to git registries, which
++        // do not contain a `+` specifier.
++        if !url.scheme().contains('+') {
++            // For GitHub URLs specifically, just lower-case everything. GitHub
++            // treats both the same, but they hash differently, and we're gonna be
++            // hashing them. This wants a more general solution, and also we're
++            // almost certainly not using the same case conversion rules that GitHub
++            // does. (See issue #84)
++            if url.host_str() == Some("github.com") {
++                url = format!("https{}", &url[url::Position::AfterScheme..])
++                    .parse()
++                    .unwrap();
++                let path = url.path().to_lowercase();
++                url.set_path(&path);
++            }
+ 
+-        // Repos can generally be accessed with or without `.git` extension.
+-        let needs_chopping = url.path().ends_with(".git");
+-        if needs_chopping {
+-            let last = {
+-                let last = url.path_segments().unwrap().next_back().unwrap();
+-                last[..last.len() - 4].to_owned()
+-            };
+-            url.path_segments_mut().unwrap().pop().push(&last);
++            // Repos can generally be accessed with or without `.git` extension.
++            let needs_chopping = url.path().ends_with(".git");
++            if needs_chopping {
++                let last = {
++                    let last = url.path_segments().unwrap().next_back().unwrap();
++                    last[..last.len() - 4].to_owned()
++                };
++                url.path_segments_mut().unwrap().pop().push(&last);
++            }
+         }
+ 
+         Ok(CanonicalUrl(url))
+diff --git a/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/git/source.rs b/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/git/source.rs
+index 13e266b04..867561bcc 100644
+--- a/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/git/source.rs
++++ b/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/git/source.rs
+@@ -256,6 +256,13 @@ mod test {
+         assert_eq!(ident1, ident2);
+     }
+ 
++    #[test]
++    fn test_canonicalize_idents_does_not_strip_dot_git_for_sparse() {
++        let ident1 = ident(&url("sparse+https://crates.io/fake-registry"));
++        let ident2 = ident(&url("sparse+https://crates.io/fake-registry.git"));
++        assert_ne!(ident1, ident2);
++    }
++
+     #[test]
+     fn test_canonicalize_cannot_be_a_base_urls() {
+         assert!(ident(&url("github.com:PistonDevelopers/piston")).is_err());
+-- 
+2.43.0
+

--- a/SPECS/rust/CVE-2026-5222_1.75.patch
+++ b/SPECS/rust/CVE-2026-5222_1.75.patch
@@ -1,0 +1,89 @@
+From c4d63a44234de22dc745231c416b80ed848d997f Mon Sep 17 00:00:00 2001
+From: Arlo Siemsen <arkixml@gmail.com>
+Date: Mon, 25 May 2026 09:49:43 +0200
+Subject: [PATCH] CVE-2026-5222: avoid stripping .git suffix when for non git
+ registries
+
+Upstream Patch reference: https://github.com/rust-lang/cargo/commit/c4d63a44234de22dc745231c416b80ed848d997f.patch
+---
+ .../cargo/src/cargo/sources/git/source.rs     |  7 +++
+ .../cargo/src/cargo/util/canonical_url.rs     | 44 ++++++++++---------
+ 2 files changed, 31 insertions(+), 20 deletions(-)
+
+diff --git a/src/tools/cargo/src/cargo/sources/git/source.rs b/src/tools/cargo/src/cargo/sources/git/source.rs
+index a75c1ec6d..1c8dbc836 100644
+--- a/src/tools/cargo/src/cargo/sources/git/source.rs
++++ b/src/tools/cargo/src/cargo/sources/git/source.rs
+@@ -377,6 +377,13 @@ mod test {
+         assert_eq!(ident1, ident2);
+     }
+ 
++    #[test]
++    fn test_canonicalize_idents_does_not_strip_dot_git_for_sparse() {
++        let ident1 = ident(&src("sparse+https://crates.io/fake-registry"));
++        let ident2 = ident(&src("sparse+https://crates.io/fake-registry.git"));
++        assert_ne!(ident1, ident2);
++    }
++
+     fn src(s: &str) -> SourceId {
+         SourceId::for_git(&s.into_url().unwrap(), GitReference::DefaultBranch).unwrap()
+     }
+diff --git a/src/tools/cargo/src/cargo/util/canonical_url.rs b/src/tools/cargo/src/cargo/util/canonical_url.rs
+index 7516e0356..2716d2d4f 100644
+--- a/src/tools/cargo/src/cargo/util/canonical_url.rs
++++ b/src/tools/cargo/src/cargo/util/canonical_url.rs
+@@ -33,27 +33,31 @@ impl CanonicalUrl {
+             url.path_segments_mut().unwrap().pop_if_empty();
+         }
+ 
+-        // For GitHub URLs specifically, just lower-case everything. GitHub
+-        // treats both the same, but they hash differently, and we're gonna be
+-        // hashing them. This wants a more general solution, and also we're
+-        // almost certainly not using the same case conversion rules that GitHub
+-        // does. (See issue #84)
+-        if url.host_str() == Some("github.com") {
+-            url = format!("https{}", &url[url::Position::AfterScheme..])
+-                .parse()
+-                .unwrap();
+-            let path = url.path().to_lowercase();
+-            url.set_path(&path);
+-        }
++        // Perform further canonicalization specific to git registries, which
++        // do not contain a `+` specifier.
++        if !url.scheme().contains('+') {
++            // For GitHub URLs specifically, just lower-case everything. GitHub
++            // treats both the same, but they hash differently, and we're gonna be
++            // hashing them. This wants a more general solution, and also we're
++            // almost certainly not using the same case conversion rules that GitHub
++            // does. (See issue #84)
++            if url.host_str() == Some("github.com") {
++                url = format!("https{}", &url[url::Position::AfterScheme..])
++                    .parse()
++                    .unwrap();
++                let path = url.path().to_lowercase();
++                url.set_path(&path);
++            }
+ 
+-        // Repos can generally be accessed with or without `.git` extension.
+-        let needs_chopping = url.path().ends_with(".git");
+-        if needs_chopping {
+-            let last = {
+-                let last = url.path_segments().unwrap().next_back().unwrap();
+-                last[..last.len() - 4].to_owned()
+-            };
+-            url.path_segments_mut().unwrap().pop().push(&last);
++            // Repos can generally be accessed with or without `.git` extension.
++            let needs_chopping = url.path().ends_with(".git");
++            if needs_chopping {
++                let last = {
++                    let last = url.path_segments().unwrap().next_back().unwrap();
++                    last[..last.len() - 4].to_owned()
++                };
++                url.path_segments_mut().unwrap().pop().push(&last);
++            }
+         }
+ 
+         Ok(CanonicalUrl(url))
+-- 
+2.43.0
+

--- a/SPECS/rust/CVE-2026-5223.patch
+++ b/SPECS/rust/CVE-2026-5223.patch
@@ -1,0 +1,209 @@
+From 285cebf58911eca5b7f177f5d0b1c53e1f646577 Mon Sep 17 00:00:00 2001
+From: Josh Triplett <josh@joshtriplett.org>
+Date: Mon, 30 Mar 2026 10:35:55 -0700
+Subject: [PATCH] CVE-2026-5223: prohibit unpacking symlinks and other
+ unexpected entries
+
+Cargo has historically not allowed creating .crate packages containing
+symlinks. (It packages the symlink target in place of the symlink,
+instead.) So, any package containing a symlink would have to be
+hand-constructed. Such packages are also not allowed on crates.io, so it
+could only come from an alternate registry.
+
+Rather than dealing with symlink traversal attacks when unpacking a
+crate, just prohibit symlinks entirely.
+
+In the process, also prohibit other kinds of unusual entries. As an
+exception, allow character devices but warn about them, because some
+exist in crates on crates.io.
+
+Upstream Patch reference: https://github.com/rust-lang/cargo/commit/285cebf58911eca5b7f177f5d0b1c53e1f646577.patch
+---
+ .../cargo/src/cargo/sources/registry/mod.rs   |  8 +++++
+ src/tools/cargo/tests/testsuite/registry.rs   | 31 ++++++++++---------
+ .../src/cargo/sources/registry/mod.rs         | 11 ++++++-
+ .../cargo-0.87.1/tests/testsuite/registry.rs  | 31 ++++++++++---------
+ .../cargo/src/cargo/sources/registry/mod.rs   | 10 +++++-
+ 5 files changed, 59 insertions(+), 32 deletions(-)
+
+diff --git a/src/tools/cargo/src/cargo/sources/registry/mod.rs b/src/tools/cargo/src/cargo/sources/registry/mod.rs
+index 69bb2d875..6f8005866 100644
+--- a/src/tools/cargo/src/cargo/sources/registry/mod.rs
++++ b/src/tools/cargo/src/cargo/sources/registry/mod.rs
+@@ -1072,6 +1072,14 @@ fn unpack(
+             )
+         }
+ 
++        // Prevent unpacking symlinks and other unexpected entry types
++        match entry.header().entry_type() {
++            EntryType::Regular | EntryType::Directory => {}
++            t => anyhow::bail!(
++                "invalid tarball downloaded, contains an entry at {entry_path:?} with invalid type {t:?}",
++            ),
++        }
++
+         // Prevent unpacking the lockfile from the crate itself.
+         if entry_path
+             .file_name()
+diff --git a/src/tools/cargo/tests/testsuite/registry.rs b/src/tools/cargo/tests/testsuite/registry.rs
+index 60a01b045..906047af3 100644
+--- a/src/tools/cargo/tests/testsuite/registry.rs
++++ b/src/tools/cargo/tests/testsuite/registry.rs
+@@ -3273,8 +3273,7 @@ fn package_lock_inside_package_is_overwritten() {
+ }
+ 
+ #[cargo_test]
+-fn package_lock_as_a_symlink_inside_package_is_overwritten() {
+-    let registry = registry::init();
++fn package_lock_as_a_symlink_inside_package_is_invalid() {
+     let p = project()
+         .file(
+             "Cargo.toml",
+@@ -3297,21 +3296,23 @@ fn package_lock_as_a_symlink_inside_package_is_overwritten() {
+         .symlink(".cargo-ok", "src/lib.rs")
+         .publish();
+ 
+-    p.cargo("check").run();
++    p.cargo("check")
++        .with_status(101)
++        .with_stderr_data(str![[r#"
++[UPDATING] `dummy-registry` index
++[LOCKING] 1 package to latest compatible version
++[DOWNLOADING] crates ...
++[DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
++[ERROR] failed to download replaced source registry `crates-io`
+ 
+-    let id = SourceId::for_registry(registry.index_url()).unwrap();
+-    let hash = cargo::util::hex::short_hash(&id);
+-    let pkg_root = paths::cargo_home()
+-        .join("registry")
+-        .join("src")
+-        .join(format!("-{}", hash))
+-        .join("bar-0.0.1");
+-    let ok = pkg_root.join(".cargo-ok");
+-    let librs = pkg_root.join("src/lib.rs");
++Caused by:
++  failed to unpack package `bar v0.0.1 (registry `dummy-registry`)`
+ 
+-    // Is correctly overwritten and doesn't affect the file linked to
+-    assert_eq!(ok.metadata().unwrap().len(), 7);
+-    assert_eq!(fs::read_to_string(librs).unwrap(), "pub fn f() {}");
++Caused by:
++  invalid tarball downloaded, contains an entry at "bar-0.0.1/.cargo-ok" with invalid type Symlink
++
++"#]])
++        .run();
+ }
+ 
+ #[cargo_test]
+diff --git a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/registry/mod.rs b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/registry/mod.rs
+index bf10f81fc..313258fc9 100644
+--- a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/registry/mod.rs
++++ b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/src/cargo/sources/registry/mod.rs
+@@ -197,7 +197,7 @@ use cargo_util::paths::{self, exclude_from_backups_and_indexing};
+ use flate2::read::GzDecoder;
+ use serde::Deserialize;
+ use serde::Serialize;
+-use tar::Archive;
++use tar::{Archive, EntryType};
+ use tracing::debug;
+ 
+ use crate::core::dependency::Dependency;
+@@ -662,6 +662,15 @@ impl<'gctx> RegistrySource<'gctx> {
+                     prefix
+                 )
+             }
++
++            // Prevent unpacking symlinks and other unexpected entry types
++            match entry.header().entry_type() {
++                EntryType::Regular | EntryType::Directory => {}
++                t => anyhow::bail!(
++                    "invalid tarball downloaded, contains an entry at {entry_path:?} with invalid type {t:?}",
++                ),
++            }
++
+             // Prevent unpacking the lockfile from the crate itself.
+             if entry_path
+                 .file_name()
+diff --git a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/tests/testsuite/registry.rs b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/tests/testsuite/registry.rs
+index e4c23f5c3..3bf48299e 100644
+--- a/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/tests/testsuite/registry.rs
++++ b/src/tools/rustc-perf/collector/compile-benchmarks/cargo-0.87.1/tests/testsuite/registry.rs
+@@ -3286,8 +3286,7 @@ fn package_lock_inside_package_is_overwritten() {
+ }
+ 
+ #[cargo_test]
+-fn package_lock_as_a_symlink_inside_package_is_overwritten() {
+-    let registry = registry::init();
++fn package_lock_as_a_symlink_inside_package_is_invalid() {
+     let p = project()
+         .file(
+             "Cargo.toml",
+@@ -3310,21 +3309,23 @@ fn package_lock_as_a_symlink_inside_package_is_overwritten() {
+         .symlink(".cargo-ok", "src/lib.rs")
+         .publish();
+ 
+-    p.cargo("check").run();
++    p.cargo("check")
++        .with_status(101)
++        .with_stderr_data(str![[r#"
++[UPDATING] `dummy-registry` index
++[LOCKING] 1 package to latest compatible version
++[DOWNLOADING] crates ...
++[DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
++[ERROR] failed to download replaced source registry `crates-io`
+ 
+-    let id = SourceId::for_registry(registry.index_url()).unwrap();
+-    let hash = cargo::util::hex::short_hash(&id);
+-    let pkg_root = paths::cargo_home()
+-        .join("registry")
+-        .join("src")
+-        .join(format!("-{}", hash))
+-        .join("bar-0.0.1");
+-    let ok = pkg_root.join(".cargo-ok");
+-    let librs = pkg_root.join("src/lib.rs");
++Caused by:
++  failed to unpack package `bar v0.0.1 (registry `dummy-registry`)`
+ 
+-    // Is correctly overwritten and doesn't affect the file linked to
+-    assert_eq!(ok.metadata().unwrap().len(), 7);
+-    assert_eq!(fs::read_to_string(librs).unwrap(), "pub fn f() {}");
++Caused by:
++  invalid tarball downloaded, contains an entry at "bar-0.0.1/.cargo-ok" with invalid type Symlink
++
++"#]])
++        .run();
+ }
+ 
+ #[cargo_test]
+diff --git a/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/registry/mod.rs b/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/registry/mod.rs
+index c967e2ebc..1c2766c23 100644
+--- a/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/registry/mod.rs
++++ b/src/tools/rustc-perf/collector/compile-benchmarks/cargo/src/cargo/sources/registry/mod.rs
+@@ -167,7 +167,7 @@ use std::path::{PathBuf, Path};
+ use flate2::read::GzDecoder;
+ use semver::Version;
+ use serde::de;
+-use tar::Archive;
++use tar::{Archive, EntryType};
+ 
+ use core::{Source, SourceId, PackageId, Package, Summary, Registry};
+ use core::dependency::{Dependency, Kind};
+@@ -333,6 +333,14 @@ impl<'cfg> RegistrySource<'cfg> {
+                                    entry_path, prefix).into())
+             }
+ 
++            // Prevent unpacking symlinks and other unexpected entry types
++            match entry.header().entry_type() {
++                EntryType::Regular | EntryType::Directory => {}
++                t => anyhow::bail!(
++                    "invalid tarball downloaded, contains an entry at {entry_path:?} with invalid type {t:?}",
++                ),
++            }
++
+             // Once that's verified, unpack the entry as usual.
+             entry.unpack_in(parent).chain_err(|| {
+                 format!("failed to unpack entry at `{}`", entry_path.display())
+-- 
+2.43.0
+

--- a/SPECS/rust/CVE-2026-5223.patch
+++ b/SPECS/rust/CVE-2026-5223.patch
@@ -18,18 +18,28 @@ exception, allow character devices but warn about them, because some
 exist in crates on crates.io.
 
 Upstream Patch reference: https://github.com/rust-lang/cargo/commit/285cebf58911eca5b7f177f5d0b1c53e1f646577.patch
+
 ---
- .../cargo/src/cargo/sources/registry/mod.rs   |  8 +++++
+ .../cargo/src/cargo/sources/registry/mod.rs   | 10 +++++-
  src/tools/cargo/tests/testsuite/registry.rs   | 31 ++++++++++---------
  .../src/cargo/sources/registry/mod.rs         | 11 ++++++-
  .../cargo-0.87.1/tests/testsuite/registry.rs  | 31 ++++++++++---------
  .../cargo/src/cargo/sources/registry/mod.rs   | 10 +++++-
- 5 files changed, 59 insertions(+), 32 deletions(-)
+ 5 files changed, 60 insertions(+), 33 deletions(-)
 
 diff --git a/src/tools/cargo/src/cargo/sources/registry/mod.rs b/src/tools/cargo/src/cargo/sources/registry/mod.rs
-index 69bb2d875..6f8005866 100644
+index 69bb2d875..dc587473c 100644
 --- a/src/tools/cargo/src/cargo/sources/registry/mod.rs
 +++ b/src/tools/cargo/src/cargo/sources/registry/mod.rs
+@@ -196,7 +196,7 @@ use cargo_util::paths::{self, exclude_from_backups_and_indexing};
+ use flate2::read::GzDecoder;
+ use serde::Deserialize;
+ use serde::Serialize;
+-use tar::Archive;
++use tar::{Archive, EntryType};
+ use tracing::debug;
+ 
+ use crate::core::dependency::Dependency;
 @@ -1072,6 +1072,14 @@ fn unpack(
              )
          }

--- a/SPECS/rust/CVE-2026-5223_1.75.patch
+++ b/SPECS/rust/CVE-2026-5223_1.75.patch
@@ -1,0 +1,108 @@
+From 285cebf58911eca5b7f177f5d0b1c53e1f646577 Mon Sep 17 00:00:00 2001
+From: Josh Triplett <josh@joshtriplett.org>
+Date: Mon, 30 Mar 2026 10:35:55 -0700
+Subject: [PATCH] CVE-2026-5223: prohibit unpacking symlinks and other
+ unexpected entries
+
+Cargo has historically not allowed creating .crate packages containing
+symlinks. (It packages the symlink target in place of the symlink,
+instead.) So, any package containing a symlink would have to be
+hand-constructed. Such packages are also not allowed on crates.io, so it
+could only come from an alternate registry.
+
+Rather than dealing with symlink traversal attacks when unpacking a
+crate, just prohibit symlinks entirely.
+
+In the process, also prohibit other kinds of unusual entries. As an
+exception, allow character devices but warn about them, because some
+exist in crates on crates.io.
+
+Upstream Patch reference: https://github.com/rust-lang/cargo/commit/285cebf58911eca5b7f177f5d0b1c53e1f646577.patch
+---
+ .../cargo/src/cargo/sources/registry/mod.rs   | 11 ++++++-
+ src/tools/cargo/tests/testsuite/registry.rs   | 31 ++++++++++---------
+ 2 files changed, 26 insertions(+), 16 deletions(-)
+
+diff --git a/src/tools/cargo/src/cargo/sources/registry/mod.rs b/src/tools/cargo/src/cargo/sources/registry/mod.rs
+index 7ee461edd..66c9007a5 100644
+--- a/src/tools/cargo/src/cargo/sources/registry/mod.rs
++++ b/src/tools/cargo/src/cargo/sources/registry/mod.rs
+@@ -197,7 +197,7 @@ use cargo_util::paths::{self, exclude_from_backups_and_indexing};
+ use flate2::read::GzDecoder;
+ use serde::Deserialize;
+ use serde::Serialize;
+-use tar::Archive;
++use tar::{Archive, EntryType};
+ use tracing::debug;
+ 
+ use crate::core::dependency::Dependency;
+@@ -636,6 +636,15 @@ impl<'cfg> RegistrySource<'cfg> {
+                     prefix
+                 )
+             }
++
++            // Prevent unpacking symlinks and other unexpected entry types
++            match entry.header().entry_type() {
++                EntryType::Regular | EntryType::Directory => {}
++                t => anyhow::bail!(
++                    "invalid tarball downloaded, contains an entry at {entry_path:?} with invalid type {t:?}",
++                ),
++            }
++
+             // Prevent unpacking the lockfile from the crate itself.
+             if entry_path
+                 .file_name()
+diff --git a/src/tools/cargo/tests/testsuite/registry.rs b/src/tools/cargo/tests/testsuite/registry.rs
+index b5dff2746..178bfff66 100644
+--- a/src/tools/cargo/tests/testsuite/registry.rs
++++ b/src/tools/cargo/tests/testsuite/registry.rs
+@@ -2550,8 +2550,7 @@ fn package_lock_inside_package_is_overwritten() {
+ }
+ 
+ #[cargo_test]
+-fn package_lock_as_a_symlink_inside_package_is_overwritten() {
+-    let registry = registry::init();
++fn package_lock_as_a_symlink_inside_package_is_invalid() {
+     let p = project()
+         .file(
+             "Cargo.toml",
+@@ -2573,21 +2572,23 @@ fn package_lock_as_a_symlink_inside_package_is_overwritten() {
+         .symlink(".cargo-ok", "src/lib.rs")
+         .publish();
+ 
+-    p.cargo("check").run();
++    p.cargo("check")
++        .with_status(101)
++        .with_stderr_data(str![[r#"
++[UPDATING] `dummy-registry` index
++[LOCKING] 1 package to latest compatible version
++[DOWNLOADING] crates ...
++[DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
++[ERROR] failed to download replaced source registry `crates-io`
+ 
+-    let id = SourceId::for_registry(registry.index_url()).unwrap();
+-    let hash = cargo::util::hex::short_hash(&id);
+-    let pkg_root = cargo_home()
+-        .join("registry")
+-        .join("src")
+-        .join(format!("-{}", hash))
+-        .join("bar-0.0.1");
+-    let ok = pkg_root.join(".cargo-ok");
+-    let librs = pkg_root.join("src/lib.rs");
++Caused by:
++  failed to unpack package `bar v0.0.1 (registry `dummy-registry`)`
+ 
+-    // Is correctly overwritten and doesn't affect the file linked to
+-    assert_eq!(ok.metadata().unwrap().len(), 7);
+-    assert_eq!(fs::read_to_string(librs).unwrap(), "pub fn f() {}");
++Caused by:
++  invalid tarball downloaded, contains an entry at "bar-0.0.1/.cargo-ok" with invalid type Symlink
++
++"#]])
++        .run();
+ }
+ 
+ #[cargo_test]
+-- 
+2.43.0
+

--- a/SPECS/rust/rust-1.75.spec
+++ b/SPECS/rust/rust-1.75.spec
@@ -9,7 +9,7 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.75.0
-Release:        29%{?dist}
+Release:        30%{?dist}
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -54,6 +54,9 @@ Patch9:         CVE-2023-48795_1.75.patch
 Patch10:        CVE-2026-33056_1.75.patch
 Patch11:        CVE-2026-33055_1.75.patch
 Patch12:        CVE-2026-34743_1.75.patch
+Patch13:        CVE-2026-5222_1.75.patch
+Patch14:        CVE-2026-5223_1.75.patch
+Patch15:        CVE-2026-40034_1.75.patch
 
 BuildRequires:  binutils
 BuildRequires:  cmake
@@ -188,6 +191,9 @@ rm %{buildroot}%{_bindir}/*.old
 %{_mandir}/man1/*
 
 %changelog
+* Thu Jun 04 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.75.0-30
+- Add patch for CVE-2026-5222,CVE-2026-5223 & CVE-2026-40034
+
 * Thu May 07 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.75.0-29
 - Bump to rebuild with updated glibc
 

--- a/SPECS/rust/rust-1.75.spec
+++ b/SPECS/rust/rust-1.75.spec
@@ -192,7 +192,7 @@ rm %{buildroot}%{_bindir}/*.old
 
 %changelog
 * Thu Jun 04 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.75.0-30
-- Add patch for CVE-2026-5222,CVE-2026-5223 & CVE-2026-40034
+- Add patch for CVE-2026-5222, CVE-2026-5223 & CVE-2026-40034
 
 * Thu May 07 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.75.0-29
 - Bump to rebuild with updated glibc

--- a/SPECS/rust/rust-1.75.spec
+++ b/SPECS/rust/rust-1.75.spec
@@ -56,7 +56,7 @@ Patch11:        CVE-2026-33055_1.75.patch
 Patch12:        CVE-2026-34743_1.75.patch
 Patch13:        CVE-2026-5222_1.75.patch
 Patch14:        CVE-2026-5223_1.75.patch
-Patch15:        CVE-2026-40034_1.75.patch
+Patch15:        0001-Backport-CVE-2026-40034.patch
 
 BuildRequires:  binutils
 BuildRequires:  cmake
@@ -192,7 +192,8 @@ rm %{buildroot}%{_bindir}/*.old
 
 %changelog
 * Thu Jun 04 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.75.0-30
-- Add patch for CVE-2026-5222, CVE-2026-5223 & CVE-2026-40034
+- Add patch for CVE-2026-5222, CVE-2026-5223
+- Backport patch for CVE-2026-40034
 
 * Thu May 07 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.75.0-29
 - Bump to rebuild with updated glibc

--- a/SPECS/rust/rust-1.75.spec
+++ b/SPECS/rust/rust-1.75.spec
@@ -56,7 +56,7 @@ Patch11:        CVE-2026-33055_1.75.patch
 Patch12:        CVE-2026-34743_1.75.patch
 Patch13:        CVE-2026-5222_1.75.patch
 Patch14:        CVE-2026-5223_1.75.patch
-Patch15:        0001-Backport-CVE-2026-40034.patch
+Patch15:        CVE-2026-40034_1.75.patch
 
 BuildRequires:  binutils
 BuildRequires:  cmake

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -9,7 +9,7 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.90.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -57,6 +57,10 @@ Patch12:        CVE-2026-2006.patch
 Patch13:        CVE-2026-33056.patch
 Patch14:        CVE-2026-33055.patch
 Patch15:        CVE-2026-34743.patch
+Patch16:        CVE-2026-5222.patch
+Patch17:        CVE-2026-5223.patch
+Patch18:        CVE-2026-40034.patch
+
 BuildRequires:  binutils
 BuildRequires:  cmake
 # make sure rust relies on curl from CBL-Mariner (instead of using its vendored flavor)
@@ -194,6 +198,9 @@ rm %{buildroot}%{_docdir}/docs/html/.lock
 %{_mandir}/man1/*
 
 %changelog
+* Thu Jun 04 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.90.0-9
+- Add patch for CVE-2026-5222, CVE-2026-5223 & CVE-2026-40034
+
 * Thu May 07 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.90.0-8
 - Bump to rebuild with updated glibc
 


### PR DESCRIPTION
Summary
Patch rust for CVE-2026-40034, CVE-2026-5222 and CVE-2026-5223
- Backported CVE-2026-40034 by adapting the upstream gix-submodule fix to the older vendored gix-config::string_filter API in Rust 1.75

Change Log
- modified:   SPECS-EXTENDED/rust-cbindgen/rust-cbindgen.spec
- modified:   SPECS-EXTENDED/tardev-snapshotter/tardev-snapshotter.spec
- modified:   SPECS/clamav/clamav.spec
- modified:   SPECS/cloud-hypervisor/cloud-hypervisor.spec
- modified:   SPECS/flux/flux.spec
- modified:   SPECS/influxdb/influxdb.spec
- modified:   SPECS/kata-containers-cc/kata-containers-cc.spec
- modified:   SPECS/kata-containers/kata-containers.spec
- modified:   SPECS/librsvg2/librsvg2.spec
- modified:   SPECS/mesa/mesa.spec
- modified:   SPECS/netavark/netavark.spec
- modified:   SPECS/rpm-ostree/rpm-ostree.spec
- new file:   SPECS/rust/CVE-2026-40034.patch
- new file:   SPECS/rust/CVE-2026-5222.patch
- new file:   SPECS/rust/CVE-2026-5223.patch
- new file:   SPECS/rust/CVE-2026-40034_1.75.patch
- new file:   SPECS/rust/CVE-2026-5222_1.75.patch
- new file:   SPECS/rust/CVE-2026-5223_1.75.patch
- modified:   SPECS/rust/rust-1.75.spec
- modified:   SPECS/rust/rust.spec

Does this affect the toolchain?
NO

Links to CVEs
https://nvd.nist.gov/vuln/detail/CVE-2026-5222
https://nvd.nist.gov/vuln/detail/CVE-2026-5223
https://nvd.nist.gov/vuln/detail/CVE-2026-40034

Test Methodology
Buddy build: 
