### PR TITLE
feat(wsl): add POSIX text/scripting baseline tools

### DIFF
--- a/base/images/wsl/wsl.kiwi
+++ b/base/images/wsl/wsl.kiwi
@@ -39,9 +39,14 @@
         <package name="curl"/>
         <package name="dbus"/>
         <package name="default-editor"/>
+        <package name="diffutils"/>
         <package name="file"/>
+        <package name="findutils"/>
+        <package name="gawk"/>
         <package name="glibc-langpack-en"/>
         <package name="gnupg2"/>
+        <package name="grep"/>
+        <package name="gzip"/>
         <package name="iproute"/>
         <package name="iputils"/>
         <package name="less"/>
@@ -51,9 +56,11 @@
         <package name="nmap-ncat"/>
         <package name="openssh-clients"/>
         <package name="passwd"/>
+        <package name="patch"/>
         <package name="pciutils"/>
         <package name="procps-ng"/>
         <package name="rsync"/>
+        <package name="sed"/>
         <package name="shadow-utils"/>
         <package name="sudo"/>
         <package name="symlinks"/>
@@ -73,6 +80,7 @@
         <package name="which"/>
         <package name="whois"/>
         <package name="wsl-setup"/>
+        <package name="xz"/>
         <package name="zip"/>
         <package name="zram-generator-defaults"/>
     </packages>


### PR DESCRIPTION
The WSL image list enumerates user-facing basics explicitly (tar, which,
less, curl, file) but omitted several classic POSIX text-processing and
scripting tools that scripts and interactive users universally assume.

Add them so they are guaranteed present rather than relying on transitive
dependencies of a minimal install:

  - gawk      (awk)
  - diffutils (diff, cmp)
  - findutils (find, xargs)
  - patch
  - xz        (.tar.xz is one of the dominant tarball format)
  - grep
  - sed
  - gzip      (gzip, gunzip, zcat)

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
