### PR TITLE
fix: remove golang version cap for nvidia container runtime

### DIFF
--- a/SPECS/libnvidia-container/libnvidia-container.spec
+++ b/SPECS/libnvidia-container/libnvidia-container.spec
@@ -4,7 +4,7 @@
 Summary:        NVIDIA container runtime library
 Name:           libnvidia-container
 Version:        1.17.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD AND ASL2.0 AND GPLv3+ AND LGPLv3+ AND MIT AND GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -21,7 +21,7 @@ BuildRequires:  libtirpc-devel
 BuildRequires:  make
 BuildRequires:  rpcsvc-proto
 BuildRequires:  which
-BuildRequires:  golang < 1.24.0
+BuildRequires:  golang
 
 %description
 The nvidia-container library provides an interface to configure GNU/Linux
@@ -135,6 +135,9 @@ This package contains command-line tools that facilitate using the library.
 %{_bindir}/*
 
 %changelog
+* Fri Jul 10 2026 Henry Li <lihl@microsoft.com> - 1.17.8-2
+- Remove golang version cap
+
 * Thu Jul 24 2025 Sam Meluch <sammeluch@microsoft.com> - 1.17.8-1
 - Upgrade to version 1.17.8 in sync with nvidia-container-toolkit
 

--- a/SPECS/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/SPECS/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 Summary:        NVIDIA container runtime hook
 Name:           nvidia-container-toolkit
 Version:        1.17.8
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ALS2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -31,7 +31,7 @@ Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2025-22872.patch
 Patch1:         CVE-2026-39830.patch
 Patch2:         CVE-2026-39834.patch
-BuildRequires:  golang < 1.24.0
+BuildRequires:  golang
 Obsoletes: nvidia-container-runtime <= 3.5.0-1, nvidia-container-runtime-hook <= 1.4.0-2
 Provides: nvidia-container-runtime
 Provides: nvidia-container-runtime-hook
@@ -90,6 +90,9 @@ rm -f %{_bindir}/nvidia-container-toolkit
 %{_bindir}/nvidia-cdi-hook
 
 %changelog
+* Fri Jul 10 2026 Henry Li <lihl@microsoft.com> - 1.17.8-4
+- Remove golang version cap
+
 * Wed May 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.17.8-3
 - Patch for CVE-2026-39834, CVE-2026-39830
 


### PR DESCRIPTION
This change removes the version cap placed on libnvidia-container and nvidia-container-toolkit so that the build process will pick up the latest supported golang version to build these two packages. Both components can be built successfully with the latest golang 1.26.5 that is supported on 3.0-dev branch.