### PR TITLE
Patch kernel to fix CVE-2026-43456

### DIFF
--- a/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
+++ b/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
@@ -7,7 +7,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-64k-signed-%{buildarch}
 Version:        6.6.144.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,6 +105,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Sat Jul 11 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.144.1-2
+- Bump release to match kernel (CVE-2026-43456)
+
 * Mon Jul 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.144.1-1
 - Auto-upgrade to 6.6.144.1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        6.6.144.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -145,6 +145,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Sat Jul 11 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.144.1-2
+- Bump release to match kernel (CVE-2026-43456)
+
 * Mon Jul 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.144.1-1
 - Auto-upgrade to 6.6.144.1
 

--- a/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
+++ b/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed Unified Kernel Image for %{buildarch} systems
 Name:           kernel-uki-signed-%{buildarch}
 Version:        6.6.144.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -68,6 +68,9 @@ popd
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Sat Jul 11 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.144.1-2
+- Bump release to match kernel (CVE-2026-43456)
+
 * Mon Jul 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.144.1-1
 - Auto-upgrade to 6.6.144.1
 

--- a/SPECS/kernel-64k/CVE-2026-43456.patch
+++ b/SPECS/kernel-64k/CVE-2026-43456.patch
@@ -1,0 +1,143 @@
+From 950803f7254721c1c15858fbbfae3deaaeeecb11 Mon Sep 17 00:00:00 2001
+From: Jiayuan Chen <jiayuan.chen@shopee.com>
+Date: Fri, 6 Mar 2026 10:15:07 +0800
+Subject: [PATCH] bonding: fix type confusion in bond_setup_by_slave()
+
+kernel BUG at net/core/skbuff.c:2306!
+Oops: invalid opcode: 0000 [#1] SMP KASAN NOPTI
+RIP: 0010:pskb_expand_head+0xa08/0xfe0 net/core/skbuff.c:2306
+RSP: 0018:ffffc90004aff760 EFLAGS: 00010293
+RAX: 0000000000000000 RBX: ffff88807e3c8780 RCX: ffffffff89593e0e
+RDX: ffff88807b7c4900 RSI: ffffffff89594747 RDI: ffff88807b7c4900
+RBP: 0000000000000820 R08: 0000000000000005 R09: 0000000000000000
+R10: 00000000961a63e0 R11: 0000000000000000 R12: ffff88807e3c8780
+R13: 00000000961a6560 R14: dffffc0000000000 R15: 00000000961a63e0
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 00007fe1a0ed8df0 CR3: 000000002d816000 CR4: 00000000003526f0
+Call Trace:
+ <TASK>
+ ipgre_header+0xdd/0x540 net/ipv4/ip_gre.c:900
+ dev_hard_header include/linux/netdevice.h:3439 [inline]
+ packet_snd net/packet/af_packet.c:3028 [inline]
+ packet_sendmsg+0x3ae5/0x53c0 net/packet/af_packet.c:3108
+ sock_sendmsg_nosec net/socket.c:727 [inline]
+ __sock_sendmsg net/socket.c:742 [inline]
+ ____sys_sendmsg+0xa54/0xc30 net/socket.c:2592
+ ___sys_sendmsg+0x190/0x1e0 net/socket.c:2646
+ __sys_sendmsg+0x170/0x220 net/socket.c:2678
+ do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
+ do_syscall_64+0x106/0xf80 arch/x86/entry/syscall_64.c:94
+ entry_SYSCALL_64_after_hwframe+0x77/0x7f
+RIP: 0033:0x7fe1a0e6c1a9
+
+When a non-Ethernet device (e.g. GRE tunnel) is enslaved to a bond,
+bond_setup_by_slave() directly copies the slave's header_ops to the
+bond device:
+
+    bond_dev->header_ops = slave_dev->header_ops;
+
+This causes a type confusion when dev_hard_header() is later called
+on the bond device. Functions like ipgre_header(), ip6gre_header(),all use
+netdev_priv(dev) to access their device-specific private data. When
+called with the bond device, netdev_priv() returns the bond's private
+data (struct bonding) instead of the expected type (e.g. struct
+ip_tunnel), leading to garbage values being read and kernel crashes.
+
+Fix this by introducing bond_header_ops with wrapper functions that
+delegate to the active slave's header_ops using the slave's own
+device. This ensures netdev_priv() in the slave's header functions
+always receives the correct device.
+
+The fix is placed in the bonding driver rather than individual device
+drivers, as the root cause is bond blindly inheriting header_ops from
+the slave without considering that these callbacks expect a specific
+netdev_priv() layout.
+
+The type confusion can be observed by adding a printk in
+ipgre_header() and running the following commands:
+
+    ip link add dummy0 type dummy
+    ip addr add 10.0.0.1/24 dev dummy0
+    ip link set dummy0 up
+    ip link add gre1 type gre local 10.0.0.1
+    ip link add bond1 type bond mode active-backup
+    ip link set gre1 master bond1
+    ip link set gre1 up
+    ip link set bond1 up
+    ip addr add fe80::1/64 dev bond1
+
+Fixes: 1284cd3a2b74 ("bonding: two small fixes for IPoIB support")
+Suggested-by: Jay Vosburgh <jv@jvosburgh.net>
+Reviewed-by: Eric Dumazet <edumazet@google.com>
+Signed-off-by: Jiayuan Chen <jiayuan.chen@shopee.com>
+Link: https://patch.msgid.link/20260306021508.222062-1-jiayuan.chen@linux.dev
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/bonding/bond_main.c | 47 ++++++++++++++++++++++++++++++++-
+ 1 file changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/bonding/bond_main.c b/drivers/net/bonding/bond_main.c
+index e57e129..f22a832 100644
+--- a/drivers/net/bonding/bond_main.c
++++ b/drivers/net/bonding/bond_main.c
+@@ -1551,6 +1551,50 @@ done:
+ 	netdev_change_features(bond_dev);
+ }
+ 
++static int bond_header_create(struct sk_buff *skb, struct net_device *bond_dev,
++			      unsigned short type, const void *daddr,
++			      const void *saddr, unsigned int len)
++{
++	struct bonding *bond = netdev_priv(bond_dev);
++	const struct header_ops *slave_ops;
++	struct slave *slave;
++	int ret = 0;
++
++	rcu_read_lock();
++	slave = rcu_dereference(bond->curr_active_slave);
++	if (slave) {
++		slave_ops = READ_ONCE(slave->dev->header_ops);
++		if (slave_ops && slave_ops->create)
++			ret = slave_ops->create(skb, slave->dev,
++						type, daddr, saddr, len);
++	}
++	rcu_read_unlock();
++	return ret;
++}
++
++static int bond_header_parse(const struct sk_buff *skb, unsigned char *haddr)
++{
++	struct bonding *bond = netdev_priv(skb->dev);
++	const struct header_ops *slave_ops;
++	struct slave *slave;
++	int ret = 0;
++
++	rcu_read_lock();
++	slave = rcu_dereference(bond->curr_active_slave);
++	if (slave) {
++		slave_ops = READ_ONCE(slave->dev->header_ops);
++		if (slave_ops && slave_ops->parse)
++			ret = slave_ops->parse(skb, haddr);
++	}
++	rcu_read_unlock();
++	return ret;
++}
++
++static const struct header_ops bond_header_ops = {
++	.create	= bond_header_create,
++	.parse	= bond_header_parse,
++};
++
+ static void bond_setup_by_slave(struct net_device *bond_dev,
+ 				struct net_device *slave_dev)
+ {
+@@ -1558,7 +1602,8 @@ static void bond_setup_by_slave(struct net_device *bond_dev,
+ 
+ 	dev_close(bond_dev);
+ 
+-	bond_dev->header_ops	    = slave_dev->header_ops;
++	bond_dev->header_ops	    = slave_dev->header_ops ?
++				      &bond_header_ops : NULL;
+ 
+ 	bond_dev->type		    = slave_dev->type;
+ 	bond_dev->hard_header_len   = slave_dev->hard_header_len;

--- a/SPECS/kernel-64k/kernel-64k.spec
+++ b/SPECS/kernel-64k/kernel-64k.spec
@@ -27,7 +27,7 @@
 Summary:        Linux Kernel
 Name:           kernel-64k
 Version:        6.6.144.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -41,6 +41,7 @@ Source4:        cpupower
 Source5:        cpupower.service
 Patch0:         0001-add-mstflint-kernel-%{mstflintver}.patch
 Patch1:         0002-efi-Added-efi-cmdline-line-option-to-dynamically-adj.patch
+Patch2:         CVE-2026-43456.patch
 ExclusiveArch:  aarch64
 BuildRequires:  audit-devel
 BuildRequires:  bash
@@ -380,6 +381,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Sat Jul 11 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.144.1-2
+- Add patch to fix CVE-2026-43456 (bonding: type confusion in bond_setup_by_slave())
+
 * Mon Jul 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.144.1-1
 - Auto-upgrade to 6.6.144.1
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.6.144.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +75,9 @@ done
 %endif
 
 %changelog
+* Sat Jul 11 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.144.1-2
+- Bump release to match kernel (CVE-2026-43456)
+
 * Mon Jul 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.144.1-1
 - Auto-upgrade to 6.6.144.1
 

--- a/SPECS/kernel/CVE-2026-43456.patch
+++ b/SPECS/kernel/CVE-2026-43456.patch
@@ -1,0 +1,143 @@
+From 950803f7254721c1c15858fbbfae3deaaeeecb11 Mon Sep 17 00:00:00 2001
+From: Jiayuan Chen <jiayuan.chen@shopee.com>
+Date: Fri, 6 Mar 2026 10:15:07 +0800
+Subject: [PATCH] bonding: fix type confusion in bond_setup_by_slave()
+
+kernel BUG at net/core/skbuff.c:2306!
+Oops: invalid opcode: 0000 [#1] SMP KASAN NOPTI
+RIP: 0010:pskb_expand_head+0xa08/0xfe0 net/core/skbuff.c:2306
+RSP: 0018:ffffc90004aff760 EFLAGS: 00010293
+RAX: 0000000000000000 RBX: ffff88807e3c8780 RCX: ffffffff89593e0e
+RDX: ffff88807b7c4900 RSI: ffffffff89594747 RDI: ffff88807b7c4900
+RBP: 0000000000000820 R08: 0000000000000005 R09: 0000000000000000
+R10: 00000000961a63e0 R11: 0000000000000000 R12: ffff88807e3c8780
+R13: 00000000961a6560 R14: dffffc0000000000 R15: 00000000961a63e0
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 00007fe1a0ed8df0 CR3: 000000002d816000 CR4: 00000000003526f0
+Call Trace:
+ <TASK>
+ ipgre_header+0xdd/0x540 net/ipv4/ip_gre.c:900
+ dev_hard_header include/linux/netdevice.h:3439 [inline]
+ packet_snd net/packet/af_packet.c:3028 [inline]
+ packet_sendmsg+0x3ae5/0x53c0 net/packet/af_packet.c:3108
+ sock_sendmsg_nosec net/socket.c:727 [inline]
+ __sock_sendmsg net/socket.c:742 [inline]
+ ____sys_sendmsg+0xa54/0xc30 net/socket.c:2592
+ ___sys_sendmsg+0x190/0x1e0 net/socket.c:2646
+ __sys_sendmsg+0x170/0x220 net/socket.c:2678
+ do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
+ do_syscall_64+0x106/0xf80 arch/x86/entry/syscall_64.c:94
+ entry_SYSCALL_64_after_hwframe+0x77/0x7f
+RIP: 0033:0x7fe1a0e6c1a9
+
+When a non-Ethernet device (e.g. GRE tunnel) is enslaved to a bond,
+bond_setup_by_slave() directly copies the slave's header_ops to the
+bond device:
+
+    bond_dev->header_ops = slave_dev->header_ops;
+
+This causes a type confusion when dev_hard_header() is later called
+on the bond device. Functions like ipgre_header(), ip6gre_header(),all use
+netdev_priv(dev) to access their device-specific private data. When
+called with the bond device, netdev_priv() returns the bond's private
+data (struct bonding) instead of the expected type (e.g. struct
+ip_tunnel), leading to garbage values being read and kernel crashes.
+
+Fix this by introducing bond_header_ops with wrapper functions that
+delegate to the active slave's header_ops using the slave's own
+device. This ensures netdev_priv() in the slave's header functions
+always receives the correct device.
+
+The fix is placed in the bonding driver rather than individual device
+drivers, as the root cause is bond blindly inheriting header_ops from
+the slave without considering that these callbacks expect a specific
+netdev_priv() layout.
+
+The type confusion can be observed by adding a printk in
+ipgre_header() and running the following commands:
+
+    ip link add dummy0 type dummy
+    ip addr add 10.0.0.1/24 dev dummy0
+    ip link set dummy0 up
+    ip link add gre1 type gre local 10.0.0.1
+    ip link add bond1 type bond mode active-backup
+    ip link set gre1 master bond1
+    ip link set gre1 up
+    ip link set bond1 up
+    ip addr add fe80::1/64 dev bond1
+
+Fixes: 1284cd3a2b74 ("bonding: two small fixes for IPoIB support")
+Suggested-by: Jay Vosburgh <jv@jvosburgh.net>
+Reviewed-by: Eric Dumazet <edumazet@google.com>
+Signed-off-by: Jiayuan Chen <jiayuan.chen@shopee.com>
+Link: https://patch.msgid.link/20260306021508.222062-1-jiayuan.chen@linux.dev
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/bonding/bond_main.c | 47 ++++++++++++++++++++++++++++++++-
+ 1 file changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/bonding/bond_main.c b/drivers/net/bonding/bond_main.c
+index e57e129..f22a832 100644
+--- a/drivers/net/bonding/bond_main.c
++++ b/drivers/net/bonding/bond_main.c
+@@ -1551,6 +1551,50 @@ done:
+ 	netdev_change_features(bond_dev);
+ }
+ 
++static int bond_header_create(struct sk_buff *skb, struct net_device *bond_dev,
++			      unsigned short type, const void *daddr,
++			      const void *saddr, unsigned int len)
++{
++	struct bonding *bond = netdev_priv(bond_dev);
++	const struct header_ops *slave_ops;
++	struct slave *slave;
++	int ret = 0;
++
++	rcu_read_lock();
++	slave = rcu_dereference(bond->curr_active_slave);
++	if (slave) {
++		slave_ops = READ_ONCE(slave->dev->header_ops);
++		if (slave_ops && slave_ops->create)
++			ret = slave_ops->create(skb, slave->dev,
++						type, daddr, saddr, len);
++	}
++	rcu_read_unlock();
++	return ret;
++}
++
++static int bond_header_parse(const struct sk_buff *skb, unsigned char *haddr)
++{
++	struct bonding *bond = netdev_priv(skb->dev);
++	const struct header_ops *slave_ops;
++	struct slave *slave;
++	int ret = 0;
++
++	rcu_read_lock();
++	slave = rcu_dereference(bond->curr_active_slave);
++	if (slave) {
++		slave_ops = READ_ONCE(slave->dev->header_ops);
++		if (slave_ops && slave_ops->parse)
++			ret = slave_ops->parse(skb, haddr);
++	}
++	rcu_read_unlock();
++	return ret;
++}
++
++static const struct header_ops bond_header_ops = {
++	.create	= bond_header_create,
++	.parse	= bond_header_parse,
++};
++
+ static void bond_setup_by_slave(struct net_device *bond_dev,
+ 				struct net_device *slave_dev)
+ {
+@@ -1558,7 +1602,8 @@ static void bond_setup_by_slave(struct net_device *bond_dev,
+ 
+ 	dev_close(bond_dev);
+ 
+-	bond_dev->header_ops	    = slave_dev->header_ops;
++	bond_dev->header_ops	    = slave_dev->header_ops ?
++				      &bond_header_ops : NULL;
+ 
+ 	bond_dev->type		    = slave_dev->type;
+ 	bond_dev->hard_header_len   = slave_dev->hard_header_len;

--- a/SPECS/kernel/kernel-uki.spec
+++ b/SPECS/kernel/kernel-uki.spec
@@ -13,7 +13,7 @@
 Summary:        Unified Kernel Image
 Name:           kernel-uki
 Version:        6.6.144.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -70,6 +70,9 @@ cp %{buildroot}/boot/vmlinuz-uki-%{kernelver}.efi %{buildroot}/boot/efi/EFI/Linu
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Sat Jul 11 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.144.1-2
+- Bump release to match kernel (CVE-2026-43456)
+
 * Mon Jul 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.144.1-1
 - Auto-upgrade to 6.6.144.1
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -32,7 +32,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.144.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -46,6 +46,7 @@ Source4:        azurelinux-ca-20230216.pem
 Source5:        cpupower
 Source6:        cpupower.service
 Patch0:         0001-add-mstflint-kernel-%{mstflintver}.patch
+Patch1:         CVE-2026-43456.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -440,6 +441,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Sat Jul 11 2026 Omkhar Arasaratnam <omkhar@linkedin.com> - 6.6.144.1-2
+- Add patch to fix CVE-2026-43456 (bonding: type confusion in bond_setup_by_slave())
+
 * Mon Jul 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.6.144.1-1
 - Auto-upgrade to 6.6.144.1
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
-kernel-headers-6.6.144.1-1.azl3.noarch.rpm
+kernel-headers-6.6.144.1-2.azl3.noarch.rpm
 glibc-2.38-20.azl3.aarch64.rpm
 glibc-devel-2.38-20.azl3.aarch64.rpm
 glibc-i18n-2.38-20.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
-kernel-headers-6.6.144.1-1.azl3.noarch.rpm
+kernel-headers-6.6.144.1-2.azl3.noarch.rpm
 glibc-2.38-20.azl3.x86_64.rpm
 glibc-devel-2.38-20.azl3.x86_64.rpm
 glibc-i18n-2.38-20.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.aarch64.rpm
 kbd-debuginfo-2.2.0-2.azl3.aarch64.rpm
-kernel-headers-6.6.144.1-1.azl3.noarch.rpm
+kernel-headers-6.6.144.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -165,8 +165,8 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.x86_64.rpm
 kbd-debuginfo-2.2.0-2.azl3.x86_64.rpm
-kernel-cross-headers-6.6.144.1-1.azl3.noarch.rpm
-kernel-headers-6.6.144.1-1.azl3.noarch.rpm
+kernel-cross-headers-6.6.144.1-2.azl3.noarch.rpm
+kernel-headers-6.6.144.1-2.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist
- [x] The toolchain has been rebuilt successfully (or no changes were made to it) <!-- kernel-headers Release bump only; toolchain/pkggen_core manifests updated to match -->
- [x] The toolchain/worker package manifests are up-to-date <!-- kernel-headers 6.6.143.1-1 -> -2 in toolchain_{x86_64,aarch64}.txt + pkggen_core_{x86_64,aarch64}.txt -->
- [x] Any updated packages successfully build (or no packages were changed) <!-- patch applies -p1 cleanly via %autosetup; kernel behaviour wire-validated, see Test Methodology -->
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented. <!-- N/A - no static components changed -->
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files <!-- kernel spec has no %check section -->
- [x] All package sources are available <!-- Source0 unchanged; a Patch (not a Source) was added under SPECS/kernel and SPECS/kernel-64k -->
- [x] cgmanifest files are up-to-date and sorted <!-- unchanged; a patch-add does not alter package sources -->
- [x] LICENSE-MAP files are up-to-date <!-- unchanged -->
- [x] All source files have up-to-date hashes in the `*.signatures.json` files <!-- unchanged; a PatchN (not a Source) was added, no source hash required -->
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass <!-- N/A - no Go changes -->
- [x] Documentation has been updated to match any changes to the build system <!-- N/A -->
- [ ] Ready to merge <!-- deferred pending CI + a maintainer decision on handling; see "Note to maintainers" below -->

###### Summary
Backport the upstream fix for **CVE-2026-43456**, a type confusion in the bonding driver's `bond_setup_by_slave()`.

When a non-Ethernet slave (e.g. a GRE tunnel) is enslaved to a bond, the bond blindly copied the slave's `header_ops` onto itself:

```
bond_dev->header_ops = slave_dev->header_ops;
```

A later `dev_hard_header()` on the bond then invokes e.g. `ipgre_header()` **with the bond device**, so `netdev_priv()` returns the bond's `struct bonding` reinterpreted as the slave protocol's private type (e.g. `struct ip_tunnel`) — a type confusion that leads to garbage reads / controlled corruption and **local privilege escalation**. A public exploit exists (Google kernelCTF, reliable LPE; trigger only needs `CAP_NET_ADMIN`, obtainable via unprivileged user namespaces).

The upstream fix introduces `bond_header_ops` wrapper functions that delegate to the active slave's `header_ops` **using the slave's own device**, so `netdev_priv()` always sees the correct type.

Upstream commit: torvalds/linux `950803f7254721c1c15858fbbfae3deaaeeecb11`
- Author: Jiayuan Chen &lt;jiayuan.chen@shopee.com&gt;
- Fixes: `1284cd3a2b74` ("bonding: two small fixes for IPoIB support") (2007)
- Reviewed-by: Eric Dumazet &lt;edumazet@google.com&gt;
- Signed-off-by: Paolo Abeni &lt;pabeni@redhat.com&gt;

The fix is a single file (`drivers/net/bonding/bond_main.c`) and applies cleanly to the `6.6.143.1` (rolling-lts/mariner-3) source via `%autosetup -p1`.

###### Change Log
- Add `CVE-2026-43456.patch` (upstream `950803f7`, attribution preserved) to the two from-source kernels: `SPECS/kernel` (`Patch1`) and `SPECS/kernel-64k` (`Patch2`).
- Bump `Release` `6.6.143.1-1` -> `-2` across the entangled kernel spec set: `kernel`, `kernel-64k`, `kernel-headers`, `kernel-signed`, `kernel-64k-signed`, `kernel-uki-signed`.
- Update the `kernel-headers` NVR (`-1` -> `-2`) in `toolchain_{x86_64,aarch64}.txt` and `pkggen_core_{x86_64,aarch64}.txt`.
- Fixes CVE-2026-43456.

###### Does this affect the toolchain?
**YES** — `kernel-headers` is a core/toolchain package, so its `Release` bump requires the `toolchain_*.txt` / `pkggen_core_*.txt` manifest update (included). No toolchain *source* changes.

###### Links to CVEs
- https://nvd.nist.gov/vuln/detail/CVE-2026-43456

###### Test Methodology
Validated against the exact `6.6.143.1` (rolling-lts/mariner-3) kernel source this spec consumes:

- **Patch application:** `patch -p1 --dry-run` of `CVE-2026-43456.patch` against the consumed `bond_main.c` returns RC=0; post-apply the raw `header_ops` copy is gone and the `bond_header_ops`/`bond_header_create`/`bond_header_parse` guard is present.
- **Vulnerability reproduced (unpatched 6.6.143.1, self-built KASAN kernel, booted):** an `ipgre_header` kprobe capturing the `dev` argument shows the bond device (`bond1`) being passed on **7/7** trigger sends — i.e. the type confusion path is reached (`netdev_priv(bond1)` = `struct bonding` handed to GRE code expecting `struct ip_tunnel`).
- **Fix verified (patched 6.6.143.1, same method):** the same trigger now shows `bond_header_create(bond1) -> ipgre_header(gre1)` on **12/12** sends, **0** `bond1` — the wrapper routes to the slave's own device, eliminating the confusion.
- **Regression:** LTP `net.ipv6_lib` + `net.multicast` (the single-VM-tolerant `drivers/net` subsystem suites) — **0 new failures** patched vs baseline (the 3 `net.multicast` fails are Azure-VNet-blocks-L2-multicast environmental, identical on both sides).

(The type confusion is an in-bounds wrong-type read, so it does not crash a naive PoC / KASAN — the kprobe `dev`-argument differential is the deterministic signal; a crash requires exploit-grade heap shaping, per the public kernelCTF exploit.)

###### Note to maintainers
This is intentionally an **out-of-tree carry**: `950803f7` is not yet in `linux-6.6.y` stable (it is already in `6.12.y` and `6.18.y`), so `[AUTOPATCHER-kernel]` cannot pull it yet. I recognise the kernel is normally serviced by auto-upgrade rather than hand-added CVE patches — I'm raising this manually **only** because there is a public, reliable LPE exploit against the currently-shipping `6.6.143.1`, and I'd rather not leave that window open until 6.6.y catches up.

Happy to defer to your preference: keep this as a carry until AUTOPATCHER pulls the stable backport (and I'll close it then), or drop it if you'd rather wait. Also glad to route it through `fasttrack/3.0` if that's the appropriate channel for an exigent kernel CVE — please advise.

There is a follow-up upstream commit `b7405dcf7385` ("bonding: prevent potential infinite loop in bond_header_parse()", `Fixes: 950803f7`) that hardens the code this patch adds; it is a broader `header_ops->parse` ABI change (9 files) and addresses a separate, lower-severity `CAP_NET_ADMIN`-gated DoS, so I've kept it out of this PR and can raise it separately if you'd like.
