### PR TITLE
(security) golang: bump Go version to 1.25.12-1 (#17939)

### DIFF
--- a/SPECS/golang/golang-1.25.signatures.json
+++ b/SPECS/golang/golang-1.25.signatures.json
@@ -3,7 +3,7 @@
     "go.20230802.5.src.tar.gz": "56b9e0e0c3c13ca95d5efa6de4e7d49a9d190eca77919beff99d33cd3fa74e95",
     "go.20240206.2.src.tar.gz": "7982e0011aa9ab95fd0530404060410af4ba57326d26818690f334fdcb6451cd",
     "go1.22.12-20250211.4.src.tar.gz": "e1cc3bff8fdf1f24843ffc9f0eaddfd344eb40fd9ca0d9ba2965165be519eeb7",
-    "go1.25.11-20260602.7.src.tar.gz": "f0ce925ee38cf2c87a1e23f75b9da20a0fccf64bbe6f697679c58331da7ada9b",
+    "go1.25.12-20260707.5.src.tar.gz": "a8193780d5d4db6f2857f0c8c2e71667576cbfd829de08183ce63d9fc6951ea8",
     "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
   }
 }

--- a/SPECS/golang/golang-1.25.spec
+++ b/SPECS/golang/golang-1.25.spec
@@ -1,6 +1,6 @@
 %global goroot          %{_libdir}/golang
 %global gopath          %{_datadir}/gocode
-%global ms_go_filename  go1.25.11-20260602.7.src.tar.gz
+%global ms_go_filename  go1.25.12-20260707.5.src.tar.gz
 %global ms_go_revision  1
 %ifarch aarch64
 %global gohostarch      arm64
@@ -14,8 +14,8 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.25.11
-Release:        3%{?dist}
+Version:        1.25.12
+Release:        1%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -166,6 +166,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Wed Jul 08 2026 bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com> - 1.25.12-1
+- Bump version to 1.25.12-1
+
 
 * Fri June 26 2026 Amit Upadhyay amitupadhyay@microsoft.com - 1.25.11-3
 - Remove the remaining final bootstrap component to reduce attack surface; the residual bootstrap artifact has had prior vulnerability exposure, so removing it is a security improvement.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4770,8 +4770,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.25.11",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.25.11-1/go1.25.11-20260602.7.src.tar.gz"
+          "version": "1.25.12",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.25.12-1/go1.25.12-20260707.5.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Co-authored-by: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
(cherry picked from commit a0104b2d8927254a71201a4bef195eb8857d318b)
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
