### PR TITLE
Ignore Enter Key for 50ms When Showing New View in Attended Installer

### DIFF
--- a/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
+++ b/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
@@ -36,6 +36,8 @@ import (
 const (
 	defaultGridWeight = 1
 
+	enterCooldown = 300 * time.Millisecond
+
 	textRow        = 3
 	textColumn     = 0
 	textRowSpan    = 1
@@ -68,6 +70,7 @@ type AttendedInstaller struct {
 	grid              *tview.Grid
 	pauseCustomInput  bool
 	pauseSpeakupInput bool
+	ignoreEnterUntil  time.Time
 	currentView       int
 	allViews          []views.View
 	backdropStyle     tview.Theme
@@ -199,6 +202,9 @@ func (ai *AttendedInstaller) showView(newView int) (err error) {
 		return
 	}
 
+	// Apply Enter cooldown to all views to prevent carried key events from auto-advancing.
+	ai.ignoreEnterUntil = time.Now().Add(enterCooldown)
+
 	ai.grid.AddItem(view.Primitive(), primaryContentRow, primaryContentColumn, primaryContentRowSpan, primaryContentColumnSpan, primaryContentMinSize, primaryContentMinSize, true)
 	ai.app.SetFocus(ai.grid)
 	ai.currentView = newView
@@ -221,6 +227,10 @@ func (ai *AttendedInstaller) quit() {
 }
 
 func (ai *AttendedInstaller) globalInputCapture(event *tcell.EventKey) *tcell.EventKey {
+	if event.Key() == tcell.KeyEnter && !ai.ignoreEnterUntil.IsZero() && time.Now().Before(ai.ignoreEnterUntil) {
+		return nil
+	}
+
 	// If we're clearing the speakup buffer, don't process keypresses
 	// tcell has no easy way of differentiating between keypad enter (speakup clear) and enter
 	if ai.pauseSpeakupInput && event.Key() == tcell.KeyEnter {

--- a/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
+++ b/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
@@ -36,7 +36,7 @@ import (
 const (
 	defaultGridWeight = 1
 
-	enterCooldown = 300 * time.Millisecond
+	enterCooldown = 50 * time.Millisecond
 
 	textRow        = 3
 	textColumn     = 0


### PR DESCRIPTION
When running the ISO attended installer from a USB drive on a computer, the Enter key somehow stays buffered or gets repeated and the terminal installer automatically selects the first option and jumps to the next screen. The problem is also seen when trying to go backwards resulting in failure to return to the previous screen (select Back, previous view selects Next and the current view comes back).

This issue is not seen when mounting the installer as a virtual USB to install on a server.

When using a USB stick, there is also a risk of the USB getting corrupted as it shows up as /dev/sda, and the installer automatically selects the USB stick as the target and jumps over the screen. During testing, I could not see the Disk selection screen and would end up inadvertently trying to install on it.

Adding a 50ms ignore interval for the Enter key when switching views resolves the issue. I did not see an option in the tcell library to filter out repeated keys. If there's a better way to resolve this please let me know!