### PR TITLE
fix(grub2): disable os-prober by default

### DIFF
--- a/base/comps/grub2/0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/base/comps/grub2/0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,0 +1,84 @@
+From f0b1c8c9aeae9f48910668a9a1df80e9fdde1151 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 9 Jun 2026 19:43:35 +0000
+Subject: Revert "Revert "templates: Disable the os-prober by
+ default""
+
+This reverts the Fedora downstream patch
+"0003-Revert-templates-Disable-the-os-prober-by-default.patch", thereby
+re-applying upstream GRUB commit e346414725a70e5c74ee87ca14e580c66f517666
+("templates: Disable the os-prober by default").
+
+Automatic and silent execution of os-prober is a known attack vector, so
+os-prober must remain disabled by default. Rather than dropping Patch0003
+from the series (which shifts context and breaks later patches), this
+change re-applies the upstream behaviour as a trailing patch. The
+grub.texi hunk is reconciled with Patch0034 (grub-mkconfig ->
+grub2-mkconfig).
+---
+ docs/grub.texi              | 18 ++++++++++--------
+ util/grub.d/30_os-prober.in |  5 ++++-
+ 2 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/docs/grub.texi b/docs/grub.texi
+index ae01e8c..defa75e 100644
+--- a/docs/grub.texi
++++ b/docs/grub.texi
+@@ -1559,10 +1559,13 @@ boot sequence.  If you have problems, set this option to @samp{text} and
+ GRUB will tell Linux to boot in normal text mode.
+ 
+ @item GRUB_DISABLE_OS_PROBER
+-Normally, @command{grub2-mkconfig} will try to use the external
+-@command{os-prober} program, if installed, to discover other operating
+-systems installed on the same system and generate appropriate menu entries
+-for them.  Set this option to @samp{true} to disable this.
++The @command{grub2-mkconfig} has a feature to use the external
++@command{os-prober} program to discover other operating systems installed on
++the same machine and generate appropriate menu entries for them. It is disabled
++by default since automatic and silent execution of @command{os-prober}, and
++creating boot entries based on that data, is a potential attack vector. Set
++this option to @samp{false} to enable this feature in the
++@command{grub2-mkconfig} command.
+ 
+ @item GRUB_OS_PROBER_SKIP_LIST
+ List of space-separated FS UUIDs of filesystems to be ignored from os-prober
+@@ -1893,10 +1896,9 @@ than zero; otherwise 0.
+ @section Multi-boot manual config
+ 
+ Currently autogenerating config files for multi-boot environments depends on
+-os-prober and has several shortcomings. While fixing it is scheduled for the
+-next release, meanwhile you can make use of the power of GRUB syntax and do it
+-yourself. A possible configuration is detailed here, feel free to adjust to your
+-needs.
++os-prober and has several shortcomings. Due to that it is disabled by default.
++It is advised to use the power of GRUB syntax and do it yourself. A possible
++configuration is detailed here, feel free to adjust to your needs.
+ 
+ First create a separate GRUB partition, big enough to hold GRUB. Some of the
+ following entries show how to load OS installer images from this same partition,
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index 18fe02c..f11f856 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,7 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
++  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
+   exit 0
+ fi
+ 
+@@ -39,6 +40,8 @@ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
++else
++  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {
+-- 
+2.45.4
+

--- a/base/comps/grub2/0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/base/comps/grub2/0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,0 +1,83 @@
+From 1c5a574543ecd06631dbf8dd46cb8dd55e93f056 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 9 Jun 2026 19:43:35 +0000
+Subject: Revert "Revert "templates: Properly disable the os-prober
+ by default""
+
+This reverts the Fedora downstream patch
+"0002-Revert-templates-Properly-disable-the-os-prober-by-d.patch", thereby
+re-applying upstream GRUB commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925
+("templates: Properly disable the os-prober by default").
+
+This restores the GRUB_DISABLE_OS_PROBER="true" default in
+grub-mkconfig and the corresponding warning logic in 30_os-prober.in, so
+os-prober is disabled by default. Applied as a trailing patch to avoid
+disturbing the context of later patches in the series.
+---
+ util/grub-mkconfig.in       | 5 ++++-
+ util/grub.d/30_os-prober.in | 8 ++++----
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index 1cfb587..e53e19c 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -155,6 +155,9 @@ GRUB_DEVICE_PARTUUID="`${grub_probe} --device ${GRUB_DEVICE} --target=partuuid 2
+ GRUB_DEVICE_BOOT="`${grub_probe} --target=device /boot`"
+ GRUB_DEVICE_BOOT_UUID="`${grub_probe} --device ${GRUB_DEVICE_BOOT} --target=fs_uuid 2> /dev/null`" || true
+ 
++# Disable os-prober by default due to security reasons.
++GRUB_DISABLE_OS_PROBER="true"
++
+ # Filesystem for the device containing our userland.  Used for stuff like
+ # choosing Hurd filesystem module.
+ GRUB_FS="`${grub_probe} --device ${GRUB_DEVICE} --target=fs 2> /dev/null || echo unknown`"
+@@ -218,6 +221,7 @@ export GRUB_DEVICE \
+   GRUB_DEVICE_PARTUUID \
+   GRUB_DEVICE_BOOT \
+   GRUB_DEVICE_BOOT_UUID \
++  GRUB_DISABLE_OS_PROBER \
+   GRUB_FS \
+   GRUB_FONT \
+   GRUB_PRELOAD_MODULES \
+@@ -263,7 +267,6 @@ export GRUB_DEFAULT \
+   GRUB_BACKGROUND \
+   GRUB_THEME \
+   GRUB_GFXPAYLOAD_LINUX \
+-  GRUB_DISABLE_OS_PROBER \
+   GRUB_INIT_TUNE \
+   GRUB_SAVEDEFAULT \
+   GRUB_ENABLE_CRYPTODISK \
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index f11f856..c08dfc4 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,8 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
+-  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
++  grub_warn "$(gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.")"
+   exit 0
+ fi
+ 
+@@ -36,12 +36,12 @@ if ! command -v os-prober > /dev/null || ! command -v linux-boot-prober > /dev/n
+   exit 0
+ fi
+ 
++grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
++
+ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
+-else
+-  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {
+-- 
+2.45.4
+

--- a/base/comps/grub2/0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch
+++ b/base/comps/grub2/0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch
@@ -1,0 +1,34 @@
+From 02294c746691d1c4683af4550dee35b7143633c3 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 16 Jun 2026 19:03:21 +0000
+Subject: Revert "Revert "templates: Fix user-facing typo with an
+ incorrect use of "it's"""
+
+This reverts the Fedora downstream patch
+"0001-Revert-templates-Fix-user-facing-typo-with-an-incorr.patch", thereby
+re-applying upstream GRUB commit 722737630889607c3b5761f1f5a48f1674cd2821
+("templates: Fix user-facing typo with an incorrect use of "it's").
+
+Restores the correct possessive "Its output" in the os-prober warning
+message in util/grub.d/30_os-prober.in. Applied as a trailing patch after
+Patch0383/Patch0384 so the full os-prober block matches upstream.
+---
+ util/grub.d/30_os-prober.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index c08dfc4..cae0530 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -36,7 +36,7 @@ if ! command -v os-prober > /dev/null || ! command -v linux-boot-prober > /dev/n
+   exit 0
+ fi
+ 
+-grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
++grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIts output will be used to detect bootable binaries on them and create new boot entries.")"
+ 
+ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+-- 
+2.45.4
+

--- a/base/comps/grub2/grub2.comp.toml
+++ b/base/comps/grub2/grub2.comp.toml
@@ -16,3 +16,51 @@ type = "file-search-replace"
 file = "grub.macros"
 regex = '%global with_xen_pvh_arch 1'
 replacement = '%global with_xen_pvh_arch 0'
+
+# Re-disable os-prober by default. The Fedora grub2 package carries three
+# downstream reverts -- Patch0001, Patch0002 and Patch0003 -- that undo upstream's
+# os-prober changes (re-enabling it by default and re-introducing an "it's" typo).
+# Automatic, silent execution of os-prober is a known attack vector, so Azure
+# Linux restores upstream GRUB's secure default. Rather than dropping the Fedora
+# reverts (which would shift line numbers and break the context of later
+# patches), these three trailing patches are appended to the end of the
+# grub.patches series and are exact git reverts of the Fedora reverts.
+#
+# NOTE: grub2's patch series lives in the %include'd grub.patches file (Source11),
+# not as inline PatchNNNN: tags in the spec, so the patch-add overlay cannot see
+# the existing 382 patches to number new ones correctly. Instead we stage the
+# files with file-add and append their Patch0383/Patch0384/Patch0385 entries to
+# grub.patches directly.
+[[components.grub2.overlays]]
+description = "Stage os-prober revert patch 0383 (revert of Fedora Patch0003)"
+type = "file-add"
+file = "0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch"
+source = "0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch"
+
+[[components.grub2.overlays]]
+description = "Stage os-prober revert patch 0384 (revert of Fedora Patch0002), restoring GRUB_DISABLE_OS_PROBER=true"
+type = "file-add"
+file = "0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch"
+source = "0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch"
+
+[[components.grub2.overlays]]
+description = "Stage os-prober revert patch 0385 (revert of Fedora Patch0001), restoring upstream's 'Its output' typo fix"
+type = "file-add"
+file = "0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch"
+source = "0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch"
+
+[[components.grub2.overlays]]
+description = "Append Patch0383/Patch0384/Patch0385 (os-prober reverts) to the end of the grub.patches series"
+type = "file-search-replace"
+file = "grub.patches"
+# Match the exact Patch0382 line. file-search-replace does a literal replacement
+# (no regex backreferences), so the matched text is re-emitted verbatim ahead of
+# the three appended os-prober reverts. Matching the full filename is deliberate:
+# the regex and replacement must stay in lockstep, and if Fedora ever renames the
+# 0382 patch this overlay fails loudly at render time rather than silently
+# rewriting the line back to the stale name.
+regex = 'Patch0382: 0382-Set-correctly-the-memory-attributes-for-the-kernel-P\.patch'
+replacement = '''Patch0382: 0382-Set-correctly-the-memory-attributes-for-the-kernel-P.patch
+Patch0383: 0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
+Patch0384: 0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+Patch0385: 0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch'''

--- a/locks/grub2.lock
+++ b/locks/grub2.lock
@@ -3,5 +3,5 @@ version = 1
 import-commit = '354c77b195316a4aa09979793a73ea4485217769'
 upstream-commit = '354c77b195316a4aa09979793a73ea4485217769'
 manual-bump = 1
-input-fingerprint = 'sha256:218bb17939644ac159ceee0573390edcbf722424a674b8a95182f580bc99dbbb'
+input-fingerprint = 'sha256:696727eb72078e8299e033cf6f3831acaf4b8db09db369bbfe47cd5b1e23b114'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/grub2/0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/specs/g/grub2/0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,0 +1,84 @@
+From f0b1c8c9aeae9f48910668a9a1df80e9fdde1151 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 9 Jun 2026 19:43:35 +0000
+Subject: Revert "Revert "templates: Disable the os-prober by
+ default""
+
+This reverts the Fedora downstream patch
+"0003-Revert-templates-Disable-the-os-prober-by-default.patch", thereby
+re-applying upstream GRUB commit e346414725a70e5c74ee87ca14e580c66f517666
+("templates: Disable the os-prober by default").
+
+Automatic and silent execution of os-prober is a known attack vector, so
+os-prober must remain disabled by default. Rather than dropping Patch0003
+from the series (which shifts context and breaks later patches), this
+change re-applies the upstream behaviour as a trailing patch. The
+grub.texi hunk is reconciled with Patch0034 (grub-mkconfig ->
+grub2-mkconfig).
+---
+ docs/grub.texi              | 18 ++++++++++--------
+ util/grub.d/30_os-prober.in |  5 ++++-
+ 2 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/docs/grub.texi b/docs/grub.texi
+index ae01e8c..defa75e 100644
+--- a/docs/grub.texi
++++ b/docs/grub.texi
+@@ -1559,10 +1559,13 @@ boot sequence.  If you have problems, set this option to @samp{text} and
+ GRUB will tell Linux to boot in normal text mode.
+ 
+ @item GRUB_DISABLE_OS_PROBER
+-Normally, @command{grub2-mkconfig} will try to use the external
+-@command{os-prober} program, if installed, to discover other operating
+-systems installed on the same system and generate appropriate menu entries
+-for them.  Set this option to @samp{true} to disable this.
++The @command{grub2-mkconfig} has a feature to use the external
++@command{os-prober} program to discover other operating systems installed on
++the same machine and generate appropriate menu entries for them. It is disabled
++by default since automatic and silent execution of @command{os-prober}, and
++creating boot entries based on that data, is a potential attack vector. Set
++this option to @samp{false} to enable this feature in the
++@command{grub2-mkconfig} command.
+ 
+ @item GRUB_OS_PROBER_SKIP_LIST
+ List of space-separated FS UUIDs of filesystems to be ignored from os-prober
+@@ -1893,10 +1896,9 @@ than zero; otherwise 0.
+ @section Multi-boot manual config
+ 
+ Currently autogenerating config files for multi-boot environments depends on
+-os-prober and has several shortcomings. While fixing it is scheduled for the
+-next release, meanwhile you can make use of the power of GRUB syntax and do it
+-yourself. A possible configuration is detailed here, feel free to adjust to your
+-needs.
++os-prober and has several shortcomings. Due to that it is disabled by default.
++It is advised to use the power of GRUB syntax and do it yourself. A possible
++configuration is detailed here, feel free to adjust to your needs.
+ 
+ First create a separate GRUB partition, big enough to hold GRUB. Some of the
+ following entries show how to load OS installer images from this same partition,
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index 18fe02c..f11f856 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,7 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
++  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
+   exit 0
+ fi
+ 
+@@ -39,6 +40,8 @@ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
++else
++  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {
+-- 
+2.45.4
+

--- a/specs/g/grub2/0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/specs/g/grub2/0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,0 +1,83 @@
+From 1c5a574543ecd06631dbf8dd46cb8dd55e93f056 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 9 Jun 2026 19:43:35 +0000
+Subject: Revert "Revert "templates: Properly disable the os-prober
+ by default""
+
+This reverts the Fedora downstream patch
+"0002-Revert-templates-Properly-disable-the-os-prober-by-d.patch", thereby
+re-applying upstream GRUB commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925
+("templates: Properly disable the os-prober by default").
+
+This restores the GRUB_DISABLE_OS_PROBER="true" default in
+grub-mkconfig and the corresponding warning logic in 30_os-prober.in, so
+os-prober is disabled by default. Applied as a trailing patch to avoid
+disturbing the context of later patches in the series.
+---
+ util/grub-mkconfig.in       | 5 ++++-
+ util/grub.d/30_os-prober.in | 8 ++++----
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index 1cfb587..e53e19c 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -155,6 +155,9 @@ GRUB_DEVICE_PARTUUID="`${grub_probe} --device ${GRUB_DEVICE} --target=partuuid 2
+ GRUB_DEVICE_BOOT="`${grub_probe} --target=device /boot`"
+ GRUB_DEVICE_BOOT_UUID="`${grub_probe} --device ${GRUB_DEVICE_BOOT} --target=fs_uuid 2> /dev/null`" || true
+ 
++# Disable os-prober by default due to security reasons.
++GRUB_DISABLE_OS_PROBER="true"
++
+ # Filesystem for the device containing our userland.  Used for stuff like
+ # choosing Hurd filesystem module.
+ GRUB_FS="`${grub_probe} --device ${GRUB_DEVICE} --target=fs 2> /dev/null || echo unknown`"
+@@ -218,6 +221,7 @@ export GRUB_DEVICE \
+   GRUB_DEVICE_PARTUUID \
+   GRUB_DEVICE_BOOT \
+   GRUB_DEVICE_BOOT_UUID \
++  GRUB_DISABLE_OS_PROBER \
+   GRUB_FS \
+   GRUB_FONT \
+   GRUB_PRELOAD_MODULES \
+@@ -263,7 +267,6 @@ export GRUB_DEFAULT \
+   GRUB_BACKGROUND \
+   GRUB_THEME \
+   GRUB_GFXPAYLOAD_LINUX \
+-  GRUB_DISABLE_OS_PROBER \
+   GRUB_INIT_TUNE \
+   GRUB_SAVEDEFAULT \
+   GRUB_ENABLE_CRYPTODISK \
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index f11f856..c08dfc4 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -26,8 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
+-if [ "x${GRUB_DISABLE_OS_PROBER}" = "xfalse" ]; then
+-  gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.\n"
++if [ "x${GRUB_DISABLE_OS_PROBER}" = "xtrue" ]; then
++  grub_warn "$(gettext_printf "os-prober will not be executed to detect other bootable partitions.\nSystems on them will not be added to the GRUB boot configuration.\nCheck GRUB_DISABLE_OS_PROBER documentation entry.")"
+   exit 0
+ fi
+ 
+@@ -36,12 +36,12 @@ if ! command -v os-prober > /dev/null || ! command -v linux-boot-prober > /dev/n
+   exit 0
+ fi
+ 
++grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
++
+ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+   # empty os-prober output, nothing doing
+   exit 0
+-else
+-  grub_warn "$(gettext_printf "os-prober was executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
+ fi
+ 
+ osx_entry() {
+-- 
+2.45.4
+

--- a/specs/g/grub2/0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch
+++ b/specs/g/grub2/0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch
@@ -1,0 +1,34 @@
+From 02294c746691d1c4683af4550dee35b7143633c3 Mon Sep 17 00:00:00 2001
+From: Vince Perri <5596945+vinceaperri@users.noreply.github.com>
+Date: Tue, 16 Jun 2026 19:03:21 +0000
+Subject: Revert "Revert "templates: Fix user-facing typo with an
+ incorrect use of "it's"""
+
+This reverts the Fedora downstream patch
+"0001-Revert-templates-Fix-user-facing-typo-with-an-incorr.patch", thereby
+re-applying upstream GRUB commit 722737630889607c3b5761f1f5a48f1674cd2821
+("templates: Fix user-facing typo with an incorrect use of "it's").
+
+Restores the correct possessive "Its output" in the os-prober warning
+message in util/grub.d/30_os-prober.in. Applied as a trailing patch after
+Patch0383/Patch0384 so the full os-prober block matches upstream.
+---
+ util/grub.d/30_os-prober.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
+index c08dfc4..cae0530 100644
+--- a/util/grub.d/30_os-prober.in
++++ b/util/grub.d/30_os-prober.in
+@@ -36,7 +36,7 @@ if ! command -v os-prober > /dev/null || ! command -v linux-boot-prober > /dev/n
+   exit 0
+ fi
+ 
+-grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIt's output will be used to detect bootable binaries on them and create new boot entries.")"
++grub_warn "$(gettext_printf "os-prober will be executed to detect other bootable partitions.\nIts output will be used to detect bootable binaries on them and create new boot entries.")"
+ 
+ OSPROBED="`os-prober | tr ' ' '^' | paste -s -d ' '`"
+ if [ -z "${OSPROBED}" ] ; then
+-- 
+2.45.4
+

--- a/specs/g/grub2/grub.patches
+++ b/specs/g/grub2/grub.patches
@@ -379,3 +379,6 @@ Patch0379: 0379-loader-efi-chainloader-Fix-double-free.patch
 Patch0380: 0380-loader-efi-chainloader-Fix-null-pointer-dereference.patch
 Patch0381: 0381-osdep-linux-getroot-Detect-DDF-container-similar-to-.patch
 Patch0382: 0382-Set-correctly-the-memory-attributes-for-the-kernel-P.patch
+Patch0383: 0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
+Patch0384: 0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+Patch0385: 0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch

--- a/specs/g/grub2/grub2.spec
+++ b/specs/g/grub2/grub2.spec
@@ -20,7 +20,7 @@
 Name:		grub2
 Epoch:		1
 Version:	2.12
-Release: 44%{?dist}
+Release: 45%{?dist}
 Summary:	Bootloader with support for Linux, Multiboot and more
 License:	GPL-3.0-or-later
 URL:		http://www.gnu.org/software/grub/


### PR DESCRIPTION
## Summary

Restore upstream GRUB's secure, correct os-prober behaviour. The two key changes:

1. **os-prober is disabled by default.** Automatic, silent execution of `os-prober` (and creating boot entries from its output) is a known attack vector, so it must not run unless an admin explicitly opts in.
2. **A user-facing typo is fixed** (`It's output` → `Its output`) in the os-prober warning message.

Fedora ships three downstream reverts — `Patch0001`, `Patch0002`, and `Patch0003` — that undo upstream's os-prober work (re-enabling it by default and re-introducing the typo). This change re-applies the upstream behaviour.

## Approach

Rather than **dropping** the Fedora reverts (which shifts patch line numbers and breaks the context of later patches in the 382-patch series — exactly the failure that caused the previous attempt, #17375, to be reverted by f526821d2702), this PR **appends three trailing patches** that are exact `git revert`s of the Fedora reverts:

| Patch | Reverts | Effect |
|-------|---------|--------|
| `Patch0383` | Fedora `Patch0003` (`Revert "templates: Disable the os-prober by default"`) | Restores secure docs + `30_os-prober` gate (`xtrue`) |
| `Patch0384` | Fedora `Patch0002` (`Revert "templates: Properly disable the os-prober by default"`) | Restores `GRUB_DISABLE_OS_PROBER="true"` default in `grub-mkconfig` |
| `Patch0385` | Fedora `Patch0001` (`Revert "templates: Fix user-facing typo with an incorrect use of "it's""`) | Restores the correct possessive `Its output` in the os-prober warning |

Implemented as overlays in `base/comps/grub2/grub2.comp.toml` (three `file-add` + one `file-search-replace` appending `Patch0383`/`Patch0384`/`Patch0385` to the end of `grub.patches`). Because they apply last, all 382 prior patches keep their context and the build does not break.