### PR TITLE
Patch `python-virtualenv` for CVE-2026-8643

### DIFF
--- a/SPECS/python-virtualenv/CVE-2026-8643v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-8643v0.patch
@@ -1,0 +1,58 @@
+From 7f85b4d60f6efc690baf11266650eaba0b1d6c46 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Mon, 18 May 2026 23:04:43 -0400
+Subject: [PATCH] Reject entry point names that escape scripts dir
+
+Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/14000.patch
+---
+ pip/_internal/operations/install/wheel.py | 26 ++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/pip/_internal/operations/install/wheel.py b/pip/_internal/operations/install/wheel.py
+index aef42aa..84ae542 100644
+--- a/pip/_internal/operations/install/wheel.py
++++ b/pip/_internal/operations/install/wheel.py
+@@ -405,17 +405,37 @@ class MissingCallableSuffix(InstallationError):
+         )
+ 
+ 
+-def _raise_for_invalid_entrypoint(specification: str) -> None:
++def _script_within_dir(name: str, scripts_dir: str) -> bool:
++    """Return whether script ``name`` resolves to a path inside the ``scripts_dir``.
++
++    distlib joins the entry point name onto the scripts directory, so a name
++    with path separators or ``..`` components can resolve elsewhere.
++    """
++    root = os.path.normpath(scripts_dir)
++    dest = os.path.normpath(os.path.join(scripts_dir, name))
++    return dest.startswith(root + os.sep)
++
++
++def _raise_for_invalid_entrypoint(specification: str, scripts_dir: str) -> None:
+     entry = get_export_entry(specification)
+-    if entry is not None and entry.suffix is None:
++    if entry is None:
++        return
++
++    if entry.suffix is None:
+         raise MissingCallableSuffix(str(entry))
+ 
++    if not _script_within_dir(entry.name, scripts_dir):
++        raise InstallationError(
++            f"Invalid script entry point name {entry.name!r}: the script "
++            f"would be installed outside the scripts directory ({scripts_dir})."
++        )
++
+ 
+ class PipScriptMaker(ScriptMaker):
+     def make(
+         self, specification: str, options: Optional[Dict[str, Any]] = None
+     ) -> List[str]:
+-        _raise_for_invalid_entrypoint(specification)
++        _raise_for_invalid_entrypoint(specification, self.target_dir)
+         return super().make(specification, options)
+ 
+ 
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/CVE-2026-8643v1.patch
+++ b/SPECS/python-virtualenv/CVE-2026-8643v1.patch
@@ -1,0 +1,60 @@
+From 7f85b4d60f6efc690baf11266650eaba0b1d6c46 Mon Sep 17 00:00:00 2001
+From: Damian Shaw <damian.peter.shaw@gmail.com>
+Date: Mon, 18 May 2026 23:04:43 -0400
+Subject: [PATCH] Reject entry point names that escape scripts dir
+
+Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/14000.patch
+---
+ pip/_internal/operations/install/wheel.py | 26 ++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/pip/_internal/operations/install/wheel.py b/pip/_internal/operations/install/wheel.py
+index 2724f15..ec2faaa 100644
+--- a/pip/_internal/operations/install/wheel.py
++++ b/pip/_internal/operations/install/wheel.py
+@@ -397,11 +397,31 @@ class MissingCallableSuffix(InstallationError):
+         )
+ 
+ 
+-def _raise_for_invalid_entrypoint(specification: str) -> None:
++def _script_within_dir(name: str, scripts_dir: str) -> bool:
++    """Return whether script ``name`` resolves to a path inside the ``scripts_dir``.
++
++    distlib joins the entry point name onto the scripts directory, so a name
++    with path separators or ``..`` components can resolve elsewhere.
++    """
++    root = os.path.normpath(scripts_dir)
++    dest = os.path.normpath(os.path.join(scripts_dir, name))
++    return dest.startswith(root + os.sep)
++
++
++def _raise_for_invalid_entrypoint(specification: str, scripts_dir: str) -> None:
+     entry = get_export_entry(specification)
+-    if entry is not None and entry.suffix is None:
++    if entry is None:
++        return
++
++    if entry.suffix is None:
+         raise MissingCallableSuffix(str(entry))
+ 
++    if not _script_within_dir(entry.name, scripts_dir):
++        raise InstallationError(
++            f"Invalid script entry point name {entry.name!r}: the script "
++            f"would be installed outside the scripts directory ({scripts_dir})."
++        )
++
+ 
+ class PipScriptMaker(ScriptMaker):
+     # Override distlib's default script template with one that
+@@ -420,7 +440,7 @@ class PipScriptMaker(ScriptMaker):
+     def make(
+         self, specification: str, options: dict[str, Any] | None = None
+     ) -> list[str]:
+-        _raise_for_invalid_entrypoint(specification)
++        _raise_for_invalid_entrypoint(specification, self.target_dir)
+         return super().make(specification, options)
+ 
+ 
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/python-virtualenv.spec
+++ b/SPECS/python-virtualenv/python-virtualenv.spec
@@ -1,7 +1,7 @@
 Summary:        Virtual Python Environment builder
 Name:           python-virtualenv
 Version:        20.36.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -18,6 +18,8 @@ Patch1005:      CVE-2026-3219v0.patch
 Patch1006:      CVE-2026-3219v1.patch
 Patch1007:      CVE-2026-6357v0.patch
 Patch1008:      CVE-2026-6357v1.patch
