### PR TITLE
Update SymCrypt-OpenSSL to 1.10 with ML-KEM support

### DIFF
--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "SymCrypt-OpenSSL-1.9.5.tar.gz": "f62a66c772a05fe925d12f6981bfdc642711c104858f8152ed7a3a8bdf003c08"
+    "SymCrypt-OpenSSL-1.10.0.tar.gz": "015aa57c7d8bf6089cdd53bb7ce9fa52e5e37aa0281531b7406440cd4e3a3b7f"
   }
 }

--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
@@ -89,7 +89,7 @@ install SymCryptProvider/symcrypt_prov.cnf %{buildroot}%{_sysconfdir}/pki/tls/sy
 %dir %attr(1733, root, root) %{_localstatedir}/log/keysinuse/
 
 %changelog
-* Thi Jul 9 2026 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.10.0-1
+* Thu Jul 9 2026 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.10.0-1
 - Add ML-KEM and ML-KEM hybrid
 
 * Fri Mar 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.9.5-1

--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
@@ -1,6 +1,6 @@
 Summary:        The SymCrypt engine for OpenSSL (SCOSSL) allows the use of OpenSSL with SymCrypt as the provider for core cryptographic operations
 Name:           SymCrypt-OpenSSL
-Version:        1.9.5
+Version:        1.10.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -89,6 +89,9 @@ install SymCryptProvider/symcrypt_prov.cnf %{buildroot}%{_sysconfdir}/pki/tls/sy
 %dir %attr(1733, root, root) %{_localstatedir}/log/keysinuse/
 
 %changelog
+* Thi Jul 9 2026 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.10.0-1
+- Add ML-KEM and ML-KEM hybrid
+
 * Fri Mar 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.9.5-1
 - Auto-upgrade to 1.9.5 - bug fixes
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29026,8 +29026,8 @@
         "type": "other",
         "other": {
           "name": "SymCrypt-OpenSSL",
-          "version": "1.9.5",
-          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.9.5.tar.gz"
+          "version": "1.10.0",
+          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.10.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
## Summary 

SymCrypt-OpenSSL 1.10 was created as a special release to backport ML-KEM into the stable 1.9 version that's currently available on AZL3. The backport isolated changes to the new ML-KEM and ML-KEM hybrid algorithms to avoid regressions to existing algorithms. Changes can be found here: https://github.com/microsoft/SymCrypt-OpenSSL/pull/171

This PR bumps the SymCrypt-OpenSSL package to 1.10 with ML-KEM and ML-KEM hybrid support. No changes to SymCrypt are required.

## Testing

The changes were tested in the SymCrypt-OpenSSL build CI/CD pipeline, which includes OpensSSL EVP tests, and integration tests. The changes were validated against the relevant test suites for the AZL3 versions of CURL, .NET runtime 8/9, golang, nginx, NodeJs, perl, and rust-openssl.

The changes were built into a preview package and deployed to PPE. Confirmed no regressions and little to no overhead to TLS connections when using the new ML-KEM key exchange groups.