### PR TITLE
fix(vm-iso-installer): download remote kickstart files locally

### DIFF
--- a/base/images/vm-iso-installer/anaconda-launcher.sh
+++ b/base/images/vm-iso-installer/anaconda-launcher.sh
@@ -14,6 +14,15 @@ done
 CUSTOM_KS=""
 if grep -qo 'inst\.ks=[^ ]*' /proc/cmdline 2>/dev/null; then
     CUSTOM_KS=$(grep -o 'inst\.ks=[^ ]*' /proc/cmdline | sed 's/inst\.ks=//')
+
+    if [[ "$CUSTOM_KS" == http* ]]; then
+        if ! curl -sf -o /tmp/ks.cfg "$CUSTOM_KS"; then
+            echo "ERROR: Failed to download kickstart from $CUSTOM_KS" >&2
+            exec /bin/bash
+        fi
+        CUSTOM_KS="/tmp/ks.cfg"
+    fi
+
     echo ""
     echo "========================================"
     echo "  Azure Linux 4.0 Offline Installer"


### PR DESCRIPTION
When PXE booting with an HTTP kickstart URL in the kernel cmdline (inst.ks),
anaconda-launcher.sh passed the URL directly to anaconda as a subprocess.
Anaconda requires a local file path in this context and would fail with a
missing file error.

This commit updates anaconda-launcher.sh to download HTTP/HTTPS URLs
via curl to /tmp/ks.cfg before passing it to anaconda, resolving
deployments that rely on remote kickstarts.

Fixes #17915
