### PR TITLE
fix(vm-iso-installer): include rootfiles in target install

### DIFF
--- a/base/images/vm-iso-installer/config.sh
+++ b/base/images/vm-iso-installer/config.sh
@@ -99,6 +99,7 @@ INSTALL_PKGS=(
     azurelinux-release
     "$AZL_REPOS_PKG"
     setup
+    rootfiles
     shadow-utils
     util-linux
     selinux-policy-targeted


### PR DESCRIPTION
`rootfiles` ships the default skeleton dotfiles for root's home directory (.bashrc, .bash_profile, .bash_logout, .cshrc, .tcshrc). Without it, the installed system has an empty /root, which causes `sudo su` (and similar login shells) to not show the root@.. for normal user sudo su.

Add it to INSTALL_PKGS so it lands in both the kickstart %packages section and the offline repo.

Fixes: [AB#20512](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20512)