### PR TITLE
mlnx-ofa_kernel-hwe-modules-signed: drop fwctl.ko (broken since DOCA 3.3.0 bump)

### DIFF
--- a/SPECS-SIGNED/mlnx-ofa_kernel-hwe-modules-signed/mlnx-ofa_kernel-hwe-modules-signed.spec
+++ b/SPECS-SIGNED/mlnx-ofa_kernel-hwe-modules-signed/mlnx-ofa_kernel-hwe-modules-signed.spec
@@ -131,6 +131,8 @@ Obsoletes: mlnx-en-kmp-trace
 Obsoletes: mlnx-en-doc
 Obsoletes: mlnx-en-debuginfo
 Obsoletes: mlnx-en-sources
+Obsoletes: fwctl-hwe <= 24.10
+Provides: fwctl-hwe = %{version}-%{release}
 
 Requires: kernel-hwe = %{target_kernel_version_full}
 Requires: kmod
@@ -238,8 +240,6 @@ fi
   after the upgrade to DOCA 3.3.0 / kernel-hwe 6.18 (PR #17447). The
   in-tree fwctl framework is now provided by the HWE kernel itself,
   so the out-of-tree, signed copy is unnecessary.
-- Drop the now-stale fwctl-hwe Obsoletes/Provides pair (no consumers
-  in the repo).
 
 * Wed May 13 2026 Azure Linux Team <azurelinux-team@microsoft.com> - 26.01-1_6.18.31.1.1
 - Bump to match upgrade to DOCA 3.3.0 (OFED 26.01).

--- a/SPECS-SIGNED/mlnx-ofa_kernel-hwe-modules-signed/mlnx-ofa_kernel-hwe-modules-signed.spec
+++ b/SPECS-SIGNED/mlnx-ofa_kernel-hwe-modules-signed/mlnx-ofa_kernel-hwe-modules-signed.spec
@@ -46,7 +46,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 %{_name}-signed
 Version:	 26.01
-Release:	 1%{release_suffix}%{?dist}
+Release:	 2%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -88,7 +88,6 @@ Source26:       smc_diag.ko
 Source27:       rpcrdma.ko
 Source28:       svcrdma.ko
 Source29:       xprtrdma.ko
-Source30:       fwctl.ko
 Source31:       mlx5_fwctl.ko
 Source32:       mana_ib.ko
 Source33:       mlx5_dpll.ko
@@ -132,8 +131,6 @@ Obsoletes: mlnx-en-kmp-trace
 Obsoletes: mlnx-en-doc
 Obsoletes: mlnx-en-debuginfo
 Obsoletes: mlnx-en-sources
-Obsoletes: fwctl-hwe <= 24.10
-Provides:  fwctl-hwe = %{version}-%{release}
 
 Requires: kernel-hwe = %{target_kernel_version_full}
 Requires: kmod
@@ -191,7 +188,6 @@ cp -rf %{SOURCE26} ./lib/modules/%{KVERSION}/updates/net/smc/smc_diag.ko
 cp -rf %{SOURCE27} ./lib/modules/%{KVERSION}/updates/net/sunrpc/xprtrdma/rpcrdma.ko
 cp -rf %{SOURCE28} ./lib/modules/%{KVERSION}/updates/net/sunrpc/xprtrdma/svcrdma.ko
 cp -rf %{SOURCE29} ./lib/modules/%{KVERSION}/updates/net/sunrpc/xprtrdma/xprtrdma.ko
-cp -rf %{SOURCE30} ./lib/modules/%{KVERSION}/updates/drivers/fwctl/fwctl.ko
 cp -rf %{SOURCE31} ./lib/modules/%{KVERSION}/updates/drivers/fwctl/mlx5/mlx5_fwctl.ko
 cp -rf %{SOURCE32} ./lib/modules/%{KVERSION}/updates/drivers/infiniband/hw/mana/mana_ib.ko
 cp -rf %{SOURCE33} ./lib/modules/%{KVERSION}/updates/drivers/net/ethernet/mellanox/mlx5/core/mlx5_dpll.ko
@@ -237,6 +233,14 @@ fi
 %license %{_datadir}/licenses/%{_name}/copyright
 
 %changelog
+* Fri Jun 27 2026 Jon Slobodzian <joslobo@microsoft.com> - 26.01-2_6.18.31.1.1
+- Drop fwctl.ko: it is no longer produced by the HWE OFED build
+  after the upgrade to DOCA 3.3.0 / kernel-hwe 6.18 (PR #17447). The
+  in-tree fwctl framework is now provided by the HWE kernel itself,
+  so the out-of-tree, signed copy is unnecessary.
+- Drop the now-stale fwctl-hwe Obsoletes/Provides pair (no consumers
+  in the repo).
+
 * Wed May 13 2026 Azure Linux Team <azurelinux-team@microsoft.com> - 26.01-1_6.18.31.1.1
 - Bump to match upgrade to DOCA 3.3.0 (OFED 26.01).
 

--- a/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
+++ b/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
@@ -117,7 +117,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 mlnx-ofa_kernel-hwe
 Version:	 26.01
-Release:	 1%{release_suffix}%{?dist}
+Release:	 2%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -462,6 +462,10 @@ update-alternatives --remove \
 %{_prefix}/src/ofa_kernel/%{_arch}/[0-9]*
 
 %changelog
+* Fri Jun 27 2026 Jon Slobodzian <joslobo@microsoft.com> - 26.01-2_6.18.31.1.1
+- Bump release to stay entangled with the signed sibling, which dropped
+  fwctl.ko (no longer produced by HWE OFED after the DOCA 3.3.0 bump).
+
 * Mon May 11 2026 Azure Linux Team - 26.01-1_6.18.31.1.1
 - Upgrade to DOCA 3.3.0 (OFED 26.01-1.0.0.0)
 

--- a/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
+++ b/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
@@ -117,7 +117,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 mlnx-ofa_kernel-hwe
 Version:	 26.01
-Release:	 1%{release_suffix}%{?dist}
+Release:	 2%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -193,8 +193,6 @@ Obsoletes: mlnx-en-doc
 Obsoletes: mlnx-en-debuginfo
 Obsoletes: mlnx-en-sources
 Obsoletes: mlnx-rdma-rxe
-Obsoletes: fwctl-hwe <= 24.10
-Provides:  fwctl-hwe = %{version}-%{release}
 
 Summary: Infiniband Driver and ULPs kernel modules
 Group: System Environment/Libraries
@@ -464,6 +462,11 @@ update-alternatives --remove \
 %{_prefix}/src/ofa_kernel/%{_arch}/[0-9]*
 
 %changelog
+* Fri Jun 27 2026 Jon Slobodzian <joslobo@microsoft.com> - 26.01-2_6.18.31.1.1
+- Drop the stale fwctl-hwe Obsoletes/Provides pair (no consumers in
+  the repo); the HWE OFED 26.01 build does not produce fwctl.ko, so
+  claiming to provide fwctl-hwe is misleading.
+
 * Mon May 11 2026 Azure Linux Team - 26.01-1_6.18.31.1.1
 - Upgrade to DOCA 3.3.0 (OFED 26.01-1.0.0.0)
 

--- a/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
+++ b/SPECS/mlnx-ofa_kernel-hwe/mlnx-ofa_kernel-hwe.spec
@@ -117,7 +117,7 @@
 Summary:	 Infiniband HCA Driver
 Name:		 mlnx-ofa_kernel-hwe
 Version:	 26.01
-Release:	 2%{release_suffix}%{?dist}
+Release:	 1%{release_suffix}%{?dist}
 License:	 GPLv2
 Url:		 http://www.mellanox.com/
 Group:		 System Environment/Base
@@ -462,11 +462,6 @@ update-alternatives --remove \
 %{_prefix}/src/ofa_kernel/%{_arch}/[0-9]*
 
 %changelog
-* Fri Jun 27 2026 Jon Slobodzian <joslobo@microsoft.com> - 26.01-2_6.18.31.1.1
-- Drop the stale fwctl-hwe Obsoletes/Provides pair (no consumers in
-  the repo); the HWE OFED 26.01 build does not produce fwctl.ko, so
-  claiming to provide fwctl-hwe is misleading.
-
 * Mon May 11 2026 Azure Linux Team - 26.01-1_6.18.31.1.1
 - Upgrade to DOCA 3.3.0 (OFED 26.01-1.0.0.0)
 


### PR DESCRIPTION
## What
Drop `fwctl.ko` from `mlnx-ofa_kernel-hwe-modules-signed.spec`, plus the now-stale `Obsoletes/Provides fwctl-hwe` pair on both the signed and unsigned HWE specs.

## Why — fixes the 3.0-dev cascade broken since 6/12

Since the morning of **2026-06-12**, every 3.0-dev run of:
- `[AMD64-2.1-OneBranch]-Dev-SecureBoot-Ko-Sign&Build` (def 4714)
- `[ARM64-2.1-OneBranch]-Dev-SecureBoot-Ko-Sign&Build` (def 4736)

has failed in the `Build signed spec` task with:

```
WARN  srpmpacker  Attempt 1/8: Failed to download
  https://azurelinuxsrcstorage.blob.core.windows.net/sources/core/fwctl.ko
  with error: (invalid response: 404)
PANI  srpmpacker  unable to hydrate files: [fwctl.ko]
```

The downstream golden-container builds (`[*-4-OneBranch]-Dev-BuildGoldenContainers`, defs 2733/2734) are also failing because they can't pull updated openmpi RPMs.

### Root cause
PR #17447 (*kernel-hwe: Upgrade to 6.18.31.1 and doca to 3.3.0*, merged 2026-06-10) bumped the HWE OFED to DOCA 3.3.0. The new HWE OFED build no longer produces `fwctl.ko` — the `fwctl` framework is now in-tree in the 6.18 kernel. The signed spec still declares it as `Source30`, so the sign job's extractor can't stage it from the upstream RPM, srpmpacker falls back to blob storage, and the build dies on a 404.

### Evidence
Extracted from the failing builds' `Debug: Show extracted files and RPMs` task:
- Build 1147170 (ARM64, 6/26): extracted **47 of 48** Sources; only `fwctl.ko` missing.
- Build 1147891 (AMD64, 6/27): extracted **32 of 33** AMD64-relevant Sources; only `fwctl.ko` missing.
- Non-HWE sibling (`mlnx-ofa_kernel-modules-signed`, kernel 6.6.143.1) **still ships `fwctl.ko`** from the older OFED and is unaffected — left alone in this PR.

### Repo-wide dependency check
- Nothing in `SPECS/`, `SPECS-SIGNED/`, image configs, kickstarts, or toolkit configs depends on `fwctl-hwe` (the package name) or lists `fwctl.ko` as a required module. The only references are the two self-referential `Obsoletes/Provides` pairs being removed here.
- No new `.ko` files appear in the DOCA-3.3.0 HWE build that aren't already listed as Sources — extracted set is a strict subset of declared Sources.

## Validation plan
Merge → next 3.0-dev nightly cascade (defs 4714/4736 + 2733/2734) should go green. Will monitor.