### PR TITLE
fix(azurelinux-release): correct OS CPE to well-formed CPE 2.3 string

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -233,7 +233,7 @@ mkdir -p licenses
 %install
 install -d %{buildroot}%{_prefix}/lib
 echo "Azure Linux release %{version} (%{release_name})" > %{buildroot}%{_prefix}/lib/azurelinux-release
-echo "cpe:/o:microsoft:azurelinux:%{version}" > %{buildroot}%{_prefix}/lib/system-release-cpe
+echo "cpe:2.3:o:microsoft:azure_linux:%{version}:*:*:*:*:*:*:*" > %{buildroot}%{_prefix}/lib/system-release-cpe
 
 # Symlink the -release files
 install -d %{buildroot}%{_sysconfdir}
@@ -295,7 +295,7 @@ VERSION_CODENAME=""
 PRETTY_NAME="Azure Linux %{dist_version} (%{release_name}%{?prerelease})"
 ANSI_COLOR="0;38;2;60;110;180"
 LOGO=azurelinux-logo-icon
-CPE_NAME="cpe:/o:azurelinuxproject:azurelinux:%{dist_version}"
+CPE_NAME="cpe:2.3:o:microsoft:azure_linux:%{dist_version}:*:*:*:*:*:*:*"
 DEFAULT_HOSTNAME="azurelinux"
 HOME_URL="%{dist_home_url}"
 DOCUMENTATION_URL="https://aka.ms/azurelinux"
@@ -476,6 +476,11 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Wed Jun 10 2026 Andrew Phelps <anphel@microsoft.com> - 4.0-18
+- Update CPE_NAME in os-release to a well-formed CPE 2.3 formatted string
+  (microsoft:azure_linux), replacing the legacy CPE 2.2 URI binding
+- Update system-release-cpe to the matching CPE 2.3 formatted string
+
 * Thu May 14 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-17
 - Redefine azurelinux macro as major version.
 

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:124623b2ce048aa85c9d4af46ea9f151155be5cb62cdf4c8814c82af8c0064f7'
+input-fingerprint = 'sha256:6a105d4aacebb7e35a9084dba13aa064805f0a4382cf893a844d351d8ac1cdce'

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -236,7 +236,7 @@ mkdir -p licenses
 %install
 install -d %{buildroot}%{_prefix}/lib
 echo "Azure Linux release %{version} (%{release_name})" > %{buildroot}%{_prefix}/lib/azurelinux-release
-echo "cpe:/o:microsoft:azurelinux:%{version}" > %{buildroot}%{_prefix}/lib/system-release-cpe
+echo "cpe:2.3:o:microsoft:azure_linux:%{version}:*:*:*:*:*:*:*" > %{buildroot}%{_prefix}/lib/system-release-cpe
 
 # Symlink the -release files
 install -d %{buildroot}%{_sysconfdir}
@@ -298,7 +298,7 @@ VERSION_CODENAME=""
 PRETTY_NAME="Azure Linux %{dist_version} (%{release_name}%{?prerelease})"
 ANSI_COLOR="0;38;2;60;110;180"
 LOGO=azurelinux-logo-icon
-CPE_NAME="cpe:/o:azurelinuxproject:azurelinux:%{dist_version}"
+CPE_NAME="cpe:2.3:o:microsoft:azure_linux:%{dist_version}:*:*:*:*:*:*:*"
 DEFAULT_HOSTNAME="azurelinux"
 HOME_URL="%{dist_home_url}"
 DOCUMENTATION_URL="https://aka.ms/azurelinux"
@@ -479,6 +479,11 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Wed Jun 10 2026 Andrew Phelps <anphel@microsoft.com> - 4.0-18
+- Update CPE_NAME in os-release to a well-formed CPE 2.3 formatted string
+  (microsoft:azure_linux), replacing the legacy CPE 2.2 URI binding
+- Update system-release-cpe to the matching CPE 2.3 formatted string
+
 * Thu May 14 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-17
 - Redefine azurelinux macro as major version.
 


### PR DESCRIPTION
## Summary

Updates the CPE identifier shipped by `azurelinux-release` to use the **CPE 2.3
formatted-string binding** with the correct Microsoft vendor and `azure_linux`
product name. This affects both places the CPE is emitted:

- `CPE_NAME=` in `/etc/os-release` (via `/usr/lib/os-release`)
- the standalone `/usr/lib/system-release-cpe` file (and its `/etc/system-release-cpe` symlink)

Fixes [AB#21833](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/21833)

### Before

| Location | Value |
|---|---|
| `os-release` `CPE_NAME` | `cpe:/o:azurelinuxproject:azurelinux:4.0` |
| `system-release-cpe`    | `cpe:/o:microsoft:azurelinux:4.0` |

### After

| Location | Value |
|---|---|
| `os-release` `CPE_NAME` | `cpe:2.3:o:microsoft:azure_linux:4.0:*:*:*:*:*:*:*` |
| `system-release-cpe`    | `cpe:2.3:o:microsoft:azure_linux:4.0:*:*:*:*:*:*:*` |

Both files now carry an identical, consistent value.

## Motivation

The two CPE strings were inconsistent with each other (`azurelinuxproject` vs
`microsoft` vendor) and both used the legacy CPE 2.2 URI binding (`cpe:/o:...`).
This change standardizes on:

- **CPE 2.3 formatted-string binding** (`cpe:2.3:o:...`), the current spec
- **`microsoft`** as the vendor
- **`azure_linux`** as the product name

## Changes

- `base/comps/azurelinux-release/azurelinux-release.spec`
  - `CPE_NAME` in the generated os-release block → `cpe:2.3:o:microsoft:azure_linux:4.0:*:*:*:*:*:*:*`
  - `system-release-cpe` content → `cpe:2.3:o:microsoft:azure_linux:4.0:*:*:*:*:*:*:*`
  - `Release:` bump 17 → 18 + changelog entry
- Re-rendered `specs/a/azurelinux-release/azurelinux-release.spec`
- Refreshed `locks/azurelinux-release.lock`

## Testing

- `azldev comp build -p azurelinux-release` succeeds; all subpackages produced.
- Extracted the built RPMs and verified:
  - `azurelinux-release-identity-basic` → `/usr/lib/os-release` contains
    `CPE_NAME="cpe:2.3:o:microsoft:azure_linux:4.0:*:*:*:*:*:*:*"`
  - `azurelinux-release-common` → `/usr/lib/system-release-cpe` contains
    `cpe:2.3:o:microsoft:azure_linux:4.0:*:*:*:*:*:*:*`
- `azldev comp render` reports no drift post-commit.
