### PR TITLE
containerd2: build with default Go toolchain to fix stdlib CVEs

### DIFF
--- a/SPECS/containerd2/containerd2.spec
+++ b/SPECS/containerd2/containerd2.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: %{upstream_name}2
 Version: 2.2.4
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -35,7 +35,7 @@ Patch15:	CVE-2026-42502.patch
 
 %{?systemd_requires}
 
-BuildRequires: golang < 1.25
+BuildRequires: golang
 BuildRequires: go-md2man
 BuildRequires: make
 BuildRequires: systemd-rpm-macros
@@ -69,10 +69,15 @@ used directly by developers or end-users.
 
 %build
 export BUILDTAGS="-mod=vendor"
+# cgo-less OpenSSL backend for our CGO_ENABLED=0 build (Go 1.26 systemcrypto needs cgo).
+# Go 1.26-only flag: remove at golang >= 1.27 (auto-selected there; else build fails).
+# Ref: https://github.com/microsoft/go/blob/microsoft/main/eng/doc/NocgoOpenSSL.md
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 make VERSION="%{version}" REVISION="%{commit_hash}" binaries man
 
 %check
 export BUILDTAGS="-mod=vendor"
+export GOEXPERIMENT=ms_nocgo_opensslcrypto
 make VERSION="%{version}" REVISION="%{commit_hash}" test
 
 %install
@@ -108,6 +113,10 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Thu Jul 09 2026 Aadhar Agarwal <aadagarwal@microsoft.com> - 2.2.4-5
+- Remove 'BuildRequires: golang < 1.25' and set GOEXPERIMENT=ms_nocgo_opensslcrypto
+  to build with the default Go toolchain, resolving Go stdlib CVE-2026-25679,
+  CVE-2026-27139, CVE-2026-33811, CVE-2026-39836 (was built on Go 1.24.13).
 
 * Fri Jun 19 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.2.4-4
 - Patch for CVE-2026-42502, CVE-2026-25681, CVE-2026-25680


### PR DESCRIPTION
###### Merge Checklist
- [x] The toolchain has been rebuilt successfully
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build 
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted
- [x] LICENSE-MAP files are up-to-date
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### Summary
`containerd2` is built with `BuildRequires: golang < 1.25`, so its binaries carry unfixed Go standard-library CVEs. This drops the `BuildRequires: golang < 1.25` pin to rebuild with the **default Go toolchain (1.26.x)**, and sets `GOEXPERIMENT=ms_nocgo_opensslcrypto` so the `CGO_ENABLED=0` build works with the new toolchain's OpenSSL backend.

###### Change Log
- Remove `BuildRequires: golang < 1.25` -> build with the default Go toolchain (1.26.x).
- Set `GOEXPERIMENT=ms_nocgo_opensslcrypto` in `%build`/`%check` (Go 1.26 bridge; remove at Go 1.27).
- Release: 4 -> 5.
- Fixes Go stdlib CVE-2026-25679, CVE-2026-27139, CVE-2026-33811, CVE-2026-39836.

###### Does this affect the toolchain?
**NO** 

###### Associated issues
- Microsoft ADO work item 63028495.

###### Links to CVEs
- https://nvd.nist.gov/vuln/detail/CVE-2026-25679
- https://nvd.nist.gov/vuln/detail/CVE-2026-27139
- https://nvd.nist.gov/vuln/detail/CVE-2026-33811
- https://nvd.nist.gov/vuln/detail/CVE-2026-39836

###### Test Methodology
- Validated on an Azure Linux VM that the containerd binaries were built with Go 1.26.x and that govulncheck no longer reports the four targeted stdlib CVEs.