### PR TITLE
grub2: disable os-prober by default (security)

### DIFF
--- a/base/comps/grub2/0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/base/comps/grub2/0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,0 +1,85 @@
+From f0b1c8c9aeae9f48910668a9a1df80e9fdde1151 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 9 Jun 2026 19:43:35 +0000
+Subject: [PATCH 1/2] Revert "Revert "templates: Disable the os-prober by
+ default""
+
+This reverts the Fedora downstream patch
+"0003-Revert-templates-Disable-the-os-prober-by-default.patch"
+(Patch0003), thereby re-applying upstream GRUB commit
+e346414725a70e5c74ee87ca14e580c66f517666 ("templates: Disable the
+os-prober by default").
+
+Automatic and silent execution of os-prober is a known attack vector, so
+os-prober must remain disabled by default. Rather than dropping Patch0003
+from the series (which shifts context and breaks later patches), this
+change re-applies the upstream behaviour as a trailing patch. The
+grub.texi hunk is reconciled with Patch0034 (grub-mkconfig ->
+grub2-mkconfig).
+---
+ docs/grub.texi              | 18 ++++++++++--------
+ util/grub.d/30_os-prober.in |  5 ++++-
+ 2 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/docs/grub.texi b/docs/grub.texi
+index ae01e8c..defa75e 100644
+--- a/docs/grub.texi
++++ b/docs/grub.texi
+@@ -1559,10 +1559,13 @@ boot sequence.  If you have problems, set this option to @samp{text} and
+ GRUB will tell Linux to boot in normal text mode.
+ 
+ @item GRUB_DISABLE_OS_PROBER
+-Normally, @command{grub2-mkconfig} will try to use the external
+-@command{os-prober} program, if installed, to discover other operating
+-systems installed on the same system and generate appropriate menu entries
+-for them.  Set this option to @samp{true} to disable this.
++The @command{grub2-mkconfig} has a feature to use the external
++@command{os-prober} program to discover other operating systems installed on
++the same machine and generate appropriate menu entries for them. It is disabled
++by default since automatic and silent execution of @command{os-prober}, and
++creating boot entries based on that data, is a potential attack vector. Set
++this option to @samp{false} to enable this feature in the
++@command{grub2-mkconfig} command.
+ 
+ @item GRUB_OS_PROBER_SKIP_LIST
+ List of space-separated FS UUIDs of filesystems to be ignored from os-prober
+@@ -1893,10 +1896,9 @@ than zero; otherwise 0.
+ @section Multi-boot manual config
+ 
+ Currently autogenerating config files for multi-boot environments depends on
+-os-prober and has several shortcomings. While fixing it is scheduled for the
+-next release, meanwhile you can make use of the power of GRUB syntax and do it
+-yourself. A possible configuration is detailed here, feel free to adjust to your
+-needs.
++os-prober and has several shortcomings. Due to that it is disabled by default.
++It is advised to use the power of GRUB syntax and do it yourself. A possible
++configuration is detailed here, feel free to adjust to your needs.
+ 
+ First create a separate GRUB partition, big enough to hold GRUB. Some of the
+ following entries show how to load OS installer images from this same partition,
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index 18fe02c..f11f856 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,7 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
++  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
+   exit 0
+ fi
+ 
+@@ -39,6 +40,8 @@ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
++else
++  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {
+-- 
+2.45.4
+

--- a/base/comps/grub2/0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/base/comps/grub2/0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,0 +1,84 @@
+From 1c5a574543ecd06631dbf8dd46cb8dd55e93f056 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 9 Jun 2026 19:43:35 +0000
+Subject: [PATCH 2/2] Revert "Revert "templates: Properly disable the os-prober
+ by default""
+
+This reverts the Fedora downstream patch
+"0002-Revert-templates-Properly-disable-the-os-prober-by-d.patch"
+(Patch0002), thereby re-applying upstream GRUB commit
+54e0a1bbf1e9106901a557195bb35e5e20fb3925 ("templates: Properly disable
+the os-prober by default").
+
+This restores the GRUB_DISABLE_OS_PROBER="true" default in
+grub-mkconfig and the corresponding warning logic in 30_os-prober.in, so
+os-prober is disabled by default. Applied as a trailing patch to avoid
+disturbing the context of later patches in the series.
+---
+ util/grub-mkconfig.in       | 5 ++++-
+ util/grub.d/30_os-prober.in | 8 ++++----
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index 1cfb587..e53e19c 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -155,6 +155,9 @@ GRUB_DEVICE_PARTUUID="`${grub_probe} --device ${GRUB_DEVICE} --target=partuuid 2
+ GRUB_DEVICE_BOOT="`${grub_probe} --target=device /boot`"
+ GRUB_DEVICE_BOOT_UUID="`${grub_probe} --device ${GRUB_DEVICE_BOOT} --target=fs_uuid 2> /dev/null`" || true
+ 
++# Disable os-prober by default due to security reasons.
++GRUB_DISABLE_OS_PROBER="true"
++
+ # Filesystem for the device containing our userland.  Used for stuff like
+ # choosing Hurd filesystem module.
+ GRUB_FS="`${grub_probe} --device ${GRUB_DEVICE} --target=fs 2> /dev/null || echo unknown`"
+@@ -218,6 +221,7 @@ export GRUB_DEVICE \
+   GRUB_DEVICE_PARTUUID \
+   GRUB_DEVICE_BOOT \
+   GRUB_DEVICE_BOOT_UUID \
++  GRUB_DISABLE_OS_PROBER \
+   GRUB_FS \
+   GRUB_FONT \
+   GRUB_PRELOAD_MODULES \
+@@ -263,7 +267,6 @@ export GRUB_DEFAULT \
+   GRUB_BACKGROUND \
+   GRUB_THEME \
+   GRUB_GFXPAYLOAD_LINUX \
+-  GRUB_DISABLE_OS_PROBER \
+   GRUB_INIT_TUNE \
+   GRUB_SAVEDEFAULT \
+   GRUB_ENABLE_CRYPTODISK \
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index f11f856..c08dfc4 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,8 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
+-  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
++  grub_warn "$(gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.")"
+   exit 0
+ fi
+ 
+@@ -36,12 +36,12 @@ if ! command -v os-prober > /dev/null || ! command -v linux-boot-prober > /dev/n
+   exit 0
+ fi
+ 
++grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
++
+ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
+-else
+-  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {
+-- 
+2.45.4
+

--- a/base/comps/grub2/grub2.comp.toml
+++ b/base/comps/grub2/grub2.comp.toml
@@ -16,3 +16,38 @@ type = "file-search-replace"
 file = "grub.macros"
 regex = '%global with_xen_pvh_arch 1'
 replacement = '%global with_xen_pvh_arch 0'
+
+# Re-disable os-prober by default (security). The Fedora grub2 package carries
+# two downstream reverts -- Patch0002 and Patch0003 -- that re-enable os-prober
+# by default. Automatic, silent execution of os-prober is a known attack vector,
+# so Azure Linux restores upstream GRUB's secure default. Rather than dropping
+# the Fedora reverts (which would shift line numbers and break the context of
+# later patches in the 382-patch series -- the failure that got the previous
+# attempt reverted), these two trailing patches are appended to the end of the
+# grub.patches series and are exact git reverts of the Fedora reverts.
+#
+# NOTE: grub2's patch series lives in the %include'd grub.patches file (Source11),
+# not as inline PatchNNNN: tags in the spec, so the patch-add overlay cannot see
+# the existing 382 patches to number new ones correctly. Instead we stage the two
+# files with file-add and append their Patch0383/Patch0384 entries to grub.patches
+# directly; do_common_setup applies them last via `git am %{patches}`.
+[[components.grub2.overlays]]
+description = "Stage os-prober revert patch 0383 (revert of Fedora Patch0003)"
+type = "file-add"
+file = "0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch"
+source = "0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch"
+
+[[components.grub2.overlays]]
+description = "Stage os-prober revert patch 0384 (revert of Fedora Patch0002), restoring GRUB_DISABLE_OS_PROBER=true"
+type = "file-add"
+file = "0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch"
+source = "0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch"
+
+[[components.grub2.overlays]]
+description = "Append Patch0383/Patch0384 (os-prober reverts) to the end of the grub.patches series"
+type = "file-search-replace"
+file = "grub.patches"
+regex = 'Patch0382: 0382-Set-correctly-the-memory-attributes-for-the-kernel-P\.patch'
+replacement = '''Patch0382: 0382-Set-correctly-the-memory-attributes-for-the-kernel-P.patch
+Patch0383: 0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
+Patch0384: 0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch'''

--- a/locks/grub2.lock
+++ b/locks/grub2.lock
@@ -3,5 +3,5 @@ version = 1
 import-commit = '354c77b195316a4aa09979793a73ea4485217769'
 upstream-commit = '354c77b195316a4aa09979793a73ea4485217769'
 manual-bump = 1
-input-fingerprint = 'sha256:218bb17939644ac159ceee0573390edcbf722424a674b8a95182f580bc99dbbb'
+input-fingerprint = 'sha256:5e370b734a7897af14b6a9e2b266d6d59e3e3f74b14f5a947a1a6ab47b15153f'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'


### PR DESCRIPTION
## Summary

Restore upstream GRUB's secure default in which **os-prober is disabled by default**. Automatic, silent execution of `os-prober` (and creating boot entries from its output) is a known attack vector, so it must not run unless an admin explicitly opts in.

Azure Linux's `grub2` is sourced from Fedora dist-git and customized via azldev `comp.toml` overlays. Fedora ships two downstream reverts — `Patch0002` and `Patch0003` — that re-enable os-prober by default. This change re-disables it.

## Approach

Rather than **dropping** the Fedora reverts (which shifts patch line numbers and breaks the context of later patches in the 382-patch series — exactly the failure that caused the previous attempt, #17375, to be reverted by f526821d2702), this PR **appends two trailing patches** that are exact `git revert`s of the Fedora reverts:

| Patch | Reverts | Effect |
|-------|---------|--------|
| `Patch0383` | Fedora `Patch0003` (`Revert "templates: Disable the os-prober by default"`) | Restores secure docs + `30_os-prober` gate |
| `Patch0384` | Fedora `Patch0002` (`Revert "templates: Properly disable the os-prober by default"`) | Restores `GRUB_DISABLE_OS_PROBER="true"` default in `grub-mkconfig` |

Implemented as three overlays in `base/comps/grub2/grub2.comp.toml` (two `file-add` + one `file-search-replace` appending `Patch0383`/`Patch0384` to the end of `grub.patches`). Because they apply last, all 382 prior patches keep their context and the build does not break.

## Verification

Built locally with `azldev component build -p grub2 --no-check` (succeeds end-to-end). The resulting `grub2-tools` RPM was extracted and confirmed:

- `grub2-mkconfig` contains `GRUB_DISABLE_OS_PROBER="true"` (the security default)
- `etc/grub.d/30_os-prober` is gated on `[ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]` → `exit 0`
