### PR TITLE
test: Add Database Tests For Container Images - Postgres, Redis, Valkey, Memcached

### DIFF
--- a/base/images/tests/README.md
+++ b/base/images/tests/README.md
@@ -167,6 +167,7 @@ base/images/
 | `container_exec` | function | callable | `(args) → ContainerExecResult` |
 | `wait_for_http` | function | callable | `(url, *, retries=5, delay=1.0, connect_timeout=2.0, max_time=5.0) → ContainerExecResult` — polls an in-container HTTP endpoint with `curl`; raises after retries |
 | `assert_http_server` | function | callable | `(start_command, url, expected, *, retries=5, delay=1.0) → ContainerExecResult` — starts a server, waits for `url`, asserts `expected` in body |
+| `client_server_exec_shell` | function | tuple | Networked server and client containers for cross-container tests |
 
 ## Adding tests
 
@@ -236,9 +237,10 @@ Dockerfile only trigger one build.
 > `container_exec_shell("nginx")`. This keeps behaviour predictable and
 > ensures each test controls exactly what runs.
 
-For service tests, poll readiness with a short bounded loop before asserting on
-responses; do not assume the service binds synchronously. Foreground services
-should be backgrounded explicitly, for example
+For service tests, poll readiness before asserting on responses; do not assume the
+service binds synchronously — use `wait_until_service_ready(exec_shell, probe_cmd,
+contains=...)` from `utils.container_runtime`. Foreground services should be
+backgrounded explicitly, for example
 `container_exec_shell("nohup my-service > /tmp/my-service.log 2>&1 &")`.
 
 ## Adding a native-tool dependency

--- a/base/images/tests/cases/runtime/container-base/test_basic.py
+++ b/base/images/tests/cases/runtime/container-base/test_basic.py
@@ -8,8 +8,10 @@ running container. Each test gets a fresh container instance via the
 
 from __future__ import annotations
 
+from utils.container_runtime import ExecShell
 
