### PR TITLE
Upgrade azurelinux-image-tools to version v1.5.1

### DIFF
--- a/.pipelines/containerSourceData/imagecustomizer/Dockerfile-imagecustomizer
+++ b/.pipelines/containerSourceData/imagecustomizer/Dockerfile-imagecustomizer
@@ -15,12 +15,6 @@ RUN tdnf update -y && \
    tdnf install -y azurelinux-repos-cloud-native && \
    tdnf update -y && \
    tdnf install -y oras && \
-   if [ "$TARGETARCH" = "amd64" ]; then \
-       echo "Installing AMD64-specific packages..."; \
-       tdnf install -y grub2-pc systemd-ukify; \
-   else \
-       echo "Skipping AMD64-specific packages for $TARGETARCH"; \
-   fi && \
    tdnf clean all
 
 # Create virtual environment and install Python dependencies for telemetry

--- a/SPECS/azurelinux-image-tools/azurelinux-image-tools.signatures.json
+++ b/SPECS/azurelinux-image-tools/azurelinux-image-tools.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "azurelinux-image-tools-1.5.0-vendor.tar.gz": "e7ee04afa1d716b20f34ac6062e7196d27dca6173f2e06bffba2cc125553cb59",
-  "azurelinux-image-tools-1.5.0.tar.gz": "982bbb18735d8cd39055b497da7826ab1d048a2708131ab9d02cc1099d58a6de"
+  "azurelinux-image-tools-1.5.1-vendor.tar.gz": "e7ee04afa1d716b20f34ac6062e7196d27dca6173f2e06bffba2cc125553cb59",
+  "azurelinux-image-tools-1.5.1.tar.gz": "bd060041dd8073bd6a1cbc8b87cadfc8f0115f163210bc9eb2857724afca7cf0"
  }
 }

--- a/SPECS/azurelinux-image-tools/azurelinux-image-tools.spec
+++ b/SPECS/azurelinux-image-tools/azurelinux-image-tools.spec
@@ -48,9 +48,9 @@ Requires: lsof
 Requires: python3
 Requires: python3-pip
 Requires: jq
+Requires: systemd-ukify
 %ifarch x86_64
 Requires: grub2-pc
-Requires: systemd-ukify
 %endif
 
 %description imagecustomizer
@@ -112,6 +112,7 @@ go test -C toolkit/tools ./...
 %changelog
 * Tue Jul 7 2026 Chris Gunn <chrisgunn>@microsoft.com> - 1.5.1-1
 - Upgrade to version 1.5.1
+- Enable systemd-ukify for arm64
 
 * Fri May 29 2026 Chris Gunn <chrisgunn>@microsoft.com> - 1.5.0-1
 - Upgrade to version 1.5.0

--- a/SPECS/azurelinux-image-tools/azurelinux-image-tools.spec
+++ b/SPECS/azurelinux-image-tools/azurelinux-image-tools.spec
@@ -2,7 +2,7 @@
 
 Summary:        Azure Linux Image Tools
 Name:           azurelinux-image-tools
-Version:        1.5.0
+Version:        1.5.1
 Release:        1%{?dist}
 License:        MIT
 URL:            https://github.com/microsoft/azure-linux-image-tools/
@@ -110,6 +110,9 @@ go test -C toolkit/tools ./...
 %{_bindir}/osmodifier
 
 %changelog
+* Tue Jul 7 2026 Chris Gunn <chrisgunn>@microsoft.com> - 1.5.1-1
+- Upgrade to version 1.5.1
+
 * Fri May 29 2026 Chris Gunn <chrisgunn>@microsoft.com> - 1.5.0-1
 - Upgrade to version 1.5.0
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -925,8 +925,8 @@
         "type": "other",
         "other": {
           "name": "azurelinux-image-tools",
-          "version": "1.5.0",
-          "downloadUrl": "https://github.com/microsoft/azure-linux-image-tools/archive/refs/tags/v1.5.0.tar.gz"
+          "version": "1.5.1",
+          "downloadUrl": "https://github.com/microsoft/azure-linux-image-tools/archive/refs/tags/v1.5.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
This PR updates the azurelinux-image-tools package to version 1.5.1 to reflect the new Image Customizer release.