### PR TITLE
trident: update to version 0.26.0

### DIFF
--- a/SPECS/trident/trident.signatures.json
+++ b/SPECS/trident/trident.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "trident-0.24.0.tar.gz": "945ba4516c361868decd9d314eca85cf1823937c0eea82537de37030d9d0a7ac",
-    "trident-0.24.0-cargo.tar.gz": "a56e87bb7cb84b969ae4c22402896e5edd0d19c2345d2c0f71d6c269d2a42c24"
+    "trident-0.25.0.tar.gz": "a53b276174319a1efaffb08bceaa48a129cb4c3d51075a0c0fdcaff5ba7d2da3",
+    "trident-0.25.0-cargo.tar.gz": "5acf73ecd949562784529ecae569697b9bac75cb81256965769622b02d85017b"
   }
 }

--- a/SPECS/trident/trident.signatures.json
+++ b/SPECS/trident/trident.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "trident-0.25.0.tar.gz": "a53b276174319a1efaffb08bceaa48a129cb4c3d51075a0c0fdcaff5ba7d2da3",
-    "trident-0.25.0-cargo.tar.gz": "5acf73ecd949562784529ecae569697b9bac75cb81256965769622b02d85017b"
+    "trident-0.26.0.tar.gz": "335db982d8eb7096beb88db685cafab76b2d6a8466299c4ff16c45ecee5b1216",
+    "trident-0.26.0-cargo.tar.gz": "f5f0091580081960edffb55dd73d0b76e91bfe33929219ba0a6ba980706a2779"
   }
 }

--- a/SPECS/trident/trident.spec
+++ b/SPECS/trident/trident.spec
@@ -9,7 +9,7 @@
 Summary:        Declarative, security-first OS lifecycle agent designed primarily for Azure Linux
 Name:           trident
 # Use hard-coded versions for distro build
-Version:        0.25.0
+Version:        0.26.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -313,8 +313,8 @@ mkdir -p "$pcrlockroot"
 )
 
 %changelog
-* Wed Jul 15 2026 Brian Fjeldstad <bfjelds@microsoft.com> - 0.25.0-1
-- Update to version 0.25.0
+* Wed Jul 29 2026 Brian Fjeldstad <bfjelds@microsoft.com> - 0.26.0-1
+- Update to version 0.26.0
 
 * Wed Jun 18 2026 Brian Fjeldstad <bfjelds@microsoft.com> 0.24.0-1
 - Update to version 0.24.0

--- a/SPECS/trident/trident.spec
+++ b/SPECS/trident/trident.spec
@@ -9,7 +9,7 @@
 Summary:        Declarative, security-first OS lifecycle agent designed primarily for Azure Linux
 Name:           trident
 # Use hard-coded versions for distro build
-Version:        0.24.0
+Version:        0.25.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -313,6 +313,9 @@ mkdir -p "$pcrlockroot"
 )
 
 %changelog
+* Wed Jul 15 2026 Brian Fjeldstad <bfjelds@microsoft.com> - 0.25.0-1
+- Update to version 0.25.0
+
 * Wed Jun 18 2026 Brian Fjeldstad <bfjelds@microsoft.com> 0.24.0-1
 - Update to version 0.24.0
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29606,8 +29606,8 @@
         "type": "other",
         "other": {
           "name": "trident",
-          "version": "0.24.0",
-          "downloadUrl": "https://github.com/microsoft/trident/archive/refs/tags/v0.24.0.tar.gz"
+          "version": "0.25.0",
+          "downloadUrl": "https://github.com/microsoft/trident/archive/refs/tags/v0.25.0.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29606,8 +29606,8 @@
         "type": "other",
         "other": {
           "name": "trident",
-          "version": "0.25.0",
-          "downloadUrl": "https://github.com/microsoft/trident/archive/refs/tags/v0.25.0.tar.gz"
+          "version": "0.26.0",
+          "downloadUrl": "https://github.com/microsoft/trident/archive/refs/tags/v0.26.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Updates Trident from v0.24.0 to v0.26.0. Includes changes from both the v0.25.0 and v0.26.0 releases.

## Changes

See release notes:
- https://github.com/microsoft/trident/releases/tag/v0.25.0
- https://github.com/microsoft/trident/releases/tag/v0.26.0

Adds ACL support for ImageCustomizer 1.5.0 COSI files (v0.25.0). Fixes ACL firstboot UKI addon to only apply on clean install (v0.26.0).

## Validation

### Tarball Uploads (Pipeline 2284)
- [x] Source tarball upload (v0.26.0): [Run 1170915](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_build/results?buildId=1170915)
- [x] Cargo tarball upload (v0.26.0): [Run 1170916](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_build/results?buildId=1170916)

### RPM Buddy Build (Pipeline 2190)
- [x] RPM build succeeded: [Run 1170925](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_build/results?buildId=1170925)

### RPM Test (Pipeline 5455)
- [x] RPM test succeeded: [Run 1170951](https://dev.azure.com/mariner-org/2afa5696-2a1d-438f-ac9e-db12e0b4ae27/_build/results?buildId=1170951)
