### PR TITLE
feat(wsl): add git, tmux, jq, ethtool to WSL image

### DIFF
--- a/base/images/wsl/wsl.kiwi
+++ b/base/images/wsl/wsl.kiwi
@@ -40,15 +40,18 @@
         <package name="dbus"/>
         <package name="default-editor"/>
         <package name="diffutils"/>
+        <package name="ethtool"/>
         <package name="file"/>
         <package name="findutils"/>
         <package name="gawk"/>
+        <package name="git"/>
         <package name="glibc-langpack-en"/>
         <package name="gnupg2"/>
         <package name="grep"/>
         <package name="gzip"/>
         <package name="iproute"/>
         <package name="iputils"/>
+        <package name="jq"/>
         <package name="less"/>
         <package name="lsof"/>
         <package name="man-db"/>
@@ -70,6 +73,7 @@
         <package name="tar"/>
         <package name="tcpdump"/>
         <package name="time"/>
+        <package name="tmux"/>
         <package name="traceroute"/>
         <package name="tree"/>
         <package name="unzip"/>


### PR DESCRIPTION
Extend the WSL image package list (derived from Fedora 43's WSL
composition) with utilities useful in the WSL command-line / developer
workflow that upstream's composition does not ship:

- git     : ubiquitous in WSL developer workflows
- tmux    : terminal multiplexer (single choice; screen intentionally
            omitted to avoid shipping two tools for one job)
- jq      : JSON processing for scripting
- ethtool : NIC diagnostics / MTU manipulation for troubleshooting
            WSL2 virtualized-networking issues

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
