### PR TITLE
docs(kmod): expand out-of-tree kmod packaging strategy

### DIFF
--- a/docs/oss-kmod-packaging-strategy.md
+++ b/docs/oss-kmod-packaging-strategy.md
@@ -4,6 +4,18 @@
 
 Azure Linux 4.0 builds out-of-tree kernel modules (kmods) as **subpackages of the kernel RPM** rather than as standalone packages. This ensures tight coupling between the kernel binary and its companion modules — eliminating version skew, simplifying dependency resolution, and guaranteeing that modules are always compiled against the exact kernel headers they will run on.
 
+## Two Packaging Patterns
+
+Both patterns build the kernel modules **within the kernel component's build scope**, so the modules are always compiled against the exact kernel they ship with. They differ in how the packaging is authored:
+
+1. **Pure OSS kmods → kernel subpackage** (the default; the rest of this document). A self-contained `kmod-<name>.inc` file defines a `kmod-<name>` subpackage via phase-gated `%include`s. Used for standalone module sets such as `kmod-nvidia-open`.
+
+2. **Combined kmod + userspace packages → `.inc` based on the upstream packaging.** Some vendor stacks ship kernel modules *and* userspace components together — for example the DOCA / NVIDIA MLNX OFED packages such as `mlnx-ofa_kernel`. For these we still use a `.inc` file wired into the kernel component (so the modules are built alongside — and against — the kernel), but instead of separating the kernel-module and userspace halves or renaming the kernel-modules subpackage, we base the `.inc` **on the upstream packaging**, keeping it as close to the upstream spec as possible. Concretely, `mlnx-ofa_kernel` derives its `.inc` from the upstream spec and is added to the Azure Linux 4.0 kernel build so its modules track the kernel they are built with, while its userspace pieces stay faithful to upstream.
+
+   Prefer this pattern when a package is more than a bare set of `.ko` files (it has userspace libraries, tools, or its own subpackage layout), or when tracking a complex upstream spec is more maintainable than porting it to the phase-gated `.inc` framework.
+
+   > **Known limitation — userspace cannot be multi-version.** Because the kmod is built in the kernel scope, its `.ko` files live under `/lib/modules/%{KVERREL}/` and are marked install-only, so the *module* half coexists cleanly across kernels. The **userspace** half (shared libraries, tools, headers) is a normal package: it installs to fixed, non-kernel-qualified paths and is *not* install-only. That means only one version of the userspace can be installed at a time. We hit this with `mlnx-ofa_kernel`: when two kernels each pulled in their own build, the kernel-module portions coexisted fine, but the accompanying userspace packages collided on identical paths / could not be installed side-by-side, so supporting multiple userspace versions simultaneously was not possible. If you need genuinely parallel-installable userspace, that userspace must be split into a separate, kernel-independent component with versioned paths — it cannot ride along inside the kernel scope.
+
 ## Architecture
 consider kmod-nvidia-open as an example:
 ```
@@ -55,7 +67,7 @@ This allows a single `.inc` file to contain all phases of a kmod's lifecycle whi
 
 | Phase | Injection Point | Purpose |
 |-------|----------------|---------|
-| `package` | After `%description` | Declare `%package -n kmod-<name>-<version>`, Provides, Requires |
+| `package` | After `%description` | Declare `%package -n kmod-<name>` (Version = driver, Release = kernel NVR), Provides, Requires |
 | `prep` | End of `%prep` | Extract kmod source tarball |
 | `build` | End of `%build` | Compile modules against kernel build tree |
 | `install` | End of `%install` | Install `.ko` files, configs, licenses |
@@ -63,28 +75,135 @@ This allows a single `.inc` file to contain all phases of a kmod's lifecycle whi
 
 ## Naming and Versioning Strategy
 
-The driver version is embedded directly in the kmod subpackage name (e.g., `kmod-nvidia-open-595.58.03`).
-
-The subpackage is declared as:
+The kmod subpackage name is **stable** — it does *not* embed the driver version
+(e.g., `kmod-nvidia-open`). The driver version and the kernel it was built for
+are encoded in the RPM Version/Release instead:
 
 ```spec
