### PR TITLE
imageconfig: marketplace-gen2-kernel-mshv: install nested virt packages

### DIFF
--- a/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
+++ b/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
@@ -59,7 +59,8 @@
                 "packagelists/core-packages-image.json",
                 "packagelists/marketplace-tools-packages.json",
                 "packagelists/azurevm-packages.json",
-                "packagelists/hyperv-packages.json"
+                "packagelists/hyperv-packages.json",
+                "packagelists/nested-virtualization-packages.json"
             ],
             "AdditionalFiles": {
                 "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg",

--- a/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
+++ b/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
@@ -59,7 +59,8 @@
                 "packagelists/core-packages-image.json",
                 "packagelists/marketplace-tools-packages.json",
                 "packagelists/azurevm-packages.json",
-                "packagelists/hyperv-packages.json"
+                "packagelists/hyperv-packages.json",
+                "packagelists/mshv-packages.json"
             ],
             "AdditionalFiles": {
                 "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg",

--- a/toolkit/imageconfigs/packagelists/mshv-packages.json
+++ b/toolkit/imageconfigs/packagelists/mshv-packages.json
@@ -1,0 +1,7 @@
+{
+    "packages": [
+        "edk2-hvloader",
+        "mshv",
+        "mshv-bootloader-lx"
+    ]
+}

--- a/toolkit/imageconfigs/packagelists/nested-virtualization-packages.json
+++ b/toolkit/imageconfigs/packagelists/nested-virtualization-packages.json
@@ -1,0 +1,7 @@
+{
+    "packages": [
+        "edk2-hvloader",
+        "mshv",
+        "mshv-bootloader-lx"
+    ]
+}


### PR DESCRIPTION
This image will now support both nested and L1VH virtualization, so install
necessary packages for nested virtualization.

item: https://dev.azure.com/mariner-org/container-runtime/_workitems/edit/20373

test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1186565&view=results installs
```
time="2026-08-21T03:12:24Z" level=debug msg="Executing: [rpm -qp /mnt/vss/_work/1/s/build/imagegen/marketplace-gen2-kernel-mshv/fetcher_tmp/outputrpms/mshv-26100.30000.2607061535.1-1.azl3.x86_64.rpm]"
time="2026-08-21T03:12:24Z" level=debug msg="Executing: [rpm -qp /mnt/vss/_work/1/s/build/imagegen/marketplace-gen2-kernel-mshv/fetcher_tmp/outputrpms/mshv-bootloader-lx-26100.30000.2607061535.1-1.azl3.x86_64.rpm]"
```