### PR TITLE
toolkit: add 'find-name-present' query mode to repoquerywrapper

### DIFF
--- a/toolkit/tools/repoquerywrapper/repoquerywrapper.go
+++ b/toolkit/tools/repoquerywrapper/repoquerywrapper.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	QueryCmdFindPresent = "find-present"
+	QueryCmdFindPresent     = "find-present"
+	QueryCmdFindNamePresent = "find-name-present"
 )
 
 var (
@@ -33,7 +34,7 @@ var (
 	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz").Required().ExistingFile()
 	buildDir  = app.Flag("worker-dir", "Directory to store chroot while running repo query.").Required().String()
 
-	queryCmd        = app.Flag("query-cmd", "The query commands to run. Available command is: 'find-present'.").Required().String()
+	queryCmd        = app.Flag("query-cmd", "The query commands to run. Available commands are: 'find-present', 'find-name-present'.").Required().String()
 	queryInputFile  = app.Flag("query-input-file", "Path to a file with the query input data.").Required().String()
 	queryOutputFile = app.Flag("query-output-file", "Path to a file for the query output data.").Required().String()
 )
@@ -83,6 +84,51 @@ func main() {
 		}
 	}
 
+	// cmd         : 'find-name-present'
+	// query input : a file where each line is a bare rpm package name
+	//               (no version/release/arch) to search for.
+	// query output: a file where each line is a name that has AT LEAST ONE
+	//               matching RPM (any version/release/arch) available in the
+	//               queried repos.
+	//
+	// Motivation: image composition uses a fetcher that walks ordered repos
+	// first-match; the local toolchain-repo shadows PMC even when PMC has a
+	// newer NEVRA for the same package name. Callers use this query to identify
+	// which toolchain packages can be safely scrubbed so PMC's copy is used
+	// instead. See rpmrepocloner.go and toolkit/resources/manifests/package/local.repo.
+	if *queryCmd == QueryCmdFindNamePresent {
+
+		// Build a set of package names present in the queried repos by
+		// stripping "-<version>-<release>.<arch>" from each basename.
+		presentNames := make(map[string]bool)
+		for basename := range packagesAvailableFromRepos {
+			name := packageNameFromNEVRA(basename)
+			if name != "" {
+				presentNames[name] = true
+			}
+		}
+
+		inputNames, err := readFileLines(*queryInputFile)
+		if err != nil {
+			logger.PanicOnError(err)
+		}
+
+		var outputNames []string
+		for _, inputName := range inputNames {
+			if inputName == "" {
+				continue
+			}
+			if presentNames[inputName] {
+				outputNames = append(outputNames, inputName)
+			}
+		}
+
+		err = writeFileLines(outputNames, *queryOutputFile)
+		if err != nil {
+			logger.PanicOnError(err)
+		}
+	}
+
 	if logger.Log.IsLevelEnabled(logrus.DebugLevel) {
 		for i, pkg := range packagesAvailableFromRepos {
 			logger.Log.Debugf("Found package: %s, %s", i, pkg)
@@ -108,4 +154,32 @@ func writeFileLines(lines []string, fileName string) (err error) {
 		return err
 	}
 	return nil
+}
+
+// packageNameFromNEVRA parses an RPM basename of the form
+// "<name>-<version>-<release>.<arch>" (with the ".rpm" suffix already stripped)
+// and returns just the "<name>" portion. Returns an empty string if the input
+// does not have the expected structure.
+//
+// Per RPM rules, <version> and <release> may not contain '-', but <name> may.
+// So we parse from the right: strip ".<arch>", then "-<release>", then
+// "-<version>", leaving the name.
+func packageNameFromNEVRA(basename string) string {
+	lastDot := strings.LastIndex(basename, ".")
+	if lastDot < 0 {
+		return ""
+	}
+	nameVerRel := basename[:lastDot]
+
+	lastDash := strings.LastIndex(nameVerRel, "-")
+	if lastDash < 0 {
+		return ""
+	}
+	nameVer := nameVerRel[:lastDash]
+
+	lastDash = strings.LastIndex(nameVer, "-")
+	if lastDash < 0 {
+		return ""
+	}
+	return nameVer[:lastDash]
 }


### PR DESCRIPTION
### Why

The image fetcher (`imagepkgfetcher`) resolves image-composition packages by name only, then delegates to `tdnf install` against an ordered `allrepos.repo`. Per `toolkit/resources/manifests/package/local.repo` and the priority-simulation logic in `rpmrepocloner.go`, `toolchain-repo` sits at priority 1 (top of the concatenated list). TDNF walks first-match, so a same-name package in the toolchain overlay shadows PMC — even when PMC has a newer NEVRA.

That is correct for hermetic package builds. It is wrong for image composition when `COMPOSE_IMAGES_WITH_PUBLISHED_PACKAGES=true` (which is the pipeline default for monthlies): the whole point is to prefer PMC's latest.

BuildImage.sh already scrubs `out/RPMS/` of anything present on PMC by exact NEVRA (`find-present`). Extending the same protection to `build/toolchain_rpms/` requires a name-only lookup, which is what this PR adds.

### What

Adds `find-name-present` to `repoquerywrapper`:
- **Input:** file with one bare package name per line.
- **Output:** subset of those names that have at least one available RPM in the queried repos.

Small helper `packageNameFromNEVRA` parses `<name>-<version>-<release>.<arch>` right-to-left so hyphenated names like `curl-libs` are handled correctly.

### Companion PR

The consumer of this new query mode is a `BuildImage.sh` change in CBL-Mariner-Pipelines (users/joslobo/scrub-toolchain-published). That pipelines PR references this one and should merge after this lands on `3.0`.

### Test

- `go build ./repoquerywrapper/...` (via CI — no local Go available)
- End-to-end validation planned once the companion pipelines PR is queued against Fast-Track PROD / a delta monthly rerun where a fasttrack has published a newer NEVRA than the reseed toolchain (repro from monthly 3.0.20260712 with curl-9 vs curl-10).

### Real-world repro

Monthly `3.0.20260712-3.0-1158503` shipped `curl-8.11.1-9` in the base container despite `curl-8.11.1-10` being on PMC at build time (published Sat 7/11 via FT PROD 1157932, well before Stage 6 started Sun 7/12 4:33 PM PDT).