### PR TITLE
chore(codeowners): require distro reviewers team for all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # CODEOWNERS file for automatic review assignment
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# All TOML files require review from these owners
-*.toml @ddstreetmicrosoft @reubeno @christopherco
-**/*.toml @ddstreetmicrosoft @reubeno @christopherco
+# All files require review from these owners
+* @microsoft/azurelinux-distro-reviewers


### PR DESCRIPTION
Replace the individual reviewers (@ddstreetmicrosoft, @reubeno, @christopherco) with the @microsoft/azurelinux-distro-reviewers team and broaden the scope from TOML files only to all files. Using a team keeps review assignment in sync with team membership instead of a hardcoded list, and covering every path ensures changes outside *.toml also receive owner review.

Fixes: [AB#21695](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/21695)