### PR TITLE
fix(qt6-qtmultimedia): drop gstreamer-plugins-bad BR to unbreak KDE dep chain

### DIFF
--- a/base/comps/qt6-qtmultimedia/qt6-qtmultimedia.comp.toml
+++ b/base/comps/qt6-qtmultimedia/qt6-qtmultimedia.comp.toml
@@ -7,3 +7,32 @@
 # Part of the distro-wide effort to remove ffmpeg/libav* from Azure Linux.
 [components.qt6-qtmultimedia]
 build.without = ["ffmpeg"]
+
+# gstreamer1-plugins-bad-free is not shipped in AZL4. Remove the BR to avoid
+# linking against libgstplay/libgstphotography (unresolved runtime deps that
+# break all transitive consumers up to libplasma).
+[[components.qt6-qtmultimedia.overlays]]
+description = "Remove gstreamer-plugins-bad BR — gstreamer1-plugins-bad-free not shipped in AZL"
+type = "spec-remove-tag"
+tag = "BuildRequires"
+value = "pkgconfig(gstreamer-plugins-bad-%{gst})"
+
+# Without gstreamer-plugins-bad headers, the GStreamer media plugin
+# (libgstreamermediaplugin.so) is not built. Remove it from %files
+# along with the empty multimedia plugin directory.
+# Note: replacement leaves blank lines — the tool operates per-line and
+# cannot delete lines entirely. This is cosmetic only; RPM ignores blanks
+# in %files.
+[[components.qt6-qtmultimedia.overlays]]
+description = "Remove empty multimedia plugin dir from %files — no plugins install here (gst-bad disabled, ffmpeg gated by bcond), so %dir would fail the build"
+type = "spec-search-replace"
+section = "%files"
+regex = '^%dir %\{_qt6_plugindir\}/multimedia$'
+replacement = ''
+
+[[components.qt6-qtmultimedia.overlays]]
+description = "Remove libgstreamermediaplugin.so from %files (not built without gstreamer-plugins-bad)"
+type = "spec-search-replace"
+section = "%files"
+regex = '^%\{_qt6_plugindir\}/multimedia/libgstreamermediaplugin\.so$'
+replacement = ''

--- a/locks/qt6-qtmultimedia.lock
+++ b/locks/qt6-qtmultimedia.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '66b4dd09782f23900e04dc2a93470c6ef8a02537'
 upstream-commit = '66b4dd09782f23900e04dc2a93470c6ef8a02537'
-input-fingerprint = 'sha256:48ed2959e662ebe45219b0376e254f6700fd8efc1b78789cb62b4802219dcc8a'
+input-fingerprint = 'sha256:796992d13039bed1d8a28f20772baec8dcbb76e0f433968e82c6767aabb56d2e'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/q/qt6-qtmultimedia/qt6-qtmultimedia.spec
+++ b/specs/q/qt6-qtmultimedia/qt6-qtmultimedia.spec
@@ -27,7 +27,7 @@
 Summary: Qt6 - Multimedia support
 Name:    qt6-%{qt_module}
 Version: 6.10.2
-Release: 3%{?dist}
+Release: 4%{?dist}
 
 License: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 Url:     http://www.qt.io
@@ -68,7 +68,6 @@ BuildRequires: pkgconfig(gstreamer-app-%{gst})
 BuildRequires: pkgconfig(gstreamer-audio-%{gst})
 BuildRequires: pkgconfig(gstreamer-base-%{gst})
 BuildRequires: pkgconfig(gstreamer-pbutils-%{gst})
-BuildRequires: pkgconfig(gstreamer-plugins-bad-%{gst})
 BuildRequires: pkgconfig(gstreamer-video-%{gst})
 BuildRequires: pkgconfig(libpulse) pkgconfig(libpulse-mainloop-glib)
 %if %{with ffmpeg}
@@ -161,8 +160,8 @@ rm -r %{buildroot}%{_qt6_archdatadir}/mkspecs/features/ios/add_ios_ffmpeg_librar
 %{_qt6_archdatadir}/qml/QtMultimedia/
 %dir %{_qt6_archdatadir}/qml/QtQuick3D/SpatialAudio
 %{_qt6_archdatadir}/qml/QtQuick3D/SpatialAudio/
-%dir %{_qt6_plugindir}/multimedia
-%{_qt6_plugindir}/multimedia/libgstreamermediaplugin.so
+
+
 %if %{with ffmpeg}
 %{_qt6_plugindir}/multimedia/libffmpegmediaplugin.so
 %endif


### PR DESCRIPTION
## Summary

Removes the `pkgconfig(gstreamer-plugins-bad-1.0)` BuildRequires from qt6-qtmultimedia. The built RPM was linking against `libgstplay`/`libgstphotography` from `gstreamer1-plugins-bad-free`, which is not shipped in AZL4 — making the package uninstallable and breaking all transitive consumers.

## Problem

Koji nightly build of **libplasma** (task 2590944) fails at buildroot resolution (mock exit 30). The dep chain:

```
libplasma BR: cmake(KF6Parts)
  → kf6-kparts-devel → kf6-ktextwidgets → qt6-qtspeech
    → qt6-qtmultimedia → libgstplay-1.0.so.0 (not in AZL4)
```

## Fix

Drop the gstreamer-plugins-bad BR and remove the corresponding `%files` entries for the gstreamer media backend plugin that is no longer built. Base gstreamer plugins and PulseAudio/PipeWire backends remain functional.

## Validation

After rebuild of qt6-qtmultimedia, libplasma buildroot resolution succeeds.

Split out of [AB#20330](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20330).