### PR TITLE
fix(azurelinux-release): ship azure kvp config in cloud identity package

### DIFF
--- a/base/comps/azurelinux-release/10-azure-kvp.cfg
+++ b/base/comps/azurelinux-release/10-azure-kvp.cfg
@@ -1,0 +1,5 @@
+reporting:
+  logging:
+    type: log
+  telemetry:
+    type: hyperv

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -55,6 +55,7 @@ Source21:       50-azure-cloud.conf
 Source22:       70-azurelinux-hardening.conf
 Source23:       50-client-alive-interval.conf
 Source24:       50-permit-root-login.conf
+Source25:       10-azure-kvp.cfg
 
 BuildArch:      noarch
 
@@ -342,6 +343,7 @@ install -Dm0644 %{SOURCE17} -t %{buildroot}%{_prefix}/lib/sysctl.d/
 install -Dm0644 %{SOURCE20} -t %{buildroot}%{_sysconfdir}/chrony.d/
 install -Dm0644 %{SOURCE21} -t %{buildroot}%{_prefix}/lib/systemd/networkd.conf.d/
 install -Dm0600 %{SOURCE23} -t %{buildroot}%{_sysconfdir}/ssh/sshd_config.d/
+install -Dm0644 %{SOURCE25} -t %{buildroot}%{_sysconfdir}/cloud/cloud.cfg.d/
 %endif
 
 %if %{with container}
@@ -454,6 +456,7 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 %{_sysconfdir}/chrony.d/chrony-azure.conf
 %{_prefix}/lib/systemd/networkd.conf.d/50-azure-cloud.conf
 %{_sysconfdir}/ssh/sshd_config.d/50-client-alive-interval.conf
+%config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 %endif
 
 
@@ -476,6 +479,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Wed Jul 08 2026 Mitch Zhu <mitchzhu@microsoft.com> - 4.0-20
+- Add cloud-init Azure KVP telemetry config to the cloud identity package
+
 * Tue Jul 07 2026 Brian Fjeldstad <bfjelds@microsoft.com> - 4.0-19
 - Enable netplan-configure.service by default via 90-default.preset
 

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:a8eb2f2547e2127ae622fc4f17385b43adbe6a050e414b97f902d4a5ad177f3a'
+input-fingerprint = 'sha256:93eeecefaa1eabd161cd6eaa514fbad9f3e2ad1eb8c90c964b13d50a7e1e2b6f'

--- a/specs/a/azurelinux-release/10-azure-kvp.cfg
+++ b/specs/a/azurelinux-release/10-azure-kvp.cfg
@@ -1,0 +1,5 @@
+reporting:
+  logging:
+    type: log
+  telemetry:
+    type: hyperv

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -58,6 +58,7 @@ Source21:       50-azure-cloud.conf
 Source22:       70-azurelinux-hardening.conf
 Source23:       50-client-alive-interval.conf
 Source24:       50-permit-root-login.conf
+Source25:       10-azure-kvp.cfg
 
 BuildArch:      noarch
 
@@ -345,6 +346,7 @@ install -Dm0644 %{SOURCE17} -t %{buildroot}%{_prefix}/lib/sysctl.d/
 install -Dm0644 %{SOURCE20} -t %{buildroot}%{_sysconfdir}/chrony.d/
 install -Dm0644 %{SOURCE21} -t %{buildroot}%{_prefix}/lib/systemd/networkd.conf.d/
 install -Dm0600 %{SOURCE23} -t %{buildroot}%{_sysconfdir}/ssh/sshd_config.d/
+install -Dm0644 %{SOURCE25} -t %{buildroot}%{_sysconfdir}/cloud/cloud.cfg.d/
 %endif
 
 %if %{with container}
@@ -457,6 +459,7 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 %{_sysconfdir}/chrony.d/chrony-azure.conf
 %{_prefix}/lib/systemd/networkd.conf.d/50-azure-cloud.conf
 %{_sysconfdir}/ssh/sshd_config.d/50-client-alive-interval.conf
+%config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 %endif
 
 
@@ -479,6 +482,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Wed Jul 08 2026 Mitch Zhu <mitchzhu@microsoft.com> - 4.0-20
+- Add cloud-init Azure KVP telemetry config to the cloud identity package
+
 * Tue Jul 07 2026 Brian Fjeldstad <bfjelds@microsoft.com> - 4.0-19
 - Enable netplan-configure.service by default via 90-default.preset
 


### PR DESCRIPTION
Add the cloud-init Hyper-V KVP telemetry reporting config used by Azure guest VMs:

`/etc/cloud/cloud.cfg.d/10-azure-kvp.cfg`

The config will be shipped by the existing `azurelinux-release-identity-cloud` subpackage, alongside the other Cloud VM variant-specific configuration such as the Azure `chrony`, `systemd-networkd`, and `sshd` defaults.

Validation:
  - azldev local build and install passed
  - control Tower build: passed

Fixes: [AB#22287](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22287)