### PR TITLE
kata-containers-cc: fix tarfs build with kernel 6.6+ (i_ctime removal)

### DIFF
--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -3,7 +3,7 @@
 
 Name:         kata-containers-cc
 Version:      3.15.0.aks0
-Release:      13%{?dist}
+Release:      14%{?dist}
 Summary:      Kata Confidential Containers package developed for Confidential Containers on AKS
 License:      ASL 2.0
 URL:          https://github.com/microsoft/kata-containers
@@ -15,6 +15,7 @@ Patch0:       rust-1.90-fixes.patch
 Patch1:       CVE-2026-41602.patch
 Patch2:       CVE-2026-39821.patch
 Patch3:       CVE-2026-33814.patch
+Patch4:       tarfs-fix-ictime-kernel-6.6.patch
 ExclusiveArch: x86_64
 
 BuildRequires:  azurelinux-release
@@ -153,6 +154,9 @@ fi
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Mon Jun 16 2026 Roaa Sakr <romoh@microsoft.com> - 3.15.0.aks0-14
+- Fix tarfs kernel module build failure with kernel 6.6+ (i_ctime removed from struct inode)
+
 * Fri Jun 05 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.15.0-aks0-13
 - Bump release to rebuild with rust
 

--- a/SPECS/kata-containers-cc/tarfs-fix-ictime-kernel-6.6.patch
+++ b/SPECS/kata-containers-cc/tarfs-fix-ictime-kernel-6.6.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roaa Sakr <romoh@microsoft.com>
+Date: Mon, 16 Jun 2026 00:00:00 +0000
+Subject: [PATCH] tarfs: use inode_set_ctime accessor for kernel 6.6+
+
+Linux kernel 6.6 removed the i_ctime field from struct inode and replaced
+it with accessor functions inode_set_ctime() and inode_get_ctime(). The
+tarfs kernel module directly accessed inode->i_ctime, which fails to
+compile against kernel headers >= 6.6.
+
+Use a LINUX_VERSION_CODE guard to call inode_set_ctime() on 6.6+ while
+preserving backward compatibility with older kernels.
+
+Signed-off-by: Roaa Sakr <romoh@microsoft.com>
+---
+ src/tarfs/tarfs.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/src/tarfs/tarfs.c b/src/tarfs/tarfs.c
+index 92de8bc..47450eb 100644
+--- a/src/tarfs/tarfs.c
++++ b/src/tarfs/tarfs.c
+@@ -319,9 +319,19 @@ static struct inode *tarfs_iget(struct super_block *sb, u64 ino)
+ 
+ 	set_nlink(inode, 1);
+ 
+-	inode->i_mtime.tv_sec = inode->i_atime.tv_sec = inode->i_ctime.tv_sec =
+-		(((u64)disk_inode.hmtime & 0xf) << 32) | le32_to_cpu(disk_inode.lmtime);
+-	inode->i_mtime.tv_nsec = inode->i_atime.tv_nsec = inode->i_ctime.tv_nsec = 0;
++	{
++		u64 ts_sec = (((u64)disk_inode.hmtime & 0xf) << 32) |
++			le32_to_cpu(disk_inode.lmtime);
++
++		inode->i_mtime.tv_sec = inode->i_atime.tv_sec = ts_sec;
++		inode->i_mtime.tv_nsec = inode->i_atime.tv_nsec = 0;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
++		inode_set_ctime(inode, ts_sec, 0);
++#else
++		inode->i_ctime.tv_sec = ts_sec;
++		inode->i_ctime.tv_nsec = 0;
++#endif
++	}
+ 
+ 	inode->i_mode = mode;
+ 	inode->i_size = le64_to_cpu(disk_inode.size);
+-- 
+2.39.0


### PR DESCRIPTION
Linux kernel 6.6 removed the i_ctime field from struct inode, replacing it with inode_set_ctime()/inode_get_ctime() accessors. The tarfs kernel module shipped in kata-containers-cc-tools directly accessed inode->i_ctime, causing a build failure when compiling against kernel-uvm 6.6.137.mshv1-1.azl3 headers.

This patch adds a LINUX_VERSION_CODE guard to use the new accessor on 6.6+ while preserving backward compatibility.

Fixes: mariner-org/mariner#19827