### PR TITLE
nftables: Add patch to fix segfault when listing ruleset containing user-data (udata) in rule expressions

### DIFF
--- a/SPECS/nftables/fix_crash_when_ops_dont_support_udata.patch
+++ b/SPECS/nftables/fix_crash_when_ops_dont_support_udata.patch
@@ -1,0 +1,32 @@
+From be737a1986bfee0ddea4bee7863dca0123a2bcbc Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Thu, 8 May 2025 16:29:04 +0200
+Subject: src: netlink: fix crash when ops doesn't support udata
+
+Whenever a new version adds udata support to an expression, then old
+versions of nft will crash when trying to list such a ruleset generated
+by a more recent version of nftables.
+
+Fix this by falling back to 'type' format.
+
+Fixes: 6e48df5329ea ('src: add "typeof" build/parse/print support')
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Reviewed-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ src/netlink.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/netlink.c b/src/netlink.c
+index 86ca3214..d8891245 100644
+--- a/src/netlink.c
++++ b/src/netlink.c
+@@ -937,7 +937,7 @@ static struct expr *set_make_key(const struct nftnl_udata *attr)
+ 
+ 	etype = nftnl_udata_get_u32(ud[NFTNL_UDATA_SET_TYPEOF_EXPR]);
+ 	ops = expr_ops_by_type_u32(etype);
+-	if (!ops)
++	if (!ops || !ops->parse_udata)
+ 		return NULL;
+ 
+ 	expr = ops->parse_udata(ud[NFTNL_UDATA_SET_TYPEOF_DATA]);
+-- 

--- a/SPECS/nftables/fix_crash_when_ops_dont_support_udata.patch
+++ b/SPECS/nftables/fix_crash_when_ops_dont_support_udata.patch
@@ -12,6 +12,7 @@ Fix this by falling back to 'type' format.
 Fixes: 6e48df5329ea ('src: add "typeof" build/parse/print support')
 Signed-off-by: Florian Westphal <fw@strlen.de>
 Reviewed-by: Pablo Neira Ayuso <pablo@netfilter.org>
+Upstream Patch Reference : https://git.netfilter.org/nftables/commit/?id=be737a1986bfee0ddea4bee7863dca0123a2bcbc
 ---
  src/netlink.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/SPECS/nftables/nftables.spec
+++ b/SPECS/nftables/nftables.spec
@@ -12,7 +12,7 @@ Source2:        nftables.conf
 Source3:        main.nft
 Source4:        router.nft
 Source5:        nat.nft
-Patch0:          fix_crash_when_ops_dont_support_udata.patch
+Patch0:         fix_crash_when_ops_dont_support_udata.patch
 
 BuildRequires:  asciidoc
 BuildRequires:  bison

--- a/SPECS/nftables/nftables.spec
+++ b/SPECS/nftables/nftables.spec
@@ -12,7 +12,7 @@ Source2:        nftables.conf
 Source3:        main.nft
 Source4:        router.nft
 Source5:        nat.nft
-Patch:          fix_crash_when_ops_dont_support_udata.patch
+Patch0:          fix_crash_when_ops_dont_support_udata.patch
 
 BuildRequires:  asciidoc
 BuildRequires:  bison

--- a/SPECS/nftables/nftables.spec
+++ b/SPECS/nftables/nftables.spec
@@ -1,7 +1,7 @@
 Summary:        Netfilter Tables userspace utillites
 Name:           nftables
 Version:        1.0.9
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -12,6 +12,7 @@ Source2:        nftables.conf
 Source3:        main.nft
 Source4:        router.nft
 Source5:        nat.nft
+Patch:          fix_crash_when_ops_dont_support_udata.patch
 
 BuildRequires:  asciidoc
 BuildRequires:  bison
@@ -134,6 +135,10 @@ sed -i -e 's/\(sofile=\)".*"/\1"'$sofile'"/' \
 %{python3_sitelib}/nftables/
 
 %changelog
+* Thu Jun 18 2026 Sumedh Sharma <sumsharma@microsoft.com> - 1.0.9-2
+- Fix segmentation fault when listing ruleset containing unsupported
+  udata in expression.
+
 * Mon Feb 26 2024 Neha Agarwal <nehaagarwal@microsoft.com> - 1.0.9-1
 - Update to v1.0.9
 


### PR DESCRIPTION
### Summary
This commit fixes a backward-incompatibility between nftables versions 1.1.2+ and ≤1.1.1 where nftables 1.1.2+ began writing user-data (udata) fields when creating sets. In kubernetes deployment scenarios like using distroless istio CNI containers with nftables 1.1.2+, we end up using both older & newer nftables version on the host. This causes older versions to segfault when reading rulesets written by newer version in host network namespace, for ex in this case udata.

### Changes
[Upstream Patch](https://git.netfilter.org/nftables/commit/?id=be737a1986bfee0ddea4bee7863dca0123a2bcbc)

### Reference
[Upstream Issue](https://github.com/istio/istio/issues/58492#issuecomment-4620880090)

### Bug
https://microsoft.visualstudio.com/OS/_workitems/edit/62591721