### PR TITLE
container-publishing: retry ACR ops on transient failures

### DIFF
--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -88,40 +88,56 @@ function acr_login {
         --password "$oras_access_token"
 }
 
+# Retry a registry-touching command with exponential backoff.
+# ACR occasionally returns transient "error pinging v2 registry" /
+# connection-timeout errors while a long-running publish batch is in flight.
+# Any docker/oras call that talks to ACR should be wrapped here.
+# $1: human-readable description (for logging)
+# $2..: command + args to invoke
+function retry_registry_op {
+    local desc=$1; shift
+    local max_retries=${MAX_REGISTRY_RETRIES:-5}
+    local retry_count=0
+    local backoff=5
+
+    while [ $retry_count -lt $max_retries ]; do
+        echo "+++ $desc (attempt $((retry_count + 1))/$max_retries)"
+        if "$@"; then
+            return 0
+        fi
+        retry_count=$((retry_count + 1))
+        if [ $retry_count -lt $max_retries ]; then
+            echo "+++ $desc failed; retrying in ${backoff}s..."
+            sleep $backoff
+            backoff=$((backoff * 2))
+        else
+            echo "+++ $desc failed after $max_retries attempts"
+            return 1
+        fi
+    done
+}
+
 # Attach the end-of-life annotation to the container image.
 # $1: image name
 function oras_attach {
     local image_name=$1
-    local max_retries=3
-    local retry_count=0
-
-    while [ $retry_count -lt $max_retries ]; do
-        echo "+++ Attempting to attach lifecycle annotation to $image_name (attempt $((retry_count + 1))/$max_retries)"
-        
-        if oras attach \
+    retry_registry_op "attach lifecycle annotation to $image_name" \
+        oras attach \
             --artifact-type "application/vnd.microsoft.artifact.lifecycle" \
             --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$END_OF_LIFE_1_YEAR" \
-            "$image_name"; then
-            echo "+++ Successfully attached lifecycle annotation to $image_name"
-            return 0
-        else
-            retry_count=$((retry_count + 1))
-            if [ $retry_count -lt $max_retries ]; then
-                echo "+++ Failed to attach lifecycle annotation to $image_name. Retrying in 5 seconds..."
-                sleep 5
-            else
-                echo "+++ Failed to attach lifecycle annotation to $image_name after $max_retries attempts"
-                return 1
-            fi
-        fi
-    done
+            "$image_name"
 }
 
 # Detach the end-of-life annotation from the container image.
 # $1: image name
 function oras_detach {
     local image_name=$1
-    lifecycle_manifests=$(oras discover -o json  --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name")
+    local lifecycle_manifests
+    if ! lifecycle_manifests=$(retry_registry_op "discover lifecycle manifests for $image_name" \
+                                oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
+        echo "+++ Warning: could not discover lifecycle manifests for $image_name; skipping detach"
+        return
+    fi
     manifests=$(echo "$lifecycle_manifests" | jq -r '.manifests')
 
     if [[ -z $manifests ]]; then
@@ -136,7 +152,8 @@ function oras_detach {
         digest=$(echo "$lifecycle_manifests" | jq -r ".manifests[$i].digest")
         echo "Deleting manifest with digest: $digest"
         imageNameWithoutTag=${image_name%:*}
-        oras manifest delete --force "$imageNameWithoutTag@$digest"
+        retry_registry_op "delete lifecycle manifest $imageNameWithoutTag@$digest" \
+            oras manifest delete --force "$imageNameWithoutTag@$digest"
     done
 }
 
@@ -218,19 +235,22 @@ function create_multi_arch_tags {
     fi
 
     # create, annotate, and push manifest
-    docker manifest create "$full_multiarch_tag" --amend "$original_container-amd64"
+    retry_registry_op "docker manifest create $full_multiarch_tag (amd64)" \
+        docker manifest create "$full_multiarch_tag" --amend "$original_container-amd64"
     docker manifest annotate "$full_multiarch_tag" "$original_container-amd64" \
         --os-version "$OS_VERSION_PREFIX$azure_linux_version"
 
     if [[ $architecture_build == *"ARM64"*  ]]; then
-        docker manifest create "$full_multiarch_tag" --amend "$original_container-arm64"
+        retry_registry_op "docker manifest create $full_multiarch_tag (arm64)" \
+            docker manifest create "$full_multiarch_tag" --amend "$original_container-arm64"
         docker manifest annotate "$full_multiarch_tag" "$original_container-arm64" \
             --os-version "$OS_VERSION_PREFIX$azure_linux_version" \
             --variant "v8"
     fi
 
     echo "+++ push $full_multiarch_tag tag"
-    docker manifest push "$full_multiarch_tag"
+    retry_registry_op "docker manifest push $full_multiarch_tag" \
+        docker manifest push "$full_multiarch_tag"
     echo "+++ $full_multiarch_tag tag pushed successfully"
     oras_detach "$full_multiarch_tag"
     oras_attach "$full_multiarch_tag"

--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -134,7 +134,7 @@ function oras_detach {
     local image_name=$1
     local lifecycle_manifests
     if ! lifecycle_manifests=$(retry_registry_op "discover lifecycle manifests for $image_name" \
-                                oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
+                                oras discover --format json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
         echo "+++ Warning: could not discover lifecycle manifests for $image_name; skipping detach"
         return
     fi


### PR DESCRIPTION
### Problem

The Publish Containers step in `[NoArch-OneBranch]-Prod-PublishGoldenContainers` (def 2907) has recently hit **back-to-back intermittent failures** with:

```
failed to configure transport: error pinging v2 registry:
  Get "https://cblmarineracr2mcr.azurecr.io/v2/":
  net/http: request canceled while waiting for connection
  (Client.Timeout exceeded while awaiting headers)
```

after successfully publishing **160+ containers** in the same run. Latest reproducer: build [1159834](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1159834) (from FT PROD 1157932), which failed at the very last container (prometheus) right after ``Created manifest list ...``.

### Root cause

Inspecting `PublishContainers.sh`, only `oras_attach` has retry logic. All other registry-touching operations run one-shot and fail the whole batch on the first ACR blip:

| Operation | Line | Had retry before this PR? |
|---|---|---|
| `oras attach` | 101 | ✅ 3× (hard-coded, no backoff) |
| `docker manifest create --amend` (amd64) | 221 | ❌ |
| `docker manifest create --amend` (arm64) | 226 | ❌ |
| `docker manifest push` | 233 | ❌ |
| `oras discover` (in `oras_detach`) | 124 | ❌ |
| `oras manifest delete` (in `oras_detach`) | 139 | ❌ |

The specific failure on build 1159834 hit inside the arm64 `docker manifest create --amend` or the `docker manifest push` immediately following it — both previously unprotected.

### Fix

Factor the retry loop into a generic **`retry_registry_op`** helper with **exponential backoff** (5, 10, 20, 40, 80 seconds; 5 attempts by default, tunable via `MAX_REGISTRY_RETRIES`), and apply it to all five previously-unprotected call sites plus the existing `oras_attach` (which becomes a one-liner).

### Testing

- `bash -n` clean.
- Behavior on happy path unchanged (first-attempt success returns immediately).
- Behavior on hard failure unchanged (still fails the job after retries are exhausted).
- The wrapper emits the same style of `+++` progress markers, so existing log-grep tooling still works.

### Backport

Targeting `3.0-dev` (this file only lives on the 3.0 line). Fine to cherry-pick to `fasttrack/3.0` after merge.
