### PR TITLE
[High] Patch `nodejs` for CVE-2026-12151, CVE-2026-9679 and CVE-2026-11525

### DIFF
--- a/SPECS/nodejs/CVE-2026-11525.nopatch
+++ b/SPECS/nodejs/CVE-2026-11525.nopatch
@@ -1,0 +1,1 @@
+# This CVE is fixed by CVE-2026-9679.patch

--- a/SPECS/nodejs/CVE-2026-12151.patch
+++ b/SPECS/nodejs/CVE-2026-12151.patch
@@ -1,0 +1,208 @@
+From b7f252e7c0841418fb9d95cd297bdd9fad9d2a53 Mon Sep 17 00:00:00 2001
+From: Matteo Collina <hello@matteocollina.com>
+Date: Mon, 15 Jun 2026 15:01:37 +0200
+Subject: [PATCH] Backport WebSocket maxPayloadSize fixes to v7.x (#5423)
+ (#5428)
+
+* feat: add configurable maxPayloadSize for WebSocket (#4955)
+
+(cherry picked from commit bd91f86730c3d597ab8b29a014672deba36d0b5e)
+
+
+* test: fix flaky permessage-deflate limit timeout (#5229)
+
+(cherry picked from commit 9d82667f8f04268198642a5e21d4b02ebf9727b0)
+
+
+* fix(websocket): enforce max payload size across fragments
+
+Account for previously received fragment bytes when checking WebSocket payload size limits, so fragmented messages cannot exceed maxPayloadSize by splitting the payload across frames.
+
+Add coverage for cumulative fragmented payload size enforcement.
+
+
+(cherry picked from commit b4c287b3821a723d8c0912986fd2d8945399728d)
+
+
+* websocket: handle empty fragments and stream limits
+
+Treat zero-byte frames as real fragments so fragmented messages can start
+with an empty frame and empty continuations still count toward
+maxFragments.
+
+Pass dispatcher WebSocket limits through to WebSocketStream's parser, add
+regression coverage for WebSocket and WebSocketStream fragment limits, make
+the fragment close tests wait for both endpoints, and fix the Client docs
+typo for maxFragments.
+
+
+(cherry picked from commit c5ed78756914b17501223dcc345b3a966351604a)
+
+
+---------
+
+Signed-off-by: Matteo Collina <hello@matteocollina.com>
+Co-authored-by: Matthew Aitken <maitken033380023@gmail.com>
+Co-authored-by: Luigi Pinca <luigipinca@gmail.com>
+Co-authored-by: Ulises Gascon <ulisesgascongonzalez@gmail.com>
+
+Upstream Patch Reference: https://github.com/nodejs/undici/commit/b7f252e7.patch
+---
+ .../undici/docs/docs/api/Client.md            |  1 +
+ .../undici/lib/dispatcher/dispatcher-base.js  |  1 +
+ .../undici/lib/web/websocket/receiver.js      | 39 +++++++++++++++----
+ .../undici/lib/web/websocket/websocket.js     |  5 ++-
+ 4 files changed, 37 insertions(+), 9 deletions(-)
+
+diff --git a/deps/npm/node_modules/undici/docs/docs/api/Client.md b/deps/npm/node_modules/undici/docs/docs/api/Client.md
+index fdee5ea7..e0d41b47 100644
+--- a/deps/npm/node_modules/undici/docs/docs/api/Client.md
++++ b/deps/npm/node_modules/undici/docs/docs/api/Client.md
+@@ -27,6 +27,7 @@ Returns: `Client`
+ * **maxHeaderSize** `number | null` (optional) - Default: `--max-http-header-size` or `16384` - The maximum length of request headers in bytes. Defaults to Node.js' --max-http-header-size or 16KiB.
+ * **maxResponseSize** `number | null` (optional) - Default: `-1` - The maximum length of response body in bytes. Set to `-1` to disable.
+ * **webSocket** `WebSocketOptions` (optional) - WebSocket-specific configuration options.
++  * **maxFragments** `number` (optional) - Default: `131072` - Maximum number of fragments in a message. Set to 0 to disable the limit.
+   * **maxPayloadSize** `number` (optional) - Default: `134217728` (128 MB) - Maximum allowed payload size in bytes for WebSocket messages. Applied to uncompressed messages, compressed frame payloads, and decompressed (permessage-deflate) messages. Set to 0 to disable the limit.
+ * **pipelining** `number | null` (optional) - Default: `1` - The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Carefully consider your workload and environment before enabling concurrent requests as pipelining may reduce performance if used incorrectly. Pipelining is sensitive to network stack settings as well as head of line blocking caused by e.g. long running requests. Set to `0` to disable keep-alive connections.
+ * **connect** `ConnectOptions | Function | null` (optional) - Default: `null`.
+diff --git a/deps/npm/node_modules/undici/lib/dispatcher/dispatcher-base.js b/deps/npm/node_modules/undici/lib/dispatcher/dispatcher-base.js
+index c999b2c2..371a3ea1 100644
+--- a/deps/npm/node_modules/undici/lib/dispatcher/dispatcher-base.js
++++ b/deps/npm/node_modules/undici/lib/dispatcher/dispatcher-base.js
+@@ -26,6 +26,7 @@ class DispatcherBase extends Dispatcher {
+ 
+   get webSocketOptions () {
+     return {
++      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
+       maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
+     }
+   }
+diff --git a/deps/npm/node_modules/undici/lib/web/websocket/receiver.js b/deps/npm/node_modules/undici/lib/web/websocket/receiver.js
+index 53e427eb..a7dea7fa 100644
+--- a/deps/npm/node_modules/undici/lib/web/websocket/receiver.js
++++ b/deps/npm/node_modules/undici/lib/web/websocket/receiver.js
+@@ -20,6 +20,11 @@ const { closeWebSocketConnection } = require('./connection')
+ const { PerMessageDeflate } = require('./permessage-deflate')
+ const { MessageSizeExceededError } = require('../../core/errors')
+ 
++function failWebsocketConnectionWithCode (ws, code, reason) {
++  closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason))
++  failWebsocketConnection(ws, reason)
++}
++
+ // This code was influenced by ws released under the MIT license.
+ // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+ // Copyright (c) 2013 Arnout Kazemier and contributors
+@@ -39,19 +44,23 @@ class ByteParser extends Writable {
+   /** @type {Map<string, PerMessageDeflate>} */
+   #extensions
+ 
++  /** @type {number} */
++  #maxFragments
++
+   /** @type {number} */
+   #maxPayloadSize
+ 
+   /**
+    * @param {import('./websocket').WebSocket} ws
+    * @param {Map<string, string>|null} extensions
+-   * @param {{ maxPayloadSize?: number }} [options]
++   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
+    */
+   constructor (ws, extensions, options = {}) {
+     super()
+ 
+     this.ws = ws
+     this.#extensions = extensions == null ? new Map() : extensions
++    this.#maxFragments = options.maxFragments ?? 0
+     this.#maxPayloadSize = options.maxPayloadSize ?? 0
+ 
+     if (this.#extensions.has('permessage-deflate')) {
+@@ -75,9 +84,9 @@ class ByteParser extends Writable {
+     if (
+       this.#maxPayloadSize > 0 &&
+       !isControlFrame(this.#info.opcode) &&
+-      this.#info.payloadLength > this.#maxPayloadSize
++      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
+     ) {
+-      failWebsocketConnection(this.ws, 'Payload size exceeds maximum allowed size')
++      failWebsocketConnectionWithCode(this.ws, 1009, 'Payload size exceeds maximum allowed size')
+       return false
+     }
+ 
+@@ -242,10 +251,12 @@ class ByteParser extends Writable {
+           this.#state = parserStates.INFO
+         } else {
+           if (!this.#info.compressed) {
+-            this.writeFragments(body)
++            if (!this.writeFragments(body)) {
++              return
++            }
+ 
+             if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+-              failWebsocketConnection(this.ws, new MessageSizeExceededError().message)
++              failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message)
+               return
+             }
+ 
+@@ -264,14 +275,17 @@ class ByteParser extends Writable {
+               this.#info.fin,
+               (error, data) => {
+                 if (error) {
+-                  failWebsocketConnection(this.ws, error.message)
++                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007
++                  failWebsocketConnectionWithCode(this.ws, code, error.message)
+                   return
+                 }
+ 
+-                this.writeFragments(data)
++                if (!this.writeFragments(data)) {
++                  return
++                }
+ 
+                 if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+-                  failWebsocketConnection(this.ws, new MessageSizeExceededError().message)
++                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message)
+                   return
+                 }
+ 
+@@ -341,8 +355,17 @@ class ByteParser extends Writable {
+   }
+ 
+   writeFragments (fragment) {
++    if (
++      this.#maxFragments > 0 &&
++      this.#fragments.length === this.#maxFragments
++    ) {
++      failWebsocketConnectionWithCode(this.ws, 1008, 'Too many message fragments')
++      return false
++    }
++
+     this.#fragmentsBytes += fragment.length
+     this.#fragments.push(fragment)
++    return true
+   }
+ 
+   consumeFragments () {
+diff --git a/deps/npm/node_modules/undici/lib/web/websocket/websocket.js b/deps/npm/node_modules/undici/lib/web/websocket/websocket.js
+index ccedb792..80991e96 100644
+--- a/deps/npm/node_modules/undici/lib/web/websocket/websocket.js
++++ b/deps/npm/node_modules/undici/lib/web/websocket/websocket.js
+@@ -435,9 +435,12 @@ class WebSocket extends EventTarget {
+     // once this happens, the connection is open
+     this[kResponse] = response
+ 
+-    const maxPayloadSize = this[kController]?.dispatcher?.webSocketOptions?.maxPayloadSize
++    const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions
++    const maxFragments = webSocketOptions?.maxFragments
++    const maxPayloadSize = webSocketOptions?.maxPayloadSize
+ 
+     const parser = new ByteParser(this, parsedExtensions, {
++      maxFragments,
+       maxPayloadSize
+     })
+     parser.on('drain', onParserDrain)
+-- 
+2.45.4
+

--- a/SPECS/nodejs/CVE-2026-9679.patch
+++ b/SPECS/nodejs/CVE-2026-9679.patch
@@ -1,0 +1,69 @@
+From 25efa447997f74d5881edd144525c3fd7db945a4 Mon Sep 17 00:00:00 2001
+From: Matteo Collina <hello@matteocollina.com>
+Date: Thu, 11 Jun 2026 11:24:59 +0200
+Subject: [PATCH] fix(cookies): preserve values and parse SameSite strictly
+
+Signed-off-by: Matteo Collina <hello@matteocollina.com>
+(cherry picked from commit 5655ea43af4add559ee5f94b6cd72e08a55aa621)
+
+Upstream Patch Reference: https://github.com/nodejs/undici/commit/25efa447.patch
+---
+ .../undici/lib/web/cookies/parse.js           | 39 ++++++++-----------
+ 1 file changed, 16 insertions(+), 23 deletions(-)
+
+diff --git a/deps/npm/node_modules/undici/lib/web/cookies/parse.js b/deps/npm/node_modules/undici/lib/web/cookies/parse.js
+index 3c48c26b..b3c25fb9 100644
+--- a/deps/npm/node_modules/undici/lib/web/cookies/parse.js
++++ b/deps/npm/node_modules/undici/lib/web/cookies/parse.js
+@@ -275,32 +275,25 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {})
+     // If the attribute-name case-insensitively matches the string
+     // "SameSite", the user agent MUST process the cookie-av as follows:
+ 
+-    // 1. Let enforcement be "Default".
+-    let enforcement = 'Default'
+-
+     const attributeValueLowercase = attributeValue.toLowerCase()
+-    // 2. If cookie-av's attribute-value is a case-insensitive match for
+-    //    "None", set enforcement to "None".
+-    if (attributeValueLowercase.includes('none')) {
+-      enforcement = 'None'
+-    }
+ 
+-    // 3. If cookie-av's attribute-value is a case-insensitive match for
+-    //    "Strict", set enforcement to "Strict".
+-    if (attributeValueLowercase.includes('strict')) {
+-      enforcement = 'Strict'
++    // 1. If cookie-av's attribute-value is a case-insensitive match for
++    //    "None", append an attribute to the cookie-attribute-list with an
++    //    attribute-name of "SameSite" and an attribute-value of "None".
++    if (attributeValueLowercase === 'none') {
++      cookieAttributeList.sameSite = 'None'
++    } else if (attributeValueLowercase === 'strict') {
++      // 2. If cookie-av's attribute-value is a case-insensitive match for
++      //    "Strict", append an attribute to the cookie-attribute-list with
++      //    an attribute-name of "SameSite" and an attribute-value of
++      //    "Strict".
++      cookieAttributeList.sameSite = 'Strict'
++    } else if (attributeValueLowercase === 'lax') {
++      // 3. If cookie-av's attribute-value is a case-insensitive match for
++      //    "Lax", append an attribute to the cookie-attribute-list with an
++      //    attribute-name of "SameSite" and an attribute-value of "Lax".
++      cookieAttributeList.sameSite = 'Lax'
+     }
+-
+-    // 4. If cookie-av's attribute-value is a case-insensitive match for
+-    //    "Lax", set enforcement to "Lax".
+-    if (attributeValueLowercase.includes('lax')) {
+-      enforcement = 'Lax'
+-    }
+-
+-    // 5. Append an attribute to the cookie-attribute-list with an
+-    //    attribute-name of "SameSite" and an attribute-value of
+-    //    enforcement.
+-    cookieAttributeList.sameSite = enforcement
+   } else {
+     cookieAttributeList.unparsed ??= []
+ 
+-- 
+2.45.4
+

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -16,7 +16,7 @@ Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
 Version:        24.17.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD AND MIT AND Public Domain AND NAIST-2003 AND Artistic-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -35,6 +35,8 @@ Patch2:         CVE-2024-22195.patch
 Patch3:         CVE-2020-28493.patch
 Patch4:         CVE-2024-34064.patch
 Patch5:         CVE-2025-27516.patch
+Patch6:         CVE-2026-12151.patch
+Patch7:         CVE-2026-9679.patch
 BuildRequires:  brotli-devel
 BuildRequires:  c-ares-devel
 BuildRequires:  coreutils >= 8.22
@@ -192,6 +194,9 @@ make cctest
 %{_prefix}/lib/node_modules/*
 
 %changelog
+* Tue Jun 30 2026 Aditya Singh <v-aditysing@microsoft.com> - 24.17.0-2
+- Patch for CVE-2026-12151 and CVE-2026-9679
+
 * Tue Jun 23 2026 Sumit Jena <sumitjena@microsoft.com> - 24.17.0-1
 - Upgrade to 24.17.0 (bundled npm 11.13.0).
 - Bump bundled ICU to 78.3 (tools/icu/current_ver.dep).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

- Patch `nodejs` for `CVE-2026-12151`
   - The upstream patch has been backported manually.
   - The Patch matches with upstream patch except changes in below mentioned files are not included, as they dont exist in current source -
      - `test/websocket/fragments.js`
      -  `test/websocket/fragments.js`
      - `types/client.d.ts`
   - Upstream Patch reference: https://github.com/nodejs/undici/commit/b7f252e7.patch

- Patch `nodejs` for `CVE-2026-9679`
   - The upstream patch has been backported manually.
   - The Patch matches with upstream patch except changes in below mentioned files are not included, as they dont exist in current source -
      - `test/cookie/cookies.js`
   - This patch also fixes `CVE-2026-11525`
   - Upstream Patch reference: https://github.com/nodejs/undici/commit/25efa447.patch

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/nodejs/CVE-2026-12151.patch
- new file:   SPECS/nodejs/CVE-2026-9679.patch
- new file:   SPECS/nodejs/CVE-2026-11525.nopatch
- modified: SPECS/nodejs/nodejs.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-12151
- https://nvd.nist.gov/vuln/detail/CVE-2026-9679
- https://nvd.nist.gov/vuln/detail/CVE-2026-11525

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build could not be triggered due to resource limitation.