### PR TITLE
fix(mock): point stage2 base/sdk repos at packages.microsoft.com

### DIFF
--- a/distro/mock/azl4/stage2/azurelinux-4.0.tpl
+++ b/distro/mock/azl4/stage2/azurelinux-4.0.tpl
@@ -89,13 +89,13 @@ user_agent={{ user_agent }}
 
 [base]
 name=base
-baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/base/$basearch
+baseurl=https://packages.microsoft.com/azurelinux/4.0/beta/base/$basearch
 enabled=1
 skip_if_unavailable=False
 
 [sdk]
 name=sdk
-baseurl=https://stcontroltowerdevjwisitg.blob.core.windows.net/azl4-dev/sdk/$basearch
+baseurl=https://packages.microsoft.com/azurelinux/4.0/beta/sdk/$basearch
 enabled=1
 skip_if_unavailable=False
 


### PR DESCRIPTION
## What

Update the `base` and `sdk` repository URLs in
`distro/mock/azl4/stage2/azurelinux-4.0.tpl` to the public Azure Linux
package location:

- `base` / `sdk` baseurl → https://packages.microsoft.com/azurelinux/4.0/beta/{base,sdk}/$basearch

## Why

The previous URLs pointed at a location that is not a reliable public
source. `packages.microsoft.com` is the public Azure Linux package
location with stable public access.

## Validation

- `base` and `sdk` repodata for both `x86_64` and `aarch64` return HTTP 200 at the new location.

## Scope

Limited to this file. The same URLs are still referenced in other files
(`config.sh`, the kiwi definitions, and the `azurelinux-repos.spec` files);
those are left for a separate change.