### PR TITLE
Patch kernel: backport ipv6 fraggap OOB-write fix (torvalds/linux@736b380e)

### DIFF
--- a/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
+++ b/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
@@ -33,7 +33,7 @@
 Summary:        Linux Kernel
 Name:           kernel-ipe
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -460,6 +460,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Release bump to stay in lockstep with the kernel spec entanglement group for the ipv6 fraggap fix (torvalds/linux@736b380e28d0).
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
+++ b/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
@@ -7,7 +7,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-64k-signed-%{buildarch}
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,6 +105,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Release bump to stay in lockstep with the kernel spec entanglement group for the ipv6 fraggap fix (torvalds/linux@736b380e28d0).
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -145,6 +145,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Release bump to stay in lockstep with the kernel spec entanglement group for the ipv6 fraggap fix (torvalds/linux@736b380e28d0).
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
+++ b/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed Unified Kernel Image for %{buildarch} systems
 Name:           kernel-uki-signed-%{buildarch}
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -68,6 +68,9 @@ popd
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Release bump to stay in lockstep with the kernel spec entanglement group for the ipv6 fraggap fix (torvalds/linux@736b380e28d0).
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/SPECS/kernel-64k/0001-ipv6-account-for-fraggap-on-the-paged-allocation-pat.patch
+++ b/SPECS/kernel-64k/0001-ipv6-account-for-fraggap-on-the-paged-allocation-pat.patch
@@ -1,0 +1,79 @@
+From 736b380e28d0480c7bc3e022f1950f31fe53a7c5 Mon Sep 17 00:00:00 2001
+From: Wongi Lee <qw3rtyp0@gmail.com>
+Date: Tue, 16 Jun 2026 22:46:17 +0900
+Subject: ipv6: account for fraggap on the paged allocation path
+
+In __ip6_append_data(), when the paged-allocation branch is taken
+(MSG_MORE / NETIF_F_SG / large fraglen), alloclen and pagedlen are
+computed as
+
+	alloclen = fragheaderlen + transhdrlen;
+	pagedlen = datalen - transhdrlen;
+
+datalen already includes fraggap (datalen = length + fraggap). When
+fraggap is non-zero, this is not the first skb and transhdrlen is zero.
+The fraggap bytes carried over from the previous skb are copied just past
+the fragment headers in the new skb's linear area. The linear area is
+therefore undersized by fraggap bytes while pagedlen is overstated by the
+same amount, and the copy writes past skb->end into the trailing
+skb_shared_info.
+
+An unprivileged user can trigger this via a UDPv6 socket using
+MSG_MORE together with MSG_SPLICE_PAGES.
+
+The bad accounting was introduced by commit 773ba4fe9104 ("ipv6:
+avoid partial copy for zc"). Before commit ce650a166335 ("udp6: Fix
+__ip6_append_data()'s handling of MSG_SPLICE_PAGES"), the negative
+copy value caused -EINVAL to be returned. That later commit allowed
+MSG_SPLICE_PAGES to proceed in this case, making the corruption
+triggerable.
+
+The non-paged branch sets alloclen to fraglen, which already accounts
+for fraggap because datalen does. Bring the paged branch in line by
+adding fraggap to alloclen and subtracting it from pagedlen.
+
+After this adjustment, copy no longer collapses to -fraggap on the
+paged path, so remove the stale comment describing that old arithmetic.
+Since a negative copy is no longer expected for a valid MSG_SPLICE_PAGES
+case, remove the MSG_SPLICE_PAGES exception from the negative copy check.
+
+Fixes: 773ba4fe9104 ("ipv6: avoid partial copy for zc")
+Signed-off-by: Jungwoo Lee <jwlee2217@gmail.com>
+Signed-off-by: Wongi Lee <qw3rtyp0@gmail.com>
+Reviewed-by: Ido Schimmel <idosch@nvidia.com>
+Link: https://patch.msgid.link/ajFTqRljatR17fFy@DESKTOP-19IMU7U.localdomain
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ net/ipv6/ip6_output.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/net/ipv6/ip6_output.c b/net/ipv6/ip6_output.c
+index 9f1e0e4f74641..368e4fa3b43ca 100644
+--- a/net/ipv6/ip6_output.c
++++ b/net/ipv6/ip6_output.c
+@@ -1667,8 +1667,8 @@ alloc_new_skb:
+ 				  !(rt->dst.dev->features & NETIF_F_SG)))
+ 				alloclen = fraglen;
+ 			else {
+-				alloclen = fragheaderlen + transhdrlen;
+-				pagedlen = datalen - transhdrlen;
++				alloclen = fragheaderlen + transhdrlen + fraggap;
++				pagedlen = datalen - transhdrlen - fraggap;
+ 			}
+ 			alloclen += alloc_extra;
+ 
+@@ -1683,10 +1683,7 @@ alloc_new_skb:
+ 			fraglen = datalen + fragheaderlen;
+ 
+ 			copy = datalen - transhdrlen - fraggap - pagedlen;
+-			/* [!] NOTE: copy may be negative if pagedlen>0
+-			 * because then the equation may reduces to -fraggap.
+-			 */
+-			if (copy < 0 && !(flags & MSG_SPLICE_PAGES)) {
++			if (copy < 0) {
+ 				err = -EINVAL;
+ 				goto error;
+ 			}
+-- 
+cgit 1.3-korg
+

--- a/SPECS/kernel-64k/kernel-64k.spec
+++ b/SPECS/kernel-64k/kernel-64k.spec
@@ -27,7 +27,7 @@
 Summary:        Linux Kernel
 Name:           kernel-64k
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -41,6 +41,7 @@ Source4:        cpupower
 Source5:        cpupower.service
 Patch0:         0001-add-mstflint-kernel-%{mstflintver}.patch
 Patch1:         0002-efi-Added-efi-cmdline-line-option-to-dynamically-adj.patch
+Patch2:         0001-ipv6-account-for-fraggap-on-the-paged-allocation-pat.patch
 ExclusiveArch:  aarch64
 BuildRequires:  audit-devel
 BuildRequires:  bash
@@ -380,6 +381,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Backport upstream torvalds/linux@736b380e28d0 ("ipv6: account for fraggap on the paged allocation path") to fix an OOB-write in __ip6_append_data().
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +75,9 @@ done
 %endif
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Release bump to stay in lockstep with the kernel spec entanglement group for the ipv6 fraggap fix (torvalds/linux@736b380e28d0).
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/SPECS/kernel/0001-ipv6-account-for-fraggap-on-the-paged-allocation-pat.patch
+++ b/SPECS/kernel/0001-ipv6-account-for-fraggap-on-the-paged-allocation-pat.patch
@@ -1,0 +1,79 @@
+From 736b380e28d0480c7bc3e022f1950f31fe53a7c5 Mon Sep 17 00:00:00 2001
+From: Wongi Lee <qw3rtyp0@gmail.com>
+Date: Tue, 16 Jun 2026 22:46:17 +0900
+Subject: ipv6: account for fraggap on the paged allocation path
+
+In __ip6_append_data(), when the paged-allocation branch is taken
+(MSG_MORE / NETIF_F_SG / large fraglen), alloclen and pagedlen are
+computed as
+
+	alloclen = fragheaderlen + transhdrlen;
+	pagedlen = datalen - transhdrlen;
+
+datalen already includes fraggap (datalen = length + fraggap). When
+fraggap is non-zero, this is not the first skb and transhdrlen is zero.
+The fraggap bytes carried over from the previous skb are copied just past
+the fragment headers in the new skb's linear area. The linear area is
+therefore undersized by fraggap bytes while pagedlen is overstated by the
+same amount, and the copy writes past skb->end into the trailing
+skb_shared_info.
+
+An unprivileged user can trigger this via a UDPv6 socket using
+MSG_MORE together with MSG_SPLICE_PAGES.
+
+The bad accounting was introduced by commit 773ba4fe9104 ("ipv6:
+avoid partial copy for zc"). Before commit ce650a166335 ("udp6: Fix
+__ip6_append_data()'s handling of MSG_SPLICE_PAGES"), the negative
+copy value caused -EINVAL to be returned. That later commit allowed
+MSG_SPLICE_PAGES to proceed in this case, making the corruption
+triggerable.
+
+The non-paged branch sets alloclen to fraglen, which already accounts
+for fraggap because datalen does. Bring the paged branch in line by
+adding fraggap to alloclen and subtracting it from pagedlen.
+
+After this adjustment, copy no longer collapses to -fraggap on the
+paged path, so remove the stale comment describing that old arithmetic.
+Since a negative copy is no longer expected for a valid MSG_SPLICE_PAGES
+case, remove the MSG_SPLICE_PAGES exception from the negative copy check.
+
+Fixes: 773ba4fe9104 ("ipv6: avoid partial copy for zc")
+Signed-off-by: Jungwoo Lee <jwlee2217@gmail.com>
+Signed-off-by: Wongi Lee <qw3rtyp0@gmail.com>
+Reviewed-by: Ido Schimmel <idosch@nvidia.com>
+Link: https://patch.msgid.link/ajFTqRljatR17fFy@DESKTOP-19IMU7U.localdomain
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ net/ipv6/ip6_output.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/net/ipv6/ip6_output.c b/net/ipv6/ip6_output.c
+index 9f1e0e4f74641..368e4fa3b43ca 100644
+--- a/net/ipv6/ip6_output.c
++++ b/net/ipv6/ip6_output.c
+@@ -1667,8 +1667,8 @@ alloc_new_skb:
+ 				  !(rt->dst.dev->features & NETIF_F_SG)))
+ 				alloclen = fraglen;
+ 			else {
+-				alloclen = fragheaderlen + transhdrlen;
+-				pagedlen = datalen - transhdrlen;
++				alloclen = fragheaderlen + transhdrlen + fraggap;
++				pagedlen = datalen - transhdrlen - fraggap;
+ 			}
+ 			alloclen += alloc_extra;
+ 
+@@ -1683,10 +1683,7 @@ alloc_new_skb:
+ 			fraglen = datalen + fragheaderlen;
+ 
+ 			copy = datalen - transhdrlen - fraggap - pagedlen;
+-			/* [!] NOTE: copy may be negative if pagedlen>0
+-			 * because then the equation may reduces to -fraggap.
+-			 */
+-			if (copy < 0 && !(flags & MSG_SPLICE_PAGES)) {
++			if (copy < 0) {
+ 				err = -EINVAL;
+ 				goto error;
+ 			}
+-- 
+cgit 1.3-korg
+

--- a/SPECS/kernel/kernel-uki.spec
+++ b/SPECS/kernel/kernel-uki.spec
@@ -13,7 +13,7 @@
 Summary:        Unified Kernel Image
 Name:           kernel-uki
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -70,6 +70,9 @@ cp %{buildroot}/boot/vmlinuz-uki-%{kernelver}.efi %{buildroot}/boot/efi/EFI/Linu
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Release bump to stay in lockstep with the kernel spec entanglement group for the ipv6 fraggap fix (torvalds/linux@736b380e28d0).
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -32,7 +32,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.143.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -46,6 +46,9 @@ Source4:        azurelinux-ca-20230216.pem
 Source5:        cpupower
 Source6:        cpupower.service
 Patch0:         0001-add-mstflint-kernel-%{mstflintver}.patch
+# Backport of upstream torvalds/linux@736b380e28d0 ("ipv6: account for fraggap
+# on the paged allocation path"): fixes an OOB-write in __ip6_append_data().
+Patch1:         0001-ipv6-account-for-fraggap-on-the-paged-allocation-pat.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -440,6 +443,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Jun 29 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.143.1-2
+- Backport upstream torvalds/linux@736b380e28d0 ("ipv6: account for fraggap on the paged allocation path") to fix an OOB-write in __ip6_append_data().
+
 * Wed Jun 24 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.143.1-1
 - Auto-upgrade to 6.6.143.1
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
-kernel-headers-6.6.143.1-1.azl3.noarch.rpm
+kernel-headers-6.6.143.1-2.azl3.noarch.rpm
 glibc-2.38-20.azl3.aarch64.rpm
 glibc-devel-2.38-20.azl3.aarch64.rpm
 glibc-i18n-2.38-20.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
-kernel-headers-6.6.143.1-1.azl3.noarch.rpm
+kernel-headers-6.6.143.1-2.azl3.noarch.rpm
 glibc-2.38-20.azl3.x86_64.rpm
 glibc-devel-2.38-20.azl3.x86_64.rpm
 glibc-i18n-2.38-20.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.aarch64.rpm
 kbd-debuginfo-2.2.0-2.azl3.aarch64.rpm
-kernel-headers-6.6.143.1-1.azl3.noarch.rpm
+kernel-headers-6.6.143.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -165,8 +165,8 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.x86_64.rpm
 kbd-debuginfo-2.2.0-2.azl3.x86_64.rpm
-kernel-cross-headers-6.6.143.1-1.azl3.noarch.rpm
-kernel-headers-6.6.143.1-1.azl3.noarch.rpm
+kernel-cross-headers-6.6.143.1-2.azl3.noarch.rpm
+kernel-headers-6.6.143.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm


### PR DESCRIPTION
Backport upstream fix for the IPv6 fraggap out-of-bounds write in
`__ip6_append_data()` (no CVE assigned upstream as of 2026-06-29).

Upstream commit: torvalds/linux@736b380e28d0480c7bc3e022f1950f31fe53a7c5
  Author:        Wongi Lee <qw3rtyp0@gmail.com>, Jungwoo Lee <jwlee2217@gmail.com>
  Reviewed-by:   Ido Schimmel <idosch@nvidia.com>
  Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  Fixes:         773ba4fe9104 ("ipv6: avoid partial copy for zc")
LKML thread:     https://lore.kernel.org/all/ajFTqRljatR17fFy@DESKTOP-19IMU7U.localdomain/

## The bug

On the paged-allocation branch of `__ip6_append_data()` (MSG_MORE / NETIF_F_SG /
large fraglen), `alloclen`/`pagedlen` are computed as `alloclen = fragheaderlen +
transhdrlen; pagedlen = datalen - transhdrlen;`. `datalen` already includes
`fraggap`, so when `fraggap != 0` (a non-first skb carrying bytes over from the
previous skb) the linear skb area is undersized by `fraggap` and the fraggap copy
writes past `skb->end` into the trailing `skb_shared_info`. Introduced by
773ba4fe9104 (v6.0); became reachable once ce650a166335 (v6.5) let MSG_SPLICE_PAGES
proceed past the previously-`-EINVAL` negative-`copy` case. **An unprivileged user
can trigger it via a corked UDPv6 socket using MSG_SPLICE_PAGES.** Both gating
commits are present in 6.6.143.1, so Azure Linux 3.0 is affected.

The fix adds `fraggap` to `alloclen` and subtracts it from `pagedlen`, and removes
the now-stale MSG_SPLICE_PAGES exception in the negative-`copy` check.

## Vulnerable behaviour reproduced on Azure Linux 3.0 6.6.143.1

Built KASAN diagnostic kernels from the spec's exact source tag
(`rolling-lts/mariner-3/6.6.143.1`, config matching `SPECS/kernel/config`):
`6.6.143.1-fraggap-baseline+` (unpatched) and `-fraggap-fixed+` (this patch).

An unprivileged process (corked UDPv6 + two `splice`/MSG_SPLICE_PAGES chunks over a
640-byte type-4 SRH at IPV6_MTU 1280) corrupts `skb_shared_info`. **The witness is
the free-time crash** when the corrupted `nr_frags`/`frag_list` is walked on
finalize — a real KASAN report on the unmodified kernel:

```
general protection fault, probably for non-canonical address 0xdffffc0000000001 [#1] PREEMPT SMP KASAN
KASAN: null-ptr-deref in range [0x0000000000000008-0x000000000000000f]
CPU: ... Comm: <unprivileged> ... 6.6.143.1-fraggap-baseline+
RIP: skb_release_data+0x3cb/0x6d0
Call Trace:
  kfree_skb_reason
  __ip6_flush_pending_frames        (and via udpv6_destroy_sock <- __x64_sys_close)
  ip6_flush_pending_frames
  udpv6_sendmsg / udp_lib_close
```

  Unpatched: 10/10 runs crash (GPF / KASAN null-ptr-deref in skb_release_data).
  Patched:   0/10 runs (alloclen enlarged by fraggap; the copy lands in-bounds;
             skb_shared_info is never corrupted).

Why no copy-site `KASAN: slab-out-of-bounds Write`: the 8-byte overshoot lands
*in-object* (the trailing `skb_shared_info` sits between `skb->end` and the
kmalloc-1024 object end), which KASAN does not poison — so the witnessable signal
is the downstream free-path null-ptr-deref, confirmed by live address
instrumentation (write at `skb->end+8` baseline vs `-1016` in-bounds patched,
10/10 -> 0/10). Both witnesses are deterministic. Full analysis in the validation
bundle (`kasan-mechanism-note.md`).

## LTP regression (baseline vs patched, same run)

LTP 20260130 (kirk), `net.ipv6 net.ipv6_lib net.multicast` on both kernels:

  Baseline: 127 passed, 0 failed, 0 broken, 7 skipped
  Patched:  127 passed, 0 failed, 0 broken, 7 skipped

No passed→failed transitions. Subsystem coverage proven via a kprobe on
`__ip6_append_data` (6187× baseline / 8088× patched).

## Scope — the entangled kernel spec family

A kernel `Release` bump on Azure Linux 3.0 must keep the entangled spec family in
lockstep (CI `Spec Entanglement Mismatch Check`), so this is **not** a 2-file
change:

- Patch + `Release: 1 → 2` + `%changelog` on the specs that build the kernel FROM
  SOURCE: `SPECS/kernel/kernel.spec` AND `SPECS/kernel-64k/kernel-64k.spec`
  (patching only `kernel` while release-bumping `kernel-64k` would ship a
  fake-fixed 64k release). The patch is verbatim upstream `git format-patch`
  (trailers preserved), applied by the existing `%autosetup -p1`.
- `Release: 1 → 2` + `%changelog` only on the repackaging/headers siblings:
  `kernel-uki`, `kernel-headers`, `kernel-signed`, `kernel-64k-signed`,
  `kernel-uki-signed`.
- Bumping `kernel-headers` cascades into `Check Manifests`, so the
  `kernel-headers`/`kernel-cross-headers` NVR is bumped in
  `toolkit/resources/manifests/package/{toolchain,pkggen_core}_{x86_64,aarch64}.txt`.

No `kernel.signatures.json` / cgmanifest / LICENSE-MAP change (those track
`SourceN`/licenses, unchanged; `Source Signature Check (SPECS)` passes without
them). 13 files total; all CI green.

## Out-of-tree carry ahead of stable — justification (live PoC)

As of 2026-06-29 the fix is in torvalds/master but NOT yet in `linux-6.6.y` stable.
Requesting it ahead of stable because the bug has a **working
local-privilege-escalation exploit**: the `IPV6_FRAG_ESCAPE` chain weaponizes this
exact fraggap OOB-write (corrupt `skb_shared_info->nr_frags` → page-UAF →
dirty-pagetable → unprivileged container/root escape, demonstrated on the
6.12/el10 sibling), and the same unprivileged trigger + OOB-write are wire-proven
on this 6.6.143.1 kernel here. It is reachable by any unprivileged user via a
plain UDPv6 socket.

Promotion: merge to `3.0-dev` → publishes to `3.0` on the next cadence. CLA agreed
via the bot comment.

## Checklist

- [x] Patch byte-identical to upstream `git format-patch -1 736b380e` (trailers preserved)
- [x] Release 1→2 across the entangled kernel spec family + toolchain manifests; CI all green
- [x] Unprivileged OOB-write reproduces 10/10 unpatched → 0/10 patched (free-time GPF / KASAN null-ptr-deref in skb_release_data, unmodified kernels)
- [x] LTP baseline-vs-patched: 127/0/0 both sides, 0 new regressions, coverage proven
- [x] No signatures.json / cgmanifest / LICENSE-MAP needed for a patch-add (verified)
