### PR TITLE
feat(dpkg): add dpkg to base rpm repo

### DIFF
--- a/base/comps/components-publish-channels.toml
+++ b/base/comps/components-publish-channels.toml
@@ -259,6 +259,7 @@ components = [
     "double-conversion",
     "doxygen",
     "dpdk",
+    "dpkg",
     "dracut",
     "driverctl",
     "drpm",


### PR DESCRIPTION
In commit 8d904bb9e270cb08d9eadd647a135ba2cd1ed1e0 we added `debootstrap`, putting it in the base rpm repo. But we missed `dpkg`, which is a dependency of `debootstrap`. This change adds `dpkg` to the base rpm repo.

Built locally and installed via local yum repo. Both `dpkg` and `debootsrap` install correctly.