### PR TITLE
[HIGH] Patch `kata-containers-cc` for CVE-2025-5791 and CVE-2025-4574

### DIFF
--- a/SPECS/kata-containers-cc/CVE-2025-4574.patch
+++ b/SPECS/kata-containers-cc/CVE-2025-4574.patch
@@ -1,0 +1,74 @@
+From ca3fc0dfaa51eae914bdd8bb88b34bce3561709e Mon Sep 17 00:00:00 2001
+From: Petros Angelatos <petrosagg@gmail.com>
+Date: Tue, 8 Apr 2025 22:07:19 +0300
+Subject: [PATCH] crossbeam-channel: prevent double free on Drop
+
+This PR is fixing a regression introduced by #1084 that can lead to a
+double free when dropping the channel.
+
+The method `Channel::discard_all_messages` has the property that if it
+observes `head.block` pointing to a non-null pointer it will attempt to
+free it.
+
+The same property holds for the `Channel::drop` method and so it is
+critical that whenever `head.block` is freed it must also be set to a
+null pointer so that it is freed exactly once.
+
+Before #1084 the behavior of `discard_all_messages` ensured `head.block`
+was `null` after its execution due to the atomic store right before
+exiting [1].
+
+After #1084 `discard_all_messages` atomically swaps the current value of
+`head.block` with a null pointer at the moment the value is read instead
+of waiting for the end of the function.
+
+The problem lies in the fact that `dicard_all_messages` contained two
+paths that could lead to `head.block` being read but only one of them
+would swap the value. This meant that `dicard_all_messages` could end up
+observing a non-null block pointer (and therefore attempting to free it)
+without setting `head.block` to null. This would then lead to
+`Channel::drop` making a second attempt at dropping the same pointer.
+
+The bug is similar to the one previously fixed by #972 and the double
+free can be reproduced by reverting the reproduction commit from that PR
+[2].
+
+As with #972 it is quite difficult to trigger this bug without
+introducing artificial sleeps in critical points so this PR does not
+include a test.
+
+[1] https://github.com/crossbeam-rs/crossbeam/blob/crossbeam-channel-0.5.11/crossbeam-channel/src/flavors/list.rs#L625
+[2] https://github.com/crossbeam-rs/crossbeam/pull/972/commits/2d2262823de47492fdfa9555a47cfd999772f396
+
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+
+Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/crossbeam-rs/crossbeam/pull/1187.patch
+---
+ src/agent/vendor/crossbeam-channel/.cargo-checksum.json | 2 +-
+ src/agent/vendor/crossbeam-channel/src/flavors/list.rs  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/agent/vendor/crossbeam-channel/.cargo-checksum.json b/src/agent/vendor/crossbeam-channel/.cargo-checksum.json
+index b6da487d..5cba471f 100644
+--- a/src/agent/vendor/crossbeam-channel/.cargo-checksum.json
++++ b/src/agent/vendor/crossbeam-channel/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"CHANGELOG.md":"4a7e4bc790fa3e9acb9577c489964690aa3a9ef549571fefd9e15362022901c2","Cargo.lock":"a4cbda8f2355ee7e9543e1eb01fb67173c079ae0337146c12fa577a4df81fa83","Cargo.toml":"a61aa427c7e7b3d318db6130cb49e4d1a0a2677853a3f9b6774c0cba93106cf8","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","LICENSE-THIRD-PARTY":"b16db96b93b1d7cf7bea533f572091ec6bca3234fbe0a83038be772ff391a44c","README.md":"5dfb91ebb498dec49948a440a53977109ec532388170e567c3c2a0339589aa4c","benches/crossbeam.rs":"96cb1abd23cac3ef8a7174a802e94609926b555bb02c9658c78723d433f1dd92","examples/fibonacci.rs":"4e88fa40048cdc31e9c7bb60347d46f92543d7ddf39cab3b52bfe44affdb6a02","examples/matching.rs":"63c250e164607a7a9f643d46f107bb5da846d49e89cf9069909562d20e530f71","examples/stopwatch.rs":"d02121258f08d56f1eb7997e19bcb9bacb6836cfa0abbba90a9e59d8a50ae5cf","src/channel.rs":"13fbbe12d4ec361855af1c3587fc80aea5f537db8dc44dd4f66c9e2b4ae9f5c1","src/context.rs":"0c5f278572d3db33ed3dfba45f62c8db372c9153db0695a5cdecf700c2ba73a5","src/counter.rs":"b8f1e48ec634a7dab8e04c485209161587ecbbd2d57b0825467164d4554c6249","src/err.rs":"44cb2024ee6b0cd6fd24996430e53720769f64b4ac35016bc3e05cb9db48681d","src/flavors/array.rs":"79bc219187c9f40b156b9fe551c1176b66bf73e6d48905b23a2d74c6366a2205","src/flavors/at.rs":"04e07861534f2f7d5b5f884f2f5bc9c008427e6d0afa1c8ad401e1d7e54b57eb","src/flavors/list.rs":"a1269b2a9b83e688cbd4ba2f06f6ce02763ca5dcb3ed27214d0dc64a97de30f6","src/flavors/mod.rs":"3d9d43bc38b0adb18c96c995c2bd3421d8e33ab6c30b20c3c467d21d48e485dc","src/flavors/never.rs":"747da857aa1a7601641f23f4930e6ad00ebaf50456d9be5c7aa270e2ecc24dcb","src/flavors/tick.rs":"0916ca3faef30b8cc591137701c456d5fc5b5b49cb1edad1e3a80d35bae222bb","src/flavors/zero.rs":"f9cbc9e035fadce808a4af86a223cfded89990ba1e9acfe731fb17a7fe12b432","src/lib.rs":"5b1c406fd1ce6140feae9000be361858da2aabe7fc9fffd0eafcb88020d2b268","src/select.rs":"301c765751586204371bedb69162e23bcf7e094cbc37b72203698a18b889550f","src/select_macro.rs":"f30b726dff104b17c2dfbd67b271758d8c06d63ec4811ffab88b2e1dac43e3df","src/utils.rs":"9bd81aeb385a81409a63f4b9edc35444c7fd1d2724725f9c34ad7ca39dd69a18","src/waker.rs":"017f87a120d945502701c0dba79062c7fe55d44e5907cc6f8605b4510c90d529","tests/after.rs":"0154a8e152880db17a20514ecdd49dabc361d3629858d119b9746b5e932c780c","tests/array.rs":"a57ae6264e676f573d7adb5c4b024994e98bc6811352516adb3444f880f7125e","tests/golang.rs":"7b2ef219ba8a21841c133512f3a540f8279a2458304e9bbed7da81d6091ecd82","tests/iter.rs":"25dc02135bbae9d47a30f9047661648e66bdc134e40ba78bc2fbacbb8b3819bc","tests/list.rs":"e71d34f790af290e463707c2336ff221f7841767e961b91747aa00e21df0ad32","tests/mpsc.rs":"5fbb5342fa7c9e4bcda5545255e0979dc6b9ba638edee127acf75372c18c925f","tests/never.rs":"ee40c4fc4dd5af4983fae8de6927f52b81174d222c162f745b26c4a6c7108e4f","tests/ready.rs":"4361352fa94254041e6c73e97b13be032c2d51c741f2a50519efe3000cf4dc28","tests/same_channel.rs":"2bab761443671e841e1b2476bd8082d75533a2f6be7946f5dbcee67cdc82dccb","tests/select.rs":"101ea8afd9a40d24c2d2aec29e5f2fdc4faac51aa1d7c9fe077b364f12edd206","tests/select_macro.rs":"e83bd33b34c47d703abe06420a23868809468516943347bdbfb6af4db0cec65a","tests/thread_locals.rs":"f42fcddca959b3b44cd545b92949d65e33a54332b27f490ec92f9f29b7f8290c","tests/tick.rs":"5f697bd14c48505d932e82065b5302ef668e1cc19cac18e8ac22e0c83c221c1d","tests/zero.rs":"9c5af802d5efb2c711f8242b8905ed29cc2601e48dbd95e41c7e6fbfe2918398"},"package":"06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"4a7e4bc790fa3e9acb9577c489964690aa3a9ef549571fefd9e15362022901c2","Cargo.lock":"a4cbda8f2355ee7e9543e1eb01fb67173c079ae0337146c12fa577a4df81fa83","Cargo.toml":"a61aa427c7e7b3d318db6130cb49e4d1a0a2677853a3f9b6774c0cba93106cf8","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"5734ed989dfca1f625b40281ee9f4530f91b2411ec01cb748223e7eb87e201ab","LICENSE-THIRD-PARTY":"b16db96b93b1d7cf7bea533f572091ec6bca3234fbe0a83038be772ff391a44c","README.md":"5dfb91ebb498dec49948a440a53977109ec532388170e567c3c2a0339589aa4c","benches/crossbeam.rs":"96cb1abd23cac3ef8a7174a802e94609926b555bb02c9658c78723d433f1dd92","examples/fibonacci.rs":"4e88fa40048cdc31e9c7bb60347d46f92543d7ddf39cab3b52bfe44affdb6a02","examples/matching.rs":"63c250e164607a7a9f643d46f107bb5da846d49e89cf9069909562d20e530f71","examples/stopwatch.rs":"d02121258f08d56f1eb7997e19bcb9bacb6836cfa0abbba90a9e59d8a50ae5cf","src/channel.rs":"13fbbe12d4ec361855af1c3587fc80aea5f537db8dc44dd4f66c9e2b4ae9f5c1","src/context.rs":"0c5f278572d3db33ed3dfba45f62c8db372c9153db0695a5cdecf700c2ba73a5","src/counter.rs":"b8f1e48ec634a7dab8e04c485209161587ecbbd2d57b0825467164d4554c6249","src/err.rs":"44cb2024ee6b0cd6fd24996430e53720769f64b4ac35016bc3e05cb9db48681d","src/flavors/array.rs":"79bc219187c9f40b156b9fe551c1176b66bf73e6d48905b23a2d74c6366a2205","src/flavors/at.rs":"04e07861534f2f7d5b5f884f2f5bc9c008427e6d0afa1c8ad401e1d7e54b57eb","src/flavors/list.rs":"03eda8e9e36022eb7f15b1d17e182efc56c8a1c4a7db5a60c0acd808012ceae8","src/flavors/mod.rs":"3d9d43bc38b0adb18c96c995c2bd3421d8e33ab6c30b20c3c467d21d48e485dc","src/flavors/never.rs":"747da857aa1a7601641f23f4930e6ad00ebaf50456d9be5c7aa270e2ecc24dcb","src/flavors/tick.rs":"0916ca3faef30b8cc591137701c456d5fc5b5b49cb1edad1e3a80d35bae222bb","src/flavors/zero.rs":"f9cbc9e035fadce808a4af86a223cfded89990ba1e9acfe731fb17a7fe12b432","src/lib.rs":"5b1c406fd1ce6140feae9000be361858da2aabe7fc9fffd0eafcb88020d2b268","src/select.rs":"301c765751586204371bedb69162e23bcf7e094cbc37b72203698a18b889550f","src/select_macro.rs":"f30b726dff104b17c2dfbd67b271758d8c06d63ec4811ffab88b2e1dac43e3df","src/utils.rs":"9bd81aeb385a81409a63f4b9edc35444c7fd1d2724725f9c34ad7ca39dd69a18","src/waker.rs":"017f87a120d945502701c0dba79062c7fe55d44e5907cc6f8605b4510c90d529","tests/after.rs":"0154a8e152880db17a20514ecdd49dabc361d3629858d119b9746b5e932c780c","tests/array.rs":"a57ae6264e676f573d7adb5c4b024994e98bc6811352516adb3444f880f7125e","tests/golang.rs":"7b2ef219ba8a21841c133512f3a540f8279a2458304e9bbed7da81d6091ecd82","tests/iter.rs":"25dc02135bbae9d47a30f9047661648e66bdc134e40ba78bc2fbacbb8b3819bc","tests/list.rs":"e71d34f790af290e463707c2336ff221f7841767e961b91747aa00e21df0ad32","tests/mpsc.rs":"5fbb5342fa7c9e4bcda5545255e0979dc6b9ba638edee127acf75372c18c925f","tests/never.rs":"ee40c4fc4dd5af4983fae8de6927f52b81174d222c162f745b26c4a6c7108e4f","tests/ready.rs":"4361352fa94254041e6c73e97b13be032c2d51c741f2a50519efe3000cf4dc28","tests/same_channel.rs":"2bab761443671e841e1b2476bd8082d75533a2f6be7946f5dbcee67cdc82dccb","tests/select.rs":"101ea8afd9a40d24c2d2aec29e5f2fdc4faac51aa1d7c9fe077b364f12edd206","tests/select_macro.rs":"e83bd33b34c47d703abe06420a23868809468516943347bdbfb6af4db0cec65a","tests/thread_locals.rs":"f42fcddca959b3b44cd545b92949d65e33a54332b27f490ec92f9f29b7f8290c","tests/tick.rs":"5f697bd14c48505d932e82065b5302ef668e1cc19cac18e8ac22e0c83c221c1d","tests/zero.rs":"9c5af802d5efb2c711f8242b8905ed29cc2601e48dbd95e41c7e6fbfe2918398"},"package":"06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"}
+diff --git a/src/agent/vendor/crossbeam-channel/src/flavors/list.rs b/src/agent/vendor/crossbeam-channel/src/flavors/list.rs
+index 6c15991f..8f1faaa8 100644
+--- a/src/agent/vendor/crossbeam-channel/src/flavors/list.rs
++++ b/src/agent/vendor/crossbeam-channel/src/flavors/list.rs
+@@ -611,7 +611,7 @@ impl<T> Channel<T> {
+             // In that case, just wait until it gets initialized.
+             while block.is_null() {
+                 backoff.snooze();
+-                block = self.head.block.load(Ordering::Acquire);
++                block = self.head.block.swap(ptr::null_mut(), Ordering::AcqRel);
+             }
+         }
+ 
+-- 
+2.45.4
+

