### PR TITLE
fix(qt6-qtmultimedia): remove leftover GStreamer media plugin devel f…

### DIFF
--- a/base/comps/qt6-qtmultimedia/qt6-qtmultimedia.comp.toml
+++ b/base/comps/qt6-qtmultimedia/qt6-qtmultimedia.comp.toml
@@ -36,3 +36,18 @@ type = "spec-search-replace"
 section = "%files"
 regex = '^%\{_qt6_plugindir\}/multimedia/libgstreamermediaplugin\.so$'
 replacement = ''
+
+# Dropping the gstreamer-plugins-bad BR also stops the GStreamer media plugin
+# devel artifacts (QtGstreamerMediaPluginImpl headers/.a/.prl/cmake) from being
+# built. The runtime %files entries were removed above, but the matching
+# %files devel entries were missed, so qt6-qtmultimedia-devel packaging fails
+# with "File/Directory not found". A single line-based regex drops every devel
+# %files entry that references QtGstreamerMediaPluginImpl (headers, .a, .prl,
+# the cmake %dir, and the cmake glob).
+[[components.qt6-qtmultimedia.overlays]]
+description = "Remove all QtGstreamerMediaPluginImpl devel %files entries (not built without gstreamer-plugins-bad)"
+type = "spec-search-replace"
+section = "%files"
+package = "devel"
+regex = '^.*GstreamerMediaPluginImpl.*$'
+replacement = ''

--- a/locks/qt6-qtmultimedia.lock
+++ b/locks/qt6-qtmultimedia.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '66b4dd09782f23900e04dc2a93470c6ef8a02537'
 upstream-commit = '66b4dd09782f23900e04dc2a93470c6ef8a02537'
-input-fingerprint = 'sha256:796992d13039bed1d8a28f20772baec8dcbb76e0f433968e82c6767aabb56d2e'
+input-fingerprint = 'sha256:7912965e3b6ac8f0339d2f8e6ceff4805e727df0bcf72dd305691ae15153f20a'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/q/qt6-qtmultimedia/qt6-qtmultimedia.spec
+++ b/specs/q/qt6-qtmultimedia/qt6-qtmultimedia.spec
@@ -27,7 +27,7 @@
 Summary: Qt6 - Multimedia support
 Name:    qt6-%{qt_module}
 Version: 6.10.2
-Release: 4%{?dist}
+Release: 5%{?dist}
 
 License: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 Url:     http://www.qt.io
@@ -170,7 +170,7 @@ rm -r %{buildroot}%{_qt6_archdatadir}/mkspecs/features/ios/add_ios_ffmpeg_librar
 %if %{with ffmpeg}
 %{_qt6_headerdir}/QtFFmpegMediaPluginImpl/
 %endif
-%{_qt6_headerdir}/QtGstreamerMediaPluginImpl/
+
 %{_qt6_headerdir}/QtMultimedia/
 %{_qt6_headerdir}/QtMultimediaTestLib/
 %{_qt6_headerdir}/QtMultimediaQuick/
@@ -182,8 +182,8 @@ rm -r %{buildroot}%{_qt6_archdatadir}/mkspecs/features/ios/add_ios_ffmpeg_librar
 %{_qt6_libdir}/libQt6FFmpegMediaPluginImpl.a
 %{_qt6_libdir}/libQt6FFmpegMediaPluginImpl.prl
 %endif
-%{_qt6_libdir}/libQt6GstreamerMediaPluginImpl.a
-%{_qt6_libdir}/libQt6GstreamerMediaPluginImpl.prl
+
+
 %{_qt6_libdir}/libQt6Multimedia.so
 %{_qt6_libdir}/libQt6Multimedia.prl
 %{_qt6_libdir}/libQt6MultimediaTestLib.a
@@ -201,7 +201,7 @@ rm -r %{buildroot}%{_qt6_archdatadir}/mkspecs/features/ios/add_ios_ffmpeg_librar
 %if %{with ffmpeg}
 %dir %{_qt6_libdir}/cmake/Qt6FFmpegMediaPluginImplPrivate
 %endif
-%dir %{_qt6_libdir}/cmake/Qt6GstreamerMediaPluginImplPrivate
+
 %dir %{_qt6_libdir}/cmake/Qt6Multimedia
 %dir %{_qt6_libdir}/cmake/Qt6MultimediaPrivate
 %dir %{_qt6_libdir}/cmake/Qt6MultimediaTestLibPrivate/
@@ -217,7 +217,7 @@ rm -r %{buildroot}%{_qt6_archdatadir}/mkspecs/features/ios/add_ios_ffmpeg_librar
 %if %{with ffmpeg}
 %{_qt6_libdir}/cmake/Qt6FFmpegMediaPluginImplPrivate/*.cmake
 %endif
-%{_qt6_libdir}/cmake/Qt6GstreamerMediaPluginImplPrivate/*.cmake
+
 %{_qt6_libdir}/cmake/Qt6Multimedia/*.cmake
 %{_qt6_libdir}/cmake/Qt6MultimediaPrivate/*.cmake
 %{_qt6_libdir}/cmake/Qt6MultimediaQuickPrivate/*.cmake


### PR DESCRIPTION
PR #17652 dropped the gstreamer-plugins-bad BuildRequires (so the GStreamer media plugin is no longer built) and cleaned up the runtime %files, but the matching %files devel entries for QtGstreamerMediaPluginImpl were missed. This broke qt6-qtmultimedia-devel packaging. This PR removes those leftover devel %files entries to fix the build.

Note: an earlier revision of this PR also overlaid away a duplicate %dir for QtQuick3D/SpatialAudio ("File listed twice") and an unescaped %{version} in a comment ("Macro expanded in comment"). A full build confirmed both are only non-fatal RPM *warnings*, not errors, so those overlays were removed to minimize divergence from the Fedora spec.