### PR TITLE
wpa_supplicant: enable WPA3 (SAE), PMF, and OWE

### DIFF
--- a/SPECS/wpa_supplicant/wpa_supplicant.spec
+++ b/SPECS/wpa_supplicant/wpa_supplicant.spec
@@ -1,7 +1,7 @@
 Summary:        WPA client
 Name:           wpa_supplicant
 Version:        2.10
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -40,11 +40,13 @@ CONFIG_EAP_PEAP=y
 CONFIG_EAP_TLS=y
 CONFIG_EAP_TTLS=y
 CONFIG_IEEE8021X_EAPOL=y
+CONFIG_IEEE80211W=y
 CONFIG_IPV6=y
 CONFIG_LIBNL32=y
-CONFIG_PEERKEY=y
+CONFIG_OWE=y
 CONFIG_PKCS12=y
 CONFIG_READLINE=y
+CONFIG_SAE=y
 CFLAGS += -I/usr/include/libnl3
 EOF
 
@@ -97,6 +99,11 @@ EOF
 %{_sysconfdir}/wpa_supplicant/wpa_supplicant-wlan0.conf
 
 %changelog
+* Tue Jun 23 2026 Sindhu Karri <lakarri@microsoft.com> - 2.10-4
+- Enable WPA3-Personal (SAE), Protected Management Frames (IEEE80211W),
+  and Opportunistic Wireless Encryption (OWE) in build config.
+- Remove obsolete CONFIG_PEERKEY (removed upstream in 2.10).
+
 * Wed Mar 26 2025 Kanishk-Bansal <kanbansal@microsoft.com> - 2.10-3
 - Patch CVE-2025-24912
 


### PR DESCRIPTION
## Summary
Enables WPA3-Personal (SAE), Protected Management Frames (PMF / IEEE 802.11w), and Opportunistic Wireless Encryption (OWE) in the `wpa_supplicant` build config. Removes the obsolete `CONFIG_PEERKEY` symbol (removed from upstream in 2.10).

## Motivation
- [**ADO #62728349**](https://microsoft.visualstudio.com/OS/_workitems/edit/62728349) — netplan generates Wi-Fi configurations with `key-mgmt=sae` per the modern WPA3 standard, but the current Azure Linux `wpa_supplicant` package rejects them because SAE is not compiled in. Users have to hand-edit generated configs to downgrade to WPA2.
- Aligns Azure Linux with Fedora, Debian, and Ubuntu defaults (all enable SAE/PMF/OWE since ~2018–2019).

## Changes
- `CONFIG_SAE=y` — WPA3-Personal (SAE / Dragonfly handshake).
- `CONFIG_IEEE80211W=y` — Protected Management Frames (prerequisite for WPA3; also independently mitigates deauth/disassoc spoofing on WPA2).
- `CONFIG_OWE=y` — Opportunistic Wireless Encryption for open networks (RFC 8110).
- Remove `CONFIG_PEERKEY=y` — symbol no longer exists in upstream wpa_supplicant 2.10.
- Release: 3 -> 4, changelog entry.

## Compatibility / Safety
- **Strictly additive** for existing WPA2/EAP/802.1X configs — new code paths only activate when the AP advertises WPA3/PMF/OWE.
- **No new BuildRequires / Requires** — all new features use the already-linked OpenSSL + libnl3.
- `Source0` and `signatures.json` unchanged.
- Existing CVE patches (CVE-2023-52160, CVE-2025-24912) untouched.
- `CONFIG_PEERKEY` removal is a no-op (upstream already deleted the symbol).
- Dragonblood-class SAE CVEs (CVE-2019-9494/95/96, CVE-2019-13377) were fixed in wpa_supplicant 2.9; we ship 2.10.

## Validation
- Buddy build [**1144931**](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1144931) (amd64 + arm64, both check stages enabled) — ✅ succeeded.

## Linked issue
[ADO #62728349](https://microsoft.visualstudio.com/OS/_workitems/edit/62728349)
