### PR TITLE
fix(containerd): set containerd service resource limits

### DIFF
--- a/SPECS/containerd2/containerd.service
+++ b/SPECS/containerd2/containerd.service
@@ -8,6 +8,14 @@ ExecStartPre=/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd
 Restart=always
 Delegate=yes
+
+# Avoid inheriting host default resource limits for container workloads.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+
+# Only systemd 226 and newer support TasksMax.
+TasksMax=infinity
 KillMode=process
 OOMScoreAdjust=-999
 

--- a/SPECS/containerd2/containerd2.signatures.json
+++ b/SPECS/containerd2/containerd2.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "containerd.service": "a07bfcf412669b06673190b0779f48e652c9adcf1758289e849a00802804eec8",
+  "containerd.service": "4908737036389849f437e5225f2b24cc4dbd2311365c2ffeffd08f19a09b0c29",
   "containerd.toml": "5b3821236f09b4c858e0e098bbe1400f4dbbb47d360e39d21c61858b088c2896",
   "containerd-2.2.4.tar.gz": "f73a4580a869426120bc99bcd812ac723701a8c934549f70c8a6067e30e1458d"
  }

--- a/SPECS/containerd2/containerd2.spec
+++ b/SPECS/containerd2/containerd2.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: %{upstream_name}2
 Version: 2.2.4
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -103,6 +103,9 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Tue Jun 23 2026 Sudipta Pandit <sudpandit@microsoft.com> - 2.2.4-4
+- Set containerd service resource limits for container workloads
+
 * Mon Jun 01 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.2.4-3
 - Patch for CVE-2026-42502, CVE-2026-25681, CVE-2026-25680
 


### PR DESCRIPTION
Configure the Azure Linux containerd service to avoid inheriting host default resource limits for container workloads.

[Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1145008&view=results)
[Work Item](https://microsoft.visualstudio.com/OS/_workitems/edit/62766510)