### PR TITLE
feat(publish): add msgpack to base-packages channel

### DIFF
--- a/base/comps/components-publish-channels.toml
+++ b/base/comps/components-publish-channels.toml
@@ -1156,6 +1156,7 @@ components = [
     "mpich",
     "mptcpd",
     "mrtg",
+    "msgpack",
     "msr-tools",
     "mstflint",
     "msv",


### PR DESCRIPTION
Add msgpack to the base-packages publishing group so its RPMs are published to rpm-base instead of the default rpm-sdk channel.

Fixes: [AB#20397](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20397)