--- a/SPECS/kata-containers-cc/CVE-2025-5791.patch
+++ b/SPECS/kata-containers-cc/CVE-2025-5791.patch
@@ -1,0 +1,55 @@
+From ac667c8bed3f171499ba67beb9d39dc0115636ff Mon Sep 17 00:00:00 2001
+From: Luca Fulchir <luker@fenrirproject.org>
+Date: Wed, 27 Jan 2021 11:33:41 +0100
+Subject: [PATCH] Fix group listing: don't add root every time
+
+Signed-off-by: Luca Fulchir <luker@fenrirproject.org>
+
+Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/rustadopt/uzers-rs/pull/1.patch
+---
+ src/utarfs/vendor/users/.cargo-checksum.json |  2 +-
+ src/utarfs/vendor/users/src/base.rs          | 10 ++++++++--
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/utarfs/vendor/users/.cargo-checksum.json b/src/utarfs/vendor/users/.cargo-checksum.json
+index 6e82fb50..a1d93732 100644
+--- a/src/utarfs/vendor/users/.cargo-checksum.json
++++ b/src/utarfs/vendor/users/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"c9ada6d2bfa84d46192e0e6fa32447593b3bff0d665fe16c767abbbdd2c65ca4","Cargo.toml":"da29cc763ec004970957799df1ebcdcc51e8f854522bdbe73980b95d80d2b32a","Justfile":"1293564ae4d6639392bd045b0cb850cea433f9d376f12723eebc17fa4be0ae26","LICENCE":"ac84d716b3ca37857b9465476a7d6adc3684a774bc775ada8318c550187ed2b5","README.md":"7376a66fd7955c3115eabe65b70acc3a3c0a9038d830331748623f96220ba72a","examples/example.rs":"1500d9c04605096ef9928883f7ae07f48a98da166007f3a91f3803818a0ac0e6","examples/groups.rs":"ba6f7307aa0f204e387451a1e457a0f93628d253d5f607ac9e370e8307726f50","examples/list.rs":"c64574b89f84ba144d7601a6c66762fbb0e23d0a81d21ea97e3e16a564e6ac4b","examples/os.rs":"46d3217736c6d2b63ca107cfa1a7425ef574191d0b374fb81b918918f0bb9809","examples/switching.rs":"6584c8f06a3c3820bdcfc9cd4e4e8842915c559822b237a0213a5b284be0e782","examples/threading.rs":"681b760bf3f976d6eb82e87f428eecc7a456014c4e5236d5b7d475d124c6259e","src/base.rs":"f65d28fb398b871316e34ce3bc4f737c67ebd7c140d2fd1dc3de47ced9a53679","src/cache.rs":"dd934d88e1059348760b6f32e933888d4fc9f85d5a15cd152b48e444c1c1adc4","src/lib.rs":"2d2805dc46e4f718f62395f8dd65349fc0169d70452d5f6d8996d951bb6fac94","src/mock.rs":"0973ab8f55b02668f0866994546c1c32ca619c24a74f28a82c5dd1422da10f9b","src/switch.rs":"7354e65c0acbdabfefa3261586201a942df8585542612eaf8978d58585351d99","src/traits.rs":"9af80b4cb6cea0ad4b6caceb6602fbf27a6ae49f7a02df768f285463664a716a"},"package":"24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"}
+\ No newline at end of file
++{"files":{"Cargo.lock":"c9ada6d2bfa84d46192e0e6fa32447593b3bff0d665fe16c767abbbdd2c65ca4","Cargo.toml":"da29cc763ec004970957799df1ebcdcc51e8f854522bdbe73980b95d80d2b32a","Justfile":"1293564ae4d6639392bd045b0cb850cea433f9d376f12723eebc17fa4be0ae26","LICENCE":"ac84d716b3ca37857b9465476a7d6adc3684a774bc775ada8318c550187ed2b5","README.md":"7376a66fd7955c3115eabe65b70acc3a3c0a9038d830331748623f96220ba72a","examples/example.rs":"1500d9c04605096ef9928883f7ae07f48a98da166007f3a91f3803818a0ac0e6","examples/groups.rs":"ba6f7307aa0f204e387451a1e457a0f93628d253d5f607ac9e370e8307726f50","examples/list.rs":"c64574b89f84ba144d7601a6c66762fbb0e23d0a81d21ea97e3e16a564e6ac4b","examples/os.rs":"46d3217736c6d2b63ca107cfa1a7425ef574191d0b374fb81b918918f0bb9809","examples/switching.rs":"6584c8f06a3c3820bdcfc9cd4e4e8842915c559822b237a0213a5b284be0e782","examples/threading.rs":"681b760bf3f976d6eb82e87f428eecc7a456014c4e5236d5b7d475d124c6259e","src/base.rs":"2e6e565490cf712bdc353875ef48626ca968503b66e9383e9465070cfbfdbe43","src/cache.rs":"dd934d88e1059348760b6f32e933888d4fc9f85d5a15cd152b48e444c1c1adc4","src/lib.rs":"2d2805dc46e4f718f62395f8dd65349fc0169d70452d5f6d8996d951bb6fac94","src/mock.rs":"0973ab8f55b02668f0866994546c1c32ca619c24a74f28a82c5dd1422da10f9b","src/switch.rs":"7354e65c0acbdabfefa3261586201a942df8585542612eaf8978d58585351d99","src/traits.rs":"9af80b4cb6cea0ad4b6caceb6602fbf27a6ae49f7a02df768f285463664a716a"},"package":"24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"}
+diff --git a/src/utarfs/vendor/users/src/base.rs b/src/utarfs/vendor/users/src/base.rs
+index ece499ad..d0267599 100644
+--- a/src/utarfs/vendor/users/src/base.rs
++++ b/src/utarfs/vendor/users/src/base.rs
+@@ -749,10 +749,12 @@ pub fn group_access_list() -> io::Result<Vec<Group>> {
+         Err(io::Error::last_os_error())
+     }
+     else {
+-        let mut groups = buff.into_iter()
++        buff.truncate(res as usize);
++        buff.sort_unstable();
++        buff.dedup();
++        let groups = buff.into_iter()
+                              .filter_map(get_group_by_gid)
+                              .collect::<Vec<_>>();
+-        groups.dedup_by_key(|i| i.gid());
+         Ok(groups)
+     }
+ }
+@@ -800,7 +802,11 @@ pub fn get_user_groups<S: AsRef<OsStr> + ?Sized>(username: &S, gid: gid_t) -> Op
+         None
+     }
+     else {
++        buff.truncate(count as usize);
++        buff.sort_unstable();
+         buff.dedup();
++        // allow trivial cast: on macos i is i32, on linux it's already gid_t
++        #[allow(trivial_numeric_casts)]
+         buff.into_iter()
+             .filter_map(|i| get_group_by_gid(i as gid_t))
+             .collect::<Vec<_>>()
+-- 
+2.45.4
+

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -15,9 +15,8 @@ Patch0:       rust-1.90-fixes.patch
 Patch1:       CVE-2026-41602.patch
 Patch2:       CVE-2026-39821.patch
 Patch3:       CVE-2026-33814.patch
-# Patch for vendor packages
-Patch1000:    CVE-2025-5791.patch
-Patch1001:    CVE-2025-4574.patch
+Patch4:       CVE-2025-5791.patch
+Patch5:       CVE-2025-4574.patch
 ExclusiveArch: x86_64
 
 BuildRequires:  azurelinux-release
@@ -50,12 +49,7 @@ Summary:        Kata Confidential Containers tools package for building the UVM
 This package contains the scripts and files required to build the UVM
 
 %prep
-%autosetup -N -n %{sourceName}-%{version}
-%autopatch -p1 -M 999
-pushd %{_builddir}/%{sourceName}-%{version}
-tar -xf %{SOURCE1}
-%autopatch -p1 -m 1000 -M 1999
-popd
+%autosetup -p1 -a1 -n %{sourceName}-%{version}
 
 %build
 pushd %{_builddir}/%{sourceName}-%{version}/tools/osbuilder/node-builder/azure-linux

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -3,7 +3,7 @@
 
 Name:         kata-containers-cc
 Version:      3.15.0.aks0
-Release:      13%{?dist}
+Release:      14%{?dist}
 Summary:      Kata Confidential Containers package developed for Confidential Containers on AKS
 License:      ASL 2.0
 URL:          https://github.com/microsoft/kata-containers
@@ -15,6 +15,9 @@ Patch0:       rust-1.90-fixes.patch
 Patch1:       CVE-2026-41602.patch
 Patch2:       CVE-2026-39821.patch
 Patch3:       CVE-2026-33814.patch
+# Patch for vendor packages
+Patch1000:    CVE-2025-5791.patch
+Patch1001:    CVE-2025-4574.patch
 ExclusiveArch: x86_64
 
 BuildRequires:  azurelinux-release
@@ -47,9 +50,11 @@ Summary:        Kata Confidential Containers tools package for building the UVM
 This package contains the scripts and files required to build the UVM
 
 %prep
-%autosetup -p1 -n %{sourceName}-%{version}
+%autosetup -N -n %{sourceName}-%{version}
+%autopatch -p1 -M 999
 pushd %{_builddir}/%{sourceName}-%{version}
 tar -xf %{SOURCE1}
+%autopatch -p1 -m 1000 -M 1999
 popd
 
 %build
@@ -153,6 +158,9 @@ fi
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Thu Jun 18 2026 Aditya Singh <v-aditysing@microsoft.com> - 3.15.0-aks0-14
+- Patch for CVE-2025-5791 and CVE-2025-4574
+
 * Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.15.0-aks0-13
 - Bump release to rebuild with rust
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---
###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Patch `kata-containers-cc` for CVE-2025-5791 and CVE-2025-4574
   - `CVE-2025-5791` -
       - Patch has been backported manually.
       - Patch matches with upstream patch.
       - Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/rustadopt/uzers-rs/pull/1.patch
       - Upstream PR - https://github.com/rustadopt/uzers-rs/pull/1
      
   - `CVE-2025-4574` -
       - Patch has been backported manually.
       - Patch matches with upstream patch.
       - Upstream Patch Reference: https://patch-diff.githubusercontent.com/raw/crossbeam-rs/crossbeam/pull/1187.patch
       - Upstream PR - https://github.com/crossbeam-rs/crossbeam/pull/1187      

- Old PR Reference - https://github.com/microsoft/azurelinux/pull/14238

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file -   SPECS/kata-containers-cc/CVE-2025-5791.patch
- new file -   SPECS/kata-containers-cc/CVE-2025-4574.patch
- modified - SPECS/kata-containers-cc/kata-containers-cc.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-5791
- https://nvd.nist.gov/vuln/detail/CVE-2025-4574

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build could not be triggered due to resource limitation.