-%package -n kmod-%{_kmod_name}-%{nvidia_open_version}
+%package -n kmod-%{_kmod_name}
+Version: %{nvidia_open_version}
+Release: %{_azl_kver}.%{_azl_krel}   # kernel Version.Release
 ```
 
-The RPM Version/Release is inherited from the **kernel** (e.g., `kmod-nvidia-open-595.58.03-6.18.5-1.8.azl4.x86_64.rpm`). The driver version is also exposed via virtual Provides so that consumers can depend on it without pinning the kernel version:
+This yields NVRAs like `kmod-nvidia-open-595.58.03-6.18.5.1.8.azl4.x86_64.rpm`,
+where `595.58.03` is the NVIDIA driver version and `6.18.5-1.8.azl4` is the
+kernel NVR. The package is marked install-only (`installonlypkg(kernel-module)`)
+so that one build per kernel can be installed side-by-side.
+
+### The `%{version}`/`%{release}` macro dance
+
+Setting `Version:`/`Release:` inside a subpackage clobbers the global
+`%{version}`/`%{release}` macros at parse time. Because this `.inc` is included
+into the middle of `kernel.spec`, the kernel NVR is snapshotted before the
+`%package` and restored **immediately after the `Version:`/`Release:` tags** —
+before anything downstream (the `Requires:` and `%description`) uses them. This
+matters because `%{KVERREL}` is defined as `%{specversion}-%{release}.%{_target_cpu}`;
+if `%{release}` is still clobbered when the `Requires: %{name}-core-uname-r =
+%{KVERREL}` line is parsed, the kmod requires a bogus, unsatisfiable kernel and
+`dnf install` fails to resolve:
+
+```spec
+%global _azl_kver %{version}    # snapshot kernel NVR
+%global _azl_krel %{release}
+%package -n kmod-%{_kmod_name}
+Version: %{nvidia_open_version}
+Release: %{_azl_kver}.%{_azl_krel}
+%global version %{_azl_kver}     # restore immediately, before %{KVERREL} is used
+%global release %{_azl_krel}
+...
+Requires: %{name}-core-uname-r = %{KVERREL}
+```
+
+The driver version is also exposed via virtual Provides so that consumers can
+depend on it without pinning the kernel version:
 
 ```spec
 Provides: nvidia-open-kmod-version = %{nvidia_open_version}
 Provides: nvidia-kmod = %{nvidia_open_version}
-Provides: kmod-nvidia-open = %{version}-%{release}
 ```
 
 This means:
-- `Requires: kmod-nvidia-open` → gets any driver version that matches the installed kernel
-- `Requires: kmod-nvidia-open-595.58.03` → pins to that specific driver version's RPM name
-- `Requires: nvidia-open-kmod-version = 595.58.03` → pins to a specific driver version via virtual Provides
+- `Requires: kmod-nvidia-open` → gets the kmod matching the installed kernel
+- `Requires: nvidia-open-kmod-version = 595.58.03` → pins a specific driver version
+- `Requires: nvidia-kmod` → any NVIDIA kmod flavor (open or closed)
 
-Consumer packages (e.g., `nvidia-cuda-driver`) should use the virtual Provides, not the RPM version directly.
+Consumer packages (e.g., `nvidia-cuda-driver`) can use the virtual Provides,
+instead of the RPM version directly.
+
+### Per-kernel file paths
+
+Files that do not already live under `/lib/modules/%{KVERREL}/` — the modprobe
+config and the license — are keyed by `%{KVERREL}` (not the driver version) so
+that multiple per-kernel kmod packages sharing the same driver version do not
+collide on identical paths:
+
+- `%{_modprobedir}/kmod-nvidia-open-%{KVERREL}.conf`
+- `%{_datadir}/licenses/kmod-nvidia-open-%{KVERREL}/COPYING`
+
+## Auto-upgrade: kernel-tracked kmod via a `-matched` sentinel
+
+### The problem
+
+The per-kernel kmod is install-only and hard-requires its exact kernel
+(`Requires: %{name}-core-uname-r = %{KVERREL}`). That guarantees a kmod is only
+ever installed next to the kernel it was built against, but it gives dnf no
+reason to install the kmod for a *newly upgraded* kernel. A plain `dnf upgrade`
+therefore pulls in the new kernel, keeps the old kernel + old kmod (both
+install-only), and leaves the new kernel with **no NVIDIA modules** — after
+rebooting into it the driver is silently missing until someone manually runs
+`dnf install kmod-nvidia-open`.
+
+### The fix — a `-matched` sentinel package
+
+Mirroring the kernel's own `kernel-modules-extra-matched` mechanism, we add a
+tiny, file-less **sentinel** subpackage plus a boolean dependency so that kmod
+installation tracks the kernel automatically — but only when the admin has
+opted in. Three pieces:
+
+1. The per-kernel kmod advertises a version-matched capability:
+
+   ```spec
+   Provides: kmod-nvidia-open-uname-r = %{KVERREL}
+   ```
+
+2. An empty meta/sentinel subpackage acts as the opt-in switch:
+
+   ```spec
+   %package -n kmod-nvidia-open-matched
+   Summary: Meta package to ensure kmod-nvidia-open is installed for all kernels
+   %description -n kmod-nvidia-open-matched
+   ...
+   %files -n kmod-nvidia-open-matched
+   # empty sentinel package — no files
+   ```
+
+3. The **base kernel package** gains a rich/boolean dependency (guarded to the
+   supported arches), right next to
+   the existing `kernel-modules-extra-matched` requirement:
+
+   ```spec
+   Requires: ((kmod-nvidia-open-uname-r = %{KVERREL}) if kmod-nvidia-open-matched)
+   ```
+
+   Read it as: *"if `kmod-nvidia-open-matched` is installed, then this kernel
+   requires the kmod built for exactly this kernel."*
+
+### Why this works
+
+- **Opt-in / opt-out:** if the sentinel is not installed, the `if` clause is
+  false, so no kernel forces an NVIDIA kmod — users who don't want the driver
+  are unaffected.
+- **Auto-tracking:** once the sentinel is installed a single time, *every*
+  kernel package (present and future) carries the conditional requirement. When
+  `dnf upgrade` installs a new kernel, that kernel's boolean `Requires` fires
+  and dnf pulls in the `kmod-nvidia-open` whose
+  `Provides: kmod-nvidia-open-uname-r = %{KVERREL}` matches the new kernel —
+  installed alongside the retained old one. Boot into the new kernel and the
+  modules are already present.
+
+The dependency is attached to the *kernel* package (not the kmod) precisely so
+that it re-evaluates for each kernel that gets installed; that is what makes
+future kernels keep dragging in their own matching kmod without any manual step.
 
 ## Adding a New kmod
 
@@ -107,10 +226,12 @@ In `kernel.comp.toml`, add the driver version define:
 
 ```toml
 [components.kernel.build.defines]
