### PR TITLE
test: add dotnet runtime tests for base container

### DIFF
--- a/base/images/tests/cases/runtime/container-base/test_dotnet/Dockerfile
+++ b/base/images/tests/cases/runtime/container-base/test_dotnet/Dockerfile
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+RUN dnf install -y dotnet-sdk-10.0 curl && dnf clean all
+WORKDIR /src
+COPY webapp/ ./webapp/
+COPY restclient/ ./restclient/
+RUN dotnet publish webapp -c Release -o /app/webapp \
+ && dotnet publish restclient -c Release -o /app/restclient
+EXPOSE 8080

--- a/base/images/tests/cases/runtime/container-base/test_dotnet/restclient/Program.cs
+++ b/base/images/tests/cases/runtime/container-base/test_dotnet/restclient/Program.cs
@@ -1,0 +1,23 @@
+using System;
+using RestSharp;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        var client = new RestClient("http://localhost:8080");
+        var request = new RestRequest("/", Method.Get);
+        var response = client.Execute(request);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.OK &&
+            response.Content == "Hello World!")
+        {
+            Console.WriteLine("RestSharp reached the .NET server.");
+            return 0;
+        }
+
+        Console.Error.WriteLine(
+            $"Unexpected response: status={response.StatusCode}, body=\"{response.Content}\"");
+        return 1;
+    }
+}

--- a/base/images/tests/cases/runtime/container-base/test_dotnet/restclient/app.csproj
+++ b/base/images/tests/cases/runtime/container-base/test_dotnet/restclient/app.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>app</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="RestSharp" Version="112.1.0" />
+  </ItemGroup>
+</Project>

--- a/base/images/tests/cases/runtime/container-base/test_dotnet/test_dotnet.py
+++ b/base/images/tests/cases/runtime/container-base/test_dotnet/test_dotnet.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+"""Validate the .NET runtime works on the container-base image.
+
+Uses ``@pytest.mark.dockerfile()`` to build a custom image with the
+.NET SDK installed on top of the image-under-test. The Dockerfile
+publishes a stdlib ``HttpListener`` web app and a RestSharp client
+that communicates with it over localhost.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+EXPECTED_RESPONSE = "Hello World!"
+
+
+@pytest.mark.dockerfile()
+def test_dotnet_version(container_exec_shell) -> None:
+    """.NET runtime must be present and report a version."""
+    result = container_exec_shell("dotnet --version")
+    assert result.exit_code == 0, f"dotnet --version failed: {result.output}"
+
+
+@pytest.mark.dockerfile()
+def test_dotnet_web(assert_http_server, container_exec_shell) -> None:
+    """A .NET server and RestSharp client must communicate over localhost."""
+    assert_http_server(
+        "nohup dotnet /app/webapp/app.dll > /tmp/server.log 2>&1 &",
+        "http://localhost:8080/",
+        EXPECTED_RESPONSE,
+    )
+    result = container_exec_shell("dotnet /app/restclient/app.dll")
+    assert result.exit_code == 0, f"dotnet app failed: {result.output}"
+    assert "RestSharp reached the .NET server." in result.output

--- a/base/images/tests/cases/runtime/container-base/test_dotnet/webapp/Program.cs
+++ b/base/images/tests/cases/runtime/container-base/test_dotnet/webapp/Program.cs
@@ -1,0 +1,18 @@
+// Minimal HttpListener server used to validate the .NET runtime.
+using System.Net;
+using System.Text;
+
+var body = "Hello World!";
+var listener = new HttpListener();
+listener.Prefixes.Add("http://*:8080/");
+listener.Start();
+
+while (true)
+{
+    var context = listener.GetContext();
+    var buffer = Encoding.UTF8.GetBytes(body);
+    context.Response.ContentType = "text/plain";
+    context.Response.ContentLength64 = buffer.Length;
+    context.Response.OutputStream.Write(buffer, 0, buffer.Length);
+    context.Response.Close();
+}

--- a/base/images/tests/cases/runtime/container-base/test_dotnet/webapp/app.csproj
+++ b/base/images/tests/cases/runtime/container-base/test_dotnet/webapp/app.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>app</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Add dotnet-10.0 runtime tests for 4.0, this is a rework of our older base and base extended container tests, renamed to reflect it's true nature.