### PR TITLE
feat(kmod-nvidia-open): add kmod-nvidia-open-matched sentinel package for opt-in automatic kernel upgrade tracking

### DIFF
--- a/base/comps/kernel/kernel.spec
+++ b/base/comps/kernel/kernel.spec
@@ -7,7 +7,7 @@
 # Azure Linux kernel build defines. These were previously injected via the
 # azldev-generated kernel.azl.macros file; they now live directly in the spec.
 # When rebuilding without a version change, bump azl_pkgrelease (manual release).
-%define azl_pkgrelease 14
+%define azl_pkgrelease 15
 # 4th version component from the AZL kernel source (6.18.31.1). Flows into
 # Release:, uname -r, and the /lib/modules/ path.
 %define kextraversion 1
@@ -781,6 +781,9 @@ Requires: %{name}-core-uname-r = %{KVERREL}
 Requires: %{name}-modules-uname-r = %{KVERREL}
 Requires: %{name}-modules-core-uname-r = %{KVERREL}
 Requires: ((%{name}-modules-extra-uname-r = %{KVERREL}) if %{name}-modules-extra-matched)
+%ifarch x86_64 aarch64
+Requires: ((kmod-nvidia-open-uname-r = %{KVERREL}) if kmod-nvidia-open-matched)
+%endif
 Provides: installonlypkg(kernel)
 %endif
 
@@ -4606,6 +4609,9 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Tue Aug 11 2026 Elaheh Dehghani <edehghani@microsoft.com> - 6.18.31-1.15
+- feat(kmod-nvidia-open): add opt-in kmod-nvidia-open-matched sentinel package for automatic kernel upgrade tracking
+
 * Fri Aug 07 2026 Rachel Menge <rachelmenge@microsoft.com> - 6.18.31-1.14
 - feat(kernel): build base variants, keep UKI, and restore selftests
 

--- a/base/comps/kernel/kmod-nvidia-open.inc
+++ b/base/comps/kernel/kmod-nvidia-open.inc
@@ -32,11 +32,14 @@ AutoReq:        no
 # Track the actual NVIDIA driver version via Provides for dependency resolution.
 Provides:       nvidia-open-kmod-version = %{nvidia_open_version}
 Provides:       nvidia-kmod = %{nvidia_open_version}
+Provides:       kmod-nvidia-open-uname-r = %{KVERREL}
 # Mark this kmod as install-only so multiple versions can coexist alongside
 # their matching kernels (dnf/dnf5 default installonlypkgs includes the
 # 'installonlypkg(kernel-module)' token).
 Provides:       installonlypkg(kernel-module)
 Requires:       %{name}-core-uname-r = %{KVERREL}
+# TODO: Add userspace package dependency when package name/version contract is finalized.
+# Requires:       <nvidia-userspace-package> = %{nvidia_open_version}
 Requires(post): kmod
 Requires(postun): kmod
 Conflicts:      nvidia-closed-kmod
@@ -51,7 +54,15 @@ Each kernel version produces a separate kmod package
 (kmod-nvidia-open-<nvidia_driver_version>-<KVERREL>) so that multiple kernel versions
 can coexist with their own NVIDIA modules.
 Use 'Requires: nvidia-open-kmod-version = %{nvidia_open_version}' to depend on a
-specific NVIDIA driver version, or 'Requires: nvidia-kmod = %{nvidia_open_version}'.
+specific NVIDIA driver version, or 'Requires: nvidia-kmod = %{nvidia_open_version}' to
+depend on a specific NVIDIA driver package version.
+
+%package -n kmod-nvidia-open-matched
+Summary:        Meta package to ensure kmod-nvidia-open is installed for all kernels
+
+%description -n kmod-nvidia-open-matched
+This meta package provides a single reference that other packages can Require to have kmod-nvidia-open installed for all kernels. When installed, the kernel package automatically pulls in the version-matched kmod-nvidia-open for each kernel version on this machine (x86_64 and aarch64 only).
+
 %endif
 
 %endif
@@ -149,6 +160,10 @@ install -D -m 0644 %{_builddir}/open-gpu-kernel-modules-%{nvidia_open_version}/C
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-uvm.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-peermem.ko.%{compext}
 %{_modprobedir}/kmod-%{_kmod_name}-%{KVERREL}.conf
+
+%files -n kmod-nvidia-open-matched
+# empty sentinel package — no files
+
 %endif
 
 %endif

--- a/base/comps/kernel/rpminspect.yaml
+++ b/base/comps/kernel/rpminspect.yaml
@@ -35,6 +35,7 @@ emptyrpm:
         - kernel-rt-64k-debug-devel-matched
         - kernel-rt-64k-devel-matched
         - kernel-rt-64k-modules-extra-matched
+        - kmod-nvidia-open-matched
 
 patches:
     ignore_list:

--- a/locks/kernel.lock
+++ b/locks/kernel.lock
@@ -1,4 +1,4 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:27c920b119cd391713299612ac7c764c3dfb8125013b4aef9bf52cdc2ad70169'
+input-fingerprint = 'sha256:c855a11b58a08f8247ecccb7f9c91e4ce0942bb028ab95df98aa4e55db4ee3d6'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/k/kernel/kernel.spec
+++ b/specs/k/kernel/kernel.spec
@@ -10,7 +10,7 @@
 # Azure Linux kernel build defines. These were previously injected via the
 # azldev-generated kernel.azl.macros file; they now live directly in the spec.
 # When rebuilding without a version change, bump azl_pkgrelease (manual release).
