### PR TITLE
rdma-core: enable and package the MANA userspace provider (libmana)

### DIFF
--- a/SPECS/rdma-core/0001-enable-mana-provider.patch
+++ b/SPECS/rdma-core/0001-enable-mana-provider.patch
@@ -1,0 +1,42 @@
+From d3ee27cdf7e7e8a369480a776e76c35efc3bbb10 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Thu, 9 Jul 2026 13:27:44 +0000
+Subject: [PATCH] Enable the MANA userspace provider (libmana)
+
+The MLNX_OFED source tarball disables most providers by wrapping their
+add_subdirectory() calls in `if (0)` blocks, keeping only efa, mlx4 and
+mlx5. As a result libmana.so was never built or shipped, even though the
+libibverbs package declares a virtual `Provides: libmana`.
+
+Move providers/mana out of the disabled block (alongside efa) so the
+shared provider library libmana.so.1 is compiled and installed. The
+mana/man documentation stays disabled, matching efa/mlx4.
+
+Signed-off-by: Kshitiz Godara <kgodara@microsoft.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2a60422..ab5cf00 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -736,6 +736,7 @@ add_subdirectory(providers/bnxt_re)
+ add_subdirectory(providers/cxgb4) # NO SPARSE
+ endif()
+ add_subdirectory(providers/efa)
++add_subdirectory(providers/mana)
+ if (0)
+ add_subdirectory(providers/efa/man)
+ add_subdirectory(providers/erdma)
+@@ -743,7 +744,6 @@ add_subdirectory(providers/hns)
+ add_subdirectory(providers/hns/man)
+ add_subdirectory(providers/ionic)
+ add_subdirectory(providers/irdma)
+-add_subdirectory(providers/mana)
+ add_subdirectory(providers/mana/man)
+ endif()
+ add_subdirectory(providers/mlx4)
+-- 
+2.53.0
+

--- a/SPECS/rdma-core/0001-providers-mana-do-not-check-cqid-on-creation.patch
+++ b/SPECS/rdma-core/0001-providers-mana-do-not-check-cqid-on-creation.patch
@@ -1,0 +1,40 @@
+From c228c1c98315d529318aa31be1fcc85bbae2d130 Mon Sep 17 00:00:00 2001
+From: Konstantin Taranov <kotaranov@microsoft.com>
+Date: Wed, 24 Dec 2025 11:27:52 +0100
+Subject: [PATCH 1/7] providers/mana: do not check cqid on creation
+
+Do not check whether cqid is assigned as mana_ib
+over ethernet assigns it later at QP creation.
+
+Signed-off-by: Konstantin Taranov <kotaranov@microsoft.com>
+---
+ providers/mana/cq.c | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/providers/mana/cq.c b/providers/mana/cq.c
+index 1d2396a..d481d86 100644
+--- a/providers/mana/cq.c
++++ b/providers/mana/cq.c
+@@ -84,18 +84,10 @@ struct ibv_cq *mana_create_cq(struct ibv_context *context, int cqe,
+ 		goto free_mem;
+ 	}
+ 
+-	if (flags & MANA_IB_CREATE_RNIC_CQ) {
+-		cq->cqid = resp.cqid;
+-		if (cq->cqid == UINT32_MAX) {
+-			errno = ENODEV;
+-			goto destroy_cq;
+-		}
+-	}
++	cq->cqid = resp.cqid;
+ 
+ 	return &cq->ibcq;
+ 
+-destroy_cq:
+-	ibv_cmd_destroy_cq(&cq->ibcq);
+ free_mem:
+ 	if (cq->buf_external)
+ 		ctx->extern_alloc.free(cq->buf, ctx->extern_alloc.data);
+-- 
+2.45.4
+

