### PR TITLE
chore: remove 'default-distro' from object model 'distribution' object

### DIFF
--- a/base/project-override-stage2-prod.toml
+++ b/base/project-override-stage2-prod.toml
@@ -2,5 +2,5 @@
 # be explicitly added to force selection of 4.0-stage2-prod as the default distro
 # version to build.
 
-[distros.azurelinux]
-default-version = "4.0-stage2-prod"
+[project]
+default-distro = { name = "azurelinux", version = "4.0-stage2-prod" }

--- a/base/project.toml
+++ b/base/project.toml
@@ -9,5 +9,5 @@ description = 'azurelinux-base'
 log-dir = 'build/logs'
 work-dir = 'build/work'
 output-dir = 'out'
-default-distro = { name = "azurelinux" }
+default-distro = { name = "azurelinux", version = "4.0-stage2" }
 rendered-specs-dir = '../specs'

--- a/distro/azurelinux.distro.toml
+++ b/distro/azurelinux.distro.toml
@@ -1,6 +1,5 @@
 [distros.azurelinux]
 description = "Azure Linux"
-default-version = "4.0-stage2"
 
 #
 # Azure Linux 4.0 Stage1

--- a/distro/fedora.distro.toml
+++ b/distro/fedora.distro.toml
@@ -1,6 +1,5 @@
 [distros.fedora]
 description = "Fedora Linux"
-default-version = "43"
 dist-git-base-uri = "https://src.fedoraproject.org/rpms/$pkg.git"
 lookaside-base-uri = "https://src.fedoraproject.org/repo/pkgs/$pkg/$filename/$hashtype/$hash/$filename"
 repos = [

--- a/distro/stage1.toml
+++ b/distro/stage1.toml
@@ -1,6 +1,0 @@
-# This config file is not included by default in the containing project, but may
-# be explicitly added to force selection of 4.0-stage1 as the default distro version
-# to build.
-
-[distros.azurelinux]
-default-version = "4.0-stage1"

--- a/distro/stage2.toml
+++ b/distro/stage2.toml
@@ -1,6 +1,0 @@
-# This config file is not included by default in the containing project, but may
-# be explicitly added to force selection of 4.0-stage2 as the default distro version
-# to build.
-
-[distros.azurelinux]
-default-version = "4.0-stage2"


### PR DESCRIPTION
The 'distribution' object is informational, not a configuration object. The correct place for configuration of the project's default distribution version is inside the project configuration.

This places it in the correct object model location in our repo, but doesn't fix the 'azldev' tool.