### PR TITLE
Upgrade `attr` to 2.6.0 for CVE-2026-54369, CVE-2026-54370, CVE-2026-54371

### DIFF
--- a/SPECS/attr/attr.signatures.json
+++ b/SPECS/attr/attr.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "attr-2.5.2.tar.gz": "39bf67452fa41d0948c2197601053f48b3d78a029389734332a6309a680c6c87"
+    "attr-2.6.0.tar.gz": "d42fa374513180bb48cb11a46696f488240e5124ff1e6ad88b0abff706985612"
   }
 }

--- a/SPECS/attr/attr.spec
+++ b/SPECS/attr/attr.spec
@@ -1,6 +1,6 @@
 Summary:        Utilities for managing filesystem extended attributes
 Name:           attr
-Version:        2.5.2
+Version:        2.6.0
 Release:        1%{?dist}
 License:        GPLv2+ AND LGPLv2+
 Vendor:         Microsoft Corporation
@@ -109,6 +109,9 @@ ln -fs ../sys/xattr.h %{buildroot}%{_includedir}/attr/xattr.h
 %config(noreplace) %{_sysconfdir}/xattr.conf
 
 %changelog
+* Mon Jun 29 2026 Kanishk Bansal <kanbansal@microsoft.com> - 2.6.0-1
+- Upgrade to 2.6.0 for CVE-2026-54369, CVE-2026-54370, CVE-2026-54371
+
 * Tue Feb 06 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.5.2-1
 - Auto-upgrade to 2.5.2 - Package upgrade for Azure Linux 3.0
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -715,8 +715,8 @@
         "type": "other",
         "other": {
           "name": "attr",
-          "version": "2.5.2",
-          "downloadUrl": "https://download.savannah.nongnu.org/releases/attr/attr-2.5.2.tar.gz"
+          "version": "2.6.0",
+          "downloadUrl": "https://download.savannah.nongnu.org/releases/attr/attr-2.6.0.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -41,8 +41,8 @@ ncurses-libs-6.4-3.azl3.aarch64.rpm
 ncurses-term-6.4-3.azl3.aarch64.rpm
 readline-8.2-2.azl3.aarch64.rpm
 readline-devel-8.2-2.azl3.aarch64.rpm
-libattr-2.5.2-1.azl3.aarch64.rpm
-attr-2.5.2-1.azl3.aarch64.rpm
+libattr-2.6.0-1.azl3.aarch64.rpm
+attr-2.6.0-1.azl3.aarch64.rpm
 libacl-2.3.1-2.azl3.aarch64.rpm
 coreutils-9.4-6.azl3.aarch64.rpm
 coreutils-lang-9.4-6.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -41,8 +41,8 @@ ncurses-libs-6.4-3.azl3.x86_64.rpm
 ncurses-term-6.4-3.azl3.x86_64.rpm
 readline-8.2-2.azl3.x86_64.rpm
 readline-devel-8.2-2.azl3.x86_64.rpm
-libattr-2.5.2-1.azl3.x86_64.rpm
-attr-2.5.2-1.azl3.x86_64.rpm
+libattr-2.6.0-1.azl3.x86_64.rpm
+attr-2.6.0-1.azl3.x86_64.rpm
 libacl-2.3.1-2.azl3.x86_64.rpm
 coreutils-9.4-6.azl3.x86_64.rpm
 coreutils-lang-9.4-6.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -1,8 +1,8 @@
 acl-2.3.1-2.azl3.aarch64.rpm
 acl-debuginfo-2.3.1-2.azl3.aarch64.rpm
 asciidoc-10.2.0-3.azl3.noarch.rpm
-attr-2.5.2-1.azl3.aarch64.rpm
-attr-debuginfo-2.5.2-1.azl3.aarch64.rpm
+attr-2.6.0-1.azl3.aarch64.rpm
+attr-debuginfo-2.6.0-1.azl3.aarch64.rpm
 audit-3.1.2-1.azl3.aarch64.rpm
 audit-debuginfo-3.1.2-1.azl3.aarch64.rpm
 audit-devel-3.1.2-1.azl3.aarch64.rpm
@@ -174,8 +174,8 @@ libarchive-devel-3.7.7-6.azl3.aarch64.rpm
 libassuan-2.5.6-1.azl3.aarch64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.aarch64.rpm
 libassuan-devel-2.5.6-1.azl3.aarch64.rpm
-libattr-2.5.2-1.azl3.aarch64.rpm
-libattr-devel-2.5.2-1.azl3.aarch64.rpm
+libattr-2.6.0-1.azl3.aarch64.rpm
+libattr-devel-2.6.0-1.azl3.aarch64.rpm
 libbacktrace-static-13.2.0-7.azl3.aarch64.rpm
 libcap-2.69-15.azl3.aarch64.rpm
 libcap-debuginfo-2.69-15.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -1,8 +1,8 @@
 acl-2.3.1-2.azl3.x86_64.rpm
 acl-debuginfo-2.3.1-2.azl3.x86_64.rpm
 asciidoc-10.2.0-3.azl3.noarch.rpm
-attr-2.5.2-1.azl3.x86_64.rpm
-attr-debuginfo-2.5.2-1.azl3.x86_64.rpm
+attr-2.6.0-1.azl3.x86_64.rpm
+attr-debuginfo-2.6.0-1.azl3.x86_64.rpm
 audit-3.1.2-1.azl3.x86_64.rpm
 audit-debuginfo-3.1.2-1.azl3.x86_64.rpm
 audit-devel-3.1.2-1.azl3.x86_64.rpm
@@ -182,8 +182,8 @@ libarchive-devel-3.7.7-6.azl3.x86_64.rpm
 libassuan-2.5.6-1.azl3.x86_64.rpm
 libassuan-debuginfo-2.5.6-1.azl3.x86_64.rpm
 libassuan-devel-2.5.6-1.azl3.x86_64.rpm
-libattr-2.5.2-1.azl3.x86_64.rpm
-libattr-devel-2.5.2-1.azl3.x86_64.rpm
+libattr-2.6.0-1.azl3.x86_64.rpm
+libattr-devel-2.6.0-1.azl3.x86_64.rpm
 libbacktrace-static-13.2.0-7.azl3.x86_64.rpm
 libcap-2.69-15.azl3.x86_64.rpm
 libcap-debuginfo-2.69-15.azl3.x86_64.rpm


### PR DESCRIPTION
Upgrade attr to 2.6.0 for CVE-2026-54369, CVE-2026-54370, CVE-2026-54371
Buddy Build - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1149289&view=results
