### PR TITLE
feat(azurelinux-rpm-config): set x86_64 cpu level to v2

### DIFF
--- a/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
+++ b/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
@@ -47,6 +47,9 @@ overlays = [
     # Update vendor macro.
     { type = "file-search-replace", file = "macros", regex = "%_vendor.*", replacement = "%_vendor azurelinux" },
 
+    # Update cflags_arch_x86_64_level macro.
+    { type = "file-search-replace", file = "macros", regex = "%__cflags_arch_x86_64_level .*", replacement = "%__cflags_arch_x86_64_level -v2" },
+
     # Remove dist.sh file; we'll replace it wholesale with our own version.
     { type = "file-remove", file = "dist.sh" },
     # Add our own version of dist.sh customized for Azure Linux.

--- a/locks/azurelinux-rpm-config.lock
+++ b/locks/azurelinux-rpm-config.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '6e4185bb29f2ca019b36bec8006e7ad60e58cade'
 upstream-commit = '6e4185bb29f2ca019b36bec8006e7ad60e58cade'
-input-fingerprint = 'sha256:cb133fba511f946ad698cc0b1eb4487223b9710e6253522195d7f277c77d2649'
+input-fingerprint = 'sha256:b93d647bc6e52070e97d9d3ad6824b61acbc7515524159f92f851c3a3c647fd2'
 resolution-input-hash = 'sha256:ed1c0158b0942459a3c1a7f3db4f08a88242ce03d0f325b50e1c411f48c8c514'

--- a/specs/a/azurelinux-rpm-config/azurelinux-rpm-config.spec
+++ b/specs/a/azurelinux-rpm-config/azurelinux-rpm-config.spec
@@ -17,7 +17,7 @@ Name: azurelinux-rpm-config
 # the older branch. When the branch diverges, bump the Version to the Fedora
 # release number.
 Version: 1004
-Release: 3%{?dist}
+Release: 4%{?dist}
 # config.guess, config.sub are GPL-3.0-or-later WITH Autoconf-exception-generic
 License: GPL-1.0-or-later AND GPL-2.0-or-later AND GPL-3.0-or-later WITH Autoconf-exception-generic
 URL: https://aka.ms/azurelinux

--- a/specs/a/azurelinux-rpm-config/macros
+++ b/specs/a/azurelinux-rpm-config/macros
@@ -146,7 +146,7 @@ for k,_ in pairs(stripped_flags) do print(k .. " ") end
 
 # Architecture-specific support.  Internal.  Do not use directly.
 
-%__cflags_arch_x86_64_level %[0%{?rhel} == 9 ? "-v2" : ""]%[0%{?rhel} > 9 ? "-v3" : ""]
+%__cflags_arch_x86_64_level -v2
 %__cflags_arch_x86_64 -march=x86-64%{?__cflags_arch_x86_64_level:%{__cflags_arch_x86_64_level}}
 
 %__cflags_arch_x86_64_common -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 %{_frame_pointers_cflags} %{_frame_pointers_cflags_x86_64}


### PR DESCRIPTION
Replace the logic that sets the x86_64 cpu level to either v2 or v3
depending on the RHEL release, to hardcoding it to v2, as we consider
v2 to be our baseline for supported hardware, and we do not plan to
support (or function on) older x86_64 v1 hardware.
    
Fixes: [AB#20423](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20423)
