### PR TITLE
Fix waagent-network-setup.service failure and update to teardown the specific interface.

### DIFF
--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -1,7 +1,7 @@
 Summary:        The Windows Azure Linux Agent
 Name:           WALinuxAgent
 Version:        2.11.1.4
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -113,6 +113,9 @@ python3 setup.py check && python3 setup.py test
 
 
 %changelog
+* Thu Jun 04 2026 Mayank Singh <mayansingh@microsoft.com> - 2.11.1.4-5
+- Fix waagent-network-setup.service failure and update to teardown the specific interface.
+
 * Tue Apr 21 2026 Mayank Singh <mayansingh@microsoft.com> - 2.11.1.4-4
 - Add support for Azure Container Linux
 

--- a/SPECS/WALinuxAgent/acl-support.patch
+++ b/SPECS/WALinuxAgent/acl-support.patch
@@ -10,21 +10,22 @@ Subject: [PATCH] add support for Azure Container Linux
 - Add retry logic in mount_resource_disk() for VMBus storage race.
 - Add ACL-specific waagent.conf, waagent.service, and sysext drop-in.
 - Document the sysext drop-in (10-waagent-sysext.conf).
-- Patch persist_firewall_rules.py service template to add After=systemd-sysext.service
-  so the dynamically-created waagent-network-setup.service waits for sysext merge.
+- Patch persist_firewall_rules.py __set_service_unit_file() to conditionally add
+  After=systemd-sysext.service for ACL so the dynamically-created
+  waagent-network-setup.service waits for sysext merge.
 - Add ACL owner entry in CODEOWNERS.
 ---
  CODEOWNERS                               |  7 +++
- azurelinuxagent/common/osutil/acl.py     | 79 ++++++++++++++++++++++++
+ azurelinuxagent/common/osutil/acl.py     | 98 ++++++++++++++++++++++++++++
  azurelinuxagent/common/osutil/factory.py |  4 ++
  azurelinuxagent/common/version.py        |  8 +++
- azurelinuxagent/ga/persist_firewall_rules.py |  1 +
+ azurelinuxagent/ga/persist_firewall_rules.py | 19 +++++++++++++------
  config/acl/waagent.conf                  | 37 +++++++++++
  init/acl/10-waagent-sysext.conf          | 13 ++++
  init/acl/waagent.service                 | 18 ++++++
  setup.py                                 | 10 +++
  tests/common/osutil/test_factory.py      |  9 +++
- 10 files changed, 176 insertions(+)
+ 10 files changed, 202 insertions(+), 4 deletions(-)
  create mode 100644 azurelinuxagent/common/osutil/acl.py
  create mode 100644 config/acl/waagent.conf
  create mode 100644 init/acl/10-waagent-sysext.conf
@@ -53,7 +54,7 @@ new file mode 100644
 index 0000000..9da215b
 --- /dev/null
 +++ b/azurelinuxagent/common/osutil/acl.py
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,98 @@
 +#
 +# Copyright 2018 Microsoft Corporation
 +#
@@ -77,7 +78,12 @@ index 0000000..9da215b
 +# inadvertently affect the immutable ACL image.
 +#
 +
++import time
++
++import azurelinuxagent.common.logger as logger
++import azurelinuxagent.common.utils.shellutil as shellutil
 +from azurelinuxagent.common.osutil.default import DefaultOSUtil
++from azurelinuxagent.common.utils.shellutil import CommandError
 +
 +
 +class AclOSUtil(DefaultOSUtil):
@@ -101,8 +107,22 @@ index 0000000..9da215b
 +    def start_network(self):
 +        self._run_command_without_raising(["systemctl", "start", "systemd-networkd"], log_error=False)
 +
