### PR TITLE
krb5: backport upstream SPNEGO mechListMIC parsing fix (ticket 9183)

### DIFF
--- a/SPECS/krb5/krb5-fix-SPNEGO-mechListMIC-parsing.patch
+++ b/SPECS/krb5/krb5-fix-SPNEGO-mechListMIC-parsing.patch
@@ -1,0 +1,169 @@
+From 942c5036e14066a1f4badfdf67716c47f2e33a39 Mon Sep 17 00:00:00 2001
+From: dovsyannikov <Dmitry.Ovsyannikov@dell.com>
+Date: Wed, 3 Sep 2025 13:52:57 +0000
+Subject: [PATCH] Fix SPNEGO mechListMIC parsing
+
+Commit fdceb225f881e2b1337eebcb9a9443fa4a9be3fd erroneously altered
+get_negTokenResp() to look for mechListMIC with tag 0xA4 instead of
+0xA3.  Fix it.
+
+Restore the t_spnego.c reselection test by constructing a
+two-mechanism SPNEGO initiator credential using the internal
+structures.
+
+[ghudson@mit.edu: added test case; rewrote commit message]
+
+ticket: 9183 (new)
+tags: pullup
+target_version: 1.21-next
+target_version: 1.22-next
+Upstream-reference: https://github.com/krb5/krb5/commit/942c5036e14066a1f4badfdf67716c47f2e33a39.patch
+---
+ src/lib/gssapi/spnego/spnego_mech.c |  2 +-
+ src/tests/gssapi/Makefile.in        |  2 +-
+ src/tests/gssapi/deps               | 19 ++++++++-
+ src/tests/gssapi/t_spnego.c         | 60 ++++++++++++++++++++++-------
+ 4 files changed, 66 insertions(+), 17 deletions(-)
+
+diff --git a/src/lib/gssapi/spnego/spnego_mech.c b/src/lib/gssapi/spnego/spnego_mech.c
+index 43ba63ab2a7..4a778364336 100644
+--- a/src/lib/gssapi/spnego/spnego_mech.c
++++ b/src/lib/gssapi/spnego/spnego_mech.c
+@@ -3515,7 +3515,7 @@ get_negTokenResp(OM_uint32 *minor_status, struct k5input *in,
+ 			return GSS_S_DEFECTIVE_TOKEN;
+ 	}
+ 
+-	if (k5_der_get_value(&seq, CONTEXT | 0x04, &field)) {
++	if (k5_der_get_value(&seq, CONTEXT | 0x03, &field)) {
+ 		*mechListMIC = get_octet_string(&field);
+ 
+                 /* Handle Windows 2000 duplicate response token */
+diff --git a/src/tests/gssapi/Makefile.in b/src/tests/gssapi/Makefile.in
+index 97a6ac3f3f7..5f57173cd8a 100644
+--- a/src/tests/gssapi/Makefile.in
++++ b/src/tests/gssapi/Makefile.in
+@@ -4,7 +4,7 @@ DEFINES = -DUSE_AUTOCONF_H
+ 
+ # For t_prf.c
+ LOCALINCLUDES = -I$(srcdir)/../../lib/gssapi/mechglue \
+-	-I$(srcdir)/../../lib/gssapi/krb5 \
++	-I$(srcdir)/../../lib/gssapi/krb5 -I$(srcdir)/../../lib/gssapi/spnego \
+ 	-I$(srcdir)/../../lib/gssapi/generic -I../../lib/gssapi/krb5 \
+ 	-I../../lib/gssapi/generic
+ 
+diff --git a/src/tests/gssapi/deps b/src/tests/gssapi/deps
+index 2c55fa51799..e93250af777 100644
+--- a/src/tests/gssapi/deps
++++ b/src/tests/gssapi/deps
+@@ -187,9 +187,24 @@ $(OUTPRE)t_saslname.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
+   $(BUILDTOP)/include/gssapi/gssapi_ext.h $(BUILDTOP)/include/gssapi/gssapi_krb5.h \
+   $(BUILDTOP)/include/krb5/krb5.h $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h \
+   common.h t_saslname.c
+-$(OUTPRE)t_spnego.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
++$(OUTPRE)t_spnego.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
++  $(BUILDTOP)/include/gssapi/gssapi.h $(BUILDTOP)/include/gssapi/gssapi_alloc.h \
+   $(BUILDTOP)/include/gssapi/gssapi_ext.h $(BUILDTOP)/include/gssapi/gssapi_krb5.h \
+-  $(BUILDTOP)/include/krb5/krb5.h $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h \
++  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
++  $(BUILDTOP)/include/profile.h $(BUILDTOP)/lib/gssapi/generic/gssapi_err_generic.h \
++  $(COM_ERR_DEPS) $(srcdir)/../../lib/gssapi/generic/gssapiP_generic.h \
++  $(srcdir)/../../lib/gssapi/generic/gssapi_ext.h $(srcdir)/../../lib/gssapi/generic/gssapi_generic.h \
++  $(srcdir)/../../lib/gssapi/mechglue/mechglue.h $(srcdir)/../../lib/gssapi/mechglue/mglueP.h \
++  $(srcdir)/../../lib/gssapi/spnego/gssapiP_negoex.h \
++  $(srcdir)/../../lib/gssapi/spnego/gssapiP_spnego.h \
++  $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-err.h \
++  $(top_srcdir)/include/k5-gmt_mktime.h $(top_srcdir)/include/k5-input.h \
++  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
++  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
++  $(top_srcdir)/include/k5-queue.h $(top_srcdir)/include/k5-thread.h \
++  $(top_srcdir)/include/k5-trace.h $(top_srcdir)/include/krb5.h \
++  $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/plugin.h \
++  $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
+   common.h t_spnego.c
+ $(OUTPRE)t_srcattrs.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
+   $(BUILDTOP)/include/gssapi/gssapi_ext.h $(BUILDTOP)/include/gssapi/gssapi_krb5.h \
+diff --git a/src/tests/gssapi/t_spnego.c b/src/tests/gssapi/t_spnego.c
+index 4091739f835..3b53097182d 100644
+--- a/src/tests/gssapi/t_spnego.c
++++ b/src/tests/gssapi/t_spnego.c
+@@ -29,6 +29,11 @@
+ #include <string.h>
+ #include <assert.h>
+ 
++/* See create_reselection_cred(). */
++#include "k5-int.h"
++#include <mglueP.h>
++#include <gssapiP_spnego.h>
++
+ #include "common.h"
+ 
+ static gss_OID_desc mech_krb5_wrong = {
+@@ -228,6 +233,47 @@ test_neghints(void)
+     (void)gss_delete_sec_context(&minor, &actx, NULL);
+ }
+ 
++/*
++ * There is currently no API to create a SPNEGO credential supporting multiple
++ * mechanisms unless a third-party mechanism is configured in the mechs file;
++ * the default credential contains only krb5 (after tickets #8021 and #8217)
++ * and a SPNEGO cred cannot be created from an existing union cred.  Using
++ * internal structures, create a two-mechanism initiator cred so that we can
++ * test reselection.
++ */
++static gss_cred_id_t
++create_reselection_cred(void)
++{
++    OM_uint32 major, minor;
++    gss_OID_desc mlist[2] = { mech_krb5, mech_iakerb };
++    gss_OID_set_desc mechs = { 2, mlist };
++    gss_cred_id_t cred;
++    spnego_gss_cred_id_t scred;
++    gss_union_cred_t ucred;
++
++    major = gss_acquire_cred(&minor, GSS_C_NO_NAME, GSS_C_INDEFINITE,
++                             &mechs, GSS_C_INITIATE, &cred, NULL, NULL);
++    check_gsserr("gss_acquire_cred(reslection)", major, minor);
++
++    scred = calloc(1, sizeof(*scred));
++    assert(scred != NULL);
++    scred->mcred = cred;
++
++    ucred = calloc(1, sizeof(*ucred));
++    assert(ucred != NULL);
++    ucred->loopback = ucred;
++    ucred->count = 1;
++    ucred->mechs_array = calloc(1, sizeof(*ucred->mechs_array));
++    ucred->cred_array = calloc(1, sizeof(*ucred->cred_array));
++    assert(ucred->mechs_array != NULL && ucred->cred_array != NULL);
++    ucred->mechs_array[0].elements = malloc(mech_spnego.length);
++    assert(ucred->mechs_array[0].elements != NULL);
++    g_OID_copy(&ucred->mechs_array[0], &mech_spnego);
++    ucred->cred_array[0] = (gss_cred_id_t)scred;
++
++    return (gss_cred_id_t)ucred;
++}
++
+ int
+ main(int argc, char *argv[])
+ {
+@@ -254,19 +300,7 @@ main(int argc, char *argv[])
+     }
+ 
+     /* Get default initiator cred. */
+-    major = gss_acquire_cred(&minor, GSS_C_NO_NAME, GSS_C_INDEFINITE,
+-                             &mechset_spnego, GSS_C_INITIATE,
+-                             &initiator_cred_handle, NULL, NULL);
+-    check_gsserr("gss_acquire_cred(initiator)", major, minor);
+-
+-    /*
+-     * The following test is designed to exercise SPNEGO reselection on the
+-     * client and server.  Unfortunately, it no longer does so after tickets
+-     * #8217 and #8021, since SPNEGO now only acquires a single krb5 cred and
+-     * there is no way to expand the underlying creds with gss_set_neg_mechs().
+-     * To fix this we need gss_acquire_cred_with_cred() or some other way to
+-     * turn a cred with a specifically requested mech set into a SPNEGO cred.
+-     */
++    initiator_cred_handle = create_reselection_cred();
+ 
+     /* Make the initiator prefer IAKERB and offer krb5 as an alternative. */
+     pref_oids[0] = mech_iakerb;

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -131,6 +131,7 @@ make check
 %changelog
 * Tue Jun 23 2026 Apurv Parekh <apurvparekh@microsoft.com> - 1.21.3-5
 - Backport upstream fix for SPNEGO mechListMIC parsing (krb5 commit 942c503, ticket 9183)
+ 
 * Fri May 01 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.21.3-4
 - Patch for CVE-2026-40356
 

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -4,7 +4,7 @@
 Summary:        The Kerberos newtork authentication system
 Name:           krb5
 Version:        1.21.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -15,6 +15,7 @@ Source1:        krb5.conf
 Patch0:         CVE-2024-26461.patch
 Patch1:         CVE-2025-24528.patch
 Patch2:         CVE-2026-40356.patch
+Patch3:         krb5-fix-SPNEGO-mechListMIC-parsing.patch
 BuildRequires:  e2fsprogs-devel
 BuildRequires:  openssl-devel
 Requires:       e2fsprogs-libs
@@ -128,6 +129,8 @@ make check
 %{_datarootdir}/locale/*
 
 %changelog
+* Tue Jun 23 2026 Apurv Parekh <apurvparekh@microsoft.com> - 1.21.3-5
+- Backport upstream fix for SPNEGO mechListMIC parsing (krb5 commit 942c503, ticket 9183)
 * Fri May 01 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.21.3-4
 - Patch for CVE-2026-40356
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -195,8 +195,8 @@ libsolv-0.7.28-3.azl3.aarch64.rpm
 libsolv-devel-0.7.28-3.azl3.aarch64.rpm
 libssh2-1.11.1-2.azl3.aarch64.rpm
 libssh2-devel-1.11.1-2.azl3.aarch64.rpm
-krb5-1.21.3-4.azl3.aarch64.rpm
-krb5-devel-1.21.3-4.azl3.aarch64.rpm
+krb5-1.21.3-5.azl3.aarch64.rpm
+krb5-devel-1.21.3-5.azl3.aarch64.rpm
 nghttp2-1.61.0-3.azl3.aarch64.rpm
 nghttp2-devel-1.61.0-3.azl3.aarch64.rpm
 curl-8.11.1-8.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -195,8 +195,8 @@ libsolv-0.7.28-3.azl3.x86_64.rpm
 libsolv-devel-0.7.28-3.azl3.x86_64.rpm
 libssh2-1.11.1-2.azl3.x86_64.rpm
 libssh2-devel-1.11.1-2.azl3.x86_64.rpm
-krb5-1.21.3-4.azl3.x86_64.rpm
-krb5-devel-1.21.3-4.azl3.x86_64.rpm
+krb5-1.21.3-5.azl3.x86_64.rpm
+krb5-devel-1.21.3-5.azl3.x86_64.rpm
 nghttp2-1.61.0-3.azl3.x86_64.rpm
 nghttp2-devel-1.61.0-3.azl3.x86_64.rpm
 curl-8.11.1-8.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -162,10 +162,10 @@ kernel-headers-6.6.139.1-1.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm
-krb5-1.21.3-4.azl3.aarch64.rpm
-krb5-debuginfo-1.21.3-4.azl3.aarch64.rpm
-krb5-devel-1.21.3-4.azl3.aarch64.rpm
-krb5-lang-1.21.3-4.azl3.aarch64.rpm
+krb5-1.21.3-5.azl3.aarch64.rpm
+krb5-debuginfo-1.21.3-5.azl3.aarch64.rpm
+krb5-devel-1.21.3-5.azl3.aarch64.rpm
+krb5-lang-1.21.3-5.azl3.aarch64.rpm
 libacl-2.3.1-2.azl3.aarch64.rpm
 libacl-devel-2.3.1-2.azl3.aarch64.rpm
 libarchive-3.7.7-6.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -170,10 +170,10 @@ kernel-headers-6.6.139.1-1.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm
-krb5-1.21.3-4.azl3.x86_64.rpm
-krb5-debuginfo-1.21.3-4.azl3.x86_64.rpm
-krb5-devel-1.21.3-4.azl3.x86_64.rpm
-krb5-lang-1.21.3-4.azl3.x86_64.rpm
+krb5-1.21.3-5.azl3.x86_64.rpm
+krb5-debuginfo-1.21.3-5.azl3.x86_64.rpm
+krb5-devel-1.21.3-5.azl3.x86_64.rpm
+krb5-lang-1.21.3-5.azl3.x86_64.rpm
 libacl-2.3.1-2.azl3.x86_64.rpm
 libacl-devel-2.3.1-2.azl3.x86_64.rpm
 libarchive-3.7.7-6.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed) <!-- to be confirmed by the GitHub PR check pipeline -->
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted
- [x] LICENSE-MAP files are up-to-date
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary
https://microsoft.visualstudio.com/OS/_workitems/edit/62817258
Azure Linux 3.0 ships **krb5 1.21.3-4**, whose `get_negTokenResp()` parses the SPNEGO `mechListMIC` field with the wrong ASN.1 context tag — **`[4]` (0xA4)** instead of the correct **`[3]` (0xA3)**. Per RFC 4178 `NegTokenResp`, `mechListMIC` is `[3]` (and `get_negTokenInit()` already uses `[3]` correctly). The bug was introduced upstream by commit `fdceb225`.

As a result the acceptor/initiator fails to read the `mechListMIC` in a `negTokenResp`, breaking SPNEGO MIC verification on that path. This is observable when authenticating **NTLM-over-SPNEGO to Windows hosts** (e.g. PowerShell/WinRM remoting from an Azure Linux container via `gss-ntlmssp`), where the MIC exchange is required.

This PR backports the upstream fix **krb5 commit [`942c503`](https://github.com/krb5/krb5/commit/942c5036e14066a1f4badfdf67716c47f2e33a39) (ticket 9183, `target_version: 1.21-next`)**, which corrects the tag and restores the `t_spnego.c` reselection regression test.

###### Change Log
- Add `SPECS/krb5/krb5-fix-SPNEGO-mechListMIC-parsing.patch` (full upstream commit `942c503`, code fix + regression test).
- `krb5.spec`: add `Patch3`, bump `Release` 4 → 5, add `%changelog` entry.
- Update `toolchain_{x86_64,aarch64}.txt` and `pkggen_core_{x86_64,aarch64}.txt` manifests to the new `1.21.3-5` RPM filenames (krb5 is a toolchain package).
- No `Source` files changed, so `krb5.signatures.json` is unchanged.

###### Does this affect the toolchain?
**YES** — krb5 is a toolchain package. No source/dependency changes, but its `Release` bump (4 → 5) requires the toolchain and pkggen_core package manifests (x86_64 + aarch64) to be updated to the new RPM filenames, which this PR does.

###### Associated issues
- Upstream: https://github.com/krb5/krb5/commit/942c5036e14066a1f4badfdf67716c47f2e33a39 (MIT krb5 ticket 9183)

###### Test Methodology
- Full upstream patch applies cleanly to the 1.21.3 source tree (`%autosetup -p1`); the restored `t_spnego.c` reselection test runs under `%check` (`make check`).
- Fix validated end-to-end in a live Azure Linux 3.0 container: with krb5 carrying this fix, SPNEGO/NTLM PowerShell remoting to a Windows SCVMM/VMM host completes successfully.
- Pipeline build id: _to be filled from the GitHub PR check run_