### PR TITLE
feat(wsl): include azure-cli in WSL image

### DIFF
--- a/base/images/wsl/wsl.kiwi
+++ b/base/images/wsl/wsl.kiwi
@@ -32,6 +32,7 @@
     <packages type="image" patternType="plusRecommended">
         <package name="attr"/>
         <package name="acl"/>
+        <package name="azure-cli"/>
         <package name="bash-color-prompt"/>
         <package name="bash-completion"/>
         <package name="bind-utils"/>


### PR DESCRIPTION
Add azure-cli to the WSL image package list so users have the Azure
management CLI available out of the box. The azure-cli component is
already defined in base/comps/components.toml.

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
