### PR TITLE
Revert "[AUTO-CHERRYPICK] [AUTOPATCHER-CORE] Upgrade `cifs-utils` to 7.6 for CVE-2026-12505 [HIGH] - branch 3.0"

### DIFF
--- a/SPECS/cifs-utils/cifs-utils.signatures.json
+++ b/SPECS/cifs-utils/cifs-utils.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "cifs-utils-7.6.tar.bz2": "7db875ff2868e5fa4e445ada0bd23ea70b9161b96188c7e276321e061ed51dd6"
+    "cifs-utils-7.3.tar.bz2": "c4e1eb5f4ad880d96e16d95a1cdbc7ec978ab51c5b6d8a20ae09dac638f36dd5"
   }
 }

--- a/SPECS/cifs-utils/cifs-utils.spec
+++ b/SPECS/cifs-utils/cifs-utils.spec
@@ -1,6 +1,6 @@
 Summary:        cifs client utils
 Name:           cifs-utils
-Version:        7.6
+Version:        7.3
 Release:        1%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
@@ -81,9 +81,6 @@ make %{?_smp_mflags} check
 %{_includedir}/cifsidmap.h
 
 %changelog
-* Sat Jun 27 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.6-1
-- Auto-upgrade to 7.6 - for CVE-2026-12505
-
 * Wed Mar 26 2025 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.3-1
 - Auto-upgrade to 7.3 - Bugfix: 56213770, 56248605
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1747,8 +1747,8 @@
         "type": "other",
         "other": {
           "name": "cifs-utils",
-          "version": "7.6",
-          "downloadUrl": "https://download.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-7.6.tar.bz2"
+          "version": "7.3",
+          "downloadUrl": "https://download.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-7.3.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
Syncing 3.0 release branch with the cifs-utils v7.6 revert.

See #17911 and #17910