### PR TITLE
[Medium] Patch cmake for CVE-2026-4873, CVE-2026-6276, CVE-2026-6253, CVE-2026-6429, CVE-2026-5545

### DIFF
--- a/SPECS/cmake/CVE-2026-4873.patch
+++ b/SPECS/cmake/CVE-2026-4873.patch
@@ -1,0 +1,35 @@
+From 507e7be573b0a76fca597b75ff7cb27a66e7d865 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 24 Mar 2026 08:35:08 +0100
+Subject: [PATCH] url: do not reuse a non-tls starttls connection if new
+ requires TLS
+
+Reported-by: Arkadi Vainbrand
+
+Closes #21082
+
+Upstream Patch Reference: https://launchpadlibrarian.net/859770355/curl_8.5.0-2ubuntu10.8_8.5.0-2ubuntu10.9.diff.gz
+https://github.com/curl/curl/commit/507e7be573b0a76fca597b75ff7cb27a66e7d865.patch
+---
+ Utilities/cmcurl/lib/url.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/Utilities/cmcurl/lib/url.c b/Utilities/cmcurl/lib/url.c
+index 5f3eae4e..b8980f87 100644
+--- a/Utilities/cmcurl/lib/url.c
++++ b/Utilities/cmcurl/lib/url.c
+@@ -1188,6 +1188,11 @@ ConnectionExists(struct Curl_easy *data,
+          (get_protocol_family(check->handler) !=
+           needle->handler->protocol || !check->bits.tls_upgraded))
+         continue;
++      else if(!(needle->handler->flags & PROTOPT_SSL) &&
++              !check->bits.tls_upgraded &&
++              data->set.use_ssl >= CURLUSESSL_CONTROL)
++        /* do not reuse a non-TLS STARTTLS connection if TLS is required */
++        continue;
+ 
+       /* If needle has "conn_to_*" set, check must match this */
+       if((needle->bits.conn_to_host && !strcasecompare(
+-- 
+2.45.4
+

--- a/SPECS/cmake/CVE-2026-5545.patch
+++ b/SPECS/cmake/CVE-2026-5545.patch
@@ -1,0 +1,41 @@
+From 33e43985b8f3b9e66691d06e70be0395849856cd Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Thu, 2 Apr 2026 11:33:39 +0200
+Subject: [PATCH] url: improve connection reuse on negotiate
+
+Check state of negotiate to allow proper connection reuse.
+
+Closes #21203
+
+Upstream Patch Reference: https://launchpadlibrarian.net/859770355/curl_8.5.0-2ubuntu10.8_8.5.0-2ubuntu10.9.diff.gz
+https://github.com/curl/curl/commit/33e43985b8f3b9e6669.patch
+---
+ Utilities/cmcurl/lib/url.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/url.c b/Utilities/cmcurl/lib/url.c
+index 319ea1ea..47451df2 100644
+--- a/Utilities/cmcurl/lib/url.c
++++ b/Utilities/cmcurl/lib/url.c
+@@ -1228,9 +1228,16 @@ ConnectionExists(struct Curl_easy *data,
+          Curl_timestrcmp(needle->passwd, check->passwd)) {
+ 
+         /* we prefer a credential match, but this is at least a connection
+-           that can be reused and "upgraded" to NTLM */
+-        if(check->http_ntlm_state == NTLMSTATE_NONE)
++         that can be reused and "upgraded" to NTLM if it does
++         not have any auth ongoing. */
++#ifdef USE_SPNEGO
++      if((check->http_ntlm_state == NTLMSTATE_NONE)
++         && (check->http_negotiate_state == GSS_AUTHNONE)) {
++#else
++      if(check->http_ntlm_state == NTLMSTATE_NONE) {
++#endif
+           chosen = check;
++      }
+         continue;
+       }
+     }
+-- 
+2.45.4
+

--- a/SPECS/cmake/CVE-2026-6253.patch
+++ b/SPECS/cmake/CVE-2026-6253.patch
@@ -1,0 +1,222 @@
+From 188c2f166a20fa97c2325b2da7d0e5cecc13725f Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 13 Apr 2026 17:17:23 +0200
+Subject: [PATCH] http: clear the proxy credentials as well on port or scheme
+ change
+
+Add tests 2009-2011 to verify switching between proxies with credentials
+when the switch is driven by a redirect
+
+Reported-by: Dwij Mehta
+
+Upstream Patch Reference: https://launchpadlibrarian.net/859770351/curl_8.14.1-2ubuntu1.2_8.14.1-2ubuntu1.3.diff.gz
+https://github.com/curl/curl/commit/188c2f166a20fa97c2325b2da7d0e5cecc13725f.patch
+---
+ Utilities/cmcurl/lib/cf-h1-proxy.c | 25 ++++++------
+ Utilities/cmcurl/lib/cf-h2-proxy.c |  2 +-
+ Utilities/cmcurl/lib/transfer.c    | 61 ++++++++++++++++++++++++------
+ Utilities/cmcurl/lib/transfer.h    |  2 +
+ Utilities/cmcurl/lib/urldata.h     |  5 +++
+ 5 files changed, 70 insertions(+), 25 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/cf-h1-proxy.c b/Utilities/cmcurl/lib/cf-h1-proxy.c
+index 093c33be..2d4a9e93 100644
+--- a/Utilities/cmcurl/lib/cf-h1-proxy.c
++++ b/Utilities/cmcurl/lib/cf-h1-proxy.c
+@@ -419,17 +419,7 @@ static CURLcode recv_CONNECT_resp(struct Curl_cfilter *cf,
+ 
+     if(ts->keepon == KEEPON_IGNORE) {
+       /* This means we are currently ignoring a response-body */
+-
+-      if(ts->cl) {
+-        /* A Content-Length based body: simply count down the counter
+-           and make sure to break out of the loop when we're done! */
+-        ts->cl--;
+-        if(ts->cl <= 0) {
+-          ts->keepon = KEEPON_DONE;
+-          break;
+-        }
+-      }
+-      else if(ts->chunked_encoding) {
++      if(ts->chunked_encoding) {
+         /* chunked-encoded body, so we need to do the chunked dance
+            properly to know when the end of the body is reached */
+         size_t consumed = 0;
+@@ -445,6 +435,15 @@ static CURLcode recv_CONNECT_resp(struct Curl_cfilter *cf,
+           ts->keepon = KEEPON_DONE;
+         }
+       }
++      else if(ts->cl) {
++        /* A Content-Length based body: count down the counter
++           and make sure to break out of the loop when we are done! */
++        ts->cl--;
++        if(ts->cl <= 0) {
++          ts->keepon = KEEPON_DONE;
++          break;
++        }
++      }
+       continue;
+     }
+ 
+@@ -908,6 +907,8 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
+       /* read what is there */
+       CURL_TRC_CF(data, cf, "CONNECT receive");
+       result = recv_CONNECT_resp(cf, data, ts, &done);
++      if(result)
++        CURL_TRC_CF(data, cf, "error receiving CONNECT response: %d", result);
+       if(Curl_pgrsUpdate(data)) {
+         result = CURLE_ABORTED_BY_CALLBACK;
+         goto out;
+@@ -961,7 +962,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
+     streamclose(conn, "proxy CONNECT failure");
+     h1_tunnel_go_state(cf, ts, H1_TUNNEL_FAILED, data);
+     failf(data, "CONNECT tunnel failed, response %d", data->req.httpcode);
+-    return CURLE_RECV_ERROR;
++    return CURLE_COULDNT_CONNECT;
+   }
+   /* 2xx response, SUCCESS! */
+   h1_tunnel_go_state(cf, ts, H1_TUNNEL_ESTABLISHED, data);
+diff --git a/Utilities/cmcurl/lib/cf-h2-proxy.c b/Utilities/cmcurl/lib/cf-h2-proxy.c
+index 0bff15f3..d3cdbe80 100644
+--- a/Utilities/cmcurl/lib/cf-h2-proxy.c
++++ b/Utilities/cmcurl/lib/cf-h2-proxy.c
+@@ -1016,7 +1016,7 @@ static CURLcode inspect_response(struct Curl_cfilter *cf,
+   }
+ 
+   /* Seems to have failed */
+-  return CURLE_RECV_ERROR;
++  return CURLE_COULDNT_CONNECT;
+ }
+ 
+ static CURLcode H2_CONNECT(struct Curl_cfilter *cf,
+diff --git a/Utilities/cmcurl/lib/transfer.c b/Utilities/cmcurl/lib/transfer.c
+index 744227eb..15aa9d29 100644
+--- a/Utilities/cmcurl/lib/transfer.c
++++ b/Utilities/cmcurl/lib/transfer.c
+@@ -559,6 +559,40 @@ void Curl_init_CONNECT(struct Curl_easy *data)
+   data->state.upload = (data->state.httpreq == HTTPREQ_PUT);
+ }
+ 
++/*
++ * Restore the user credentials to those set in options.
++ */
++CURLcode Curl_reset_userpwd(struct Curl_easy *data)
++{
++  CURLcode result;
++  if(data->set.str[STRING_USERNAME] || data->set.str[STRING_PASSWORD])
++    data->state.creds_from = CREDS_OPTION;
++  result = Curl_setstropt(&data->state.aptr.user,
++                          data->set.str[STRING_USERNAME]);
++  if(!result)
++    result = Curl_setstropt(&data->state.aptr.passwd,
++                            data->set.str[STRING_PASSWORD]);
++  return result;
++}
++
++/*
++ * Restore the proxy credentials to those set in options.
++ */
++CURLcode Curl_reset_proxypwd(struct Curl_easy *data)
++{
++#ifndef CURL_DISABLE_PROXY
++  CURLcode result = Curl_setstropt(&data->state.aptr.proxyuser,
++                                   data->set.str[STRING_PROXYUSERNAME]);
++  if(!result)
++    result = Curl_setstropt(&data->state.aptr.proxypasswd,
++                            data->set.str[STRING_PROXYPASSWORD]);
++  return result;
++#else
++  (void)data;
++  return CURLE_OK;
++#endif
++}
++
+ /*
+  * Curl_pretransfer() is called immediately before a transfer starts, and only
+  * once for one transfer no matter if it has redirects or do multi-pass
+@@ -707,19 +741,9 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
+   }
+ 
+   if(!result)
+-    result = Curl_setstropt(&data->state.aptr.user,
+-                            data->set.str[STRING_USERNAME]);
+-  if(!result)
+-    result = Curl_setstropt(&data->state.aptr.passwd,
+-                            data->set.str[STRING_PASSWORD]);
+-#ifndef CURL_DISABLE_PROXY
+-  if(!result)
+-    result = Curl_setstropt(&data->state.aptr.proxyuser,
+-                            data->set.str[STRING_PROXYUSERNAME]);
++    result = Curl_reset_userpwd(data);
+   if(!result)
+-    result = Curl_setstropt(&data->state.aptr.proxypasswd,
+-                            data->set.str[STRING_PROXYPASSWORD]);
+-#endif
++    result = Curl_reset_proxypwd(data);
+ 
+   data->req.headerbytecount = 0;
+   Curl_headers_cleanup(data);
+@@ -894,11 +918,24 @@ CURLcode Curl_follow(struct Curl_easy *data,
+         free(scheme);
+       }
+       if(clear) {
++      CURLcode result = Curl_reset_userpwd(data);
++        if(result) {
++          free(newurl);
++          return result;
++        }
+         Curl_safefree(data->state.aptr.user);
+         Curl_safefree(data->state.aptr.passwd);
+       }
+     }
+   }
++  DEBUGASSERT(newurl);
++  {
++    CURLcode result = Curl_reset_proxypwd(data);
++    if(result) {
++      free(newurl);
++      return result;
++    }
++  }
+ 
+   if(type == FOLLOW_FAKE) {
+     /* we're only figuring out the new url if we would've followed locations
+diff --git a/Utilities/cmcurl/lib/transfer.h b/Utilities/cmcurl/lib/transfer.h
+index ad0f3a20..7a1dc174 100644
+--- a/Utilities/cmcurl/lib/transfer.h
++++ b/Utilities/cmcurl/lib/transfer.h
+@@ -31,6 +31,8 @@ char *Curl_checkheaders(const struct Curl_easy *data,
+ 
+ void Curl_init_CONNECT(struct Curl_easy *data);
+ 
++CURLcode Curl_reset_userpwd(struct Curl_easy *data);
++CURLcode Curl_reset_proxypwd(struct Curl_easy *data);
+ CURLcode Curl_pretransfer(struct Curl_easy *data);
+ CURLcode Curl_posttransfer(struct Curl_easy *data);
+ 
+diff --git a/Utilities/cmcurl/lib/urldata.h b/Utilities/cmcurl/lib/urldata.h
+index fffac9f5..95ce93f7 100644
+--- a/Utilities/cmcurl/lib/urldata.h
++++ b/Utilities/cmcurl/lib/urldata.h
+@@ -1222,6 +1222,8 @@ struct urlpieces {
+   char *query;
+ };
+ 
++#define CREDS_OPTION 2 /* set with a CURLOPT_ */
++
+ struct UrlState {
+   /* Points to the connection cache */
+   struct conncache *conn_cache;
+@@ -1372,6 +1374,9 @@ struct UrlState {
+   unsigned char select_bits; /* != 0 -> bitmask of socket events for this
+                                  transfer overriding anything the socket may
+                                  report */
++  unsigned int creds_from:2; /* where is the server credentials originating
++                                from, see the CREDS_* defines above */
++
+ #ifdef CURLDEBUG
+   BIT(conncache_lock);
+ #endif
+-- 
+2.45.4
+

--- a/SPECS/cmake/CVE-2026-6276.patch
+++ b/SPECS/cmake/CVE-2026-6276.patch
@@ -1,0 +1,125 @@
+From 3a19987a87f393d9394fe5acc7643f6c263c92db Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 14 Apr 2026 08:51:44 +0200
+Subject: [PATCH] urldata: move cookiehost to struct SingleRequest
+
+To make it scoped for the single request appropriately.
+
+Reported-by: Muhamad Arga Reksapati
+
+Verify with libtest 2504: a custom Host *disabled* on reused handle
+
+Closes #21312
+Upstream Patch Reference: https://github.com/curl/curl/commit/3a19987a87f393d9394fe5ac.patch
+---
+ Utilities/cmcurl/lib/http.c    | 14 ++++++++------
+ Utilities/cmcurl/lib/request.c |  3 +++
+ Utilities/cmcurl/lib/request.h |  3 +++
+ Utilities/cmcurl/lib/url.c     |  2 +-
+ Utilities/cmcurl/lib/urldata.h |  3 ---
+ 5 files changed, 15 insertions(+), 10 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/http.c b/Utilities/cmcurl/lib/http.c
+index 2a41f807..ba05658c 100644
+--- a/Utilities/cmcurl/lib/http.c
++++ b/Utilities/cmcurl/lib/http.c
+@@ -1714,6 +1714,9 @@ CURLcode Curl_http_host(struct Curl_easy *data, struct connectdata *conn)
+     data->state.first_remote_protocol = conn->handler->protocol;
+   }
+   Curl_safefree(aptr->host);
++#ifndef CURL_DISABLE_COOKIES
++  Curl_safefree(data->req.cookiehost);
++#endif
+ 
+   ptr = Curl_checkheaders(data, STRCONST("Host"));
+   if(ptr && (!data->state.this_is_a_follow ||
+@@ -1748,8 +1751,7 @@ CURLcode Curl_http_host(struct Curl_easy *data, struct connectdata *conn)
+         if(colon)
+           *colon = 0; /* The host must not include an embedded port number */
+       }
+-      Curl_safefree(aptr->cookiehost);
+-      aptr->cookiehost = cookiehost;
++      data->req.cookiehost = cookiehost;
+     }
+ #endif
+ 
+@@ -2270,8 +2272,8 @@ CURLcode Curl_http_cookies(struct Curl_easy *data,
+     int count = 0;
+ 
+     if(data->cookies && data->state.cookie_engine) {
+-      const char *host = data->state.aptr.cookiehost ?
+-        data->state.aptr.cookiehost : conn->host.name;
++      const char *host = data->req.cookiehost ?
++        data->req.cookiehost : conn->host.name;
+       const bool secure_context =
+         conn->handler->protocol&(CURLPROTO_HTTPS|CURLPROTO_WSS) ||
+         strcasecompare("localhost", host) ||
+@@ -3096,8 +3098,8 @@ CURLcode Curl_http_header(struct Curl_easy *data,
+     if(v) {
+       /* If there is a custom-set Host: name, use it here, or else use
+        * real peer host name. */
+-      const char *host = data->state.aptr.cookiehost?
+-        data->state.aptr.cookiehost:conn->host.name;
++      const char *host = data->req.cookiehost ?
++        data->req.cookiehost : conn->host.name;
+       const bool secure_context =
+         conn->handler->protocol&(CURLPROTO_HTTPS|CURLPROTO_WSS) ||
+         strcasecompare("localhost", host) ||
+diff --git a/Utilities/cmcurl/lib/request.c b/Utilities/cmcurl/lib/request.c
+index 26741fa6..3307c746 100644
+--- a/Utilities/cmcurl/lib/request.c
++++ b/Utilities/cmcurl/lib/request.c
+@@ -110,6 +110,9 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
+    * free this safely without leaks. */
+   Curl_safefree(req->p.http);
+   Curl_safefree(req->newurl);
++#ifndef CURL_DISABLE_COOKIES
++  Curl_safefree(req->cookiehost);
++#endif
+   Curl_client_reset(data);
+   if(req->sendbuf_init)
+     Curl_bufq_reset(&req->sendbuf);
+diff --git a/Utilities/cmcurl/lib/request.h b/Utilities/cmcurl/lib/request.h
+index f9be6f29..2247c297 100644
+--- a/Utilities/cmcurl/lib/request.h
++++ b/Utilities/cmcurl/lib/request.h
+@@ -118,6 +118,9 @@ struct SingleRequest {
+ #ifndef CURL_DISABLE_DOH
+   struct dohdata *doh; /* DoH specific data for this request */
+ #endif
++#ifndef CURL_DISABLE_COOKIES
++  char *cookiehost;
++#endif
+ #ifndef CURL_DISABLE_COOKIES
+   unsigned char setcookies;
+ #endif
+diff --git a/Utilities/cmcurl/lib/url.c b/Utilities/cmcurl/lib/url.c
+index b8980f87..319ea1ea 100644
+--- a/Utilities/cmcurl/lib/url.c
++++ b/Utilities/cmcurl/lib/url.c
+@@ -318,7 +318,7 @@ CURLcode Curl_close(struct Curl_easy **datap)
+   Curl_safefree(data->state.aptr.ref);
+   Curl_safefree(data->state.aptr.host);
+ #ifndef CURL_DISABLE_COOKIES
+-  Curl_safefree(data->state.aptr.cookiehost);
++  Curl_safefree(data->req.cookiehost);
+ #endif
+ #ifndef CURL_DISABLE_RTSP
+   Curl_safefree(data->state.aptr.rtsp_transport);
+diff --git a/Utilities/cmcurl/lib/urldata.h b/Utilities/cmcurl/lib/urldata.h
+index 8b1bd65d..fffac9f5 100644
+--- a/Utilities/cmcurl/lib/urldata.h
++++ b/Utilities/cmcurl/lib/urldata.h
+@@ -1348,9 +1348,6 @@ struct UrlState {
+     char *rangeline;
+     char *ref;
+     char *host;
+-#ifndef CURL_DISABLE_COOKIES
+-    char *cookiehost;
+-#endif
+ #ifndef CURL_DISABLE_RTSP
+     char *rtsp_transport;
+ #endif
+-- 
+2.45.4
+

--- a/SPECS/cmake/CVE-2026-6429.patch
+++ b/SPECS/cmake/CVE-2026-6429.patch
@@ -1,0 +1,232 @@
+From b4024bf808bd558026fdc6096e8457f199ace306 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 16 Apr 2026 14:26:20 +0200
+Subject: [PATCH] http: clear credentials better on redirect
+
+Verify with test 2506: netrc with redirect using proxy
+
+Updated test 998 which was wrong.
+
+Reported-by: Muhamad Arga Reksapati
+
+Closes #21345
+Upstream Patch Reference: https://launchpadlibrarian.net/859770351/curl_8.14.1-2ubuntu1.2_8.14.1-2ubuntu1.3.diff.gz
+https://github.com/curl/curl/commit/b4024bf808bd558026fdc6.patch
+---
+ Utilities/cmcurl/lib/http2.c      | 22 ++++++---
+ Utilities/cmcurl/lib/transfer.c   | 82 ++++++++++---------------------
+ Utilities/cmcurl/lib/urlapi-int.h |  2 +
+ Utilities/cmcurl/lib/urlapi.c     | 33 +++++++++++++
+ 4 files changed, 76 insertions(+), 63 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/http2.c b/Utilities/cmcurl/lib/http2.c
+index f0f7b566..19531f07 100644
+--- a/Utilities/cmcurl/lib/http2.c
++++ b/Utilities/cmcurl/lib/http2.c
+@@ -810,8 +810,9 @@ static struct Curl_easy *h2_duphandle(struct Curl_cfilter *cf,
+   return second;
+ }
+ 
+-static int set_transfer_url(struct Curl_easy *data,
+-                            struct curl_pushheaders *hp)
++static int set_transfer_url(struct Curl_easy *newhandle,
++                            struct curl_pushheaders *hp,
++                            struct Curl_easy *data)
+ {
+   const char *v;
+   CURLUcode uc;
+@@ -849,6 +850,13 @@ static int set_transfer_url(struct Curl_easy *data,
+     }
+   }
+ 
++  /* We can only allow PUSH of resource from the same origin, e.g.
++   * scheme + hostname + port */
++  if(!Curl_url_same_origin(data->state.uh, u)) {
++    rc = 1;
++    goto fail;
++  }
++
+   uc = curl_url_get(u, CURLUPART_URL, &url, 0);
+   if(uc)
+     rc = 4;
+@@ -857,10 +865,10 @@ fail:
+   if(rc)
+     return rc;
+ 
+-  if(data->state.url_alloc)
+-    free(data->state.url);
+-  data->state.url_alloc = TRUE;
+-  data->state.url = url;
++  if(newhandle->state.url_alloc)
++    free(newhandle->state.url);
++  newhandle->state.url_alloc = TRUE;
++  newhandle->state.url = url;
+   return 0;
+ }
+ 
+@@ -911,7 +919,7 @@ static int push_promise(struct Curl_cfilter *cf,
+     heads.stream = stream;
+     heads.frame = frame;
+ 
+-    rv = set_transfer_url(newhandle, &heads);
++    rv = set_transfer_url(newhandle, &heads, data);
+     if(rv) {
+       discard_newhandle(cf, newhandle);
+       rv = CURL_PUSH_DENY;
+diff --git a/Utilities/cmcurl/lib/transfer.c b/Utilities/cmcurl/lib/transfer.c
+index 15aa9d29..21f7b7b1 100644
+--- a/Utilities/cmcurl/lib/transfer.c
++++ b/Utilities/cmcurl/lib/transfer.c
+@@ -871,71 +871,41 @@ CURLcode Curl_follow(struct Curl_easy *data,
+       return CURLE_OUT_OF_MEMORY;
+   }
+   else {
+-    uc = curl_url_get(data->state.uh, CURLUPART_URL, &newurl, 0);
+-    if(uc)
++    bool same_origin;
++    CURLcode result;
++    CURLU *u = curl_url();
++    if(!u)
++      return CURLE_OUT_OF_MEMORY;
++    uc = curl_url_set(u, CURLUPART_URL,
++                      data->state.url,
++                      CURLU_URLENCODE | CURLU_ALLOW_SPACE);
++    if(!uc)
++      uc = curl_url_get(data->state.uh, CURLUPART_URL, &newurl, 0);
++    if(uc) {
++      curl_url_cleanup(u);
+       return Curl_uc_to_curlcode(uc);
++    }
+ 
+-    /* Clear auth if this redirects to a different port number or protocol,
+-       unless permitted */
+-    if(!data->set.allow_auth_to_other_hosts && (type != FOLLOW_FAKE)) {
+-      char *portnum;
+-      int port;
+-      bool clear = FALSE;
+-
+-      if(data->set.use_port && data->state.allow_port)
+-        /* a custom port is used */
+-        port = (int)data->set.use_port;
+-      else {
+-        uc = curl_url_get(data->state.uh, CURLUPART_PORT, &portnum,
+-                          CURLU_DEFAULT_PORT);
+-        if(uc) {
+-          free(newurl);
+-          return Curl_uc_to_curlcode(uc);
+-        }
+-        port = atoi(portnum);
+-        free(portnum);
+-      }
+-      if(port != data->info.conn_remote_port) {
+-        infof(data, "Clear auth, redirects to port from %u to %u",
+-              data->info.conn_remote_port, port);
+-        clear = TRUE;
+-      }
+-      else {
+-        char *scheme;
+-        const struct Curl_handler *p;
+-        uc = curl_url_get(data->state.uh, CURLUPART_SCHEME, &scheme, 0);
+-        if(uc) {
+-          free(newurl);
+-          return Curl_uc_to_curlcode(uc);
+-        }
+-
+-        p = Curl_get_scheme_handler(scheme);
+-        if(p && (p->protocol != data->info.conn_protocol)) {
+-          infof(data, "Clear auth, redirects scheme from %s to %s",
+-                data->info.conn_scheme, scheme);
+-          clear = TRUE;
+-        }
+-        free(scheme);
+-      }
+-      if(clear) {
+-      CURLcode result = Curl_reset_userpwd(data);
+-        if(result) {
+-          free(newurl);
+-          return result;
+-        }
+-        Curl_safefree(data->state.aptr.user);
+-        Curl_safefree(data->state.aptr.passwd);
++    same_origin = Curl_url_same_origin(u, data->state.uh);
++    curl_url_cleanup(u);
++ 
++    if((!same_origin && !data->set.allow_auth_to_other_hosts) ||
++       !data->set.str[STRING_USERNAME]) {
++      result = Curl_reset_userpwd(data);
++      if(result) {
++        free(newurl);
++        return result;
+       }
++      Curl_safefree(data->state.aptr.user);
++      Curl_safefree(data->state.aptr.passwd);
+     }
+-  }
+-  DEBUGASSERT(newurl);
+-  {
+-    CURLcode result = Curl_reset_proxypwd(data);
++    result = Curl_reset_proxypwd(data);
+     if(result) {
+       free(newurl);
+       return result;
+     }
+   }
++  DEBUGASSERT(newurl);
+ 
+   if(type == FOLLOW_FAKE) {
+     /* we're only figuring out the new url if we would've followed locations
+diff --git a/Utilities/cmcurl/lib/urlapi-int.h b/Utilities/cmcurl/lib/urlapi-int.h
+index c40281a8..9d038a5d 100644
+--- a/Utilities/cmcurl/lib/urlapi-int.h
++++ b/Utilities/cmcurl/lib/urlapi-int.h
+@@ -35,4 +35,6 @@ CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
+                           bool has_scheme);
+ #endif
+ 
++bool Curl_url_same_origin(CURLU *base, CURLU *href);
++
+ #endif /* HEADER_CURL_URLAPI_INT_H */
+diff --git a/Utilities/cmcurl/lib/urlapi.c b/Utilities/cmcurl/lib/urlapi.c
+index eb039668..65d18b16 100644
+--- a/Utilities/cmcurl/lib/urlapi.c
++++ b/Utilities/cmcurl/lib/urlapi.c
+@@ -1993,3 +1993,36 @@ nomem:
+   }
+   return CURLUE_OK;
+ }
++
++bool Curl_url_same_origin(CURLU *base, CURLU *href)
++{
++  const struct Curl_handler *s = NULL;
++
++  /* base must be an absolute URL */
++  if(!base->scheme || !base->host)
++    return FALSE;
++  if(href->scheme && !curl_strequal(base->scheme, href->scheme))
++    return FALSE;
++  if(href->host) {
++    if(!curl_strequal(base->host, href->host))
++      return FALSE;
++    if(!curl_strequal(base->port, href->port)) {
++      /* This may still match if only one has an explicit port
++       * and it is the default for the scheme. */
++      if(base->port && href->port)
++        return FALSE;
++
++      s = Curl_get_scheme_handler(base->scheme);
++      if(!s) /* Cannot match default port for unknown scheme */
++        return FALSE;
++
++      /* The port which is set must be the default one */
++      if((base->port && (base->portnum != s->defport)) ||
++         (href->port && (href->portnum != s->defport)))
++        return FALSE;
++    }
++  }
++  else if(href->port) /* no host in href, then there must be no port */
++    return FALSE;
++  return TRUE;
++}
+-- 
+2.45.4
+

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -25,17 +25,17 @@ Patch7:         CVE-2023-44487.patch
 # Utilities/cmnghttp2/lib/includes/nghttp2/nghttp2ver.h. Manual inspection is
 # required to determine what upstream patches are included.
 Patch8:         CVE-2023-35945.patch
-Patch9:		CVE-2024-48615.patch
-Patch10:	CVE-2025-4947.patch
-Patch11:	CVE-2025-5916.patch
-Patch12:	CVE-2025-5917.patch
-Patch13:	CVE-2025-5918.patch
-Patch14:	CVE-2025-9301.patch
-Patch15:	CVE-2025-10148.patch
-Patch16:	CVE-2025-14017.patch
-Patch17:	CVE-2025-10966.patch
-Patch18:	CVE-2025-14524.patch
-Patch19:	CVE-2026-27135.patch
+Patch9:         CVE-2024-48615.patch
+Patch10:        CVE-2025-4947.patch
+Patch11:        CVE-2025-5916.patch
+Patch12:        CVE-2025-5917.patch
+Patch13:        CVE-2025-5918.patch
+Patch14:        CVE-2025-9301.patch
+Patch15:        CVE-2025-10148.patch
+Patch16:        CVE-2025-14017.patch
+Patch17:        CVE-2025-10966.patch
+Patch18:        CVE-2025-14524.patch
+Patch19:        CVE-2026-27135.patch
 Patch20:        CVE-2026-4873.patch
 Patch21:        CVE-2026-6276.patch
 Patch22:        CVE-2026-6253.patch

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -121,7 +121,7 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_libdir}/rpm/macros.d/macros.cmake
 
 %changelog
-* Tue May 26 2026 Jyoti Kanase <v-jykanase@microsoft.com> - 3.30.3-14
+* Wed May 27 2026 Jyoti Kanase <v-jykanase@microsoft.com> - 3.30.3-14
 - Patch for CVE-2026-4873, CVE-2026-6276, CVE-2026-6253, CVE-2026-6429, CVE-2026-5545
 
 * Fri Mar 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 3.30.3-13

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -121,7 +121,7 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_libdir}/rpm/macros.d/macros.cmake
 
 %changelog
-* Mon May 25 2026 Jyoti Kanase <v-jykanase@microsoft.com> - 3.30.3-14
+* Tue May 26 2026 Jyoti Kanase <v-jykanase@microsoft.com> - 3.30.3-14
 - Patch for CVE-2026-4873, CVE-2026-6276, CVE-2026-6253, CVE-2026-6429, CVE-2026-5545
 
 * Fri Mar 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 3.30.3-13

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -2,7 +2,7 @@
 Summary:        Cmake
 Name:           cmake
 Version:        3.30.3
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        BSD AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -36,6 +36,11 @@ Patch16:	CVE-2025-14017.patch
 Patch17:	CVE-2025-10966.patch
 Patch18:	CVE-2025-14524.patch
 Patch19:	CVE-2026-27135.patch
+Patch20:        CVE-2026-4873.patch
+Patch21:        CVE-2026-6276.patch
+Patch22:        CVE-2026-6253.patch
+Patch23:        CVE-2026-6429.patch
+Patch24:        CVE-2026-5545.patch
 
 BuildRequires:  bzip2
 BuildRequires:  bzip2-devel
@@ -116,6 +121,9 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_libdir}/rpm/macros.d/macros.cmake
 
 %changelog
+* Mon May 25 2026 Jyoti Kanase <v-jykanase@microsoft.com> - 3.30.3-14
+- Patch for CVE-2026-4873, CVE-2026-6276, CVE-2026-6253, CVE-2026-6429, CVE-2026-5545
+
 * Fri Mar 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 3.30.3-13
 - Patch for CVE-2026-27135
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -51,8 +51,8 @@ check-debuginfo-0.15.2-1.azl3.aarch64.rpm
 chkconfig-1.25-1.azl3.aarch64.rpm
 chkconfig-debuginfo-1.25-1.azl3.aarch64.rpm
 chkconfig-lang-1.25-1.azl3.aarch64.rpm
-cmake-3.30.3-13.azl3.aarch64.rpm
-cmake-debuginfo-3.30.3-13.azl3.aarch64.rpm
+cmake-3.30.3-14.azl3.aarch64.rpm
+cmake-debuginfo-3.30.3-14.azl3.aarch64.rpm
 coreutils-9.4-6.azl3.aarch64.rpm
 coreutils-debuginfo-9.4-6.azl3.aarch64.rpm
 coreutils-lang-9.4-6.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -54,8 +54,8 @@ check-debuginfo-0.15.2-1.azl3.x86_64.rpm
 chkconfig-1.25-1.azl3.x86_64.rpm
 chkconfig-debuginfo-1.25-1.azl3.x86_64.rpm
 chkconfig-lang-1.25-1.azl3.x86_64.rpm
-cmake-3.30.3-13.azl3.x86_64.rpm
-cmake-debuginfo-3.30.3-13.azl3.x86_64.rpm
+cmake-3.30.3-14.azl3.x86_64.rpm
+cmake-debuginfo-3.30.3-14.azl3.x86_64.rpm
 coreutils-9.4-6.azl3.x86_64.rpm
 coreutils-debuginfo-9.4-6.azl3.x86_64.rpm
 coreutils-lang-9.4-6.azl3.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch cmake for CVE-2026-4873, CVE-2026-6276, CVE-2026-6253, CVE-2026-6429, CVE-2026-5545
Backported Patch: yes
Patch reference:
1.  https://[launchpadlibrarian.net/859770351/curl_8.14.1-2ubuntu1.2_8.14.1-2ubuntu1.3.diff.gz](https://launchpadlibrarian.net/859770351/curl_8.14.1-2ubuntu1.2_8.14.1-2ubuntu1.3.diff.gz)
2. https://[launchpadlibrarian.net/859770355/curl_8.5.0-2ubuntu10.8_8.5.0-2ubuntu10.9.diff.gz](https://launchpadlibrarian.net/859770355/curl_8.5.0-2ubuntu10.8_8.5.0-2ubuntu10.9.diff.gz)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- cmake.spec
- CVE-2026-4873.patch
- CVE-2026-5545.patch
- CVE-2026-6253.patch
- CVE-2026-6276.patch
- CVE-2026-6429.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-4873
- https://nvd.nist.gov/vuln/detail/CVE-2026-5545
- https://nvd.nist.gov/vuln/detail/CVE-2026-6253
- https://nvd.nist.gov/vuln/detail/CVE-2026-6276
- https://nvd.nist.gov/vuln/detail/CVE-2026-6429


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
<img width="684" height="505" alt="Screenshot 2026-05-25 124142" src="https://github.com/user-attachments/assets/db1ed4ed-4a55-4655-8dc4-5b82b865ad8c" />

- patch application during build
<img width="1153" height="240" alt="Screenshot 2026-05-25 121801" src="https://github.com/user-attachments/assets/2d4548ab-e52e-4459-8b28-97cbfc1bbdc8" />

