### PR TITLE
test: add openmpi container test

### DIFF
--- a/base/images/tests/cases/runtime/container-base/test_openmpi/Dockerfile
+++ b/base/images/tests/cases/runtime/container-base/test_openmpi/Dockerfile
@@ -1,0 +1,5 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN dnf install -y openmpi openmpi-devel gcc && dnf clean all
+COPY send_receive.c /opt/mpi-tests/send_receive.c

--- a/base/images/tests/cases/runtime/container-base/test_openmpi/send_receive.c
+++ b/base/images/tests/cases/runtime/container-base/test_openmpi/send_receive.c
@@ -1,0 +1,45 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+    int rank, source, dest;
+    MPI_Request requests[4];
+    const int tag1 = 6;
+    const int tag2 = 10;
+    char inmsg[64];
+    const char outmsg0[] = "Using Tag1";
+    const char outmsg1[] = "Again Using Tag1";
+    const char outmsg2[] = "Using Tag2";
+    const char outmsg3[] = "Again Using Tag2";
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (rank == 0) {
+        dest = 1;
+        MPI_Isend(outmsg0, (int)strlen(outmsg0) + 1, MPI_CHAR, dest, tag1, MPI_COMM_WORLD, &requests[0]);
+        MPI_Isend(outmsg2, (int)strlen(outmsg2) + 1, MPI_CHAR, dest, tag2, MPI_COMM_WORLD, &requests[1]);
+        MPI_Isend(outmsg1, (int)strlen(outmsg1) + 1, MPI_CHAR, dest, tag1, MPI_COMM_WORLD, &requests[2]);
+        MPI_Isend(outmsg3, (int)strlen(outmsg3) + 1, MPI_CHAR, dest, tag2, MPI_COMM_WORLD, &requests[3]);
+        MPI_Waitall(4, requests, MPI_STATUSES_IGNORE);
+        printf("rank0 sent messages\n");
+    } else if (rank == 1) {
+        source = 0;
+        memset(inmsg, 0, sizeof(inmsg));
+        MPI_Recv(inmsg, sizeof(inmsg), MPI_CHAR, source, tag2, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        printf("tag2:%s\n", inmsg);
+        memset(inmsg, 0, sizeof(inmsg));
+        MPI_Recv(inmsg, sizeof(inmsg), MPI_CHAR, source, tag2, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        printf("tag2:%s\n", inmsg);
+        memset(inmsg, 0, sizeof(inmsg));
+        MPI_Recv(inmsg, sizeof(inmsg), MPI_CHAR, source, tag1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        printf("tag1:%s\n", inmsg);
+        memset(inmsg, 0, sizeof(inmsg));
+        MPI_Recv(inmsg, sizeof(inmsg), MPI_CHAR, source, tag1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        printf("tag1:%s\n", inmsg);
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/base/images/tests/cases/runtime/container-base/test_openmpi/test_openmpi.py
+++ b/base/images/tests/cases/runtime/container-base/test_openmpi/test_openmpi.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+"""Validate OpenMPI runtime behavior on container-base images.
+
+Uses ``@pytest.mark.dockerfile()`` to build a custom image with
+OpenMPI installed on top of the image-under-test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+MPI_RUN = "/usr/lib64/openmpi/bin/mpirun"
+PRTE_RUN = "/usr/lib64/openmpi/bin/prterun"
+MPI_CC = "/usr/lib64/openmpi/bin/mpicc"
+MPI_TIMEOUT_SECS = 30
+
+
+@pytest.mark.dockerfile()
+def test_openmpi_mpirun_version(container_exec_shell) -> None:
+    """mpirun binary must exist and report version."""
+    result = container_exec_shell(f"OMPI_PRTERUN={PRTE_RUN} {MPI_RUN} --version")
+    assert result.exit_code == 0, f"mpirun --version failed: {result.output}"
+    assert "Open MPI" in result.output
+
+
+@pytest.mark.dockerfile()
+def test_openmpi_runs_multiple_ranks(container_exec_shell) -> None:
+    """mpirun should launch two ranks in a single container."""
+    result = container_exec_shell(
+        f"OMPI_PRTERUN={PRTE_RUN} "
+        "OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 "
+        f"{MPI_RUN} --timeout {MPI_TIMEOUT_SECS} --oversubscribe -np 2 "
+        "/bin/sh -c 'echo rank=$OMPI_COMM_WORLD_RANK'"
+    )
+    assert result.exit_code == 0, f"mpirun rank launch failed: {result.output}"
+    ranks = sorted(
+        line.strip()
+        for line in result.output.splitlines()
+        if line.startswith("rank=")
+    )
+    assert ranks == ["rank=0", "rank=1"], f"unexpected rank output: {result.output}"
+
+
+@pytest.mark.dockerfile()
+def test_openmpi_send_receive_between_two_ranks(container_exec_shell) -> None:
+    """Two MPI ranks should exchange tagged messages successfully."""
+    compile_and_run = (
+        f"{MPI_CC} -O2 -o /tmp/send_receive "
+        "/opt/mpi-tests/send_receive.c && "
+        f"OMPI_PRTERUN={PRTE_RUN} "
+        "OMPI_ALLOW_RUN_AS_ROOT=1 "
+        "OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 "
+        f"{MPI_RUN} --timeout {MPI_TIMEOUT_SECS} --oversubscribe -np 2 /tmp/send_receive"
+    )
+    result = container_exec_shell(compile_and_run)
+    assert result.exit_code == 0, f"send/receive MPI test failed: {result.output}"
+    assert "rank0 sent messages" in result.output
+    assert "tag2:Using Tag2" in result.output
+    assert "tag2:Again Using Tag2" in result.output
+    assert "tag1:Using Tag1" in result.output
+    assert "tag1:Again Using Tag1" in result.output


### PR DESCRIPTION
Add Openmpi container test

1. test_openmpi_mpirun_version
         Validates that OpenMPI runtime is installed and usable.
         Runs mpirun --version with required OpenMPI runtime env configuration.
         Fails fast if basic OpenMPI runtime wiring is broken.
2. test_openmpi_runs_multiple_ranks
       Validates that mpirun actually launches two MPI ranks in the container.
       Executes a two-rank command and checks exact rank output: rank=0 and rank=1.
       Provides stable rank-launch verification without depending on version-string formatting.
3. test_openmpi_send_receive_between_two_ranks
       Validates real MPI communication semantics, not just process launch.
       Compiles the checked-in C program copied into the image, then runs it with two ranks.
       Asserts tagged message exchange output, proving rank-to-rank send and receive behavior works end to end.