### PR TITLE
container-publishing: fix retry helper stdout pollution + use --format json

### DIFF
--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -133,8 +133,12 @@ function oras_attach {
 function oras_detach {
     local image_name=$1
     local lifecycle_manifests
+    # NOTE: keep `-o json`; on the oras version installed on the publish
+    # agent, `--format json` does not emit the schema jq expects below and
+    # causes `parse error: Invalid numeric literal`. The deprecation
+    # warning from `-o` is harmless.
     if ! lifecycle_manifests=$(retry_registry_op "discover lifecycle manifests for $image_name" \
-                                oras discover --format json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
+                                oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
         echo "+++ Warning: could not discover lifecycle manifests for $image_name; skipping detach"
         return
     fi

--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -101,17 +101,17 @@ function retry_registry_op {
     local backoff=5
 
     while [ $retry_count -lt $max_retries ]; do
-        echo "+++ $desc (attempt $((retry_count + 1))/$max_retries)"
+        echo "+++ $desc (attempt $((retry_count + 1))/$max_retries)" >&2
         if "$@"; then
             return 0
         fi
         retry_count=$((retry_count + 1))
         if [ $retry_count -lt $max_retries ]; then
-            echo "+++ $desc failed; retrying in ${backoff}s..."
+            echo "+++ $desc failed; retrying in ${backoff}s..." >&2
             sleep $backoff
             backoff=$((backoff * 2))
         else
-            echo "+++ $desc failed after $max_retries attempts"
+            echo "+++ $desc failed after $max_retries attempts" >&2
             return 1
         fi
     done

--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -133,12 +133,8 @@ function oras_attach {
 function oras_detach {
     local image_name=$1
     local lifecycle_manifests
-    # NOTE: keep `-o json`; on the oras version installed on the publish
-    # agent, `--format json` does not emit the schema jq expects below and
-    # causes `parse error: Invalid numeric literal`. The deprecation
-    # warning from `-o` is harmless.
     if ! lifecycle_manifests=$(retry_registry_op "discover lifecycle manifests for $image_name" \
-                                oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
+                                oras discover --format json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
         echo "+++ Warning: could not discover lifecycle manifests for $image_name; skipping detach"
         return
     fi


### PR DESCRIPTION
Fixes the `jq: parse error` in PublishContainers.sh publish job seen on
builds 1160866 and 1160891, and cleans up the oras deprecation warning.

## Root cause

`retry_registry_op` (added in #18026) echoed its `+++ attempt N/5` status
line to **stdout**. In `oras_detach`, the whole thing is captured:

`ash
lifecycle_manifests=$(retry_registry_op ""..."" oras discover ...)
`

so the helper chatter got prepended to the JSON payload and jq choked at
column 4.

## Fix

1. Redirect all echoes in `retry_registry_op` to stderr (`>&2`). Status
   is still visible in the pipeline log; captured stdout is now pure JSON.
2. Swap `oras discover -o json` → `oras discover --format json` to
   silence the `[DEPRECATED] --output` warning oras emits. (Safe now that
   the stdout stream is clean — the earlier flag swap attempt failed only
   because of the stdout-pollution bug.)

## Verified

Stubbed test harness executed both fixes end-to-end:
- happy path (jq parses cleanly)
- transient failure → retry succeeds
- permanent failure → 5 attempts + backoff, graceful return
- regression check: captured stdout is valid JSON

## Companion PR

- #18033 — same change for fasttrack/3.0