### PR TITLE
Upgrade `runc` to 1.3.6 for CVE-2026-41579

### DIFF
--- a/SPECS/runc/runc.signatures.json
+++ b/SPECS/runc/runc.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "runc-1.3.3.tar.gz": "3da010af5c2c1c3d12d460255e4a7dc049c223ebc629c80fbbe4c10720997ffe"
- }
+  "Signatures": {
+    "runc-1.3.6.tar.gz": "8816e8d4181d13012d16733e837425f5f67df57dfac28bc58a68f7dfcd54291b"
+  }
 }

--- a/SPECS/runc/runc.spec
+++ b/SPECS/runc/runc.spec
@@ -2,8 +2,8 @@
 Summary:        CLI tool for spawning and running containers per OCI spec.
 Name:           runc
 # update "commit_hash" above when upgrading version
-Version:        1.3.3
-Release:        2%{?dist}
+Version:        1.3.6
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -51,6 +51,9 @@ make install-man DESTDIR=%{buildroot} PREFIX=%{_prefix}
 %{_mandir}/*
 
 %changelog
+* Wed Jul 01 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.3.6-1
+- Auto-upgrade to 1.3.6 - for CVE-2026-41579
+
 * Fri May 15 2026 Sumit Jena <sumitjena@microsoft.com> - 1.3.3-2
 - Fixed ptests failure
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27754,8 +27754,8 @@
         "type": "other",
         "other": {
           "name": "runc",
-          "version": "1.3.3",
-          "downloadUrl": "https://github.com/opencontainers/runc/archive/v1.3.3.tar.gz"
+          "version": "1.3.6",
+          "downloadUrl": "https://github.com/opencontainers/runc/archive/v1.3.6.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Micro version bump to fix the CVE. 
Commit - https://github.com/opencontainers/runc/commit/a8e53f2c6d6d25cb3dd643cc514f118aab44b097

- [x] Buddy Build 
- [x] Tarball uploaded
- [x] Changelog entry
- [x] CG Manifest
- [x] PR has `security` & `CVE-fixed-by-upgrade` tag