-def test_shell_accessible(container_exec_shell) -> None:
+
+def test_shell_accessible(container_exec_shell: ExecShell) -> None:
     """Container shell must be functional via exec."""
     result = container_exec_shell("echo hello-from-container")
     assert result.exit_code == 0, (
@@ -18,7 +20,7 @@ def test_shell_accessible(container_exec_shell) -> None:
     assert "hello-from-container" in result.output
 
 
-def test_dns_resolution(container_exec_shell) -> None:
+def test_dns_resolution(container_exec_shell: ExecShell) -> None:
     """Container must be able to resolve localhost via DNS."""
     result = container_exec_shell("getent hosts localhost")
     assert result.exit_code == 0, (

--- a/base/images/tests/cases/runtime/container-base/test_dotnet/test_dotnet.py
+++ b/base/images/tests/cases/runtime/container-base/test_dotnet/test_dotnet.py
@@ -10,19 +10,20 @@ that communicates with it over localhost.
 from __future__ import annotations
 
 import pytest
+from utils.container_runtime import AssertHttpServer, ExecShell
 
 EXPECTED_RESPONSE = "Hello World!"
 
 
 @pytest.mark.dockerfile()
-def test_dotnet_version(container_exec_shell) -> None:
+def test_dotnet_version(container_exec_shell: ExecShell) -> None:
     """.NET runtime must be present and report a version."""
     result = container_exec_shell("dotnet --version")
     assert result.exit_code == 0, f"dotnet --version failed: {result.output}"
 
 
 @pytest.mark.dockerfile()
-def test_dotnet_web(assert_http_server, container_exec_shell) -> None:
+def test_dotnet_web(assert_http_server: AssertHttpServer, container_exec_shell: ExecShell) -> None:
     """A .NET server and RestSharp client must communicate over localhost."""
     assert_http_server(
         "nohup dotnet /app/webapp/app.dll > /tmp/server.log 2>&1 &",

--- a/base/images/tests/cases/runtime/container-base/test_memcached/Dockerfile
+++ b/base/images/tests/cases/runtime/container-base/test_memcached/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+RUN dnf install -y memcached nmap-ncat && dnf clean all
+EXPOSE 11211

--- a/base/images/tests/cases/runtime/container-base/test_memcached/test_memcached.py
+++ b/base/images/tests/cases/runtime/container-base/test_memcached/test_memcached.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+"""Validate the Memcached server on the container-base image."""
+
+from __future__ import annotations
+
+import pytest
+from utils.container_runtime import wait_until_service_ready
+
+PORT = 11211
+
+
+def _start_memcached(container_exec_shell) -> None:
+    """Start memcached daemonized and wait until it accepts connections."""
+    # Run as the memcached user, since the server cannot run as root.
+    start = container_exec_shell(f"memcached -u memcached -d -p {PORT}")
+    assert start.exit_code == 0, f"memcached failed to start: {start.output}"
+
+    wait_until_service_ready(
+        container_exec_shell,
+        f"printf 'version\\r\\nquit\\r\\n' | nc localhost {PORT}",
+        contains="VERSION",
+    )
+
+
+@pytest.mark.dockerfile()
+def test_memcached_version(container_exec_shell) -> None:
+    """The Memcached server binary reports a version."""
+    result = container_exec_shell("memcached --version")
+    assert result.exit_code == 0, f"memcached --version failed: {result.output}"
+    assert "memcached" in result.output
+
+
+@pytest.mark.dockerfile()
+def test_memcached_set_get(container_exec_shell) -> None:
+    """Store a value with memcached and read it back."""
+    _start_memcached(container_exec_shell)
+    # Text protocol: "set <key> <flags> <exptime> <bytes>" + the value, then get it back.
+    result = container_exec_shell(
+        f"printf 'set TestValue 0 100 4\\r\\nTest\\r\\nget TestValue\\r\\nquit\\r\\n' | nc localhost {PORT}",
+    )
+    assert result.exit_code == 0, f"nc failed: {result.output}"
+    assert "STORED" in result.output, f"set not acknowledged: {result.output}"
+    body = result.output.replace("\r\n", "\n")
+    assert "VALUE TestValue 0 4\nTest\nEND" in body, f"unexpected get response: {result.output}"

--- a/base/images/tests/cases/runtime/container-base/test_memcached/test_memcached.py
+++ b/base/images/tests/cases/runtime/container-base/test_memcached/test_memcached.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 import pytest
-from utils.container_runtime import wait_until_service_ready
+from utils.container_runtime import ExecShell, wait_until_service_ready
 
 PORT = 11211
 
 
-def _start_memcached(container_exec_shell) -> None:
+def _start_memcached(container_exec_shell: ExecShell) -> None:
     """Start memcached daemonized and wait until it accepts connections."""
     # Run as the memcached user, since the server cannot run as root.
     start = container_exec_shell(f"memcached -u memcached -d -p {PORT}")
@@ -23,7 +23,7 @@ def _start_memcached(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_memcached_version(container_exec_shell) -> None:
+def test_memcached_version(container_exec_shell: ExecShell) -> None:
     """The Memcached server binary reports a version."""
     result = container_exec_shell("memcached --version")
     assert result.exit_code == 0, f"memcached --version failed: {result.output}"
@@ -31,7 +31,7 @@ def test_memcached_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_memcached_set_get(container_exec_shell) -> None:
+def test_memcached_set_get(container_exec_shell: ExecShell) -> None:
     """Store a value with memcached and read it back."""
     _start_memcached(container_exec_shell)
     # Text protocol: "set <key> <flags> <exptime> <bytes>" + the value, then get it back.

--- a/base/images/tests/cases/runtime/container-base/test_nginx/test_nginx.py
+++ b/base/images/tests/cases/runtime/container-base/test_nginx/test_nginx.py
@@ -8,10 +8,11 @@ nginx installed on top of the image-under-test.
 from __future__ import annotations
 
 import pytest
+from utils.container_runtime import AssertHttpServer, ExecShell
 
 
 @pytest.mark.dockerfile()
-def test_nginx_config_valid(container_exec_shell) -> None:
+def test_nginx_config_valid(container_exec_shell: ExecShell) -> None:
     """nginx configuration must pass validation."""
     result = container_exec_shell("nginx -t")
     assert result.exit_code == 0, f"nginx -t failed: {result.output}"
@@ -20,6 +21,6 @@ def test_nginx_config_valid(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_nginx_health_endpoint(assert_http_server) -> None:
+def test_nginx_health_endpoint(assert_http_server: AssertHttpServer) -> None:
     """nginx /health endpoint must return 200."""
     assert_http_server("nginx", "http://localhost:80/health", "healthy")

--- a/base/images/tests/cases/runtime/container-base/test_nodejs/test_nodejs.py
+++ b/base/images/tests/cases/runtime/container-base/test_nodejs/test_nodejs.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from utils.container_runtime import AssertHttpServer, ExecShell
 
 EXPECTED_RESPONSE = (Path(__file__).with_name("response.txt")).read_text().strip()
 
 
 @pytest.mark.dockerfile()
-def test_nodejs_version(container_exec_shell) -> None:
+def test_nodejs_version(container_exec_shell: ExecShell) -> None:
     """Node.js interpreter must be present and report a version."""
     result = container_exec_shell("node --version")
     assert result.exit_code == 0, f"node --version failed: {result.output}"
@@ -24,7 +25,7 @@ def test_nodejs_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_nodejs_http_server(assert_http_server) -> None:
+def test_nodejs_http_server(assert_http_server: AssertHttpServer) -> None:
     """A stdlib http server must serve the expected response."""
     assert_http_server(
         "nohup node /app/server.js > /tmp/server.log 2>&1 &",

--- a/base/images/tests/cases/runtime/container-base/test_openmpi/test_openmpi.py
+++ b/base/images/tests/cases/runtime/container-base/test_openmpi/test_openmpi.py
@@ -8,6 +8,7 @@ OpenMPI installed on top of the image-under-test.
 from __future__ import annotations
 
 import pytest
+from utils.container_runtime import ExecShell
 
 MPI_RUN = "/usr/lib64/openmpi/bin/mpirun"
 PRTE_RUN = "/usr/lib64/openmpi/bin/prterun"
@@ -16,7 +17,7 @@ MPI_TIMEOUT_SECS = 30
 
 
 @pytest.mark.dockerfile()
-def test_openmpi_mpirun_version(container_exec_shell) -> None:
+def test_openmpi_mpirun_version(container_exec_shell: ExecShell) -> None:
     """mpirun binary must exist and report version."""
     result = container_exec_shell(f"OMPI_PRTERUN={PRTE_RUN} {MPI_RUN} --version")
     assert result.exit_code == 0, f"mpirun --version failed: {result.output}"
@@ -24,7 +25,7 @@ def test_openmpi_mpirun_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_openmpi_runs_multiple_ranks(container_exec_shell) -> None:
+def test_openmpi_runs_multiple_ranks(container_exec_shell: ExecShell) -> None:
     """mpirun should launch two ranks in a single container."""
     result = container_exec_shell(
         f"OMPI_PRTERUN={PRTE_RUN} "
@@ -42,7 +43,7 @@ def test_openmpi_runs_multiple_ranks(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_openmpi_send_receive_between_two_ranks(container_exec_shell) -> None:
+def test_openmpi_send_receive_between_two_ranks(container_exec_shell: ExecShell) -> None:
     """Two MPI ranks should exchange tagged messages successfully."""
     compile_and_run = (
         f"{MPI_CC} -O2 -o /tmp/send_receive "

--- a/base/images/tests/cases/runtime/container-base/test_php/test_php.py
+++ b/base/images/tests/cases/runtime/container-base/test_php/test_php.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from utils.container_runtime import AssertHttpServer, ExecShell
 
 EXPECTED_RESPONSE = (Path(__file__).with_name("response.txt")).read_text().strip()
 
 
 @pytest.mark.dockerfile()
-def test_php_version(container_exec_shell) -> None:
+def test_php_version(container_exec_shell: ExecShell) -> None:
     """PHP interpreter must be present and report a version."""
     result = container_exec_shell("php --version")
     assert result.exit_code == 0, f"php --version failed: {result.output}"
@@ -24,7 +25,7 @@ def test_php_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_php_zip_extension_loaded(container_exec_shell) -> None:
+def test_php_zip_extension_loaded(container_exec_shell: ExecShell) -> None:
     """The zip extension must be loaded in the PHP runtime."""
     result = container_exec_shell("php -m")
     assert result.exit_code == 0, f"php -m failed: {result.output}"
@@ -32,7 +33,7 @@ def test_php_zip_extension_loaded(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_php_http_server(assert_http_server) -> None:
+def test_php_http_server(assert_http_server: AssertHttpServer) -> None:
     """The built-in PHP server must serve a successful zip round-trip."""
     assert_http_server(
         "nohup php -S 0.0.0.0:8080 /app/router.php > /tmp/server.log 2>&1 &",

--- a/base/images/tests/cases/runtime/container-base/test_postgres/Dockerfile
+++ b/base/images/tests/cases/runtime/container-base/test_postgres/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+RUN dnf install -y postgresql-server postgresql && dnf clean all
+EXPOSE 5432

--- a/base/images/tests/cases/runtime/container-base/test_postgres/test_postgres.py
+++ b/base/images/tests/cases/runtime/container-base/test_postgres/test_postgres.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: MIT
+"""Validate the PostgreSQL server on the container-base image."""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+from utils.container_runtime import wait_until_service_ready
+
+DB_PORT = 5432
+DB_NAME = "postgres"
+DB_USER = "postgres"
+DB_PASSWORD = "secret"  # noqa: S105 - throwaway password for the test container
+EXPECTED_ROWS = 2
+
+PG_DIR = "/var/lib/pgsql"
+PG_DATADIR = f"{PG_DIR}/data"
+PG_LOGFILE = f"{PG_DIR}/logfile"
+PG_RUNDIR = "/run/postgresql"
+
+
+@contextlib.contextmanager
+def _postgres_password_file(container_exec_shell, password: str):
+    """Yield a postgres-owned temp password file; remove it on exit."""
+    mk = container_exec_shell("mktemp")
+    assert mk.exit_code == 0, f"mktemp failed: {mk.output}"
+    filepath = mk.stdout.strip()
+    try:
+        setup = container_exec_shell(f"printf %s {password} > {filepath} && chown postgres {filepath}")
+        assert setup.exit_code == 0, f"password file setup failed: {setup.output}"
+        yield filepath
+    finally:
+        container_exec_shell(f"runuser -u postgres rm -f {filepath}")
+
+
+def _start_postgresql(container_exec_shell, *, listen_all: bool = False) -> None:
+    """Init the cluster and start the server; listen_all also opens it to remote hosts."""
+    socket = container_exec_shell(
+        f"mkdir -p {PG_RUNDIR} && chown postgres:postgres {PG_RUNDIR}",
+    )
+    assert socket.exit_code == 0, f"socket dir setup failed: {socket.output}"
+
+    # initdb and the server cannot run as root.
+    with _postgres_password_file(container_exec_shell, DB_PASSWORD) as pwfile_path:
+        initdb = container_exec_shell(
+            "runuser -l postgres -c '"
+            "initdb --locale=C --encoding=UTF8 --auth-local=peer "
+            f"--auth-host=scram-sha-256 --pwfile={pwfile_path} -D {PG_DATADIR}'",
+        )
+        assert initdb.exit_code == 0, f"initdb failed: {initdb.output}"
+
+    if listen_all:
+        # Open the server to remote TCP; it listens on localhost only by default.
+        config = container_exec_shell(
+            f"echo \"listen_addresses = '*'\" >> {PG_DATADIR}/postgresql.conf && "
+            f"echo 'host all all 0.0.0.0/0 scram-sha-256' >> {PG_DATADIR}/pg_hba.conf",
+        )
+        assert config.exit_code == 0, f"network config setup failed: {config.output}"
+
+    start = container_exec_shell(
+        f"runuser -l postgres -c 'pg_ctl -D {PG_DATADIR} -l {PG_LOGFILE} -w start'",
+    )
+    assert start.exit_code == 0, f"pg_ctl start failed: {start.output}"
+
+    wait_until_service_ready(container_exec_shell, f"pg_isready -h localhost -p {DB_PORT}")
+
+
+def _run_crud_workflow(exec_shell, host: str) -> None:
+    """Create a table, insert two rows, and read them back against the DB at ``host``."""
+    psql = f"PGPASSWORD={DB_PASSWORD} psql -h {host} -p {DB_PORT} -U {DB_USER} -d {DB_NAME}"
+
+    create = exec_shell(f'{psql} -c "CREATE TABLE cities (name varchar(80), location point);"')
+    assert create.exit_code == 0, f"create failed: {create.output}"
+    assert "CREATE TABLE" in create.output
+
+    insert_sql = (
+        "INSERT INTO cities VALUES ('San Francisco', '(-194.0, 53.0)'); "
+        "INSERT INTO cities VALUES ('Seattle', '(-150.0, 86.0)');"
+    )
+    insert = exec_shell(f'{psql} -c "{insert_sql}"')
+    assert insert.exit_code == 0, f"insert failed: {insert.output}"
+    assert insert.output.count("INSERT 0 1") == EXPECTED_ROWS, f"expected two inserts: {insert.output}"
+
+    select = exec_shell(f'{psql} -c "SELECT * FROM cities;"')
+    assert select.exit_code == 0, f"select failed: {select.output}"
+    assert f"{EXPECTED_ROWS} rows" in select.output, f"expected {EXPECTED_ROWS} rows: {select.output}"
+
+
+def _assert_bad_auth_rejected(exec_shell, host: str) -> None:
+    """A wrong password must be rejected, proving the scram rule is enforced (not trust)."""
+    bad_auth = exec_shell(
+        f"PGPASSWORD=wrong psql -h {host} -p {DB_PORT} -U {DB_USER} -d {DB_NAME} -c 'SELECT 1;'",
+    )
+    assert bad_auth.exit_code != 0, f"wrong password was accepted: {bad_auth.output}"
+    assert "authentication failed" in bad_auth.output, f"unexpected auth error: {bad_auth.output}"
+
+
+@pytest.mark.dockerfile()
+def test_postgresql_version(container_exec_shell) -> None:
+    """The PostgreSQL server binary reports a version."""
+    result = container_exec_shell("postgres --version")
+    assert result.exit_code == 0, f"postgres --version failed: {result.output}"
+    assert "postgres (PostgreSQL)" in result.output
+
+
+@pytest.mark.dockerfile()
+def test_postgresql_database_server(container_exec_shell) -> None:
+    """Server accepts TCP connections and handles create/insert/select."""
+    _start_postgresql(container_exec_shell)
+    _assert_bad_auth_rejected(container_exec_shell, "localhost")
+    _run_crud_workflow(container_exec_shell, "localhost")
+
+
+@pytest.mark.dockerfile()
+def test_postgresql_cross_container(client_server_exec_shell) -> None:
+    """A client container reaches a server container's database over the network."""
+    server_exec, client_exec, server_host = client_server_exec_shell
+
+    _start_postgresql(server_exec, listen_all=True)
+    _assert_bad_auth_rejected(client_exec, server_host)
+    _run_crud_workflow(client_exec, server_host)

--- a/base/images/tests/cases/runtime/container-base/test_postgres/test_postgres.py
+++ b/base/images/tests/cases/runtime/container-base/test_postgres/test_postgres.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterator
 
 import pytest
-from utils.container_runtime import wait_until_service_ready
+from utils.container_runtime import ExecShell, wait_until_service_ready
 
 DB_PORT = 5432
 DB_NAME = "postgres"
@@ -21,7 +22,7 @@ PG_RUNDIR = "/run/postgresql"
 
 
 @contextlib.contextmanager
-def _postgres_password_file(container_exec_shell, password: str):
+def _postgres_password_file(container_exec_shell: ExecShell, password: str) -> Iterator[str]:
     """Yield a postgres-owned temp password file; remove it on exit."""
     mk = container_exec_shell("mktemp")
     assert mk.exit_code == 0, f"mktemp failed: {mk.output}"
@@ -34,7 +35,7 @@ def _postgres_password_file(container_exec_shell, password: str):
         container_exec_shell(f"runuser -u postgres rm -f {filepath}")
 
 
-def _start_postgresql(container_exec_shell, *, listen_all: bool = False) -> None:
+def _start_postgresql(container_exec_shell: ExecShell, *, listen_all: bool = False) -> None:
     """Init the cluster and start the server; listen_all also opens it to remote hosts."""
     socket = container_exec_shell(
         f"mkdir -p {PG_RUNDIR} && chown postgres:postgres {PG_RUNDIR}",
@@ -66,7 +67,7 @@ def _start_postgresql(container_exec_shell, *, listen_all: bool = False) -> None
     wait_until_service_ready(container_exec_shell, f"pg_isready -h localhost -p {DB_PORT}")
 
 
-def _run_crud_workflow(exec_shell, host: str) -> None:
+def _run_crud_workflow(exec_shell: ExecShell, host: str) -> None:
     """Create a table, insert two rows, and read them back against the DB at ``host``."""
     psql = f"PGPASSWORD={DB_PASSWORD} psql -h {host} -p {DB_PORT} -U {DB_USER} -d {DB_NAME}"
 
@@ -87,7 +88,7 @@ def _run_crud_workflow(exec_shell, host: str) -> None:
     assert f"{EXPECTED_ROWS} rows" in select.output, f"expected {EXPECTED_ROWS} rows: {select.output}"
 
 
-def _assert_bad_auth_rejected(exec_shell, host: str) -> None:
+def _assert_bad_auth_rejected(exec_shell: ExecShell, host: str) -> None:
     """A wrong password must be rejected, proving the scram rule is enforced (not trust)."""
     bad_auth = exec_shell(
         f"PGPASSWORD=wrong psql -h {host} -p {DB_PORT} -U {DB_USER} -d {DB_NAME} -c 'SELECT 1;'",
@@ -97,7 +98,7 @@ def _assert_bad_auth_rejected(exec_shell, host: str) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_postgresql_version(container_exec_shell) -> None:
+def test_postgresql_version(container_exec_shell: ExecShell) -> None:
     """The PostgreSQL server binary reports a version."""
     result = container_exec_shell("postgres --version")
     assert result.exit_code == 0, f"postgres --version failed: {result.output}"
@@ -105,7 +106,7 @@ def test_postgresql_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_postgresql_database_server(container_exec_shell) -> None:
+def test_postgresql_database_server(container_exec_shell: ExecShell) -> None:
     """Server accepts TCP connections and handles create/insert/select."""
     _start_postgresql(container_exec_shell)
     _assert_bad_auth_rejected(container_exec_shell, "localhost")
@@ -113,7 +114,7 @@ def test_postgresql_database_server(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_postgresql_cross_container(client_server_exec_shell) -> None:
+def test_postgresql_cross_container(client_server_exec_shell: tuple[ExecShell, ExecShell, str]) -> None:
     """A client container reaches a server container's database over the network."""
     server_exec, client_exec, server_host = client_server_exec_shell
 

--- a/base/images/tests/cases/runtime/container-base/test_python/test_python.py
+++ b/base/images/tests/cases/runtime/container-base/test_python/test_python.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from utils.container_runtime import AssertHttpServer, ExecShell
 
 EXPECTED_RESPONSE = (Path(__file__).with_name("response.txt")).read_text().strip()
 
 
 @pytest.mark.dockerfile()
-def test_python_version(container_exec_shell) -> None:
+def test_python_version(container_exec_shell: ExecShell) -> None:
     """Python interpreter must be present and report version 3."""
     result = container_exec_shell("python3 --version")
     assert result.exit_code == 0, f"python3 --version failed: {result.output}"
@@ -24,7 +25,7 @@ def test_python_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_python_http_server(assert_http_server) -> None:
+def test_python_http_server(assert_http_server: AssertHttpServer) -> None:
     """A stdlib http.server app must serve the expected response."""
     assert_http_server(
         "nohup python3 /app/app.py > /tmp/server.log 2>&1 &",

--- a/base/images/tests/cases/runtime/container-base/test_redis/Dockerfile
+++ b/base/images/tests/cases/runtime/container-base/test_redis/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+RUN dnf install -y valkey-compat-redis && dnf clean all
+EXPOSE 6379

--- a/base/images/tests/cases/runtime/container-base/test_redis/test_redis.py
+++ b/base/images/tests/cases/runtime/container-base/test_redis/test_redis.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+"""Validate the Redis server on the container-base image."""
+
+from __future__ import annotations
+
+import pytest
+from utils.container_runtime import wait_until_service_ready
+
+EXPECTED_LEN = "4"
+
+
+def _start_redis(container_exec_shell) -> None:
+    """Start redis-server daemonized and wait until it answers PING."""
+    start = container_exec_shell("redis-server --protected-mode no --save 60 1 --daemonize yes")
+    assert start.exit_code == 0, f"redis-server failed to start: {start.output}"
+
+    wait_until_service_ready(container_exec_shell, "redis-cli ping", contains="PONG")
+
+
+@pytest.mark.dockerfile()
+def test_redis_version(container_exec_shell) -> None:
+    """The Redis server reports its version."""
+    _start_redis(container_exec_shell)
+    result = container_exec_shell("redis-cli INFO server")
+    assert result.exit_code == 0, f"INFO server failed: {result.output}"
+    assert "redis_version:" in result.output
+
+
+@pytest.mark.dockerfile()
+def test_redis_cross_container(client_server_exec_shell) -> None:
+    """A client container reaches the server container's Redis over the network and runs LPUSH."""
+    server_exec, client_exec, server_host = client_server_exec_shell
+
+    _start_redis(server_exec)
+
+    cli = f"redis-cli -h {server_host}"
+
+    push = client_exec(f"{cli} LPUSH mylist a b c d")
+    assert push.exit_code == 0, f"remote LPUSH failed: {push.output}"
+    assert push.output.strip() == EXPECTED_LEN, f"expected list length {EXPECTED_LEN}: {push.output}"

--- a/base/images/tests/cases/runtime/container-base/test_redis/test_redis.py
+++ b/base/images/tests/cases/runtime/container-base/test_redis/test_redis.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 import pytest
-from utils.container_runtime import wait_until_service_ready
+from utils.container_runtime import ExecShell, wait_until_service_ready
 
 EXPECTED_LEN = "4"
 
 
-def _start_redis(container_exec_shell) -> None:
+def _start_redis(container_exec_shell: ExecShell) -> None:
     """Start redis-server daemonized and wait until it answers PING."""
     start = container_exec_shell("redis-server --protected-mode no --save 60 1 --daemonize yes")
     assert start.exit_code == 0, f"redis-server failed to start: {start.output}"
@@ -18,7 +18,7 @@ def _start_redis(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_redis_version(container_exec_shell) -> None:
+def test_redis_version(container_exec_shell: ExecShell) -> None:
     """The Redis server reports its version."""
     _start_redis(container_exec_shell)
     result = container_exec_shell("redis-cli INFO server")
@@ -27,7 +27,7 @@ def test_redis_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_redis_cross_container(client_server_exec_shell) -> None:
+def test_redis_cross_container(client_server_exec_shell: tuple[ExecShell, ExecShell, str]) -> None:
     """A client container reaches the server container's Redis over the network and runs LPUSH."""
     server_exec, client_exec, server_host = client_server_exec_shell
 

--- a/base/images/tests/cases/runtime/container-base/test_ruby/test_ruby.py
+++ b/base/images/tests/cases/runtime/container-base/test_ruby/test_ruby.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from utils.container_runtime import AssertHttpServer, ExecShell
 
 EXPECTED_RESPONSE = (Path(__file__).with_name("response.txt")).read_text().strip()
 
 
 @pytest.mark.dockerfile()
-def test_ruby_version(container_exec_shell) -> None:
+def test_ruby_version(container_exec_shell: ExecShell) -> None:
     """Ruby interpreter must be present and report a version."""
     result = container_exec_shell("ruby --version")
     assert result.exit_code == 0, f"ruby --version failed: {result.output}"
@@ -24,7 +25,7 @@ def test_ruby_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_ruby_http_server(assert_http_server) -> None:
+def test_ruby_http_server(assert_http_server: AssertHttpServer) -> None:
     """A stdlib socket HTTP server must serve the expected response."""
     assert_http_server(
         "nohup ruby /app/app.rb > /tmp/server.log 2>&1 &",

--- a/base/images/tests/cases/runtime/container-base/test_telegraf/test_telegraf.py
+++ b/base/images/tests/cases/runtime/container-base/test_telegraf/test_telegraf.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
+from utils.container_runtime import ExecShell, WriteFile
 
 TELEGRAF_CONFIG = "/etc/telegraf/telegraf.conf"
 
 
 @pytest.mark.dockerfile()
-def test_telegraf_emits_mem_metrics(container_exec_shell) -> None:
+def test_telegraf_emits_mem_metrics(container_exec_shell: ExecShell) -> None:
     """telegraf --test must emit mem plugin measurement output."""
     result = container_exec_shell(f"telegraf --config {TELEGRAF_CONFIG} --test")
     assert result.exit_code == 0, f"telegraf --test failed: {result.output}"
@@ -23,7 +23,7 @@ def test_telegraf_emits_mem_metrics(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_telegraf_reports_version_and_plugin_usage(container_exec_shell) -> None:
+def test_telegraf_reports_version_and_plugin_usage(container_exec_shell: ExecShell) -> None:
     """telegraf binary should report version and cpu plugin usage details."""
     result = container_exec_shell("telegraf --version && telegraf --usage cpu")
     assert result.exit_code == 0, f"telegraf version/usage check failed: {result.output}"
@@ -33,7 +33,7 @@ def test_telegraf_reports_version_and_plugin_usage(container_exec_shell) -> None
 
 @pytest.mark.dockerfile()
 def test_telegraf_file_output_plugin_writes_metrics(
-    container_exec_shell, write_file_in_container
+    container_exec_shell: ExecShell, write_file_in_container: WriteFile
 ) -> None:
     """telegraf should be able to flush metrics to file output."""
     config_body = (

--- a/base/images/tests/cases/runtime/container-base/test_valkey/Dockerfile
+++ b/base/images/tests/cases/runtime/container-base/test_valkey/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+RUN dnf install -y valkey && dnf clean all
+EXPOSE 6379

--- a/base/images/tests/cases/runtime/container-base/test_valkey/test_valkey.py
+++ b/base/images/tests/cases/runtime/container-base/test_valkey/test_valkey.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+"""Validate the Valkey server on the container-base image."""
+
+from __future__ import annotations
+
+import pytest
+from utils.container_runtime import wait_until_service_ready
+
+EXPECTED_LEN = "4"
+
+
+def _start_valkey(container_exec_shell) -> None:
+    """Start valkey-server daemonized and wait until it answers PING."""
+    start = container_exec_shell("valkey-server --protected-mode no --save 60 1 --daemonize yes")
+    assert start.exit_code == 0, f"valkey-server failed to start: {start.output}"
+
+    wait_until_service_ready(container_exec_shell, "valkey-cli ping", contains="PONG")
+
+
+@pytest.mark.dockerfile()
+def test_valkey_version(container_exec_shell) -> None:
+    """The Valkey server reports its version."""
+    _start_valkey(container_exec_shell)
+    result = container_exec_shell("valkey-cli INFO server")
+    assert result.exit_code == 0, f"INFO server failed: {result.output}"
+    assert "valkey_version:" in result.output
+
+
+@pytest.mark.dockerfile()
+def test_valkey_cross_container(client_server_exec_shell) -> None:
+    """A client container reaches the server container's Valkey over the network and runs LPUSH."""
+    server_exec, client_exec, server_host = client_server_exec_shell
+
+    _start_valkey(server_exec)
+
+    cli = f"valkey-cli -h {server_host}"
+
+    push = client_exec(f"{cli} LPUSH mylist a b c d")
+    assert push.exit_code == 0, f"remote LPUSH failed: {push.output}"
+    assert push.output.strip() == EXPECTED_LEN, f"expected list length {EXPECTED_LEN}: {push.output}"

--- a/base/images/tests/cases/runtime/container-base/test_valkey/test_valkey.py
+++ b/base/images/tests/cases/runtime/container-base/test_valkey/test_valkey.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 import pytest
-from utils.container_runtime import wait_until_service_ready
+from utils.container_runtime import ExecShell, wait_until_service_ready
 
 EXPECTED_LEN = "4"
 
 
-def _start_valkey(container_exec_shell) -> None:
+def _start_valkey(container_exec_shell: ExecShell) -> None:
     """Start valkey-server daemonized and wait until it answers PING."""
     start = container_exec_shell("valkey-server --protected-mode no --save 60 1 --daemonize yes")
     assert start.exit_code == 0, f"valkey-server failed to start: {start.output}"
@@ -18,7 +18,7 @@ def _start_valkey(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_valkey_version(container_exec_shell) -> None:
+def test_valkey_version(container_exec_shell: ExecShell) -> None:
     """The Valkey server reports its version."""
     _start_valkey(container_exec_shell)
     result = container_exec_shell("valkey-cli INFO server")
@@ -27,7 +27,7 @@ def test_valkey_version(container_exec_shell) -> None:
 
 
 @pytest.mark.dockerfile()
-def test_valkey_cross_container(client_server_exec_shell) -> None:
+def test_valkey_cross_container(client_server_exec_shell: tuple[ExecShell, ExecShell, str]) -> None:
     """A client container reaches the server container's Valkey over the network and runs LPUSH."""
     server_exec, client_exec, server_host = client_server_exec_shell
 

--- a/base/images/tests/conftest.py
+++ b/base/images/tests/conftest.py
@@ -15,10 +15,26 @@ import subprocess
 import tempfile
 import time
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
-
+from python_on_whales import DockerClient
+from utils.container_runtime import (
+    AssertHttpServer,
+    ContainerExecResult,
+    ContainerInstance,
+    ExecShell,
+    WaitForHttp,
+    WriteFile,
+    build_image,
+    cleanup_test_images,
+    create_container,
+    destroy_container,
+    exec_in_container,
+    get_podman_client,
+    resolve_image_reference,
+)
 from utils.disk import inspect_disk
 from utils.extract import (
     inspect_oci_config,
@@ -29,15 +45,6 @@ from utils.extract import (
     unmount_container_image,
     unmount_vm_image,
     unmount_wsl_image,
-)
-from utils.container_runtime import (
-    build_image,
-    cleanup_test_images,
-    create_container,
-    destroy_container,
-    exec_in_container,
-    get_podman_client,
-    resolve_image_reference,
 )
 from utils.parsers import parse_os_release, query_rpm_package_sizes
 from utils.pytest_plugin import (
@@ -130,7 +137,7 @@ def image_type(
 
 
 @pytest.fixture(scope="session")
-def workdir(request: pytest.FixtureRequest) -> Path:
+def workdir(request: pytest.FixtureRequest) -> Iterator[Path]:
     """Working directory for mounts and extractions.
 
     If ``--workdir`` is set, the directory is reused as-is and never
@@ -176,7 +183,7 @@ def workdir(request: pytest.FixtureRequest) -> Path:
 
 
 @pytest.fixture(scope="session")
-def rootfs(image_path: Path | None, image_type: str, workdir: Path) -> Path:
+def rootfs(image_path: Path | None, image_type: str, workdir: Path) -> Iterator[Path]:
     """Mounted rootfs — session yield-fixture with cleanup.
 
     Requires ``--image-path`` (not ``--image-ref``); skips otherwise.
@@ -317,7 +324,7 @@ def podman_client(image_type: str):
 
 @pytest.fixture(scope="session")
 def container_image_ref(
-    podman_client, image_path: Path | None, image_ref: str | None,
+    podman_client: DockerClient, image_path: Path | None, image_ref: str | None,
     image_type: str,
 ) -> str | None:
     """Resolve the container image once per session and cache the reference.
@@ -333,12 +340,12 @@ def container_image_ref(
     return resolve_image_reference(podman_client, image_path=image_path, image_ref=image_ref)
 
 
-def _effective_image(podman_client, container_image_ref: str, request: pytest.FixtureRequest) -> str:
+def _effective_image(podman_client: DockerClient, container_image_ref: str, request: pytest.FixtureRequest) -> str:
     """Build the per-test image from ``@pytest.mark.dockerfile()`` if present, else use the base image."""
     marker = request.node.get_closest_marker("dockerfile")
     if marker is None:
         return container_image_ref
-    test_dir = Path(request.fspath).parent
+    test_dir = request.path.parent
     dockerfile_path = (test_dir / (marker.args[0] if marker.args else "Dockerfile")).resolve()
     if not dockerfile_path.exists():
         pytest.fail(
@@ -350,7 +357,7 @@ def _effective_image(podman_client, container_image_ref: str, request: pytest.Fi
 
 @pytest.fixture
 def running_container(
-    podman_client, image_type: str,
+    podman_client: DockerClient, image_type: str,
     container_image_ref: str | None, request: pytest.FixtureRequest,
 ):
     """Fresh container per test with guaranteed teardown.
@@ -377,7 +384,7 @@ def running_container(
 
 
 @pytest.fixture
-def container_exec(podman_client, running_container):
+def container_exec(podman_client: DockerClient, running_container: ContainerInstance):
     """Callable to execute commands in the running test container.
 
     Usage::
@@ -397,7 +404,7 @@ def container_exec(podman_client, running_container):
 
 
 @pytest.fixture
-def container_exec_shell(podman_client, running_container):
+def container_exec_shell(podman_client: DockerClient, running_container: ContainerInstance) -> ExecShell:
     """Callable to execute shell commands in the running test container.
 
     Usage::
@@ -417,7 +424,7 @@ def container_exec_shell(podman_client, running_container):
 
 
 @pytest.fixture
-def write_file_in_container(container_exec_shell):
+def write_file_in_container(container_exec_shell: ExecShell) -> WriteFile:
     """Callable to write file content into the running test container.
 
     Preserves leading whitespace and content exactly as provided, while
@@ -444,9 +451,9 @@ def write_file_in_container(container_exec_shell):
 
 @pytest.fixture
 def client_server_exec_shell(
-    podman_client, image_type: str,
+    podman_client: DockerClient, image_type: str,
     container_image_ref: str | None, request: pytest.FixtureRequest,
-):
+) -> Iterator[tuple[ExecShell, ExecShell, str]]:
     """Two networked containers, each with a callable to execute shell commands.
 
     Usage::
@@ -467,8 +474,8 @@ def client_server_exec_shell(
     network_name = f"azl-test-net-{uuid.uuid4().hex[:12]}"
     podman_client.network.create(network_name)
 
-    def _exec_shell_for(container):
-        def _exec_shell(command: str, *, shell: str = "bash"):
+    def _exec_shell_for(container: ContainerInstance) -> ExecShell:
+        def _exec_shell(command: str, *, shell: str = "bash") -> ContainerExecResult:
             return exec_in_container(podman_client, container.container_name, [shell, "-c", command])
         return _exec_shell
 
@@ -493,7 +500,7 @@ def client_server_exec_shell(
 
 
 @pytest.fixture
-def wait_for_http(container_exec_shell):
+def wait_for_http(container_exec_shell: ExecShell) -> WaitForHttp:
     """Callable that polls an in-container HTTP endpoint until it responds.
 
     Runs ``curl -sSf <url>`` inside the running test container, retrying
@@ -536,7 +543,7 @@ def wait_for_http(container_exec_shell):
 
 
 @pytest.fixture
-def assert_http_server(container_exec_shell, wait_for_http):
+def assert_http_server(container_exec_shell: ExecShell, wait_for_http: WaitForHttp) -> AssertHttpServer:
     """Start an HTTP server in the container and assert its response.
 
     Runs ``start_command`` inside the running test container, waits for

--- a/base/images/tests/conftest.py
+++ b/base/images/tests/conftest.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import uuid
 from pathlib import Path
 
 import pytest
@@ -332,6 +333,21 @@ def container_image_ref(
     return resolve_image_reference(podman_client, image_path=image_path, image_ref=image_ref)
 
 
+def _effective_image(podman_client, container_image_ref: str, request: pytest.FixtureRequest) -> str:
+    """Build the per-test image from ``@pytest.mark.dockerfile()`` if present, else use the base image."""
+    marker = request.node.get_closest_marker("dockerfile")
+    if marker is None:
+        return container_image_ref
+    test_dir = Path(request.fspath).parent
+    dockerfile_path = (test_dir / (marker.args[0] if marker.args else "Dockerfile")).resolve()
+    if not dockerfile_path.exists():
+        pytest.fail(
+            f"Dockerfile not found: {dockerfile_path} "
+            f"(from @pytest.mark.dockerfile on {request.node.name})"
+        )
+    return build_image(podman_client, dockerfile_path, container_image_ref)
+
+
 @pytest.fixture
 def running_container(
     podman_client, image_type: str,
@@ -348,25 +364,7 @@ def running_container(
     if container_image_ref is None:
         pytest.fail("container_image_ref was not resolved for a container image")
 
-    # Check for @pytest.mark.dockerfile() marker.
-    effective_image = container_image_ref
-    dockerfile_marker = request.node.get_closest_marker("dockerfile")
-    if dockerfile_marker is not None:
-        test_dir = Path(request.fspath).parent
-        if dockerfile_marker.args:
-            dockerfile_path = (test_dir / dockerfile_marker.args[0]).resolve()
-        else:
-            dockerfile_path = (test_dir / "Dockerfile").resolve()
-
-        if not dockerfile_path.exists():
-            pytest.fail(
-                f"Dockerfile not found: {dockerfile_path} "
-                f"(from @pytest.mark.dockerfile on {request.node.name})"
-            )
-
-        effective_image = build_image(
-            podman_client, dockerfile_path, container_image_ref,
-        )
+    effective_image = _effective_image(podman_client, container_image_ref, request)
 
     logger.info("Creating container for test %s", request.node.name)
     instance = create_container(podman_client, effective_image)
@@ -442,6 +440,56 @@ def write_file_in_container(container_exec_shell):
         return container_exec_shell(write_cmd)
 
     return _write
+
+
+@pytest.fixture
+def client_server_exec_shell(
+    podman_client, image_type: str,
+    container_image_ref: str | None, request: pytest.FixtureRequest,
+):
+    """Two networked containers, each with a callable to execute shell commands.
+
+    Usage::
+
+        def test_example(client_server_exec_shell):
+            server_exec, client_exec, server_host = client_server_exec_shell
+            server_exec("some-daemon &")
+            result = client_exec(f"curl http://{server_host}:8080")
+            assert result.exit_code == 0
+    """
+    if image_type != "container":
+        pytest.skip("client_server_exec_shell only applicable to container images")
+    if container_image_ref is None:
+        pytest.fail("container_image_ref was not resolved for a container image")
+
+    effective_image = _effective_image(podman_client, container_image_ref, request)
+
+    network_name = f"azl-test-net-{uuid.uuid4().hex[:12]}"
+    podman_client.network.create(network_name)
+
+    def _exec_shell_for(container):
+        def _exec_shell(command: str, *, shell: str = "bash"):
+            return exec_in_container(podman_client, container.container_name, [shell, "-c", command])
+        return _exec_shell
+
+    suffix = uuid.uuid4().hex[:12]
+    logger.info("Creating server and client containers for test %s", request.node.name)
+    server = client = None
+    try:
+        server = create_container(
+            podman_client, effective_image, f"azl-test-server-{suffix}", networks=[network_name],
+        )
+        client = create_container(
+            podman_client, effective_image, f"azl-test-client-{suffix}", networks=[network_name],
+        )
+        yield _exec_shell_for(server), _exec_shell_for(client), server.container_name
+    finally:
+        try:
+            for container in (server, client):
+                if container is not None:
+                    destroy_container(podman_client, container.container_name)
+        finally:
+            podman_client.network.remove(network_name)
 
 
 @pytest.fixture

--- a/base/images/tests/utils/container_runtime.py
+++ b/base/images/tests/utils/container_runtime.py
@@ -11,15 +11,13 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from collections.abc import Callable
 from pathlib import Path
-from typing import Iterator, NamedTuple, cast
+from typing import Iterator, NamedTuple, Protocol, cast
 
 from python_on_whales import DockerClient
 from python_on_whales.exceptions import DockerException, NoSuchContainer, NoSuchImage
 
 from .tools import NativeTool
-
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +43,46 @@ class ContainerExecResult(NamedTuple):
     stdout: str
     stderr: str
     output: str
+
+
+class ExecShell(Protocol):
+    """Run a shell command string inside a test container."""
+
+    def __call__(self, command: str, *, shell: str = "bash") -> ContainerExecResult: ...
+
+
+class WriteFile(Protocol):
+    """Write file content into a test container (trailing newline normalized)."""
+
+    def __call__(self, path: str, content: str) -> ContainerExecResult: ...
+
+
+class WaitForHttp(Protocol):
+    """Poll an in-container HTTP endpoint until it responds, or raise on timeout."""
+
+    def __call__(
+        self,
+        url: str,
+        *,
+        retries: int = 5,
+        delay: float = 1.0,
+        connect_timeout: float = 2.0,
+        max_time: float = 5.0,
+    ) -> ContainerExecResult: ...
+
+
+class AssertHttpServer(Protocol):
+    """Start an HTTP server in the container, wait for it, and assert the response body."""
+
+    def __call__(
+        self,
+        start_command: str,
+        url: str,
+        expected: str,
+        *,
+        retries: int = 5,
+        delay: float = 1.0,
+    ) -> ContainerExecResult: ...
 
 
 class ContainerInstance(NamedTuple):
@@ -315,7 +353,7 @@ def _make_exec_result(
 
 
 def wait_until_service_ready(
-    exec_shell: Callable[[str], ContainerExecResult],
+    exec_shell: ExecShell,
     command: str,
     *,
     contains: str = "",

--- a/base/images/tests/utils/container_runtime.py
+++ b/base/images/tests/utils/container_runtime.py
@@ -9,7 +9,9 @@ Podman CLI directly.
 from __future__ import annotations
 
 import logging
+import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Iterator, NamedTuple, cast
 
@@ -188,6 +190,8 @@ def create_container(
     client: DockerClient,
     image_ref: str,
     container_name: str | None = None,
+    *,
+    networks: list[str] | None = None,
 ) -> ContainerInstance:
     """Create and start a container with exec access.
 
@@ -198,6 +202,7 @@ def create_container(
         client: Active python-on-whales Podman client.
         image_ref: Image ID or reference to run.
         container_name: Optional name; auto-generated if None.
+        networks: Optional networks to attach the container to.
 
     Returns:
         A ContainerInstance with the container's ID, name, and image ref.
@@ -212,6 +217,7 @@ def create_container(
         command=["sleep", "infinity"],
         name=container_name,
         detach=True,
+        networks=networks or [],
     )
 
     # Verify the container is running and exec works.
@@ -306,6 +312,26 @@ def _make_exec_result(
         stderr=stderr,
         output=stdout + stderr,
     )
+
+
+def wait_until_service_ready(
+    exec_shell: Callable[[str], ContainerExecResult],
+    command: str,
+    *,
+    contains: str = "",
+    attempts: int = 10,
+    delay: float = 1.0,
+) -> ContainerExecResult:
+    """Poll ``command`` until it exits 0 and its output contains ``contains``."""
+    output = ""
+    for attempt in range(attempts):
+        if attempt:
+            time.sleep(delay)
+        result = exec_shell(command)
+        if result.exit_code == 0 and contains in result.output:
+            return result
+        output = result.output
+    raise AssertionError(f"{command!r} never became ready: {output}")
 
 
 def destroy_container(client: DockerClient, container_name: str) -> None:

--- a/base/images/tests/utils/extract.py
+++ b/base/images/tests/utils/extract.py
@@ -56,10 +56,10 @@ BUILDAH = NativeTool(
 )
 
 
-def _run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+def _run(cmd: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     """Run a command, logging it and raising with stderr on failure."""
     logger.info("Running: %s", " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
     if result.returncode != 0:
         logger.error(
             "Command failed (rc=%d): %s\nstdout: %s\nstderr: %s",


### PR DESCRIPTION
Commit [1](https://github.com/microsoft/azurelinux/pull/18001/changes/747f7c95547c68176fcad0e2fb5dfcac376a6c84) - Added Container Runtime Tests for 4 DataStores:
- Valkey
- Redis (available as valkey-compat-redis)
- Postgres
- Memcached

Also Added a new fixture: `client_server_shell_exec`:
- Creates 2 Contains, named `client` and `server` respectively
- Connects them to same network
- Returns their respective shell exec callable, and server container name for dns 

Each added test contains:
- Docker file to install the corresponding package
- Test file, which starts the server for each datastore, and contains 2 tests - Version Test to check the sanity / installation, and a Core Functionality Test (Create-Insert-Select for Postgres, LPUSH for Redis/Valkey, and Set-Get for Memcached)
- Also Included Cross Container Tests for Postgres, Redis, Valkey which use the new fixture to test for client-server connections.

PR Testing:
Locally built a container images and tested using azldev tool:

- Memcached Tests
<img width="2032" height="624" alt="image" src="https://github.com/user-attachments/assets/231bd6b3-f5b0-4a76-8c0b-ed33eded4c0d" />

- Postgres Tests
<img width="2050" height="965" alt="image" src="https://github.com/user-attachments/assets/0c09c321-8971-43ca-bfb1-26ae26c22a2a" />

- Redis Tests
<img width="2052" height="676" alt="image" src="https://github.com/user-attachments/assets/eba26f3a-f59d-43a1-8a85-e33110eb3644" />

- Valkey Tests
<img width="2049" height="1042" alt="image" src="https://github.com/user-attachments/assets/be68e806-8b8d-4d35-b2b8-131339bf8641" />

Commit [2](https://github.com/microsoft/azurelinux/pull/18001/changes/b7ab464fad52e714e6a2173d1c7458d2227c3105) - Fixed Pyright Errors:
- Untyped Fixture Param (`reportUnknownParameterType`, `reportMissingParameterType`)
- Incorrect Param / Return Type (`reportArgumentType`, `reportReturnType`, `reportInvalidTypeForm`, `reportCallIssue`)
- Deprecated Access Method (`reportAttributeAccessIssue`)

Previous Pyright Errors (Grouped):
<img width="1587" height="444" alt="image" src="https://github.com/user-attachments/assets/c8349ebf-d37b-482e-9a15-43eccedbf5a5" />

Fixed All Pyright Errors in latest commit:
<img width="1588" height="287" alt="image" src="https://github.com/user-attachments/assets/49123934-8854-4571-ac4e-136d30161806" />