-<name>_version = "1.0.0"     # driver version — becomes part of the RPM name
+<name>_version = "1.0.0"     # driver version — becomes the RPM Version of the kmod
 ```
 
-The driver version is embedded directly in the subpackage name (e.g., `kmod-foo-1.0.0`), enabling multiple driver versions to coexist (e.g., `kmod-foo-1.0.0` and `kmod-foo-2.0.0`).
+The driver version becomes the RPM `Version:` of the kmod subpackage while the
+subpackage name stays stable (e.g., `kmod-foo`). Combined with the install-only
+marker, this lets the per-kernel builds coexist.
 
 ### 4. Add source-files entry (if external tarball needed)
 
@@ -183,14 +304,13 @@ A successful kernel build produces (among others) the following RPMs, consider k
 kernel-6.18.5-1.8.azl4.x86_64.rpm
 kernel-core-6.18.5-1.8.azl4.x86_64.rpm
 kernel-modules-6.18.5-1.8.azl4.x86_64.rpm
-kmod-nvidia-open-595.58.03-6.18.5-1.8.azl4.x86_64.rpm   ← kmod subpackage (driver 595.58.03)
+kmod-nvidia-open-595.58.03-6.18.5.1.8.azl4.x86_64.rpm   ← kmod subpackage (Version = driver 595.58.03, Release = kernel NVR)
 ```
 
 The kmod RPM contains:
 - `/lib/modules/%{KVERREL}/extra/nvidia/*.ko.xz` — compressed kernel modules
-- `/etc/modprobe.d/kmod-nvidia-open-595.58.03.conf` — blacklist conflicting modules
-- `/etc/depmod.d/kmod-nvidia-open-595.58.03.conf` — depmod override configuration
-- `/usr/share/licenses/kmod-nvidia-open-595.58.03/COPYING` — license file
+- `/usr/lib/modprobe.d/kmod-nvidia-open-%{KVERREL}.conf` — blacklist conflicting modules
+- `/usr/share/licenses/kmod-nvidia-open-%{KVERREL}/COPYING` — license file
 
 ## Constraints and Limitations
 


### PR DESCRIPTION
- Add "Two Packaging Patterns": pure OSS kmod subpackage vs. combined  kmod+userspace 
- Rework Naming and Versioning: stable subpackage name with driver version in Version and kernel NVR in Release, plus the %{version}/%{release} macro-restore needed so %{KVERREL} resolves correctly in Requires
- Document %{KVERREL}-keyed modprobe/license paths for per-kernel coexistence
- Add the [kmod-name]-matched sentinel + boolean-Requires auto-upgrade mechanism and the problem it solves