-%define azl_pkgrelease 14
+%define azl_pkgrelease 15
 # 4th version component from the AZL kernel source (6.18.31.1). Flows into
 # Release:, uname -r, and the /lib/modules/ path.
 %define kextraversion 1
@@ -784,6 +784,9 @@ Requires: %{name}-core-uname-r = %{KVERREL}
 Requires: %{name}-modules-uname-r = %{KVERREL}
 Requires: %{name}-modules-core-uname-r = %{KVERREL}
 Requires: ((%{name}-modules-extra-uname-r = %{KVERREL}) if %{name}-modules-extra-matched)
+%ifarch x86_64 aarch64
+Requires: ((kmod-nvidia-open-uname-r = %{KVERREL}) if kmod-nvidia-open-matched)
+%endif
 Provides: installonlypkg(kernel)
 %endif
 
@@ -4609,6 +4612,9 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Tue Aug 11 2026 Elaheh Dehghani <edehghani@microsoft.com> - 6.18.31-1.15
+- feat(kmod-nvidia-open): add opt-in kmod-nvidia-open-matched sentinel package for automatic kernel upgrade tracking
+
 * Fri Aug 07 2026 Rachel Menge <rachelmenge@microsoft.com> - 6.18.31-1.14
 - feat(kernel): build base variants, keep UKI, and restore selftests
 

--- a/specs/k/kernel/kmod-nvidia-open.inc
+++ b/specs/k/kernel/kmod-nvidia-open.inc
@@ -32,11 +32,14 @@ AutoReq:        no
 # Track the actual NVIDIA driver version via Provides for dependency resolution.
 Provides:       nvidia-open-kmod-version = %{nvidia_open_version}
 Provides:       nvidia-kmod = %{nvidia_open_version}
+Provides:       kmod-nvidia-open-uname-r = %{KVERREL}
 # Mark this kmod as install-only so multiple versions can coexist alongside
 # their matching kernels (dnf/dnf5 default installonlypkgs includes the
 # 'installonlypkg(kernel-module)' token).
 Provides:       installonlypkg(kernel-module)
 Requires:       %{name}-core-uname-r = %{KVERREL}
+# TODO: Add userspace package dependency when package name/version contract is finalized.
+# Requires:       <nvidia-userspace-package> = %{nvidia_open_version}
 Requires(post): kmod
 Requires(postun): kmod
 Conflicts:      nvidia-closed-kmod
@@ -51,7 +54,15 @@ Each kernel version produces a separate kmod package
 (kmod-nvidia-open-<nvidia_driver_version>-<KVERREL>) so that multiple kernel versions
 can coexist with their own NVIDIA modules.
 Use 'Requires: nvidia-open-kmod-version = %{nvidia_open_version}' to depend on a
-specific NVIDIA driver version, or 'Requires: nvidia-kmod = %{nvidia_open_version}'.
+specific NVIDIA driver version, or 'Requires: nvidia-kmod = %{nvidia_open_version}' to
+depend on a specific NVIDIA driver package version.
+
+%package -n kmod-nvidia-open-matched
+Summary:        Meta package to ensure kmod-nvidia-open is installed for all kernels
+
+%description -n kmod-nvidia-open-matched
+This meta package provides a single reference that other packages can Require to have kmod-nvidia-open installed for all kernels. When installed, the kernel package automatically pulls in the version-matched kmod-nvidia-open for each kernel version on this machine (x86_64 and aarch64 only).
+
 %endif
 
 %endif
@@ -149,6 +160,10 @@ install -D -m 0644 %{_builddir}/open-gpu-kernel-modules-%{nvidia_open_version}/C
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-uvm.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-peermem.ko.%{compext}
 %{_modprobedir}/kmod-%{_kmod_name}-%{KVERREL}.conf
+
+%files -n kmod-nvidia-open-matched
+# empty sentinel package — no files
+
 %endif
 
 %endif

--- a/specs/k/kernel/rpminspect.yaml
+++ b/specs/k/kernel/rpminspect.yaml
@@ -35,6 +35,7 @@ emptyrpm:
         - kernel-rt-64k-debug-devel-matched
         - kernel-rt-64k-devel-matched
         - kernel-rt-64k-modules-extra-matched
+        - kmod-nvidia-open-matched
 
 patches:
     ignore_list:


### PR DESCRIPTION
Adds auto-upgrade support for kmod-nvidia-open so that when a user has the NVIDIA open kernel module installed, upgrading the kernel automatically pulls in the matching kmod-nvidia-open for the new kernel version.
A new package `kmod-nvidia-open-matched` is introduced. This is an empty sentinel/meta package (no payload files) and  this sentinel is to opt-in to automatic kmod dependency tracking for the nvidia open kmods. If the user doesn't install kmod-nvidia-open-matched, then they don't get the dependency-matching behavior.
Its purpose is to enable automatic installation of the matching `kmod-nvidia-open` package for each installed kernel version. When this sentinel is installed, kernel uses a conditional rich dependency:
`Requires: ((kmod-nvidia-open-uname-r = %{KVERREL}) if kmod-nvidia-open-matched)`
This keeps NVIDIA kernel modules aligned with kernel upgrades on x86_64/aarch64.  Removing this sentinel disables future auto-pull behavior, but does not remove already installed versioned kmod-nvidia-open packages.