### PR TITLE
libssh2: patch CVE-2026-55200 (OOB write in transport read)

### DIFF
--- a/SPECS/libssh2/CVE-2026-55200.patch
+++ b/SPECS/libssh2/CVE-2026-55200.patch
@@ -1,0 +1,42 @@
+From 97acf3dfda80c91c3a8c9f2372546301d4a1a7a8 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Fri, 12 Jun 2026 15:57:44 -0700
+Subject: [PATCH] transport.c: Additional boundary checks for packet length (#2052)
+
+Add additional bounds checking on packet length to prevent OOB write.
+
+The chacha20-poly1305 (REQUIRES_FULL_PACKET) read path parses packet_length
+without an upper bound. A crafted length near UINT32_MAX wraps the 32-bit
+total_num computation past the existing total_num > LIBSSH2_PACKET_MAXPAYLOAD
+guard, under-allocating the payload buffer that a later copy overflows
+(CWE-680). Bound packet_length directly, mirroring the guarded first-read
+branch.
+
+Note: upstream 97acf3df targets the post-1.11.1 tree (function renamed to
+ssh2_transport_read, nested conditionals merged); this is the equivalent
+guard adapted to the 1.11.1 _libssh2_transport_read() else branch.
+
+Credit:
+[TristanInSec](https://github.com/TristanInSec)
+
+Signed-off-by: Omkhar Arasaratnam <omkhar@linkedin.com>
+Upstream-reference: https://github.com/libssh2/libssh2/commit/97acf3dfda80c91c3a8c9f2372546301d4a1a7a8.patch
+---
+ src/transport.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/transport.c b/src/transport.c
+index e1120656..5180741f 100644
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -641,6 +641,8 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
+                 p->packet_length = _libssh2_ntohu32(block);
+                 if(p->packet_length < 1)
+                     return LIBSSH2_ERROR_DECRYPT;
++                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD)
++                    return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
+
+                 /* total_num may include size field, however due to existing
+                  * logic it needs to be removed after the entire packet is read
+--
+2.34.1

--- a/SPECS/libssh2/libssh2.spec
+++ b/SPECS/libssh2/libssh2.spec
@@ -3,7 +3,7 @@
 Summary:        libssh2 is a library implementing the SSH2 protocol.
 Name:           libssh2
 Version:        1.11.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD
 URL:            https://www.libssh2.org/
 Group:          System Environment/NetworkingLibraries
@@ -11,6 +11,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Source0:        https://www.libssh2.org/download/libssh2-%{version}.tar.gz
 Patch0:         CVE-2026-7598.patch
+Patch1:         CVE-2026-55200.patch
 BuildRequires:  openssl-devel
 BuildRequires:  zlib-devel
 
@@ -58,6 +59,9 @@ find %{buildroot} -name '*.la' -exec rm -f {} ';'
 %{_mandir}/man3/*
 
 %changelog
+* Thu Jun 25 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 1.11.1-3
+- Patch for CVE-2026-55200
+
 * Mon May 04 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.11.1-2
 - Patch for CVE-2026-7598
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -193,8 +193,8 @@ e2fsprogs-1.47.0-2.azl3.aarch64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.aarch64.rpm
 libsolv-0.7.28-3.azl3.aarch64.rpm
 libsolv-devel-0.7.28-3.azl3.aarch64.rpm
-libssh2-1.11.1-2.azl3.aarch64.rpm
-libssh2-devel-1.11.1-2.azl3.aarch64.rpm
+libssh2-1.11.1-3.azl3.aarch64.rpm
+libssh2-devel-1.11.1-3.azl3.aarch64.rpm
 krb5-1.21.3-5.azl3.aarch64.rpm
 krb5-devel-1.21.3-5.azl3.aarch64.rpm
 nghttp2-1.61.0-3.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -193,8 +193,8 @@ e2fsprogs-1.47.0-2.azl3.x86_64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.x86_64.rpm
 libsolv-0.7.28-3.azl3.x86_64.rpm
 libsolv-devel-0.7.28-3.azl3.x86_64.rpm
-libssh2-1.11.1-2.azl3.x86_64.rpm
-libssh2-devel-1.11.1-2.azl3.x86_64.rpm
+libssh2-1.11.1-3.azl3.x86_64.rpm
+libssh2-devel-1.11.1-3.azl3.x86_64.rpm
 krb5-1.21.3-5.azl3.x86_64.rpm
 krb5-devel-1.21.3-5.azl3.x86_64.rpm
 nghttp2-1.61.0-3.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -229,9 +229,9 @@ libsolv-0.7.28-3.azl3.aarch64.rpm
 libsolv-debuginfo-0.7.28-3.azl3.aarch64.rpm
 libsolv-devel-0.7.28-3.azl3.aarch64.rpm
 libsolv-tools-0.7.28-3.azl3.aarch64.rpm
-libssh2-1.11.1-2.azl3.aarch64.rpm
-libssh2-debuginfo-1.11.1-2.azl3.aarch64.rpm
-libssh2-devel-1.11.1-2.azl3.aarch64.rpm
+libssh2-1.11.1-3.azl3.aarch64.rpm
+libssh2-debuginfo-1.11.1-3.azl3.aarch64.rpm
+libssh2-devel-1.11.1-3.azl3.aarch64.rpm
 libstdc++-13.2.0-7.azl3.aarch64.rpm
 libstdc++-devel-13.2.0-7.azl3.aarch64.rpm
 libtasn1-4.19.0-3.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -237,9 +237,9 @@ libsolv-0.7.28-3.azl3.x86_64.rpm
 libsolv-debuginfo-0.7.28-3.azl3.x86_64.rpm
 libsolv-devel-0.7.28-3.azl3.x86_64.rpm
 libsolv-tools-0.7.28-3.azl3.x86_64.rpm
-libssh2-1.11.1-2.azl3.x86_64.rpm
-libssh2-debuginfo-1.11.1-2.azl3.x86_64.rpm
-libssh2-devel-1.11.1-2.azl3.x86_64.rpm
+libssh2-1.11.1-3.azl3.x86_64.rpm
+libssh2-debuginfo-1.11.1-3.azl3.x86_64.rpm
+libssh2-devel-1.11.1-3.azl3.x86_64.rpm
 libstdc++-13.2.0-7.azl3.x86_64.rpm
 libstdc++-devel-13.2.0-7.azl3.x86_64.rpm
 libtasn1-4.19.0-3.azl3.x86_64.rpm


### PR DESCRIPTION
### Summary

Azure Linux 3.0 ships `libssh2-1.11.1-2`, which is affected by **CVE-2026-55200** (only CVE-2026-7598 is currently patched). This adds the upstream fix as `Patch1` and bumps `Release` to 3.

### The vulnerability

`_libssh2_transport_read()`'s `chacha20-poly1305@openssh.com` (`REQUIRES_FULL_PACKET`) branch parses `packet_length` without an upper bound. A crafted length near `UINT32_MAX` wraps the 32-bit `total_num` computation past the existing `total_num > LIBSSH2_PACKET_MAXPAYLOAD` guard, under-allocating `p->payload` while the large `packet_length` drives a later copy → heap out-of-bounds write (CWE-680). A malicious or MITM SSH server can trigger it against any client that negotiates chacha20-poly1305 (libssh2's default-preferred cipher).

### The fix

Backport of upstream **PR #2052** / commit [`97acf3df`](https://github.com/libssh2/libssh2/commit/97acf3dfda80c91c3a8c9f2372546301d4a1a7a8), adapted to the 1.11.1 tree (upstream targets the post-1.11.1 source where the function was renamed and the conditionals merged). It bounds `packet_length` directly in the `else` branch, mirroring the already-guarded first-read branch.

### Validation

Built `libssh2-1.11.1` under `-fsanitize=address -DNDEBUG` (release, matching the shipped package) and exercised the real `_libssh2_transport_read()`:

- **Before:** `AddressSanitizer: negative-size-param (size=-2147483633)` at `src/transport.c:806`.
- **After this patch:** the same input returns `LIBSSH2_ERROR_OUT_OF_BOUNDARY` with no ASan event.
- A specificity/mutation sweep confirmed the fix is exact: legal lengths and large-but-non-wrapping lengths are unaffected; only the 32-bit-overflow values are rejected.

### Scope note

Only the AEAD (`chacha20-poly1305`) path is affected, so older libssh2 (1.9.0 / 1.10.0, e.g. Azure Linux 2.0) is **not** vulnerable despite NVD's "0 through 1.11.1" range — those releases carry the CVE-2019-3855 guard and have no `REQUIRES_FULL_PACKET` branch.

### Changes

- `SPECS/libssh2/CVE-2026-55200.patch` — new (upstream backport, applies at `-p1` via `%autosetup`).
- `SPECS/libssh2/libssh2.spec` — `Patch1`, `Release: 2 → 3`, changelog entry.

`signatures.json` is unchanged (it tracks only the source tarball).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
