### PR TITLE
ci: remove obsolete pr-package-build pipeline symlink

### DIFF
--- a/.github/workflows/ado/pr-package-build.yml
+++ b/.github/workflows/ado/pr-package-build.yml
@@ -1,1 +1,0 @@
-pr-check-ct.yml


### PR DESCRIPTION
## What

Remove the temporary `.github/workflows/ado/pr-package-build.yml` symlink to `pr-check-ct.yml` added in #17885.

## Why

The PR check pipeline now uses `pr-check-ct.yml` directly, so the compatibility entry point at the previous path is obsolete.