+Patch1009:      CVE-2026-8643v0.patch
+Patch1010:      CVE-2026-8643v1.patch
 BuildArch:      noarch
 
 %description
@@ -71,6 +73,8 @@ virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/commands/list.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/self_outdated_check.py for CVE-2026-6357"
 patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1007}
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl/pip/_internal/operations/install/wheel.py for CVE-2026-8643"
+patch -p1 -d unpacked_pip-25.0.1-py3-none-any < %{PATCH1009}
 # Remove the original file
 rm -f src/virtualenv/seed/wheels/embed/pip-25.0.1-py3-none-any.whl
 # After patching, re-zip the contents back into a .whl
@@ -95,6 +99,8 @@ virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pi
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/commands/list.py
 virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/self_outdated_check.py for CVE-2026-6357"
 patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1008}
+echo "Manually Patching virtualenv-20.36.1/src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl/pip/_internal/operations/install/wheel.py for CVE-2026-8643"
+patch -p1 -d unpacked_pip-25.3-py3-none-any < %{PATCH1010}
 rm -f src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl
 pushd unpacked_pip-25.3-py3-none-any
 zip -r ../src/virtualenv/seed/wheels/embed/pip-25.3-py3-none-any.whl *
@@ -157,6 +163,9 @@ tox -e py
 %{_bindir}/virtualenv
 
 %changelog
+* Wed Jun 17 2026 Aditya Singh <v-aditysing@microsoft.com> - 20.36.1-5
+- Patch for CVE-2026-8643
+
 * Mon May 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 20.36.1-4
 - Patch for CVE-2026-6357
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---
###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Patch `python-virtualenv` for `CVE-2026-8643`
   - CVE affects the `pip` package in `python-virtualenv` as `pip` version `25.0.1` and `25.3` are in affected range of `< 26.1.2`.
   - Patch has been backported manually.
   - Patch matches with the upstream patch except that the files `tests/unit/test_wheel.py` and `news/14000.bugfix.rst` are not included as they don't exist in current source.
   - Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/pypa/pip/pull/14000.patch
   - Upstream PR Reference: https://github.com/pypa/pip/pull/14000

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/python-virtualenv/CVE-2026-8643v0.patch
- new file:   SPECS/python-virtualenv/CVE-2026-8643v1.patch
- modified:   SPECS/python-virtualenv/python-virtualenv.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-8643

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.
- Patch applies cleanly
- License check script shows no warning.
- Installation and Uninstallation on docker image was successful.