### PR TITLE
rocm-examples: drop FetchContent fallback for google-benchmark

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -4524,7 +4524,7 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.rocm-bandwidth-test]
 [components.rocm-cmake]
 [components.rocm-core]
-[components.rocm-examples]
+# rocm-examples is defined in base/comps/rocm-examples/rocm-examples.comp.toml
 [components.rocm-omp]
 [components.rocm-rpm-macros]
 [components.rocm-rpp]

--- a/base/comps/rocm-examples/rocm-examples-no-fetchcontent-benchmark.patch
+++ b/base/comps/rocm-examples/rocm-examples-no-fetchcontent-benchmark.patch
@@ -1,0 +1,36 @@
+--- a/Tutorials/reduction/benchmark/CMakeLists.txt
++++ b/Tutorials/reduction/benchmark/CMakeLists.txt
+@@ -118,28 +118,11 @@
+     find_package(TBB REQUIRED)
+ endif()
+ 
+-find_package(benchmark CONFIG QUIET)
+-if(NOT TARGET benchmark::benchmark)
+-    message(STATUS "Google Benchmark not found. Fetching...")
+-    option(
+-        BENCHMARK_ENABLE_TESTING
+-        "Enable testing of the benchmark library."
+-        OFF
+-    )
+-    option(BENCHMARK_ENABLE_INSTALL "Enable installation of benchmark." OFF)
+-    include(FetchContent)
+-    FetchContent_Declare(
+-        googlebench
+-        GIT_REPOSITORY https://github.com/google/benchmark.git
+-        GIT_TAG v1.6.1
+-    )
+-    FetchContent_MakeAvailable(googlebench)
+-    if(NOT TARGET benchmark::benchmark)
+-        add_library(benchmark::benchmark ALIAS benchmark)
+-    endif()
+-else()
+-    find_package(benchmark CONFIG REQUIRED)
+-endif()
++# AzL: Google Benchmark must come from the system package
++# (google-benchmark-devel is in BuildRequires). The upstream fallback that
++# fetches https://github.com/google/benchmark via FetchContent is removed
++# so the build does not require network access.
++find_package(benchmark CONFIG REQUIRED)
+ 
+ foreach(VER RANGE 0 10)
+     set(Sources v${VER}.hip)

--- a/base/comps/rocm-examples/rocm-examples.comp.toml
+++ b/base/comps/rocm-examples/rocm-examples.comp.toml
@@ -1,0 +1,13 @@
+[components.rocm-examples]
+
+[[components.rocm-examples.overlays]]
+description = "Drop the upstream FetchContent fallback that git-clones https://github.com/google/benchmark when the system google-benchmark CMake config is not picked up. google-benchmark-devel is already a BuildRequires, so requiring the system package matches the spec's intent and lets the build succeed under network isolation."
+type = "patch-add"
+file = "rocm-examples-no-fetchcontent-benchmark.patch"
+source = "rocm-examples-no-fetchcontent-benchmark.patch"
+
+[[components.rocm-examples.overlays]]
+description = "Add libpfm-devel to BuildRequires. The system google-benchmark in Azure Linux is built with libpfm support, so /usr/lib64/cmake/benchmark/benchmarkConfig.cmake does find_dependency(PFM). Without libpfm-devel in the chroot, configure fails with 'Could NOT find PFM (missing: PFM_LIBRARY PFM_INCLUDE_DIR)'."
+type = "spec-add-tag"
+tag = "BuildRequires"
+value = "libpfm-devel"

--- a/locks/rocm-examples.lock
+++ b/locks/rocm-examples.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '33e867f3d29a679a6232c94088af2aaf059e10c3'
 upstream-commit = '33e867f3d29a679a6232c94088af2aaf059e10c3'
-input-fingerprint = 'sha256:5e97d3ebb38d42e5cbd16ba3e048297de55cabed3cf9ef8e1a8794e7117cc6ca'
+input-fingerprint = 'sha256:fce7a40e92b22861d4de3cb7e936adae0812a8e1bee9f104614afa561914056c'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/r/rocm-examples/rocm-examples-no-fetchcontent-benchmark.patch
+++ b/specs/r/rocm-examples/rocm-examples-no-fetchcontent-benchmark.patch
@@ -1,0 +1,36 @@
+--- a/Tutorials/reduction/benchmark/CMakeLists.txt
++++ b/Tutorials/reduction/benchmark/CMakeLists.txt
+@@ -118,28 +118,11 @@
+     find_package(TBB REQUIRED)
+ endif()
+ 
+-find_package(benchmark CONFIG QUIET)
+-if(NOT TARGET benchmark::benchmark)
+-    message(STATUS "Google Benchmark not found. Fetching...")
+-    option(
+-        BENCHMARK_ENABLE_TESTING
+-        "Enable testing of the benchmark library."
+-        OFF
+-    )
+-    option(BENCHMARK_ENABLE_INSTALL "Enable installation of benchmark." OFF)
+-    include(FetchContent)
+-    FetchContent_Declare(
+-        googlebench
+-        GIT_REPOSITORY https://github.com/google/benchmark.git
+-        GIT_TAG v1.6.1
+-    )
+-    FetchContent_MakeAvailable(googlebench)
+-    if(NOT TARGET benchmark::benchmark)
+-        add_library(benchmark::benchmark ALIAS benchmark)
+-    endif()
+-else()
+-    find_package(benchmark CONFIG REQUIRED)
+-endif()
++# AzL: Google Benchmark must come from the system package
++# (google-benchmark-devel is in BuildRequires). The upstream fallback that
++# fetches https://github.com/google/benchmark via FetchContent is removed
++# so the build does not require network access.
++find_package(benchmark CONFIG REQUIRED)
+ 
+ foreach(VER RANGE 0 10)
+     set(Sources v${VER}.hip)

--- a/specs/r/rocm-examples/rocm-examples.spec
+++ b/specs/r/rocm-examples/rocm-examples.spec
@@ -28,7 +28,7 @@
 
 Name:           rocm-examples
 Version:        %{rocm_version}
-Release: 3%{?dist}
+Release: 5%{?dist}
 Summary:        A collection of examples for the ROCm software stack
 Url:            https://github.com/ROCm/%{upstreamname}
 License:        MIT AND Apache-2.0
@@ -69,6 +69,8 @@ BuildRequires:  gtest-devel
 # Only x86_64 works right now:
 ExclusiveArch:  x86_64
 
+Patch0: rocm-examples-no-fetchcontent-benchmark.patch
+BuildRequires: libpfm-devel
 %description
 This repository is a collection of examples to enable new users
 to start using ROCm, as well as provide more advanced examples


### PR DESCRIPTION
Under network-isolation Koji builds (azl4-bootstrap-network-isolation), rocm-examples 6.4.2 fails in %build because
Tutorials/reduction/benchmark/CMakeLists.txt does
find_package(benchmark CONFIG QUIET) and, if benchmark::benchmark is not created, falls through to FetchContent_MakeAvailable() that git-clones https://github.com/google/benchmark.git at v1.6.1. With network blocked in the mock chroot, this fails:

  Could not resolve host: github.com

google-benchmark-devel is already a BuildRequires for non-SUSE builds, so the network fallback is not needed. Add a small overlay patch that replaces the find_package(QUIET)/FetchContent fallback with a single find_package(benchmark CONFIG REQUIRED), so the build either picks up the system google-benchmark or fails fast with a clear error instead of trying to reach the internet.

Also moves the rocm-examples component definition out of the inline components.toml entry into its own rocm-examples.comp.toml so the overlay configuration has a home.