--- a/SPECS/rdma-core/0002-providers-mana-Device-memory.patch
+++ b/SPECS/rdma-core/0002-providers-mana-Device-memory.patch
@@ -1,0 +1,134 @@
+From 6f8427b10d8afdc2ad717eb32f71e710d850560c Mon Sep 17 00:00:00 2001
+From: Konstantin Taranov <kotaranov@microsoft.com>
+Date: Fri, 14 Nov 2025 15:10:54 +0100
+Subject: [PATCH 2/7] providers/mana: Device memory
+
+Basic implementation of DM allowing to create and register
+DM memory and use its memory keys for networking.
+
+Signed-off-by: Konstantin Taranov <kotaranov@microsoft.com>
+---
+ providers/mana/mana.c | 67 +++++++++++++++++++++++++++++++++++++++++++
+ providers/mana/mana.h |  7 +++++
+ 2 files changed, 74 insertions(+)
+
+diff --git a/providers/mana/mana.c b/providers/mana/mana.c
+index 00636b7..a8091fa 100644
+--- a/providers/mana/mana.c
++++ b/providers/mana/mana.c
+@@ -258,6 +258,70 @@ int mana_dereg_mr(struct verbs_mr *vmr)
+ 	return 0;
+ }
+ 
++struct ibv_dm *mana_alloc_dm(struct ibv_context *context,
++			     struct ibv_alloc_dm_attr *dm_attr)
++{
++	struct verbs_dm *dm;
++	int ret;
++
++	dm = malloc(sizeof(*dm));
++	if (!dm)
++		return NULL;
++
++	ret = ibv_cmd_alloc_dm(context, dm_attr, dm, NULL);
++	if (ret) {
++		verbs_err(verbs_get_ctx(context),
++			  "Failed to alloc DM\n");
++		errno = ret;
++		free(dm);
++		return NULL;
++	}
++
++	return &dm->dm;
++}
++
++int mana_free_dm(struct ibv_dm *ibdm)
++{
++	struct verbs_dm *dm = container_of(ibdm, struct verbs_dm, dm);
++	int ret;
++
++	ret = ibv_cmd_free_dm(dm);
++	if (ret) {
++		verbs_err(verbs_get_ctx(ibdm->context), "Failed to free DM\n");
++		return ret;
++	}
++
++	free(dm);
++	return 0;
++}
++
++struct ibv_mr *mana_reg_dm_mr(struct ibv_pd *pd, struct ibv_dm *ibdm,
++			      uint64_t dm_offset, size_t length,
++			      unsigned int acc)
++{
++	struct verbs_dm *dm = container_of(ibdm, struct verbs_dm, dm);
++	struct verbs_mr *vmr;
++	int ret;
++
++	vmr = calloc(1, sizeof(*vmr));
++	if (!vmr) {
++		errno = ENOMEM;
++		return NULL;
++	}
++
++	ret = ibv_cmd_reg_dm_mr(pd, dm, dm_offset, length, acc,
++				vmr, NULL);
++	if (ret) {
++		verbs_err(verbs_get_ctx(pd->context),
++			  "Failed to register DM MR\n");
++		errno = ret;
++		free(vmr);
++		return NULL;
++	}
++
++	return &vmr->ibv_mr;
++}
++
+ static void mana_free_context(struct ibv_context *ibctx)
+ {
+ 	struct mana_context *context = to_mctx(ibctx);
+@@ -296,6 +360,7 @@ static void mana_async_event(struct ibv_context *context,
+ 
+ static const struct verbs_context_ops mana_ctx_ops = {
+ 	.alloc_pd = mana_alloc_pd,
++	.alloc_dm = mana_alloc_dm,
+ 	.async_event = mana_async_event,
+ 	.alloc_parent_domain = mana_alloc_parent_domain,
+ 	.create_cq = mana_create_cq,
+@@ -310,6 +375,7 @@ static const struct verbs_context_ops mana_ctx_ops = {
+ 	.destroy_rwq_ind_table = mana_destroy_rwq_ind_table,
+ 	.destroy_wq = mana_destroy_wq,
+ 	.free_context = mana_free_context,
++	.free_dm = mana_free_dm,
+ 	.modify_wq = mana_modify_wq,
+ 	.modify_qp = mana_modify_qp,
+ 	.poll_cq = mana_poll_cq,
+@@ -318,6 +384,7 @@ static const struct verbs_context_ops mana_ctx_ops = {
+ 	.query_device_ex = mana_query_device_ex,
+ 	.query_port = mana_query_port,
+ 	.reg_dmabuf_mr = mana_reg_dmabuf_mr,
++	.reg_dm_mr = mana_reg_dm_mr,
+ 	.reg_mr = mana_reg_mr,
+ 	.req_notify_cq = mana_arm_cq,
+ };
+diff --git a/providers/mana/mana.h b/providers/mana/mana.h
+index 597e33b..6f4e742 100644
+--- a/providers/mana/mana.h
++++ b/providers/mana/mana.h
+@@ -206,6 +206,13 @@ struct ibv_mr *mana_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+ struct ibv_mr *mana_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+ 			   uint64_t hca_va, int access);
+ 
++struct ibv_dm *mana_alloc_dm(struct ibv_context *context,
++			     struct ibv_alloc_dm_attr *dm_attr);
++int mana_free_dm(struct ibv_dm *ibdm);
++struct ibv_mr *mana_reg_dm_mr(struct ibv_pd *pd, struct ibv_dm *ibdm,
++			      uint64_t dm_offset, size_t length,
++			      unsigned int acc);
++
+ int mana_dereg_mr(struct verbs_mr *vmr);
+ 
+ struct ibv_cq *mana_create_cq(struct ibv_context *context, int cqe,
+-- 
+2.45.4
+

--- a/SPECS/rdma-core/0003-providers-mana-Optimize-poll-completion-path.patch
+++ b/SPECS/rdma-core/0003-providers-mana-Optimize-poll-completion-path.patch
@@ -1,0 +1,789 @@
+From 26b4433b3039a380d402e70468a95b0788feaf03 Mon Sep 17 00:00:00 2001
+From: Shiraz Saleem <shirazsaleem@microsoft.com>
+Date: Wed, 18 Jun 2025 19:03:38 -0500
+Subject: [PATCH 3/7] providers/mana: Optimize poll completion path
+
+Performance profiling on ibv_poll_cq shows 2 issues:
+
+1. 0-CQE shows latency that is O(QP_count)
+2. We have hotpaths in mana_poll_cq that point to our list walks
+--48.29%--mana_poll_cq
+               |--20.68%--mana_process_completions (inlined)
+               |--15.89%--mana_flush_completions (inlined)
+
+Re-design mana poll completion to greedily return WC as and when they
+are available by indexing into the shadow-queue of the QP for this CQE.
+This avoids expensive list walk of all healthy QPs to find the shadow
+queue in mana_process_completions.
+
+Additionally maintain an error qp list to walk for CQEs in error to
+flush.
+
+Improvements in performance measured as avg-latency/CQE for 64 QPs, and
+poll batch size = 32 via ib_write_bw
+Before,
+CQE (ne>=1): 512.4 ns
+CQE (ne==0): 292.3 ns
+
+After,
+CQE (ne>=1): 344 ns
+CQE (ne==0): 32.7 ns
+
+Signed-off-by: Konstantin Taranov <kotaranov@microsoft.com>
+Signed-off-by: Shiraz Saleem <shirazsaleem@microsoft.com>
+---
+ providers/mana/cq.c           | 430 +++++++++++++++++++---------------
+ providers/mana/mana.h         |  17 +-
+ providers/mana/qp.c           |  20 +-
+ providers/mana/shadow_queue.h |  32 +--
+ 4 files changed, 273 insertions(+), 226 deletions(-)
+
+diff --git a/providers/mana/cq.c b/providers/mana/cq.c
+index d481d86..8683e03 100644
+--- a/providers/mana/cq.c
++++ b/providers/mana/cq.c
+@@ -27,6 +27,100 @@
+ DECLARE_DRV_CMD(mana_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+ 		mana_ib_create_cq, mana_ib_create_cq_resp);
+ 
++static enum ibv_wc_status vendor_error_to_wc_error(uint32_t vendor_error)
++{
++	switch (vendor_error) {
++	case VENDOR_ERR_OK:
++		return IBV_WC_SUCCESS;
++	case VENDOR_ERR_RX_PKT_LEN:
++	case VENDOR_ERR_RX_MSG_LEN_OVFL:
++	case VENDOR_ERR_RX_READRESP_LEN_MISMATCH:
++		return IBV_WC_LOC_LEN_ERR;
++	case VENDOR_ERR_TX_GDMA_CORRUPTED_WQE:
++	case VENDOR_ERR_TX_PCIE_WQE:
++	case VENDOR_ERR_TX_PCIE_MSG:
++	case VENDOR_ERR_RX_MALFORMED_WQE:
++	case VENDOR_ERR_TX_GDMA_INVALID_STATE:
++	case VENDOR_ERR_TX_MISBEHAVING_CLIENT:
++	case VENDOR_ERR_TX_RDMA_MALFORMED_WQE_SIZE:
++	case VENDOR_ERR_TX_RDMA_MALFORMED_WQE_FIELD:
++	case VENDOR_ERR_TX_RDMA_WQE_UNSUPPORTED:
++	case VENDOR_ERR_TX_RDMA_WQE_LEN_ERR:
++	case VENDOR_ERR_TX_RDMA_MTU_ERR:
++		return IBV_WC_LOC_QP_OP_ERR;
++	case VENDOR_ERR_TX_ATB_MSG_ACCESS_VIOLATION:
++	case VENDOR_ERR_TX_ATB_MSG_ADDR_RANGE:
++	case VENDOR_ERR_TX_ATB_MSG_CONFIG_ERR:
++	case VENDOR_ERR_TX_ATB_WQE_ACCESS_VIOLATION:
++	case VENDOR_ERR_TX_ATB_WQE_ADDR_RANGE:
++	case VENDOR_ERR_TX_ATB_WQE_CONFIG_ERR:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_MISS:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_IDX_ERROR:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_TAG_MISMATCH_ERROR:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_PDID_MISMATCH_ERROR:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_AR_ERROR:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_PT_OVF:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_PT_LENGHT_MISMATCH:
++	case VENDOR_ERR_TX_RDMA_ATB_CMD_ILLEGAL_CMD:
++	case VENDOR_ERR_RX_ATB_SGE_ADDR_RANGE:
++	case VENDOR_ERR_RX_ATB_SGE_MISSCONFIG:
++		return IBV_WC_LOC_PROT_ERR;
++	case VENDOR_ERR_RX_ATB_SGE_ADDR_RIGHT:
++	case VENDOR_ERR_RX_GFID:
++		return IBV_WC_LOC_ACCESS_ERR;
++	case VENDOR_ERR_RX_OP_REQ:
++		return IBV_WC_REM_INV_REQ_ERR;
++	case VENDOR_ERR_RX_ATB_RKEY_MISCONFIG_ERR:
++	case VENDOR_ERR_RX_ATB_RKEY_ADDR_RIGHT:
++	case VENDOR_ERR_RX_ATB_RKEY_ADDR_RANGE:
++	case VENDOR_ERR_RX_REMOTE_ACCESS_NAK:
++		return IBV_WC_REM_ACCESS_ERR;
++	case VENDOR_ERR_RX_INVALID_REQ_NAK:
++	case VENDOR_ERR_RX_REMOTE_OP_ERR_NAK:
++		return IBV_WC_REM_OP_ERR;
++	case VENDOR_ERR_RX_MISBEHAVING_CLIENT:
++	case VENDOR_ERR_RX_CLIENT_ID:
++	case VENDOR_ERR_RX_PCIE:
++	case VENDOR_ERR_RX_NO_AVAIL_WQE:
++	case VENDOR_ERR_RX_ATB_WQE_MISCONFIG:
++	case VENDOR_ERR_RX_ATB_WQE_ADDR_RIGHT:
++	case VENDOR_ERR_RX_ATB_WQE_ADDR_RANGE:
++	case VENDOR_ERR_TX_RDMA_INVALID_STATE:
++	case VENDOR_ERR_TX_RDMA_INVALID_NPT:
++	case VENDOR_ERR_TX_RDMA_INVALID_SGID:
++	case VENDOR_ERR_TX_RDMA_VFID_MISMATCH:
++		return IBV_WC_FATAL_ERR;
++	case VENDOR_ERR_RX_NOT_EMPTY_ON_DISABLE:
++	case VENDOR_ERR_SW_FLUSHED:
++		return IBV_WC_WR_FLUSH_ERR;
++	case VENDOR_ERR_TX_RETRY_LIMIT_EXCEEDED:
++		return IBV_WC_RETRY_EXC_ERR;
++	case VENDOR_ERR_RX_RNR_NAK:
++		return IBV_WC_RNR_RETRY_EXC_ERR;
++	default:
++		return IBV_WC_GENERAL_ERR;
++	}
++}
++
++static void fill_verbs_from_shadow_wqe(struct mana_qp *qp, struct ibv_wc *wc,
++				       const struct shadow_wqe_header *shadow_wqe)
++{
++	const struct rc_rq_shadow_wqe *rc_wqe = (const struct rc_rq_shadow_wqe *)shadow_wqe;
++
++	wc->wr_id = shadow_wqe->wr_id;
++	wc->status = vendor_error_to_wc_error(shadow_wqe->vendor_error);
++	wc->opcode = shadow_wqe->opcode;
++	wc->vendor_err = shadow_wqe->vendor_error;
++	wc->wc_flags = shadow_wqe->flags;
++	wc->qp_num = qp->ibqp.qp.qp_num;
++	wc->pkey_index = 0;
++
++	if (shadow_wqe->opcode & IBV_WC_RECV) {
++		wc->byte_len = rc_wqe->byte_len;
++		wc->imm_data = htobe32(rc_wqe->imm_or_rkey);
++	}
++}
++
+ struct ibv_cq *mana_create_cq(struct ibv_context *context, int cqe,
+ 			      struct ibv_comp_channel *channel, int comp_vector)
+ {
+@@ -45,8 +139,8 @@ struct ibv_cq *mana_create_cq(struct ibv_context *context, int cqe,
+ 
+ 	cq_size = align_hw_size(cqe * COMP_ENTRY_SIZE);
+ 	cq->db_page = ctx->db_page;
+-	list_head_init(&cq->send_qp_list);
+-	list_head_init(&cq->recv_qp_list);
++	list_head_init(&cq->send_err_qp_list);
++	list_head_init(&cq->recv_err_qp_list);
+ 	pthread_spin_init(&cq->lock, PTHREAD_PROCESS_PRIVATE);
+ 
+ 	cq->buf_external = ctx->extern_alloc.alloc && ctx->extern_alloc.free;
+@@ -152,17 +246,20 @@ static inline bool get_next_signal_psn(struct mana_qp *qp, uint32_t *psn)
+ 	return true;
+ }
+ 
+-static inline void advance_send_completions(struct mana_qp *qp, uint32_t psn)
++static inline int advance_send_completions(struct mana_qp *qp, uint32_t psn,
++					   struct ibv_wc *wc, int nwc)
+ {
+ 	struct mana_gdma_queue *recv_queue = &qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER];
+ 	struct mana_gdma_queue *send_queue = &qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER];
+ 	struct rc_sq_shadow_wqe *shadow_wqe;
++	int produced = 0;
+ 
+ 	if (!PSN_LT(psn, qp->rc_qp.sq_psn))
+-		return;
++		return 0;
+ 
+-	while ((shadow_wqe = (struct rc_sq_shadow_wqe *)
+-		shadow_queue_get_next_to_complete(&qp->shadow_sq)) != NULL) {
++	while (produced < nwc &&
++	       (shadow_wqe = (struct rc_sq_shadow_wqe *)
++		shadow_queue_get_next_to_consume(&qp->shadow_sq)) != NULL) {
+ 		if (PSN_LT(psn, shadow_wqe->end_psn))
+ 			break;
+ 
+@@ -172,46 +269,69 @@ static inline void advance_send_completions(struct mana_qp *qp, uint32_t psn)
+ 		recv_queue->cons_idx += shadow_wqe->read_posted_wqe_size_in_bu;
+ 		recv_queue->cons_idx &= GDMA_QUEUE_OFFSET_MASK;
+ 
++		if (shadow_wqe->header.flags != MANA_NO_SIGNAL_WC) {
++			fill_verbs_from_shadow_wqe(qp, &wc[produced], &shadow_wqe->header);
++			produced++;
++		}
++
+ 		uint32_t offset = shadow_wqe->header.unmasked_queue_offset +
+ 				  shadow_wqe->header.posted_wqe_size_in_bu;
+ 		mana_ib_update_shared_mem_left_offset(qp, offset & GDMA_QUEUE_OFFSET_MASK);
+ 
+-		shadow_queue_advance_next_to_complete(&qp->shadow_sq);
++		shadow_queue_advance_consumer(&qp->shadow_sq);
+ 	}
++
++	return produced;
+ }
+ 
+-static inline void handle_rc_requester_cqe(struct mana_qp *qp, struct gdma_cqe *cqe)
++static inline int handle_rc_requester_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
++				  struct ibv_wc *wc, int nwc, bool *consumed)
+ {
+ 	struct mana_gdma_queue *recv_queue = &qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER];
+ 	uint32_t syndrome = cqe->rdma_cqe.rc_armed_completion.syndrome;
+ 	uint32_t psn = cqe->rdma_cqe.rc_armed_completion.psn;
+ 	uint32_t arm_psn;
++	int produced = 0;
+ 
+ 	if (!IB_IS_ACK(syndrome))
+-		return;
++		return 0;
+ 
+-	advance_send_completions(qp, psn);
++	produced = advance_send_completions(qp, psn, wc, nwc);
+ 
+ 	if (!get_next_signal_psn(qp, &arm_psn))
+ 		arm_psn = PSN_INC(psn);
+ 
+ 	gdma_arm_normal_cqe(recv_queue, arm_psn);
++
++	struct rc_sq_shadow_wqe *next = (struct rc_sq_shadow_wqe *)
++		shadow_queue_get_next_to_consume(&qp->shadow_sq);
++	if (!next)
++		*consumed = true;
++	else
++		*consumed = PSN_LT(psn, next->end_psn);
++
++	return produced;
+ }
+ 
+-static inline void handle_rc_responder_cqe(struct mana_qp *qp, struct gdma_cqe *cqe)
++static inline int handle_rc_responder_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
++					  struct ibv_wc *wc)
+ {
+ 	struct mana_gdma_queue *recv_queue = &qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER];
+ 	struct rc_rq_shadow_wqe *shadow_wqe;
+ 
+-	shadow_wqe = (struct rc_rq_shadow_wqe *)shadow_queue_get_next_to_complete(&qp->shadow_rq);
+-	if (!shadow_wqe)
+-		return;
++	shadow_wqe = (struct rc_rq_shadow_wqe *)shadow_queue_get_next_to_consume(&qp->shadow_rq);
++	if (!shadow_wqe) {
++		verbs_warn_datapath(verbs_get_ctx(qp->ibqp.qp.context),
++				    "responder CQE wqid=%u qp_num=%u: shadow_wqe not found\n",
++				    cqe->wqid, qp->ibqp.qp.qp_num);
++		return 0;
++	}
+ 
+ 	uint32_t offset_cqe = cqe->rdma_cqe.rc_recv.rx_wqe_offset / GDMA_WQE_ALIGNMENT_UNIT_SIZE;
+ 	uint32_t offset_wqe = shadow_wqe->header.unmasked_queue_offset & GDMA_QUEUE_OFFSET_MASK;
+ 
+ 	if (offset_cqe != offset_wqe)
+-		return;
++		return 0;
+ 
+ 	shadow_wqe->byte_len = cqe->rdma_cqe.rc_recv.msg_len;
+ 	shadow_wqe->imm_or_rkey = cqe->rdma_cqe.rc_recv.imm_data;
+@@ -233,7 +353,11 @@ static inline void handle_rc_responder_cqe(struct mana_qp *qp, struct gdma_cqe *
+ 	recv_queue->cons_idx += shadow_wqe->header.posted_wqe_size_in_bu;
+ 	recv_queue->cons_idx &= GDMA_QUEUE_OFFSET_MASK;
+ 
+-	shadow_queue_advance_next_to_complete(&qp->shadow_rq);
++	fill_verbs_from_shadow_wqe(qp, wc, &shadow_wqe->header);
++
++	shadow_queue_advance_consumer(&qp->shadow_rq);
++
++	return 1;
+ }
+ 
+ static inline bool error_cqe_is_send(struct mana_qp *qp, struct gdma_cqe *cqe)
+@@ -253,40 +377,78 @@ static inline uint32_t error_cqe_get_psn(struct gdma_cqe *cqe)
+ 	return cqe->rdma_cqe.error.psn;
+ }
+ 
+-static inline void handle_rc_error_cqe(struct mana_qp *qp, struct gdma_cqe *cqe)
++static inline int handle_rc_error_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
++				      struct ibv_wc *wc, int nwc, bool *consumed)
+ {
+-	uint32_t vendor_error = cqe->rdma_cqe.error.vendor_error;
+ 	bool is_send_error = error_cqe_is_send(qp, cqe);
+ 	uint32_t psn = error_cqe_get_psn(cqe);
+ 	struct shadow_queue *queue_with_error;
+ 	struct shadow_wqe_header *shadow_wqe;
+-
+-	mana_qp_move_flush_err(&qp->ibqp.qp);
+-	advance_send_completions(qp, psn);
++	struct mana_cq *cq;
++	int produced = 0;
++
++	if (is_send_error) {
++		/* Return all WCs for end_psn < error_psn */
++		produced = advance_send_completions(qp, PSN_DEC(psn), wc, nwc);
++
++		/* If there is no room left in the WC array, defer reporting the
++		 * error completion and keep this CQE pending.
++		 */
++		if (produced == nwc) {
++			*consumed = false;
++			return produced;
++		}
++	}
+ 
+ 	queue_with_error = is_send_error ? &qp->shadow_sq : &qp->shadow_rq;
+-	shadow_wqe = shadow_queue_get_next_to_complete(queue_with_error);
+ 
+-	if (shadow_wqe) {
+-		shadow_wqe->flags = 0;
+-		shadow_wqe->vendor_error = vendor_error;
+-		shadow_queue_advance_next_to_complete(queue_with_error);
++	shadow_wqe = shadow_queue_get_next_to_consume(queue_with_error);
++
++	if (!shadow_wqe) {
++		verbs_warn_datapath(verbs_get_ctx(qp->ibqp.qp.context),
++				    "error CQE wqid=%u psn=%u is_send=%d vendor_err=%u qp_num=%u: shadow_wqe not found\n",
++				    cqe->wqid, psn, is_send_error,
++				    cqe->rdma_cqe.error.vendor_error, qp->ibqp.qp.qp_num);
++		goto out;
++	}
++
++	shadow_wqe->flags = 0;
++	shadow_wqe->vendor_error = cqe->rdma_cqe.error.vendor_error;
++	fill_verbs_from_shadow_wqe(qp, &wc[produced], shadow_wqe);
++	shadow_queue_advance_consumer(queue_with_error);
++	produced++;
++
++	cq = container_of(is_send_error ? qp->ibqp.qp.send_cq : qp->ibqp.qp.recv_cq,
++			  struct mana_cq, ibcq);
++
++	mana_qp_move_flush_err(&qp->ibqp.qp);
++	if (is_send_error) {
++		list_add_tail(&cq->send_err_qp_list, &qp->send_err_node);
++		qp->on_err_list_send = true;
++	} else {
++		list_add_tail(&cq->recv_err_qp_list, &qp->recv_err_node);
++		qp->on_err_list_recv = true;
+ 	}
++
++out:
++	*consumed = true;
++	return produced;
+ }
+ 
+-static inline void mana_handle_cqe(struct mana_context *ctx, struct gdma_cqe *cqe)
++static inline int mana_handle_cqe(struct mana_context *ctx, struct gdma_cqe *cqe,
++				  struct ibv_wc *wc, int nwc, bool *consumed)
+ {
+ 	struct mana_qp *qp = mana_get_qp(ctx, cqe->wqid, cqe->is_sq);
+ 
+-	if (!qp)
+-		return;
++	if (unlikely(!qp))
++		return 0;
+ 
+ 	if (cqe->rdma_cqe.cqe_type == CQE_TYPE_ERROR)
+-		handle_rc_error_cqe(qp, cqe);
++		return handle_rc_error_cqe(qp, cqe, wc, nwc, consumed);
+ 	else if (cqe->rdma_cqe.cqe_type == CQE_TYPE_ARMED_CMPL)
+-		handle_rc_requester_cqe(qp, cqe);
++		return handle_rc_requester_cqe(qp, cqe, wc, nwc, consumed);
+ 	else
+-		handle_rc_responder_cqe(qp, cqe);
++		return handle_rc_responder_cqe(qp, cqe, wc);
+ }
+ 
+ static inline int gdma_read_cqe(struct mana_cq *cq, struct gdma_cqe *cqe)
+@@ -309,196 +471,88 @@ static inline int gdma_read_cqe(struct mana_cq *cq, struct gdma_cqe *cqe)
+ 	udma_from_device_barrier();
+ 	*cqe = *current_cqe;
+ 	cq->head++;
+-	return 1;
+-}
+ 
+-static enum ibv_wc_status vendor_error_to_wc_error(uint32_t vendor_error)
+-{
+-	switch (vendor_error) {
+-	case VENDOR_ERR_OK:
+-		return IBV_WC_SUCCESS;
+-	case VENDOR_ERR_RX_PKT_LEN:
+-	case VENDOR_ERR_RX_MSG_LEN_OVFL:
+-	case VENDOR_ERR_RX_READRESP_LEN_MISMATCH:
+-		return IBV_WC_LOC_LEN_ERR;
+-	case VENDOR_ERR_TX_GDMA_CORRUPTED_WQE:
+-	case VENDOR_ERR_TX_PCIE_WQE:
+-	case VENDOR_ERR_TX_PCIE_MSG:
+-	case VENDOR_ERR_RX_MALFORMED_WQE:
+-	case VENDOR_ERR_TX_GDMA_INVALID_STATE:
+-	case VENDOR_ERR_TX_MISBEHAVING_CLIENT:
+-	case VENDOR_ERR_TX_RDMA_MALFORMED_WQE_SIZE:
+-	case VENDOR_ERR_TX_RDMA_MALFORMED_WQE_FIELD:
+-	case VENDOR_ERR_TX_RDMA_WQE_UNSUPPORTED:
+-	case VENDOR_ERR_TX_RDMA_WQE_LEN_ERR:
+-	case VENDOR_ERR_TX_RDMA_MTU_ERR:
+-		return IBV_WC_LOC_QP_OP_ERR;
+-	case VENDOR_ERR_TX_ATB_MSG_ACCESS_VIOLATION:
+-	case VENDOR_ERR_TX_ATB_MSG_ADDR_RANGE:
+-	case VENDOR_ERR_TX_ATB_MSG_CONFIG_ERR:
+-	case VENDOR_ERR_TX_ATB_WQE_ACCESS_VIOLATION:
+-	case VENDOR_ERR_TX_ATB_WQE_ADDR_RANGE:
+-	case VENDOR_ERR_TX_ATB_WQE_CONFIG_ERR:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_MISS:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_IDX_ERROR:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_TAG_MISMATCH_ERROR:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_PDID_MISMATCH_ERROR:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_AR_ERROR:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_PT_OVF:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_PT_LENGHT_MISMATCH:
+-	case VENDOR_ERR_TX_RDMA_ATB_CMD_ILLEGAL_CMD:
+-	case VENDOR_ERR_RX_ATB_SGE_ADDR_RANGE:
+-	case VENDOR_ERR_RX_ATB_SGE_MISSCONFIG:
+-		return IBV_WC_LOC_PROT_ERR;
+-	case VENDOR_ERR_RX_ATB_SGE_ADDR_RIGHT:
+-	case VENDOR_ERR_RX_GFID:
+-		return IBV_WC_LOC_ACCESS_ERR;
+-	case VENDOR_ERR_RX_OP_REQ:
+-		return IBV_WC_REM_INV_REQ_ERR;
+-	case VENDOR_ERR_RX_ATB_RKEY_MISCONFIG_ERR:
+-	case VENDOR_ERR_RX_ATB_RKEY_ADDR_RIGHT:
+-	case VENDOR_ERR_RX_ATB_RKEY_ADDR_RANGE:
+-	case VENDOR_ERR_RX_REMOTE_ACCESS_NAK:
+-		return IBV_WC_REM_ACCESS_ERR;
+-	case VENDOR_ERR_RX_INVALID_REQ_NAK:
+-	case VENDOR_ERR_RX_REMOTE_OP_ERR_NAK:
+-		return IBV_WC_REM_OP_ERR;
+-	case VENDOR_ERR_RX_MISBEHAVING_CLIENT:
+-	case VENDOR_ERR_RX_CLIENT_ID:
+-	case VENDOR_ERR_RX_PCIE:
+-	case VENDOR_ERR_RX_NO_AVAIL_WQE:
+-	case VENDOR_ERR_RX_ATB_WQE_MISCONFIG:
+-	case VENDOR_ERR_RX_ATB_WQE_ADDR_RIGHT:
+-	case VENDOR_ERR_RX_ATB_WQE_ADDR_RANGE:
+-	case VENDOR_ERR_TX_RDMA_INVALID_STATE:
+-	case VENDOR_ERR_TX_RDMA_INVALID_NPT:
+-	case VENDOR_ERR_TX_RDMA_INVALID_SGID:
+-	case VENDOR_ERR_TX_RDMA_VFID_MISMATCH:
+-		return IBV_WC_FATAL_ERR;
+-	case VENDOR_ERR_RX_NOT_EMPTY_ON_DISABLE:
+-	case VENDOR_ERR_SW_FLUSHED:
+-		return IBV_WC_WR_FLUSH_ERR;
+-	case VENDOR_ERR_TX_RETRY_LIMIT_EXCEEDED:
+-		return IBV_WC_RETRY_EXC_ERR;
+-	case VENDOR_ERR_RX_RNR_NAK:
+-		return IBV_WC_RNR_RETRY_EXC_ERR;
+-	default:
+-		return IBV_WC_GENERAL_ERR;
+-	}
++	return 1;
+ }
+ 
+-static void fill_verbs_from_shadow_wqe(struct mana_qp *qp, struct ibv_wc *wc,
+-				       const struct shadow_wqe_header *shadow_wqe)
++static int mana_flush_completions_in_err(struct mana_cq *cq, struct ibv_wc *wc, int nwc)
+ {
+-	const struct rc_rq_shadow_wqe *rc_wqe = (const struct rc_rq_shadow_wqe *)shadow_wqe;
+-
+-	wc->wr_id = shadow_wqe->wr_id;
+-	wc->status = vendor_error_to_wc_error(shadow_wqe->vendor_error);
+-	wc->opcode = shadow_wqe->opcode;
+-	wc->vendor_err = shadow_wqe->vendor_error;
+-	wc->wc_flags = shadow_wqe->flags;
+-	wc->qp_num = qp->ibqp.qp.qp_num;
+-	wc->pkey_index = 0;
++	struct shadow_wqe_header *shadow_wqe;
++	struct mana_qp *qp, *tmp;
++	int wc_idx = 0;
+ 
+-	if (shadow_wqe->opcode & IBV_WC_RECV) {
+-		wc->byte_len = rc_wqe->byte_len;
+-		wc->imm_data = htobe32(rc_wqe->imm_or_rkey);
+-	}
+-}
++	list_for_each_safe(&cq->send_err_qp_list, qp, tmp, send_err_node) {
++		while (wc_idx < nwc &&
++		       (shadow_wqe = shadow_queue_get_next_to_consume(&qp->shadow_sq))) {
++			shadow_wqe->vendor_error = VENDOR_ERR_SW_FLUSHED;
++			shadow_wqe->flags = 0;
+ 
+-static int mana_process_completions(struct mana_cq *cq, int nwc, struct ibv_wc *wc)
+-{
+-	struct shadow_wqe_header *shadow_wqe;
+-	struct mana_qp *qp;
+-	int wc_index = 0;
+-
+-	/* process send shadow queue completions  */
+-	list_for_each(&cq->send_qp_list, qp, send_cq_node) {
+-		while ((shadow_wqe = shadow_queue_get_next_to_consume(&qp->shadow_sq))
+-				!= NULL) {
+-			if (wc_index >= nwc && shadow_wqe->flags != MANA_NO_SIGNAL_WC)
+-				goto out;
++			fill_verbs_from_shadow_wqe(qp, &wc[wc_idx], shadow_wqe);
++			wc_idx++;
+ 
+-			if (shadow_wqe->flags != MANA_NO_SIGNAL_WC) {
+-				fill_verbs_from_shadow_wqe(qp, &wc[wc_index], shadow_wqe);
+-				wc_index++;
+-			}
+ 			shadow_queue_advance_consumer(&qp->shadow_sq);
+ 		}
+-	}
+-
+-	/* process recv shadow queue completions */
+-	list_for_each(&cq->recv_qp_list, qp, recv_cq_node) {
+-		while ((shadow_wqe = shadow_queue_get_next_to_consume(&qp->shadow_rq))
+-				!= NULL) {
+-			if (wc_index >= nwc)
+-				goto out;
+ 
+-			fill_verbs_from_shadow_wqe(qp, &wc[wc_index], shadow_wqe);
+-			wc_index++;
+-			shadow_queue_advance_consumer(&qp->shadow_rq);
++		if (shadow_queue_empty(&qp->shadow_sq)) {
++			list_del(&qp->send_err_node);
++			qp->on_err_list_send = false;
+ 		}
+ 	}
+ 
+-out:
+-	return wc_index;
+-}
+-
+-static void mana_flush_completions(struct mana_cq *cq)
+-{
+-	struct shadow_wqe_header *shadow_wqe;
+-	struct mana_qp *qp;
+-
+-	list_for_each(&cq->send_qp_list, qp, send_cq_node) {
+-		if (qp->ibqp.qp.state != IBV_QPS_ERR)
+-			continue;
+-		while ((shadow_wqe = shadow_queue_get_next_to_complete(&qp->shadow_sq))
+-				!= NULL) {
++	list_for_each_safe(&cq->recv_err_qp_list, qp, tmp, recv_err_node) {
++		while (wc_idx < nwc &&
++		       (shadow_wqe = shadow_queue_get_next_to_consume(&qp->shadow_rq))) {
+ 			shadow_wqe->vendor_error = VENDOR_ERR_SW_FLUSHED;
+ 			shadow_wqe->flags = 0;
+-			shadow_queue_advance_next_to_complete(&qp->shadow_sq);
++
++			fill_verbs_from_shadow_wqe(qp, &wc[wc_idx], shadow_wqe);
++			wc_idx++;
++
++			shadow_queue_advance_consumer(&qp->shadow_rq);
+ 		}
+-	}
+ 
+-	list_for_each(&cq->recv_qp_list, qp, recv_cq_node) {
+-		if (qp->ibqp.qp.state != IBV_QPS_ERR)
+-			continue;
+-		while ((shadow_wqe = shadow_queue_get_next_to_complete(&qp->shadow_rq))
+-				!= NULL) {
+-			shadow_wqe->vendor_error = VENDOR_ERR_SW_FLUSHED;
+-			shadow_queue_advance_next_to_complete(&qp->shadow_rq);
++		if (shadow_queue_empty(&qp->shadow_rq)) {
++			list_del(&qp->recv_err_node);
++			qp->on_err_list_recv = false;
+ 		}
+ 	}
++
++	return wc_idx;
+ }
+ 
+ int mana_poll_cq(struct ibv_cq *ibcq, int nwc, struct ibv_wc *wc)
+ {
+ 	struct mana_cq *cq = container_of(ibcq, struct mana_cq, ibcq);
+ 	struct mana_context *ctx = to_mctx(ibcq->context);
+-	struct gdma_cqe gdma_cqe;
+ 	int num_polled = 0;
+-	int ret, i;
++	bool consumed;
++	int ret;
+ 
+ 	pthread_spin_lock(&cq->lock);
+ 
+-	for (i = 0; i < nwc; i++) {
+-		ret = gdma_read_cqe(cq, &gdma_cqe);
+-		if (ret < 0) {
+-			num_polled = -1;
+-			goto out;
++	while (num_polled < nwc) {
++		if (!cq->has_pending_cqe) {
++			ret = gdma_read_cqe(cq, &cq->pending_cqe);
++			if (ret < 0) {
++				num_polled = -1;
++				goto out;
++			}
++			if (ret == 0)
++				break;
++
++			cq->poll_credit--;
++			if (cq->poll_credit == 0)
++				gdma_ring_cq_doorbell(cq, CQ_UNARM_BIT);
+ 		}
+-		if (ret == 0)
+-			break;
+ 
+-		cq->poll_credit--;
+-		if (cq->poll_credit == 0)
+-			gdma_ring_cq_doorbell(cq, CQ_UNARM_BIT);
++		consumed = true;
++		ret = mana_handle_cqe(ctx, &cq->pending_cqe, &wc[num_polled], nwc - num_polled, &consumed);
++		num_polled += ret;
+ 
+-		mana_handle_cqe(ctx, &gdma_cqe);
++		cq->has_pending_cqe = !consumed;
+ 	}
+ 
+-	mana_flush_completions(cq);
+-	num_polled = mana_process_completions(cq, nwc, wc);
++	num_polled += mana_flush_completions_in_err(cq, &wc[num_polled], nwc - num_polled);
+ 
+ out:
+ 	pthread_spin_unlock(&cq->lock);
+diff --git a/providers/mana/mana.h b/providers/mana/mana.h
+index 6f4e742..6769fd5 100644
+--- a/providers/mana/mana.h
++++ b/providers/mana/mana.h
+@@ -9,6 +9,7 @@
+ #include "manadv.h"
+ #include <ccan/minmax.h>
+ #include "shadow_queue.h"
++#include "gdma.h"
+ 
+ #define COMP_ENTRY_SIZE 64
+ #define MANA_IB_TOEPLITZ_HASH_KEY_SIZE_IN_BYTES 40
+@@ -51,6 +52,8 @@ enum user_queue_types {
+ 	USER_RC_QUEUE_TYPE_MAX = 4,
+ };
+ 
++
++
+ static inline uint32_t align_hw_size(uint32_t size)
+ {
+ 	size = roundup_pow_of_two(size);
+@@ -133,8 +136,10 @@ struct mana_qp {
+ 	struct shadow_queue shadow_rq;
+ 	struct shadow_queue shadow_sq;
+ 
+-	struct list_node send_cq_node;
+-	struct list_node recv_cq_node;
++	struct list_node send_err_node;
++	struct list_node recv_err_node;
++	bool on_err_list_send;
++	bool on_err_list_recv;
+ };
+ 
+ struct mana_wq {
+@@ -159,10 +164,10 @@ struct mana_cq {
+ 	uint32_t head;
+ 	uint32_t poll_credit;
+ 	void *db_page;
+-	/* list of qp's that use this cq for send completions */
+-	struct list_head send_qp_list;
+-	/* list of qp's that use this cq for recv completions */
+-	struct list_head recv_qp_list;
++	struct list_head send_err_qp_list;
++	struct list_head recv_err_qp_list;
++	struct gdma_cqe pending_cqe;
++	bool has_pending_cqe;
+ 	bool buf_external;
+ };
+ 
+diff --git a/providers/mana/qp.c b/providers/mana/qp.c
+index cf47ec7..af05e34 100644
+--- a/providers/mana/qp.c
++++ b/providers/mana/qp.c
+@@ -263,8 +263,6 @@ static uint32_t get_queue_size(struct ibv_qp_init_attr *attr, enum user_queue_ty
+ static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
+ 					struct ibv_qp_init_attr *attr)
+ {
+-	struct mana_cq *send_cq = container_of(attr->send_cq, struct mana_cq, ibcq);
+-	struct mana_cq *recv_cq = container_of(attr->recv_cq, struct mana_cq, ibcq);
+ 	struct mana_context *ctx = to_mctx(ibpd->context);
+ 	struct mana_ib_create_rc_qp_resp *qp_resp_drv;
+ 	struct mana_create_rc_qp_resp qp_resp = {};
+@@ -336,14 +334,6 @@ static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
+ 		goto destroy_qp;
+ 	}
+ 
+-	pthread_spin_lock(&send_cq->lock);
+-	list_add(&send_cq->send_qp_list, &qp->send_cq_node);
+-	pthread_spin_unlock(&send_cq->lock);
+-
+-	pthread_spin_lock(&recv_cq->lock);
+-	list_add(&recv_cq->recv_qp_list, &qp->recv_cq_node);
+-	pthread_spin_unlock(&recv_cq->lock);
+-
+ 	return &qp->ibqp.qp;
+ 
+ destroy_qp:
+@@ -446,11 +436,17 @@ static void mana_drain_cqes(struct mana_qp *qp)
+ 	struct mana_cq *recv_cq = container_of(qp->ibqp.qp.recv_cq, struct mana_cq, ibcq);
+ 
+ 	pthread_spin_lock(&send_cq->lock);
+-	list_del(&qp->send_cq_node);
++	if (qp->on_err_list_send) {
++		list_del(&qp->send_err_node);
++		qp->on_err_list_send = false;
++	}
+ 	pthread_spin_unlock(&send_cq->lock);
+ 
+ 	pthread_spin_lock(&recv_cq->lock);
+-	list_del(&qp->recv_cq_node);
++	if (qp->on_err_list_recv) {
++		list_del(&qp->recv_err_node);
++		qp->on_err_list_recv = false;
++	}
+ 	pthread_spin_unlock(&recv_cq->lock);
+ }
+ 
+diff --git a/providers/mana/shadow_queue.h b/providers/mana/shadow_queue.h
+index 4190bcf..a1d18e8 100644
+--- a/providers/mana/shadow_queue.h
++++ b/providers/mana/shadow_queue.h
+@@ -45,7 +45,6 @@ struct rc_rq_shadow_wqe {
+ struct shadow_queue {
+ 	uint64_t prod_idx;
+ 	uint64_t cons_idx;
+-	uint64_t next_to_complete_idx;
+ 	uint64_t next_to_signal_idx;
+ 	uint32_t length;
+ 	uint32_t stride;
+@@ -56,7 +55,6 @@ static inline void reset_shadow_queue(struct shadow_queue *queue)
+ {
+ 	queue->prod_idx = 0;
+ 	queue->cons_idx = 0;
+-	queue->next_to_complete_idx = 0;
+ 	queue->next_to_signal_idx = 0;
+ }
+ 
+@@ -90,6 +88,14 @@ static inline bool shadow_queue_full(struct shadow_queue *queue)
+ 	return (prod_idx - cons_idx) >= queue->length;
+ }
+ 
++static inline bool shadow_queue_empty(struct shadow_queue *queue)
++{
++	uint64_t prod_idx = atomic_load_explicit(producer(queue), memory_order_acquire);
++	uint64_t cons_idx = atomic_load_explicit(consumer(queue), memory_order_relaxed);
++
++	return (prod_idx == cons_idx);
++}
++
+ static inline struct shadow_wqe_header *
+ shadow_queue_producer_entry(struct shadow_queue *queue)
+ {
+@@ -116,36 +122,22 @@ static inline struct shadow_wqe_header *
+ shadow_queue_get_next_to_consume(struct shadow_queue *queue)
+ {
+ 	uint64_t cons_idx = atomic_load_explicit(consumer(queue), memory_order_relaxed);
+-
+-	if (cons_idx == queue->next_to_complete_idx)
+-		return NULL;
+-
+-	return shadow_queue_get_element(queue, cons_idx);
+-}
+-
+-static inline struct shadow_wqe_header *
+-shadow_queue_get_next_to_complete(struct shadow_queue *queue)
+-{
+ 	uint64_t prod_idx = atomic_load_explicit(producer(queue), memory_order_acquire);
+ 
+-	if (queue->next_to_complete_idx == prod_idx)
++	if (cons_idx == prod_idx)
+ 		return NULL;
+ 
+-	return shadow_queue_get_element(queue, queue->next_to_complete_idx);
+-}
+-
+-static inline void shadow_queue_advance_next_to_complete(struct shadow_queue *queue)
+-{
+-	queue->next_to_complete_idx++;
++	return shadow_queue_get_element(queue, cons_idx);
+ }
+ 
+ static inline struct shadow_wqe_header *
+ shadow_queue_get_next_to_signal(struct shadow_queue *queue)
+ {
+ 	uint64_t prod_idx = atomic_load_explicit(producer(queue), memory_order_acquire);
++	uint64_t cons_idx = atomic_load_explicit(consumer(queue), memory_order_relaxed);
+ 	struct shadow_wqe_header *wqe = NULL;
+ 
+-	queue->next_to_signal_idx = max(queue->next_to_signal_idx, queue->next_to_complete_idx);
++	queue->next_to_signal_idx = max(queue->next_to_signal_idx, cons_idx);
+ 	while (queue->next_to_signal_idx < prod_idx) {
+ 		wqe = shadow_queue_get_element(queue, queue->next_to_signal_idx);
+ 		queue->next_to_signal_idx++;
+-- 
+2.45.4
+

--- a/SPECS/rdma-core/0004-providers-mana-Retrieve-queue-type-from-queue-ID.patch
+++ b/SPECS/rdma-core/0004-providers-mana-Retrieve-queue-type-from-queue-ID.patch
@@ -1,0 +1,295 @@
+From 149c517040e01a4153dbdaefffe1cae05b2fa42d Mon Sep 17 00:00:00 2001
+From: Konstantin Taranov <kotaranov@microsoft.com>
+Date: Wed, 17 Dec 2025 15:57:00 +0100
+Subject: [PATCH 4/7] providers/mana: Retrieve queue type from queue ID
+
+Use the two least significant bits of the queue ID to identify
+the queue type. This simplifies QP lookup during CQE processing.
+Use helper functions to retrieve the required queue for QPs.
+
+Signed-off-by: Konstantin Taranov <kotaranov@microsoft.com>
+---
+ providers/mana/cq.c   | 40 ++++++++++++++++++----------------------
+ providers/mana/mana.h | 22 +++++++++++++++++++++-
+ providers/mana/qp.c   | 41 ++++++++++++++---------------------------
+ providers/mana/wr.c   | 11 ++++++-----
+ 4 files changed, 59 insertions(+), 55 deletions(-)
+
+diff --git a/providers/mana/cq.c b/providers/mana/cq.c
+index 8683e03..372c503 100644
+--- a/providers/mana/cq.c
++++ b/providers/mana/cq.c
+@@ -249,8 +249,8 @@ static inline bool get_next_signal_psn(struct mana_qp *qp, uint32_t *psn)
+ static inline int advance_send_completions(struct mana_qp *qp, uint32_t psn,
+ 					   struct ibv_wc *wc, int nwc)
+ {
+-	struct mana_gdma_queue *recv_queue = &qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER];
+-	struct mana_gdma_queue *send_queue = &qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER];
++	struct mana_gdma_queue *recv_queue = mana_ib_get_rreq(qp);
++	struct mana_gdma_queue *send_queue = mana_ib_get_sreq(qp);
+ 	struct rc_sq_shadow_wqe *shadow_wqe;
+ 	int produced = 0;
+ 
+@@ -285,9 +285,9 @@ static inline int advance_send_completions(struct mana_qp *qp, uint32_t psn,
+ }
+ 
+ static inline int handle_rc_requester_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
+-				  struct ibv_wc *wc, int nwc, bool *consumed)
++					  struct ibv_wc *wc, int nwc, bool *consumed)
+ {
+-	struct mana_gdma_queue *recv_queue = &qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER];
++	struct mana_gdma_queue *recv_queue = mana_ib_get_rreq(qp);
+ 	uint32_t syndrome = cqe->rdma_cqe.rc_armed_completion.syndrome;
+ 	uint32_t psn = cqe->rdma_cqe.rc_armed_completion.psn;
+ 	uint32_t arm_psn;
+@@ -313,10 +313,10 @@ static inline int handle_rc_requester_cqe(struct mana_qp *qp, struct gdma_cqe *c
+ 	return produced;
+ }
+ 
+-static inline int handle_rc_responder_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
+-					  struct ibv_wc *wc)
++static inline int handle_responder_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
++				       struct ibv_wc *wc)
+ {
+-	struct mana_gdma_queue *recv_queue = &qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER];
++	struct mana_gdma_queue *recv_queue = mana_ib_get_rresp(qp);
+ 	struct rc_rq_shadow_wqe *shadow_wqe;
+ 
+ 	shadow_wqe = (struct rc_rq_shadow_wqe *)shadow_queue_get_next_to_consume(&qp->shadow_rq);
+@@ -360,16 +360,12 @@ static inline int handle_rc_responder_cqe(struct mana_qp *qp, struct gdma_cqe *c
+ 	return 1;
+ }
+ 
+-static inline bool error_cqe_is_send(struct mana_qp *qp, struct gdma_cqe *cqe)
++static inline bool error_cqe_is_send(struct gdma_cqe *cqe)
+ {
+-	if (cqe->is_sq &&
+-	    qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER].id == cqe->wqid)
+-		return true;
+-	if (!cqe->is_sq &&
+-	    qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id == cqe->wqid)
+-		return true;
+-
+-	return false;
++	if (cqe->is_sq)
++		return ((cqe->wqid & QUEUE_TYPE_MASK) != QUEUE_TYPE_SRESP);
++
++	return ((cqe->wqid & QUEUE_TYPE_MASK) == QUEUE_TYPE_RREQ);
+ }
+ 
+ static inline uint32_t error_cqe_get_psn(struct gdma_cqe *cqe)
+@@ -377,10 +373,10 @@ static inline uint32_t error_cqe_get_psn(struct gdma_cqe *cqe)
+ 	return cqe->rdma_cqe.error.psn;
+ }
+ 
+-static inline int handle_rc_error_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
+-				      struct ibv_wc *wc, int nwc, bool *consumed)
++static inline int handle_error_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
++				   struct ibv_wc *wc, int nwc, bool *consumed)
+ {
+-	bool is_send_error = error_cqe_is_send(qp, cqe);
++	bool is_send_error = error_cqe_is_send(cqe);
+ 	uint32_t psn = error_cqe_get_psn(cqe);
+ 	struct shadow_queue *queue_with_error;
+ 	struct shadow_wqe_header *shadow_wqe;
+@@ -438,17 +434,17 @@ out:
+ static inline int mana_handle_cqe(struct mana_context *ctx, struct gdma_cqe *cqe,
+ 				  struct ibv_wc *wc, int nwc, bool *consumed)
+ {
+-	struct mana_qp *qp = mana_get_qp(ctx, cqe->wqid, cqe->is_sq);
++	struct mana_qp *qp = mana_get_qp(ctx, cqe->wqid & (~QUEUE_TYPE_MASK), cqe->is_sq);
+ 
+ 	if (unlikely(!qp))
+ 		return 0;
+ 
+ 	if (cqe->rdma_cqe.cqe_type == CQE_TYPE_ERROR)
+-		return handle_rc_error_cqe(qp, cqe, wc, nwc, consumed);
++		return handle_error_cqe(qp, cqe, wc, nwc, consumed);
+ 	else if (cqe->rdma_cqe.cqe_type == CQE_TYPE_ARMED_CMPL)
+ 		return handle_rc_requester_cqe(qp, cqe, wc, nwc, consumed);
+ 	else
+-		return handle_rc_responder_cqe(qp, cqe, wc);
++		return handle_responder_cqe(qp, cqe, wc);
+ }
+ 
+ static inline int gdma_read_cqe(struct mana_cq *cq, struct gdma_cqe *cqe)
+diff --git a/providers/mana/mana.h b/providers/mana/mana.h
+index 6769fd5..970c302 100644
+--- a/providers/mana/mana.h
++++ b/providers/mana/mana.h
+@@ -52,7 +52,12 @@ enum user_queue_types {
+ 	USER_RC_QUEUE_TYPE_MAX = 4,
+ };
+ 
+-
++#define QUEUE_TYPE_MASK 0x3
++#define QUEUE_TYPE_SREQ 0x0
++#define QUEUE_TYPE_SRESP 0x1
++#define QUEUE_TYPE_SMMQ 0x2
++#define QUEUE_TYPE_RRESP 0x0
++#define QUEUE_TYPE_RREQ 0x1
+ 
+ static inline uint32_t align_hw_size(uint32_t size)
+ {
+@@ -142,6 +147,21 @@ struct mana_qp {
+ 	bool on_err_list_recv;
+ };
+ 
++static inline struct mana_gdma_queue *mana_ib_get_rresp(struct mana_qp *qp)
++{
++	return &qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER];
++}
++
++static inline struct mana_gdma_queue *mana_ib_get_rreq(struct mana_qp *qp)
++{
++	return &qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER];
++}
++
++static inline struct mana_gdma_queue *mana_ib_get_sreq(struct mana_qp *qp)
++{
++	return &qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER];
++}
++
+ struct mana_wq {
+ 	struct ibv_wq ibwq;
+ 
+diff --git a/providers/mana/qp.c b/providers/mana/qp.c
+index af05e34..a408e83 100644
+--- a/providers/mana/qp.c
++++ b/providers/mana/qp.c
+@@ -160,35 +160,25 @@ static void mana_remove_qid(struct mana_table *qp_table, uint32_t qid)
+ 
+ static int mana_store_qp(struct mana_context *ctx, struct mana_qp *qp)
+ {
+-	uint32_t sreq = qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER].id;
+-	uint32_t srep = qp->rc_qp.queues[USER_RC_SEND_QUEUE_RESPONDER].id;
+-	uint32_t rreq = qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id;
+-	uint32_t rrep = qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id;
++	struct mana_gdma_queue *sq = mana_ib_get_sreq(qp);
++	struct mana_gdma_queue *rq = mana_ib_get_rresp(qp);
++	uint32_t sqid = sq->id & (~QUEUE_TYPE_MASK);
++	uint32_t rqid = rq->id & (~QUEUE_TYPE_MASK);
+ 	int ret;
+ 
+ 	pthread_mutex_lock(&ctx->qp_table_mutex);
+-	ret = mana_store_qid(ctx->qp_stable, qp, sreq);
++	ret = mana_store_qid(ctx->qp_stable, qp, sqid);
+ 	if (ret)
+ 		goto error;
+-	ret = mana_store_qid(ctx->qp_stable, qp, srep);
++	ret = mana_store_qid(ctx->qp_rtable, qp, rqid);
+ 	if (ret)
+ 		goto remove_sreq;
+-	ret = mana_store_qid(ctx->qp_rtable, qp, rreq);
+-	if (ret)
+-		goto remove_srep;
+-	ret = mana_store_qid(ctx->qp_rtable, qp, rrep);
+-	if (ret)
+-		goto remove_rreq;
+ 
+ 	pthread_mutex_unlock(&ctx->qp_table_mutex);
+ 	return 0;
+ 
+-remove_rreq:
+-	mana_remove_qid(ctx->qp_rtable, rreq);
+-remove_srep:
+-	mana_remove_qid(ctx->qp_stable, srep);
+ remove_sreq:
+-	mana_remove_qid(ctx->qp_stable, sreq);
++	mana_remove_qid(ctx->qp_stable, sqid);
+ error:
+ 	pthread_mutex_unlock(&ctx->qp_table_mutex);
+ 	return ret;
+@@ -196,16 +186,14 @@ error:
+ 
+ static void mana_remove_qp(struct mana_context *ctx, struct mana_qp *qp)
+ {
+-	uint32_t sreq = qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER].id;
+-	uint32_t srep = qp->rc_qp.queues[USER_RC_SEND_QUEUE_RESPONDER].id;
+-	uint32_t rreq = qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id;
+-	uint32_t rrep = qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id;
++	struct mana_gdma_queue *sq = mana_ib_get_sreq(qp);
++	struct mana_gdma_queue *rq = mana_ib_get_rresp(qp);
++	uint32_t sqid = sq->id & (~QUEUE_TYPE_MASK);
++	uint32_t rqid = rq->id & (~QUEUE_TYPE_MASK);
+ 
+ 	pthread_mutex_lock(&ctx->qp_table_mutex);
+-	mana_remove_qid(ctx->qp_stable, sreq);
+-	mana_remove_qid(ctx->qp_stable, srep);
+-	mana_remove_qid(ctx->qp_rtable, rreq);
+-	mana_remove_qid(ctx->qp_rtable, rrep);
++	mana_remove_qid(ctx->qp_stable, sqid);
++	mana_remove_qid(ctx->qp_rtable, rqid);
+ 	pthread_mutex_unlock(&ctx->qp_table_mutex);
+ }
+ 
+@@ -394,8 +382,7 @@ static void mana_ib_modify_rc_qp(struct mana_qp *qp, struct ibv_qp_attr *attr, i
+ 			if (attr_mask & IBV_QP_SQ_PSN) {
+ 				qp->rc_qp.sq_ssn = 1;
+ 				qp->rc_qp.sq_psn = attr->sq_psn;
+-				gdma_arm_normal_cqe(&qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER],
+-						    attr->sq_psn);
++				gdma_arm_normal_cqe(mana_ib_get_rreq(qp), attr->sq_psn);
+ 			}
+ 			break;
+ 		default:
+diff --git a/providers/mana/wr.c b/providers/mana/wr.c
+index a9a5fe5..afff20a 100644
+--- a/providers/mana/wr.c
++++ b/providers/mana/wr.c
+@@ -139,7 +139,7 @@ static int mana_ib_rc_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
+ 	struct mana_context *mc = container_of(verbs_get_ctx(ibqp->context),
+ 					struct mana_context, ibv_ctx);
+ 	struct mana_qp *qp = container_of(ibqp, struct mana_qp, ibqp.qp);
+-	struct mana_gdma_queue *wq = &qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER];
++	struct mana_gdma_queue *wq = mana_ib_get_rresp(qp);
+ 	struct shadow_wqe_header *shadow_wqe;
+ 	struct gdma_wqe wqe_info;
+ 	uint8_t wqe_cnt = 0;
+@@ -282,6 +282,7 @@ mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+ {
+ 	bool signaled = ((wr->send_flags & IBV_SEND_SIGNALED) != 0) || qp->sq_sig_all;
+ 	enum  gdma_work_req_flags flags = GDMA_WORK_REQ_NONE;
++	struct mana_gdma_queue *wq = mana_ib_get_sreq(qp);
+ 	struct extra_large_wqe extra_wqe = {0};
+ 	struct rdma_send_oob send_oob = {0};
+ 	struct gdma_wqe gdma_wqe = {0};
+@@ -297,7 +298,7 @@ mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+ 		struct rdma_recv_oob recv_oob = {0};
+ 
+ 		recv_oob.psn_start = qp->rc_qp.sq_psn;
+-		ret = gdma_post_rq_wqe(&qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER], wr->sg_list,
++		ret = gdma_post_rq_wqe(mana_ib_get_rreq(qp), wr->sg_list,
+ 				       &recv_oob, num_sge, GDMA_WORK_REQ_CHECK_SN, &gdma_wqe);
+ 		if (ret) {
+ 			verbs_err(verbs_get_ctx(qp->ibqp.qp.context),
+@@ -305,7 +306,7 @@ mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+ 			goto cleanup;
+ 		}
+ 		shadow_wqe->read_posted_wqe_size_in_bu = gdma_wqe.size_in_bu;
+-		gdma_ring_recv_doorbell(&qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER], 1);
++		gdma_ring_recv_doorbell(mana_ib_get_rreq(qp), 1);
+ 		// for reads no sge to use dummy sgl
+ 		num_sge = 0;
+ 	}
+@@ -345,7 +346,7 @@ mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+ 		goto cleanup;
+ 	}
+ 
+-	ret = gdma_post_sq_wqe(&qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER], wr->sg_list,
++	ret = gdma_post_sq_wqe(wq, wr->sg_list,
+ 			       &send_oob, oob_sge, num_sge, MTU_SIZE(qp->mtu), flags, &gdma_wqe);
+ 	if (ret) {
+ 		verbs_err(verbs_get_ctx(qp->ibqp.qp.context),
+@@ -416,7 +417,7 @@ static int mana_ib_rc_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
+ 
+ cleanup:
+ 	if (ring)
+-		gdma_ring_send_doorbell(&qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER]);
++		gdma_ring_send_doorbell(mana_ib_get_sreq(qp));
+ 	pthread_spin_unlock(&qp->sq_lock);
+ 	if (bad_wr && ret)
+ 		*bad_wr = wr;
+-- 
+2.45.4
+

--- a/SPECS/rdma-core/0005-providers-mana-unify-rc_qp-to-be-rnic_qp.patch
+++ b/SPECS/rdma-core/0005-providers-mana-unify-rc_qp-to-be-rnic_qp.patch
@@ -1,0 +1,572 @@
+From 7c1c1bd8be8d7fe0c8f7623e4bfcef997411b411 Mon Sep 17 00:00:00 2001
+From: Konstantin Taranov <kotaranov@microsoft.com>
+Date: Wed, 17 Dec 2025 15:59:39 +0100
+Subject: [PATCH 5/7] providers/mana: unify rc_qp to be rnic_qp
+
+Abstract helpers and data structures to handle a general RNIC QP.
+This change helps to introduce new QP types and reuse the same
+helpers and the same general fields (e.g., psn, msn).
+
+Signed-off-by: Konstantin Taranov <kotaranov@microsoft.com>
+---
+ providers/mana/cq.c           | 28 ++++++++--------
+ providers/mana/gdma.h         |  2 +-
+ providers/mana/mana.c         | 15 +++++----
+ providers/mana/mana.h         | 27 ++++++++-------
+ providers/mana/qp.c           | 62 +++++++++++++++++------------------
+ providers/mana/rollback.h     |  6 ++--
+ providers/mana/shadow_queue.h |  4 +--
+ providers/mana/wr.c           | 34 +++++++++----------
+ 8 files changed, 90 insertions(+), 88 deletions(-)
+
+diff --git a/providers/mana/cq.c b/providers/mana/cq.c
+index 372c503..367d5a2 100644
+--- a/providers/mana/cq.c
++++ b/providers/mana/cq.c
+@@ -105,7 +105,7 @@ static enum ibv_wc_status vendor_error_to_wc_error(uint32_t vendor_error)
+ static void fill_verbs_from_shadow_wqe(struct mana_qp *qp, struct ibv_wc *wc,
+ 				       const struct shadow_wqe_header *shadow_wqe)
+ {
+-	const struct rc_rq_shadow_wqe *rc_wqe = (const struct rc_rq_shadow_wqe *)shadow_wqe;
++	const struct rnic_rq_shadow_wqe *rq_wqe = (const struct rnic_rq_shadow_wqe *)shadow_wqe;
+ 
+ 	wc->wr_id = shadow_wqe->wr_id;
+ 	wc->status = vendor_error_to_wc_error(shadow_wqe->vendor_error);
+@@ -116,8 +116,8 @@ static void fill_verbs_from_shadow_wqe(struct mana_qp *qp, struct ibv_wc *wc,
+ 	wc->pkey_index = 0;
+ 
+ 	if (shadow_wqe->opcode & IBV_WC_RECV) {
+-		wc->byte_len = rc_wqe->byte_len;
+-		wc->imm_data = htobe32(rc_wqe->imm_or_rkey);
++		wc->byte_len = rq_wqe->byte_len;
++		wc->imm_data = htobe32(rq_wqe->imm_or_rkey);
+ 	}
+ }
+ 
+@@ -236,8 +236,8 @@ int mana_arm_cq(struct ibv_cq *ibcq, int solicited)
+ 
+ static inline bool get_next_signal_psn(struct mana_qp *qp, uint32_t *psn)
+ {
+-	struct rc_sq_shadow_wqe *shadow_wqe =
+-		(struct rc_sq_shadow_wqe *)shadow_queue_get_next_to_signal(&qp->shadow_sq);
++	struct rnic_sq_shadow_wqe *shadow_wqe =
++		(struct rnic_sq_shadow_wqe *)shadow_queue_get_next_to_signal(&qp->shadow_sq);
+ 
+ 	if (!shadow_wqe)
+ 		return false;
+@@ -251,14 +251,14 @@ static inline int advance_send_completions(struct mana_qp *qp, uint32_t psn,
+ {
+ 	struct mana_gdma_queue *recv_queue = mana_ib_get_rreq(qp);
+ 	struct mana_gdma_queue *send_queue = mana_ib_get_sreq(qp);
+-	struct rc_sq_shadow_wqe *shadow_wqe;
++	struct rnic_sq_shadow_wqe *shadow_wqe;
+ 	int produced = 0;
+ 
+-	if (!PSN_LT(psn, qp->rc_qp.sq_psn))
++	if (!PSN_LT(psn, qp->sq_psn))
+ 		return 0;
+ 
+ 	while (produced < nwc &&
+-	       (shadow_wqe = (struct rc_sq_shadow_wqe *)
++	       (shadow_wqe = (struct rnic_sq_shadow_wqe *)
+ 		shadow_queue_get_next_to_consume(&qp->shadow_sq)) != NULL) {
+ 		if (PSN_LT(psn, shadow_wqe->end_psn))
+ 			break;
+@@ -303,7 +303,7 @@ static inline int handle_rc_requester_cqe(struct mana_qp *qp, struct gdma_cqe *c
+ 
+ 	gdma_arm_normal_cqe(recv_queue, arm_psn);
+ 
+-	struct rc_sq_shadow_wqe *next = (struct rc_sq_shadow_wqe *)
++	struct rnic_sq_shadow_wqe *next = (struct rnic_sq_shadow_wqe *)
+ 		shadow_queue_get_next_to_consume(&qp->shadow_sq);
+ 	if (!next)
+ 		*consumed = true;
+@@ -317,9 +317,9 @@ static inline int handle_responder_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
+ 				       struct ibv_wc *wc)
+ {
+ 	struct mana_gdma_queue *recv_queue = mana_ib_get_rresp(qp);
+-	struct rc_rq_shadow_wqe *shadow_wqe;
++	struct rnic_rq_shadow_wqe *shadow_wqe;
+ 
+-	shadow_wqe = (struct rc_rq_shadow_wqe *)shadow_queue_get_next_to_consume(&qp->shadow_rq);
++	shadow_wqe = (struct rnic_rq_shadow_wqe *)shadow_queue_get_next_to_consume(&qp->shadow_rq);
+ 	if (!shadow_wqe) {
+ 		verbs_warn_datapath(verbs_get_ctx(qp->ibqp.qp.context),
+ 				    "responder CQE wqid=%u qp_num=%u: shadow_wqe not found\n",
+@@ -327,14 +327,14 @@ static inline int handle_responder_cqe(struct mana_qp *qp, struct gdma_cqe *cqe,
+ 		return 0;
+ 	}
+ 
+-	uint32_t offset_cqe = cqe->rdma_cqe.rc_recv.rx_wqe_offset / GDMA_WQE_ALIGNMENT_UNIT_SIZE;
++	uint32_t offset_cqe = cqe->rdma_cqe.rnic_recv.rx_wqe_offset / GDMA_WQE_ALIGNMENT_UNIT_SIZE;
+ 	uint32_t offset_wqe = shadow_wqe->header.unmasked_queue_offset & GDMA_QUEUE_OFFSET_MASK;
+ 
+ 	if (offset_cqe != offset_wqe)
+ 		return 0;
+ 
+-	shadow_wqe->byte_len = cqe->rdma_cqe.rc_recv.msg_len;
+-	shadow_wqe->imm_or_rkey = cqe->rdma_cqe.rc_recv.imm_data;
++	shadow_wqe->byte_len = cqe->rdma_cqe.rnic_recv.msg_len;
++	shadow_wqe->imm_or_rkey = cqe->rdma_cqe.rnic_recv.imm_data;
+ 
+ 	switch (cqe->rdma_cqe.cqe_type) {
+ 	case CQE_TYPE_RC_WRITE_IMM:
+diff --git a/providers/mana/gdma.h b/providers/mana/gdma.h
+index ee0b808..1f797c7 100644
+--- a/providers/mana/gdma.h
++++ b/providers/mana/gdma.h
+@@ -180,7 +180,7 @@ union mana_rdma_cqe {
+ 		uint32_t reserved2	: 8;
+ 		uint32_t imm_data;
+ 		uint32_t rx_wqe_offset;
+-	} rc_recv;
++	} rnic_recv;
+ 	struct {
+ 		uint32_t cqe_type	: 8;
+ 		uint32_t vendor_error	: 9;
+diff --git a/providers/mana/mana.c b/providers/mana/mana.c
+index a8091fa..eb9bb99 100644
+--- a/providers/mana/mana.c
++++ b/providers/mana/mana.c
+@@ -39,6 +39,9 @@ void *mana_alloc_mem(size_t size)
+ {
+ 	void *buf;
+ 
++	if (size == 0)
++		return NULL;
++
+ 	buf = mmap(NULL, size, PROT_READ | PROT_WRITE,
+ 		   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+ 
+@@ -57,8 +60,10 @@ unmap:
+ 
+ void mana_dealloc_mem(void *buf, size_t size)
+ {
+-	ibv_dofork_range(buf, size);
+-	munmap(buf, size);
++	if (buf) {
++		ibv_dofork_range(buf, size);
++		munmap(buf, size);
++	}
+ }
+ 
+ int create_shadow_queue(struct shadow_queue *queue, uint32_t length, uint32_t stride)
+@@ -78,10 +83,8 @@ int create_shadow_queue(struct shadow_queue *queue, uint32_t length, uint32_t st
+ 
+ void destroy_shadow_queue(struct shadow_queue *queue)
+ {
+-	if (queue->buffer) {
+-		mana_dealloc_mem(queue->buffer, queue->stride * queue->length);
+-		queue->buffer = NULL;
+-	}
++	mana_dealloc_mem(queue->buffer, queue->stride * queue->length);
++	queue->buffer = NULL;
+ }
+ 
+ int mana_query_device_ex(struct ibv_context *context,
+diff --git a/providers/mana/mana.h b/providers/mana/mana.h
+index 970c302..1f8a147 100644
+--- a/providers/mana/mana.h
++++ b/providers/mana/mana.h
+@@ -45,11 +45,11 @@
+ #define PSN_ADD(PSN, DELTA) (((PSN) + (DELTA)) & PSN_MASK)
+ 
+ enum user_queue_types {
+-	USER_RC_SEND_QUEUE_REQUESTER = 0,
+-	USER_RC_SEND_QUEUE_RESPONDER = 1,
+-	USER_RC_RECV_QUEUE_REQUESTER = 2,
+-	USER_RC_RECV_QUEUE_RESPONDER = 3,
+-	USER_RC_QUEUE_TYPE_MAX = 4,
++	USER_RNIC_SEND_QUEUE_REQUESTER = 0,
++	USER_RNIC_SEND_QUEUE_RESPONDER = 1,
++	USER_RNIC_RECV_QUEUE_REQUESTER = 2,
++	USER_RNIC_RECV_QUEUE_RESPONDER = 3,
++	USER_RNIC_QUEUE_TYPE_MAX = 4,
+ };
+ 
+ #define QUEUE_TYPE_MASK 0x3
+@@ -119,20 +119,19 @@ struct mana_ib_raw_qp {
+ 	uint32_t tx_vp_offset;
+ };
+ 
+-struct mana_ib_rc_qp {
+-	struct mana_gdma_queue queues[USER_RC_QUEUE_TYPE_MAX];
+-	uint32_t sq_ssn;
+-	uint32_t sq_psn;
++struct mana_ib_rnic_qp {
++	struct mana_gdma_queue queues[USER_RNIC_QUEUE_TYPE_MAX];
+ };
+ 
+ struct mana_qp {
+ 	struct verbs_qp ibqp;
+ 	pthread_spinlock_t sq_lock;
+ 	pthread_spinlock_t rq_lock;
+-
++	uint32_t sq_ssn;
++	uint32_t sq_psn;
+ 	union {
+ 		struct mana_ib_raw_qp raw_qp;
+-		struct mana_ib_rc_qp rc_qp;
++		struct mana_ib_rnic_qp rnic_qp;
+ 	};
+ 
+ 	enum ibv_mtu mtu;
+@@ -149,17 +148,17 @@ struct mana_qp {
+ 
+ static inline struct mana_gdma_queue *mana_ib_get_rresp(struct mana_qp *qp)
+ {
+-	return &qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER];
++	return &qp->rnic_qp.queues[USER_RNIC_RECV_QUEUE_RESPONDER];
+ }
+ 
+ static inline struct mana_gdma_queue *mana_ib_get_rreq(struct mana_qp *qp)
+ {
+-	return &qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER];
++	return &qp->rnic_qp.queues[USER_RNIC_RECV_QUEUE_REQUESTER];
+ }
+ 
+ static inline struct mana_gdma_queue *mana_ib_get_sreq(struct mana_qp *qp)
+ {
+-	return &qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER];
++	return &qp->rnic_qp.queues[USER_RNIC_SEND_QUEUE_REQUESTER];
+ }
+ 
+ struct mana_wq {
+diff --git a/providers/mana/qp.c b/providers/mana/qp.c
+index a408e83..1b828ff 100644
+--- a/providers/mana/qp.c
++++ b/providers/mana/qp.c
+@@ -218,19 +218,19 @@ static uint32_t get_queue_size(struct ibv_qp_init_attr *attr, enum user_queue_ty
+ 
+ 	if (attr->qp_type == IBV_QPT_RC) {
+ 		switch (type) {
+-		case USER_RC_SEND_QUEUE_REQUESTER:
++		case USER_RNIC_SEND_QUEUE_REQUESTER:
+ 			/* WQE must have at least one SGE */
+ 			/* For write with imm we need one extra SGE */
+ 			sges = max(1U, attr->cap.max_send_sge) + 1;
+ 			size = attr->cap.max_send_wr * get_large_wqe_size(sges);
+ 			break;
+-		case USER_RC_SEND_QUEUE_RESPONDER:
++		case USER_RNIC_SEND_QUEUE_RESPONDER:
+ 			size = MANA_PAGE_SIZE;
+ 			break;
+-		case USER_RC_RECV_QUEUE_REQUESTER:
++		case USER_RNIC_RECV_QUEUE_REQUESTER:
+ 			size = MANA_PAGE_SIZE;
+ 			break;
+-		case USER_RC_RECV_QUEUE_RESPONDER:
++		case USER_RNIC_RECV_QUEUE_RESPONDER:
+ 			/* WQE must have at least one SGE */
+ 			sges = max(1U, attr->cap.max_recv_sge);
+ 			size = attr->cap.max_recv_wr * get_wqe_size(sges);
+@@ -242,14 +242,14 @@ static uint32_t get_queue_size(struct ibv_qp_init_attr *attr, enum user_queue_ty
+ 
+ 	size = align_hw_size(size);
+ 
+-	if (attr->qp_type == IBV_QPT_RC && type == USER_RC_SEND_QUEUE_REQUESTER)
++	if (attr->qp_type == IBV_QPT_RC && type == USER_RNIC_SEND_QUEUE_REQUESTER)
+ 		size += sizeof(struct mana_ib_rollback_shared_mem);
+ 
+ 	return size;
+ }
+ 
+-static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
+-					struct ibv_qp_init_attr *attr)
++static struct ibv_qp *mana_create_qp_rnic(struct ibv_pd *ibpd,
++					  struct ibv_qp_init_attr *attr)
+ {
+ 	struct mana_context *ctx = to_mctx(ibpd->context);
+ 	struct mana_ib_create_rc_qp_resp *qp_resp_drv;
+@@ -271,33 +271,33 @@ static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
+ 	qp->sq_sig_all = attr->sq_sig_all;
+ 
+ 	if (create_shadow_queue(&qp->shadow_sq, attr->cap.max_send_wr,
+-				sizeof(struct rc_sq_shadow_wqe))) {
++				sizeof(struct rnic_sq_shadow_wqe))) {
+ 		verbs_err(verbs_get_ctx(ibpd->context), "Failed to alloc sq shadow queue\n");
+ 		errno = ENOMEM;
+ 		goto free_qp;
+ 	}
+ 
+ 	if (create_shadow_queue(&qp->shadow_rq, attr->cap.max_recv_wr,
+-				sizeof(struct rc_rq_shadow_wqe))) {
+-		verbs_err(verbs_get_ctx(ibpd->context), "Failed to alloc rc shadow queue\n");
++				sizeof(struct rnic_rq_shadow_wqe))) {
++		verbs_err(verbs_get_ctx(ibpd->context), "Failed to alloc rq shadow queue\n");
+ 		errno = ENOMEM;
+ 		goto destroy_shadow_sq;
+ 	}
+ 
+-	for (i = 0; i < USER_RC_QUEUE_TYPE_MAX; ++i) {
+-		qp->rc_qp.queues[i].db_page = ctx->db_page;
+-		qp->rc_qp.queues[i].size = get_queue_size(attr, i);
+-		qp->rc_qp.queues[i].buffer = mana_alloc_mem(qp->rc_qp.queues[i].size);
++	for (i = 0; i < USER_RNIC_QUEUE_TYPE_MAX; ++i) {
++		qp->rnic_qp.queues[i].db_page = ctx->db_page;
++		qp->rnic_qp.queues[i].size = get_queue_size(attr, i);
++		qp->rnic_qp.queues[i].buffer = mana_alloc_mem(qp->rnic_qp.queues[i].size);
+ 
+-		if (!qp->rc_qp.queues[i].buffer) {
++		if (qp->rnic_qp.queues[i].size != 0 && !qp->rnic_qp.queues[i].buffer) {
+ 			verbs_err(verbs_get_ctx(ibpd->context),
+ 				  "Failed to allocate memory for RC queue %d\n", i);
+ 			errno = ENOMEM;
+ 			goto destroy_queues;
+ 		}
+ 
+-		qp_cmd_drv->queue_buf[i] = (uintptr_t)qp->rc_qp.queues[i].buffer;
+-		qp_cmd_drv->queue_size[i] = qp->rc_qp.queues[i].size;
++		qp_cmd_drv->queue_buf[i] = (uintptr_t)qp->rnic_qp.queues[i].buffer;
++		qp_cmd_drv->queue_size[i] = qp->rnic_qp.queues[i].size;
+ 	}
+ 
+ 	mana_ib_init_rb_shmem(qp);
+@@ -311,10 +311,10 @@ static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
+ 		goto free_rb;
+ 	}
+ 
+-	for (i = 0; i < USER_RC_QUEUE_TYPE_MAX; ++i)
+-		qp->rc_qp.queues[i].id = qp_resp_drv->queue_id[i];
++	for (i = 0; i < USER_RNIC_QUEUE_TYPE_MAX; ++i)
++		qp->rnic_qp.queues[i].id = qp_resp_drv->queue_id[i];
+ 
+-	qp->ibqp.qp.qp_num = qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id;
++	qp->ibqp.qp.qp_num = qp->rnic_qp.queues[USER_RNIC_RECV_QUEUE_RESPONDER].id;
+ 
+ 	ret = mana_store_qp(ctx, qp);
+ 	if (ret) {
+@@ -330,7 +330,7 @@ free_rb:
+ 	mana_ib_deinit_rb_shmem(qp);
+ destroy_queues:
+ 	while (i-- > 0)
+-		mana_dealloc_mem(qp->rc_qp.queues[i].buffer, qp->rc_qp.queues[i].size);
++		mana_dealloc_mem(qp->rnic_qp.queues[i].buffer, qp->rnic_qp.queues[i].size);
+ 	destroy_shadow_queue(&qp->shadow_rq);
+ destroy_shadow_sq:
+ 	destroy_shadow_queue(&qp->shadow_sq);
+@@ -346,7 +346,7 @@ struct ibv_qp *mana_create_qp(struct ibv_pd *ibpd,
+ 	case IBV_QPT_RAW_PACKET:
+ 		return mana_create_qp_raw(ibpd, attr);
+ 	case IBV_QPT_RC:
+-		return mana_create_qp_rc(ibpd, attr);
++		return mana_create_qp_rnic(ibpd, attr);
+ 	default:
+ 		verbs_err(verbs_get_ctx(ibpd->context),
+ 			  "QP type %u is not supported\n", attr->qp_type);
+@@ -356,7 +356,7 @@ struct ibv_qp *mana_create_qp(struct ibv_pd *ibpd,
+ 	return NULL;
+ }
+ 
+-static void mana_ib_modify_rc_qp(struct mana_qp *qp, struct ibv_qp_attr *attr, int attr_mask)
++static void mana_ib_modify_rnic_qp(struct mana_qp *qp, struct ibv_qp_attr *attr, int attr_mask)
+ {
+ 	int i;
+ 
+@@ -367,9 +367,9 @@ static void mana_ib_modify_rc_qp(struct mana_qp *qp, struct ibv_qp_attr *attr, i
+ 		qp->ibqp.qp.state = attr->qp_state;
+ 		switch (attr->qp_state) {
+ 		case IBV_QPS_RESET:
+-			for (i = 0; i < USER_RC_QUEUE_TYPE_MAX; ++i) {
+-				qp->rc_qp.queues[i].prod_idx = 0;
+-				qp->rc_qp.queues[i].cons_idx = 0;
++			for (i = 0; i < USER_RNIC_QUEUE_TYPE_MAX; ++i) {
++				qp->rnic_qp.queues[i].prod_idx = 0;
++				qp->rnic_qp.queues[i].cons_idx = 0;
+ 			}
+ 			mana_ib_reset_rb_shmem(qp);
+ 			reset_shadow_queue(&qp->shadow_rq);
+@@ -380,8 +380,8 @@ static void mana_ib_modify_rc_qp(struct mana_qp *qp, struct ibv_qp_attr *attr, i
+ 			break;
+ 		case IBV_QPS_RTS:
+ 			if (attr_mask & IBV_QP_SQ_PSN) {
+-				qp->rc_qp.sq_ssn = 1;
+-				qp->rc_qp.sq_psn = attr->sq_psn;
++				qp->sq_ssn = 1;
++				qp->sq_psn = attr->sq_psn;
+ 				gdma_arm_normal_cqe(mana_ib_get_rreq(qp), attr->sq_psn);
+ 			}
+ 			break;
+@@ -409,7 +409,7 @@ int mana_modify_qp(struct ibv_qp *ibqp, struct ibv_qp_attr *attr, int attr_mask)
+ 		goto cleanup;
+ 	}
+ 
+-	mana_ib_modify_rc_qp(qp, attr, attr_mask);
++	mana_ib_modify_rnic_qp(qp, attr, attr_mask);
+ 
+ cleanup:
+ 	pthread_spin_unlock(&qp->rq_lock);
+@@ -464,8 +464,8 @@ int mana_destroy_qp(struct ibv_qp *ibqp)
+ 		destroy_shadow_queue(&qp->shadow_sq);
+ 		destroy_shadow_queue(&qp->shadow_rq);
+ 		mana_ib_deinit_rb_shmem(qp);
+-		for (i = 0; i < USER_RC_QUEUE_TYPE_MAX; ++i)
+-			mana_dealloc_mem(qp->rc_qp.queues[i].buffer, qp->rc_qp.queues[i].size);
++		for (i = 0; i < USER_RNIC_QUEUE_TYPE_MAX; ++i)
++			mana_dealloc_mem(qp->rnic_qp.queues[i].buffer, qp->rnic_qp.queues[i].size);
+ 		break;
+ 	default:
+ 		verbs_err(verbs_get_ctx(ibqp->context),
+diff --git a/providers/mana/rollback.h b/providers/mana/rollback.h
+index e91b7ee..59621a5 100644
+--- a/providers/mana/rollback.h
++++ b/providers/mana/rollback.h
+@@ -29,7 +29,7 @@ static inline struct mana_ib_rollback_shared_mem
+ {
+ 	struct mana_ib_rollback_shared_mem *rb_shmem;
+ 	struct mana_gdma_queue *req_sq =
+-		&qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER];
++		&qp->rnic_qp.queues[USER_RNIC_SEND_QUEUE_REQUESTER];
+ 
+ 	rb_shmem = (struct mana_ib_rollback_shared_mem *)
+ 		((uint8_t *)req_sq->buffer + req_sq->size);
+@@ -41,7 +41,7 @@ static inline void mana_ib_init_rb_shmem(struct mana_qp *qp)
+ {
+ 	// take some bytes for rollback memory
+ 	struct mana_gdma_queue *req_sq =
+-		&qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER];
++		&qp->rnic_qp.queues[USER_RNIC_SEND_QUEUE_REQUESTER];
+ 	req_sq->size -= sizeof(struct mana_ib_rollback_shared_mem);
+ 
+ 	struct mana_ib_rollback_shared_mem *rb_shmem =
+@@ -56,7 +56,7 @@ static inline void mana_ib_deinit_rb_shmem(struct mana_qp *qp)
+ {
+ 	// return back bytes for rollback memory
+ 	struct mana_gdma_queue *req_sq =
+-		&qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER];
++		&qp->rnic_qp.queues[USER_RNIC_SEND_QUEUE_REQUESTER];
+ 	req_sq->size += sizeof(struct mana_ib_rollback_shared_mem);
+ }
+ 
+diff --git a/providers/mana/shadow_queue.h b/providers/mana/shadow_queue.h
+index a1d18e8..01d7e4f 100644
+--- a/providers/mana/shadow_queue.h
++++ b/providers/mana/shadow_queue.h
+@@ -30,13 +30,13 @@ struct shadow_wqe_header {
+ 	uint64_t wr_id;
+ };
+ 
+-struct rc_sq_shadow_wqe {
++struct rnic_sq_shadow_wqe {
+ 	struct  shadow_wqe_header header;
+ 	uint32_t end_psn;
+ 	uint32_t read_posted_wqe_size_in_bu;
+ };
+ 
+-struct rc_rq_shadow_wqe {
++struct rnic_rq_shadow_wqe {
+ 	struct shadow_wqe_header header;
+ 	uint32_t byte_len;
+ 	uint32_t imm_or_rkey;
+diff --git a/providers/mana/wr.c b/providers/mana/wr.c
+index afff20a..280dc59 100644
+--- a/providers/mana/wr.c
++++ b/providers/mana/wr.c
+@@ -133,8 +133,8 @@ gdma_post_rq_wqe(struct mana_gdma_queue *wq, struct ibv_sge *sgl,  struct rdma_r
+ 	return 0;
+ }
+ 
+-static int mana_ib_rc_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
+-				struct ibv_recv_wr **bad_wr)
++static int mana_ib_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
++			     struct ibv_recv_wr **bad_wr)
+ {
+ 	struct mana_context *mc = container_of(verbs_get_ctx(ibqp->context),
+ 					struct mana_context, ibv_ctx);
+@@ -191,7 +191,7 @@ int mana_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
+ {
+ 	switch (ibqp->qp_type) {
+ 	case IBV_QPT_RC:
+-		return mana_ib_rc_post_recv(ibqp, wr, bad);
++		return mana_ib_post_recv(ibqp, wr, bad);
+ 	default:
+ 		verbs_err(verbs_get_ctx(ibqp->context), "QPT not supported %d\n", ibqp->qp_type);
+ 		return EOPNOTSUPP;
+@@ -277,8 +277,8 @@ gdma_post_sq_wqe(struct mana_gdma_queue *wq, struct ibv_sge *sgl, struct rdma_se
+ }
+ 
+ static inline int
+-mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+-			     struct rc_sq_shadow_wqe *shadow_wqe)
++mana_ib_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
++			  struct rnic_sq_shadow_wqe *shadow_wqe)
+ {
+ 	bool signaled = ((wr->send_flags & IBV_SEND_SIGNALED) != 0) || qp->sq_sig_all;
+ 	enum  gdma_work_req_flags flags = GDMA_WORK_REQ_NONE;
+@@ -297,7 +297,7 @@ mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+ 	if (wr->opcode == IBV_WR_RDMA_READ) {
+ 		struct rdma_recv_oob recv_oob = {0};
+ 
+-		recv_oob.psn_start = qp->rc_qp.sq_psn;
++		recv_oob.psn_start = qp->sq_psn;
+ 		ret = gdma_post_rq_wqe(mana_ib_get_rreq(qp), wr->sg_list,
+ 				       &recv_oob, num_sge, GDMA_WORK_REQ_CHECK_SN, &gdma_wqe);
+ 		if (ret) {
+@@ -315,8 +315,8 @@ mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+ 	send_oob.fence = (wr->send_flags & IBV_SEND_FENCE) != 0;
+ 	send_oob.signaled = signaled;
+ 	send_oob.solicited = (wr->send_flags & IBV_SEND_SOLICITED) != 0;
+-	send_oob.psn = qp->rc_qp.sq_psn;
+-	send_oob.ssn = qp->rc_qp.sq_ssn;
++	send_oob.psn = qp->sq_psn;
++	send_oob.ssn = qp->sq_ssn;
+ 
+ 	switch (wr->opcode) {
+ 	case IBV_WR_SEND_WITH_INV:
+@@ -354,15 +354,15 @@ mana_ib_rc_post_send_request(struct mana_qp *qp, struct ibv_send_wr *wr,
+ 		goto cleanup;
+ 	}
+ 
+-	qp->rc_qp.sq_psn = PSN_ADD(qp->rc_qp.sq_psn, PSN_DELTA(msg_sz, qp->mtu));
+-	qp->rc_qp.sq_ssn = PSN_INC(qp->rc_qp.sq_ssn);
++	qp->sq_psn = PSN_ADD(qp->sq_psn, PSN_DELTA(msg_sz, qp->mtu));
++	qp->sq_ssn = PSN_INC(qp->sq_ssn);
+ 
+ 	shadow_wqe->header.wr_id = wr->wr_id;
+ 	shadow_wqe->header.opcode = convert_wr_to_wc(wr->opcode);
+ 	shadow_wqe->header.flags = signaled ? 0 : MANA_NO_SIGNAL_WC;
+ 	shadow_wqe->header.posted_wqe_size_in_bu = gdma_wqe.size_in_bu;
+ 	shadow_wqe->header.unmasked_queue_offset = gdma_wqe.unmasked_wqe_index;
+-	shadow_wqe->end_psn = PSN_DEC(qp->rc_qp.sq_psn);
++	shadow_wqe->end_psn = PSN_DEC(qp->sq_psn);
+ 
+ 	return 0;
+ 
+@@ -370,8 +370,8 @@ cleanup:
+ 	return EINVAL;
+ }
+ 
+-static int mana_ib_rc_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
+-				struct ibv_send_wr **bad_wr)
++static int mana_ib_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
++			     struct ibv_send_wr **bad_wr)
+ {
+ 	struct mana_qp *qp = container_of(ibqp, struct mana_qp, ibqp.qp);
+ 	int ret = 0;
+@@ -398,11 +398,11 @@ static int mana_ib_rc_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
+ 		}
+ 
+ 		/* Fill shadow queue data */
+-		struct rc_sq_shadow_wqe *shadow_wqe = (struct rc_sq_shadow_wqe *)
++		struct rnic_sq_shadow_wqe *shadow_wqe = (struct rnic_sq_shadow_wqe *)
+ 			shadow_queue_producer_entry(&qp->shadow_sq);
+-		memset(shadow_wqe, 0, sizeof(struct rc_sq_shadow_wqe));
++		memset(shadow_wqe, 0, sizeof(struct rnic_sq_shadow_wqe));
+ 
+-		ret = mana_ib_rc_post_send_request(qp, wr, shadow_wqe);
++		ret = mana_ib_post_send_request(qp, wr, shadow_wqe);
+ 		if (ret) {
+ 			verbs_err(verbs_get_ctx(qp->ibqp.qp.context),
+ 				  "Failed to post send request ret %d\n", ret);
+@@ -430,7 +430,7 @@ int mana_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
+ {
+ 	switch (ibqp->qp_type) {
+ 	case IBV_QPT_RC:
+-		return mana_ib_rc_post_send(ibqp, wr, bad);
++		return mana_ib_post_send(ibqp, wr, bad);
+ 	default:
+ 		verbs_err(verbs_get_ctx(ibqp->context), "QPT not supported %d\n", ibqp->qp_type);
+ 		return EOPNOTSUPP;
+-- 
+2.45.4
+

--- a/SPECS/rdma-core/0006-providers-mana-allocate-destroy-MWs.patch
+++ b/SPECS/rdma-core/0006-providers-mana-allocate-destroy-MWs.patch
@@ -1,0 +1,76 @@
+From efb6bc890758484582dfd80a8600662f917ce577 Mon Sep 17 00:00:00 2001
+From: Konstantin Taranov <kotaranov@microsoft.com>
+Date: Wed, 14 Jan 2026 17:01:46 +0100
+Subject: [PATCH 6/7] providers/mana: allocate/destroy MWs
+
+Implement .alloc_mw() and .dealloc_mw() for mana.
+
+Signed-off-by: Konstantin Taranov <kotaranov@microsoft.com>
+---
+ providers/mana/mana.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/providers/mana/mana.c b/providers/mana/mana.c
+index eb9bb99..a59248b 100644
+--- a/providers/mana/mana.c
++++ b/providers/mana/mana.c
+@@ -198,6 +198,40 @@ int mana_dealloc_pd(struct ibv_pd *ibpd)
+ 	return 0;
+ }
+ 
++static struct ibv_mw *
++mana_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type)
++{
++	struct ib_uverbs_alloc_mw_resp resp;
++	struct ibv_alloc_mw cmd;
++	struct ibv_mw *mw;
++	int ret;
++
++	mw = calloc(1, sizeof(*mw));
++	if (!mw)
++		return NULL;
++
++	ret = ibv_cmd_alloc_mw(pd, type, mw, &cmd, sizeof(cmd), &resp,
++			       sizeof(resp));
++	if (ret) {
++		free(mw);
++		return NULL;
++	}
++
++	return mw;
++}
++
++static int mana_dealloc_mw(struct ibv_mw *mw)
++{
++	int ret;
++
++	ret = ibv_cmd_dealloc_mw(mw);
++	if (ret)
++		return ret;
++
++	free(mw);
++	return 0;
++}
++
+ struct ibv_mr *mana_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+ 				  size_t length, uint64_t iova, int fd,
+ 				  int access)
+@@ -362,6 +396,7 @@ static void mana_async_event(struct ibv_context *context,
+ }
+ 
+ static const struct verbs_context_ops mana_ctx_ops = {
++	.alloc_mw = mana_alloc_mw,
+ 	.alloc_pd = mana_alloc_pd,
+ 	.alloc_dm = mana_alloc_dm,
+ 	.async_event = mana_async_event,
+@@ -371,6 +406,7 @@ static const struct verbs_context_ops mana_ctx_ops = {
+ 	.create_qp_ex = mana_create_qp_ex,
+ 	.create_rwq_ind_table = mana_create_rwq_ind_table,
+ 	.create_wq = mana_create_wq,
++	.dealloc_mw = mana_dealloc_mw,
+ 	.dealloc_pd = mana_dealloc_pd,
+ 	.dereg_mr = mana_dereg_mr,
+ 	.destroy_cq = mana_destroy_cq,
+-- 
+2.45.4
+

--- a/SPECS/rdma-core/0007-libibverbs-Extend-ibv_cmd_create_qp_ex2-with-driver-.patch
+++ b/SPECS/rdma-core/0007-libibverbs-Extend-ibv_cmd_create_qp_ex2-with-driver-.patch
@@ -1,0 +1,162 @@
+From 22d416ce8ed83d5a6927b92d40968f50d57d3a39 Mon Sep 17 00:00:00 2001
+From: Jiri Pirko <jiri@nvidia.com>
+Date: Tue, 5 May 2026 13:39:10 +0200
+Subject: [PATCH 7/7] libibverbs: Extend ibv_cmd_create_qp_ex2() with driver
+ chain
+
+Add a driver command-buffer chain argument to the private QP create
+helper ibv_cmd_create_qp_ex2() and build its command buffer with
+DECLARE_CMD_BUFFER_LINK_COMPAT(), mirroring ibv_cmd_create_cq_ex2().
+This lets a provider link a driver-namespace command buffer onto the
+create-QP ioctl; later commits use it to attach per-buffer UMEM
+attributes (UVERBS_ATTR_CREATE_QP_*_BUF_UMEM).
+
+Update all existing callers (mlx4, mlx5, hns, mana, rxe, ionic) to
+pass NULL as they have no driver chain to attach.
+
+Signed-off-by: Jiri Pirko <jiri@nvidia.com>
+---
+ libibverbs/cmd_qp.c              | 9 +++++----
+ libibverbs/driver.h              | 3 ++-
+ providers/hns/hns_roce_u_verbs.c | 2 +-
+ providers/ionic/ionic_verbs.c    | 2 +-
+ providers/mana/qp.c              | 2 +-
+ providers/mlx4/verbs.c           | 4 ++--
+ providers/mlx5/verbs.c           | 4 ++--
+ providers/rxe/rxe.c              | 2 +-
+ 8 files changed, 15 insertions(+), 13 deletions(-)
+
+diff --git a/libibverbs/cmd_qp.c b/libibverbs/cmd_qp.c
+index 499b241..686222a 100644
+--- a/libibverbs/cmd_qp.c
++++ b/libibverbs/cmd_qp.c
+@@ -425,11 +425,12 @@ int ibv_cmd_create_qp_ex2(struct ibv_context *context,
+ 			  struct ibv_create_qp_ex *cmd,
+ 			  size_t cmd_size,
+ 			  struct ib_uverbs_ex_create_qp_resp *resp,
+-			  size_t resp_size)
++			  size_t resp_size,
++			  struct ibv_command_buffer *driver)
+ {
+-	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_QP,
+-				  UVERBS_METHOD_QP_CREATE, cmd, cmd_size, resp,
+-				  resp_size);
++	DECLARE_CMD_BUFFER_LINK_COMPAT(cmdb, UVERBS_OBJECT_QP,
++				       UVERBS_METHOD_QP_CREATE,
++				       driver, cmd, cmd_size, resp, resp_size);
+ 
+ 	if (!check_comp_mask(attr_ex->comp_mask,
+ 			     IBV_QP_INIT_ATTR_PD |
+diff --git a/libibverbs/driver.h b/libibverbs/driver.h
+index 1e6f6be..6297d5f 100644
+--- a/libibverbs/driver.h
++++ b/libibverbs/driver.h
+@@ -669,7 +669,8 @@ int ibv_cmd_create_qp_ex2(struct ibv_context *context,
+ 			  struct ibv_create_qp_ex *cmd,
+ 			  size_t cmd_size,
+ 			  struct ib_uverbs_ex_create_qp_resp *resp,
+-			  size_t resp_size);
++			  size_t resp_size,
++			  struct ibv_command_buffer *driver);
+ int ibv_cmd_open_qp(struct ibv_context *context,
+ 		    struct verbs_qp *qp,  int vqp_sz,
+ 		    struct ibv_qp_open_attr *attr,
+diff --git a/providers/hns/hns_roce_u_verbs.c b/providers/hns/hns_roce_u_verbs.c
+index 7a861ba..e19a766 100644
+--- a/providers/hns/hns_roce_u_verbs.c
++++ b/providers/hns/hns_roce_u_verbs.c
+@@ -1446,7 +1446,7 @@ static int qp_exec_create_cmd(struct ibv_qp_init_attr_ex *attr,
+ 
+ 	ret = ibv_cmd_create_qp_ex2(&ctx->ibv_ctx.context, &qp->verbs_qp, attr,
+ 				    &cmd_ex.ibv_cmd, sizeof(cmd_ex),
+-				    &resp_ex.ibv_resp, sizeof(resp_ex));
++				    &resp_ex.ibv_resp, sizeof(resp_ex), NULL);
+ 	if (ret) {
+ 		verbs_err(&ctx->ibv_ctx,
+ 			  "failed to exec create qp cmd, ret = %d.\n", ret);
+diff --git a/providers/ionic/ionic_verbs.c b/providers/ionic/ionic_verbs.c
+index 589024c..ac7ad8a 100644
+--- a/providers/ionic/ionic_verbs.c
++++ b/providers/ionic/ionic_verbs.c
+@@ -1737,7 +1737,7 @@ static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
+ 				   &req.ibv_cmd,
+ 				   sizeof(req),
+ 				   &resp.ibv_resp,
+-				   sizeof(resp));
++				   sizeof(resp), NULL);
+ 	if (rc)
+ 		goto err_cmd;
+ 
+diff --git a/providers/mana/qp.c b/providers/mana/qp.c
+index 1b828ff..b6a9a7e 100644
+--- a/providers/mana/qp.c
++++ b/providers/mana/qp.c
+@@ -526,7 +526,7 @@ static struct ibv_qp *mana_create_qp_ex_raw(struct ibv_context *context,
+ 	cmd_drv->port = port;
+ 
+ 	ret = ibv_cmd_create_qp_ex2(context, &qp->ibqp, attr, &cmd.ibv_cmd,
+-				    sizeof(cmd), &resp.ibv_resp, sizeof(resp));
++				    sizeof(cmd), &resp.ibv_resp, sizeof(resp), NULL);
+ 	if (ret) {
+ 		verbs_err(verbs_get_ctx(context), "Create QP EX failed\n");
+ 		free(qp);
+diff --git a/providers/mlx4/verbs.c b/providers/mlx4/verbs.c
+index 67c47f6..d88c319 100644
+--- a/providers/mlx4/verbs.c
++++ b/providers/mlx4/verbs.c
+@@ -804,7 +804,7 @@ static int mlx4_cmd_create_qp_ex_rss(struct ibv_context *context,
+ 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
+ 				    attr, &cmd_ex.ibv_cmd,
+ 				    sizeof(cmd_ex), &resp.ibv_resp,
+-				    sizeof(resp));
++				    sizeof(resp), NULL);
+ 	return ret;
+ }
+ 
+@@ -863,7 +863,7 @@ static int mlx4_cmd_create_qp_ex(struct ibv_context *context,
+ 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
+ 				    attr, &cmd_ex.ibv_cmd,
+ 				    sizeof(cmd_ex), &resp.ibv_resp,
+-				    sizeof(resp));
++				    sizeof(resp), NULL);
+ 	return ret;
+ }
+ 
+diff --git a/providers/mlx5/verbs.c b/providers/mlx5/verbs.c
+index d2975c4..501ff59 100644
+--- a/providers/mlx5/verbs.c
++++ b/providers/mlx5/verbs.c
+@@ -2160,7 +2160,7 @@ static int mlx5_cmd_create_rss_qp(struct ibv_context *context,
+ 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
+ 				    attr,
+ 				    &cmd_ex_rss.ibv_cmd, sizeof(cmd_ex_rss),
+-				    &resp.ibv_resp, sizeof(resp));
++				    &resp.ibv_resp, sizeof(resp), NULL);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -2193,7 +2193,7 @@ static int mlx5_cmd_create_qp_ex(struct ibv_context *context,
+ 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
+ 				    attr, &cmd_ex.ibv_cmd,
+ 				    sizeof(cmd_ex), &resp->ibv_resp,
+-				    sizeof(*resp));
++				    sizeof(*resp), NULL);
+ 
+ 	return ret;
+ }
+diff --git a/providers/rxe/rxe.c b/providers/rxe/rxe.c
+index 423f834..b3d855e 100644
+--- a/providers/rxe/rxe.c
++++ b/providers/rxe/rxe.c
+@@ -1395,7 +1395,7 @@ static struct ibv_qp *rxe_create_qp_ex(struct ibv_context *context,
+ 
+ 	ret = ibv_cmd_create_qp_ex2(context, &qp->vqp, attr,
+ 				    &cmd, cmd_size,
+-				    &resp.ibv_resp, resp_size);
++				    &resp.ibv_resp, resp_size, NULL);
+ 	if (ret)
+ 		goto err_free;
+ 
+-- 
+2.45.4
+

--- a/SPECS/rdma-core/rdma-core.spec
+++ b/SPECS/rdma-core/rdma-core.spec
@@ -31,7 +31,7 @@
 
 Name: rdma-core
 Version: 2601.0.7
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: RDMA core userspace libraries and daemons
 Group: System Environment/Libraries
 
@@ -45,6 +45,8 @@ Url: https://github.com/linux-rdma/rdma-core
 Vendor: Microsoft Corporation
 Distribution: Azure Linux
 Source0: %{_distro_sources_url}/rdma-core-%{version}.tar.gz
+# Enable the MANA userspace provider (libmana), disabled in the OFED tarball.
+Patch0: 0001-enable-mana-provider.patch
 # OFED: Build static libs by default.
 %define with_static %{?_without_static: 0} %{?!_without_static: 1}
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -391,7 +393,7 @@ easy, object-oriented access to IB verbs.
 %endif
 
 %prep
-%setup
+%autosetup -p1
 
 %build
 
@@ -710,9 +712,11 @@ fi
 %{_libdir}/libibverbs/*.so
 %ifnarch s390x s390
 %{_libdir}/libefa.so.*
+%{_libdir}/libmana.so.*
 %{_libdir}/libmlx4.so.*
 %{_libdir}/libmlx5.so.*
 %endif
+%config(noreplace) %{_sysconfdir}/libibverbs.d/mana.driver
 %config(noreplace) %{_sysconfdir}/libibverbs.d/mlx5.driver
 %doc installed_docs/libibverbs.md
 
@@ -811,6 +815,9 @@ fi
 %endif
 
 %changelog
+* Thu Jul 09 2026 Kshitiz Godara <kgodara@microsoft.com> - 2601.0.7-2
+- Enable and package the MANA userspace provider (libmana) via Patch0.
+
 * Mon May 12 2026 Azure Linux Team - 2601.0.7-1
 - Upgrade to DOCA 3.3.0 (OFED 26.01-1.0.0.0)
 

--- a/SPECS/rdma-core/rdma-core.spec
+++ b/SPECS/rdma-core/rdma-core.spec
@@ -47,6 +47,14 @@ Distribution: Azure Linux
 Source0: %{_distro_sources_url}/rdma-core-%{version}.tar.gz
 # Enable the MANA userspace provider (libmana), disabled in the OFED tarball.
 Patch0: 0001-enable-mana-provider.patch
+# Add MANA device-memory and queue-pair enhancements.
+Patch1: 0001-providers-mana-do-not-check-cqid-on-creation.patch
+Patch2: 0002-providers-mana-Device-memory.patch
+Patch3: 0003-providers-mana-Optimize-poll-completion-path.patch
+Patch4: 0004-providers-mana-Retrieve-queue-type-from-queue-ID.patch
+Patch5: 0005-providers-mana-unify-rc_qp-to-be-rnic_qp.patch
+Patch6: 0006-providers-mana-allocate-destroy-MWs.patch
+Patch7: 0007-libibverbs-Extend-ibv_cmd_create_qp_ex2-with-driver-.patch
 # OFED: Build static libs by default.
 %define with_static %{?_without_static: 0} %{?!_without_static: 1}
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -816,9 +824,10 @@ fi
 
 %changelog
 * Thu Jul 09 2026 Kshitiz Godara <kgodara@microsoft.com> - 2601.0.7-2
-- Enable and package the MANA userspace provider (libmana) via Patch0.
+- Enable and package the MANA userspace provider (libmana)
+- All upstream patches for mana improvements
 
-* Mon May 12 2026 Azure Linux Team - 2601.0.7-1
+* Tue May 12 2026 Azure Linux Team - 2601.0.7-1
 - Upgrade to DOCA 3.3.0 (OFED 26.01-1.0.0.0)
 
 * Tue Nov 04 2025 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 59.0-1


### PR DESCRIPTION
The OFED 26.01 source tarball gates most providers off in the top-level CMakeLists.txt via `if (0)` blocks, which left the MANA provider (libmana) out of the build. As a result libibverbs shipped without a userspace provider for Azure MANA RDMA/RoCE devices (mana_0).

Add Patch0 (0001-enable-mana-provider.patch) to move add_subdirectory(providers/mana) out of the disabled block so the provider is built, and package its artifacts:
  - libmana.so.* and the mana.driver config in the libibverbs subpackage
  - libmana.so devel symlink, libmana.pc, and manadv.h via existing devel wildcards

This also adds all the upstream fixes (till version 64.0) to Azure Linux branch.

[Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1156323&view=results)