### PR TITLE
gawk: skip pma test in chroot build

### DIFF
--- a/SPECS/gawk/gawk.spec
+++ b/SPECS/gawk/gawk.spec
@@ -1,7 +1,7 @@
 Summary:        Contains programs for manipulating text files
 Name:           gawk
 Version:        5.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -40,6 +40,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 # Skip the timeout test, which is unreliable on our (vm) build machines
 sed -i 's/ timeout / /' test/Makefile
 sed -i 's/ pty1 / /' test/Makefile
+# Skip pma test - persistent memory allocator requires MAP_FIXED mmap
+# which may not work reliably in chroot build environments
+sed -i 's/$(MAKE) $(NEED_PMA)/echo "skipping pma test"/' test/Makefile
 
 # Generate locale for `en_US.iso88591` which is required for ptest
 # Ideally it should have been present. Investigate if its a `chroot` only issue
@@ -63,6 +66,10 @@ make %{?_smp_mflags} check
 %{_sysconfdir}/profile.d/gawk.sh
 
 %changelog
+* Wed Jun 17 2026 Kshitiz Godara <kgodara@microsoft.com> - 5.2.2-2
+- Skip pma (persistent memory allocator) test in chroot; it requires
+  MAP_FIXED mmap which is not reliable in build chroot environments.
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.2.2-1
 - Auto-upgrade to 5.2.2 - Azure Linux 3.0 - package upgrades
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -61,7 +61,7 @@ m4-1.4.19-2.azl3.aarch64.rpm
 grep-3.11-2.azl3.aarch64.rpm
 grep-lang-3.11-2.azl3.aarch64.rpm
 diffutils-3.10-1.azl3.aarch64.rpm
-gawk-5.2.2-1.azl3.aarch64.rpm
+gawk-5.2.2-2.azl3.aarch64.rpm
 findutils-4.9.0-1.azl3.aarch64.rpm
 findutils-lang-4.9.0-1.azl3.aarch64.rpm
 gettext-0.22-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -61,7 +61,7 @@ m4-1.4.19-2.azl3.x86_64.rpm
 grep-3.11-2.azl3.x86_64.rpm
 grep-lang-3.11-2.azl3.x86_64.rpm
 diffutils-3.10-1.azl3.x86_64.rpm
-gawk-5.2.2-1.azl3.x86_64.rpm
+gawk-5.2.2-2.azl3.x86_64.rpm
 findutils-4.9.0-1.azl3.x86_64.rpm
 findutils-lang-4.9.0-1.azl3.x86_64.rpm
 gettext-0.22-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -110,8 +110,8 @@ findutils-lang-4.9.0-1.azl3.aarch64.rpm
 flex-2.6.4-7.azl3.aarch64.rpm
 flex-debuginfo-2.6.4-7.azl3.aarch64.rpm
 flex-devel-2.6.4-7.azl3.aarch64.rpm
-gawk-5.2.2-1.azl3.aarch64.rpm
-gawk-debuginfo-5.2.2-1.azl3.aarch64.rpm
+gawk-5.2.2-2.azl3.aarch64.rpm
+gawk-debuginfo-5.2.2-2.azl3.aarch64.rpm
 gcc-13.2.0-7.azl3.aarch64.rpm
 gcc-c++-13.2.0-7.azl3.aarch64.rpm
 gcc-debuginfo-13.2.0-7.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -115,8 +115,8 @@ findutils-lang-4.9.0-1.azl3.x86_64.rpm
 flex-2.6.4-7.azl3.x86_64.rpm
 flex-debuginfo-2.6.4-7.azl3.x86_64.rpm
 flex-devel-2.6.4-7.azl3.x86_64.rpm
-gawk-5.2.2-1.azl3.x86_64.rpm
-gawk-debuginfo-5.2.2-1.azl3.x86_64.rpm
+gawk-5.2.2-2.azl3.x86_64.rpm
+gawk-debuginfo-5.2.2-2.azl3.x86_64.rpm
 gcc-13.2.0-7.azl3.x86_64.rpm
 gcc-aarch64-linux-gnu-13.2.0-7.azl3.x86_64.rpm
 gcc-c++-13.2.0-7.azl3.x86_64.rpm


### PR DESCRIPTION
Skip the pma (persistent memory allocator) test which requires MAP_FIXED mmap and is not reliable in chroot build environments.

Bump Release to 5.2.2-2 and update toolchain/pkggen_core manifests for both x86_64 and aarch64.