-+    def restart_if(self, ifname=None, retries=None, wait=None):
-+        self._run_command_without_raising(["systemctl", "restart", "systemd-networkd"])
++    def restart_if(self, ifname, retries=3, wait=5):
++        """
++        Restart an interface by bouncing the link. systemd-networkd observes
++        this event, and forces a renew of DHCP.
++        """
++        for attempt in range(1, retries + 1):
++            try:
++                shellutil.run_command(["ip", "link", "set", ifname, "down"])
++                shellutil.run_command(["ip", "link", "set", ifname, "up"])
++                return
++            except CommandError as e:
++                logger.warn("failed to restart {0}: {1}".format(ifname, e))
++                if attempt < retries:
++                    logger.info("retrying in {0} seconds".format(wait))
++                    time.sleep(wait)
++        logger.warn("exceeded restart retries for {0}".format(ifname))
 +
 +    def restart_ssh_service(self):
 +        # ACL uses sshd.socket for socket-activated SSH (similar to
@@ -178,13 +198,51 @@ diff --git a/azurelinuxagent/ga/persist_firewall_rules.py b/azurelinuxagent/ga/p
 index e7c8373..d93c984 100644
 --- a/azurelinuxagent/ga/persist_firewall_rules.py
 +++ b/azurelinuxagent/ga/persist_firewall_rules.py
-@@ -36,5 +36,6 @@ class PersistFirewallRulesHandler(object):
+@@ -25,6 +25,7 @@ from azurelinuxagent.common.osutil import get_osutil, systemd
+ from azurelinuxagent.common.utils import shellutil, fileutil, textutil
+ from azurelinuxagent.common.utils.networkutil import AddFirewallRules
+ from azurelinuxagent.common.utils.shellutil import CommandError
++from azurelinuxagent.common.version import get_distro
+ 
+ 
+ class PersistFirewallRulesHandler(object):
+@@ -36,5 +37,6 @@ class PersistFirewallRulesHandler(object):
  [Unit]
  Description=Setup network rules for WALinuxAgent 
-+After=systemd-sysext.service
++After={after_dependencies}
  Before=network-pre.target
  Wants=network-pre.target
  DefaultDependencies=no
+@@ -70,6 +72,6 @@ class PersistFirewallRulesHandler(object):
+     # The current version of the unit file; Update it whenever the unit file is modified to ensure Agent can dynamically
+     # modify the unit file on VM too
+-    _UNIT_VERSION = "1.3"
++    _UNIT_VERSION = "1.4"
+ 
+     @staticmethod
+     def get_service_file_path():
+@@ -232,10 +234,17 @@ if __name__ == '__main__':
+         service_unit_file = self.get_service_file_path()
+         binary_path = os.path.join(conf.get_lib_dir(), self.BINARY_FILE_NAME)
+         try:
+-            fileutil.write_file(service_unit_file,
+-                                self.__SERVICE_FILE_CONTENT.format(binary_path=binary_path,
+-                                                                   py_path=sys.executable,
+-                                                                   version=self._UNIT_VERSION))
++            # On Azure Container Linux, Python lives inside a sysext overlay that is only available after
++            # systemd-sysext.service merges it. Add an explicit ordering dependency so the service waits.
++            after_dependencies = "local-fs.target"
++            if get_distro()[0] == "azurecontainerlinux":
++                after_dependencies = "local-fs.target systemd-sysext.service"
++
++            service_content = self.__SERVICE_FILE_CONTENT.format(binary_path=binary_path,
++                                                                 py_path=sys.executable,
++                                                                 version=self._UNIT_VERSION,
++                                                                 after_dependencies=after_dependencies)
++            fileutil.write_file(service_unit_file, service_content)
+             fileutil.chmod(service_unit_file, 0o644)
+ 
+             # Finally enable the service. This is needed to ensure the service is started on system boot
 diff --git a/config/acl/waagent.conf b/config/acl/waagent.conf
 new file mode 100644
 index 0000000..497bd43


### PR DESCRIPTION

upstream PR merged - https://github.com/Azure/WALinuxAgent/pull/3608

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix waagent-network-setup.service failure and update to teardown the specific interface.

restart_if() now bounces the specific interface via ip link set down/up instead of restarting all of systemd-networkd, and persist_firewall_rules.py now conditionally adds After=systemd-sysext.service only on ACL.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix waagent-network-setup.service failure and update to teardown the specific interface.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/mariner-org/ACL/_workitems/edit/20602

###### Links to CVEs  <!-- optional -->
-

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1132698&view=results
