### PR TITLE
fix(glibc,criu,xdp-tools): backport Linux UAPI compatibility fixes

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -6925,7 +6925,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.xdg-user-dirs-gtk]
 [components.xdg-utils]
 [components.xdotool]
-[components.xdp-tools]
 [components.xerces-c]
 [components.xerces-j2]
 [components.xeus]

--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -276,7 +276,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.cri-o]
 [components.cri-tools]
 [components.'cri-tools1.35']
-[components.criu]
 [components.cronie]
 [components.crontabs]
 [components.cross-binutils]

--- a/base/comps/criu/0001-rseq-use-kernel-rseq.h-when-glibc-detects-it.patch
+++ b/base/comps/criu/0001-rseq-use-kernel-rseq.h-when-glibc-detects-it.patch
@@ -1,0 +1,47 @@
+From 95531dcc36c2453b9242e0de17b8fedb20ce48ca Mon Sep 17 00:00:00 2001
+From: Adrian Reber <areber@redhat.com>
+Date: Tue, 3 Mar 2026 06:29:53 +0000
+Subject: [PATCH] rseq: use kernel rseq.h when glibc detects it
+
+Recent glibc conditionally includes the kernel's linux/rseq.h when
+__GLIBC_HAVE_KERNEL_RSEQ is defined, but CRIU's own definitions conflict
+with that newer kernel header. Use the kernel definitions when glibc has
+detected them, and otherwise retain CRIU's fallback definitions.
+
+Signed-off-by: Adrian Reber <areber@redhat.com>
+---
+ criu/include/linux/rseq.h | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/criu/include/linux/rseq.h b/criu/include/linux/rseq.h
+index 5ceefbf8e..d7f81e9a2 100644
+--- a/criu/include/linux/rseq.h
++++ b/criu/include/linux/rseq.h
+@@ -14,6 +14,16 @@
+ 
+ #include "common/config.h"
+ 
++/*
++ * If glibc detected that the kernel rseq.h header exists, include
++ * it directly using angle brackets (which bypasses -iquote and finds
++ * the real kernel header). Otherwise fall back to our own copy of
++ * the definitions.
++ */
++#ifdef __GLIBC_HAVE_KERNEL_RSEQ
++#include <linux/rseq.h>
++#else /* !__GLIBC_HAVE_KERNEL_RSEQ */
++
+ #ifdef CONFIG_HAS_NO_LIBC_RSEQ_DEFS
+ /*
+  * linux/rseq.h
+@@ -45,6 +55,8 @@ enum rseq_cs_flags {
+ };
+ #endif /* CONFIG_HAS_NO_LIBC_RSEQ_DEFS */
+ 
++#endif /* !__GLIBC_HAVE_KERNEL_RSEQ */
++
+ /*
+  * Let's use our own definition of struct rseq_cs because some distros
+  * (for example Mariner GNU/Linux) declares this structure their-own way.
+-- 
+2.51.1

--- a/base/comps/criu/criu.comp.toml
+++ b/base/comps/criu/criu.comp.toml
@@ -1,0 +1,13 @@
+[components.criu]
+
+# Backport from Fedora commit 12ddfeab47d329eb37e8d7f31f97cde574930c00.
+[[components.criu.overlays]]
+description = "Use kernel rseq definitions when glibc exposes the newer Linux UAPI"
+type = "patch-add"
+source = "0001-rseq-use-kernel-rseq.h-when-glibc-detects-it.patch"
+
+[[components.criu.overlays]]
+description = "Apply the rseq compatibility patch from CRIU's explicit prep patch list"
+type = "spec-append-lines"
+section = "%prep"
+lines = ["%patch -P 100 -p1"]

--- a/base/comps/glibc/glibc-open-tree-guards.patch
+++ b/base/comps/glibc/glibc-open-tree-guards.patch
@@ -1,0 +1,38 @@
+From 3ecfa68561d723564a1fb565366182eb4acb3e8f Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Wed, 4 Mar 2026 18:32:36 +0100
+Subject: [PATCH] Linux: Only define OPEN_TREE_* macros in <sys/mount.h> if
+ undefined (bug 33921)
+
+There is a conditional inclusion of <linux/mount.h> earlier in the file.
+If that defines the macros, do not redefine them.  This addresses build
+problems as the token sequence used by the UAPI macro definitions changes
+between Linux versions.
+
+Adapted to the glibc snapshot used by Azure Linux.
+Backport-of: 3ecfa68561d723564a1fb565366182eb4acb3e8f
+---
+ sysdeps/unix/sysv/linux/sys/mount.h | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/sysdeps/unix/sysv/linux/sys/mount.h b/sysdeps/unix/sysv/linux/sys/mount.h
+index 365da1c..dbf31e9 100644
+--- a/sysdeps/unix/sysv/linux/sys/mount.h
++++ b/sysdeps/unix/sysv/linux/sys/mount.h
+@@ -264,8 +264,12 @@ enum fsconfig_command
+ #define FSOPEN_CLOEXEC          0x00000001
+ 
+ /* open_tree flags.  */
+-#define OPEN_TREE_CLONE    1         /* Clone the target tree and attach the clone */
+-#define OPEN_TREE_CLOEXEC  O_CLOEXEC /* Close the file on execve() */
++#ifndef OPEN_TREE_CLONE
++# define OPEN_TREE_CLONE    1 /* Clone the target tree and attach the clone */
++#endif
++#ifndef OPEN_TREE_CLOEXEC
++# define OPEN_TREE_CLOEXEC  O_CLOEXEC /* Close the file on execve() */
++#endif
+ 
+ 
+ __BEGIN_DECLS
+-- 
+2.51.0

--- a/base/comps/glibc/glibc.comp.toml
+++ b/base/comps/glibc/glibc.comp.toml
@@ -1,3 +1,15 @@
 [components.glibc]
 # Release: %{baserelease}%{?dist}
 release = { calculation = "manual" }
+
+[[components.glibc.overlays]]
+description = "Bump the manual release for the OPEN_TREE header compatibility fix"
+type = "spec-search-replace"
+regex = '^%global baserelease 10$'
+replacement = "%global baserelease 11"
+
+# Backport of https://sourceware.org/git/?p=glibc.git;a=commit;h=3ecfa68561d723564a1fb565366182eb4acb3e8f
+[[components.glibc.overlays]]
+description = "Avoid redefining OPEN_TREE macros provided by newer Linux UAPI headers"
+type = "patch-add"
+source = "glibc-open-tree-guards.patch"

--- a/base/comps/xdp-tools/xdp-tools-include-limits.patch
+++ b/base/comps/xdp-tools/xdp-tools-include-limits.patch
@@ -1,0 +1,27 @@
+From 5f5a7c78f42713db3ac6fe95c0445f0ff1f78968 Mon Sep 17 00:00:00 2001
+From: nucleo <nucleo@fedoraproject.org>
+Date: Thu, 26 Feb 2026 15:57:47 +0200
+Subject: [PATCH] xdpdump: include <limits.h> removed from linux/ethtool.h
+
+Removing <limits.h> from linux/ethtool.h exposed undeclared UINT_MAX and
+ULONG_MAX uses in xdpdump. Include the defining standard header directly.
+
+Signed-off-by: nucleo <nucleo@fedoraproject.org>
+---
+ xdp-dump/xdpdump.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xdp-dump/xdpdump.c b/xdp-dump/xdpdump.c
+index 19d51e4e..fa3aeb32 100644
+--- a/xdp-dump/xdpdump.c
++++ b/xdp-dump/xdpdump.c
+@@ -7,6 +7,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <inttypes.h>
++#include <limits.h>
+ #include <signal.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+-- 
+2.51.0

--- a/base/comps/xdp-tools/xdp-tools.comp.toml
+++ b/base/comps/xdp-tools/xdp-tools.comp.toml
@@ -1,0 +1,7 @@
+[components.xdp-tools]
+
+# Backport of https://github.com/xdp-project/xdp-tools/commit/5f5a7c78f42713db3ac6fe95c0445f0ff1f78968
+[[components.xdp-tools.overlays]]
+description = "Include limits.h explicitly after Linux UAPI stopped providing it transitively"
+type = "patch-add"
+source = "xdp-tools-include-limits.patch"

--- a/locks/criu.lock
+++ b/locks/criu.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'a0a8f6a514976e539722aeb20d6c263686bebfed'
 upstream-commit = 'a0a8f6a514976e539722aeb20d6c263686bebfed'
-input-fingerprint = 'sha256:08dab04e4cdd458171bc678a82fdbf781d8a8da293d4ec6efbbccfaa6bf5ff1d'
+input-fingerprint = 'sha256:099677561a5bd9878ea20afdf7ee79e37f804fd986a86823fafd49574312b6db'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/locks/glibc.lock
+++ b/locks/glibc.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '105bf4c71d7b55fdccc028b22dce154c5d5b6228'
 upstream-commit = '105bf4c71d7b55fdccc028b22dce154c5d5b6228'
-input-fingerprint = 'sha256:624878a791cf8bb40f81d27849c7a345afa251badcb72d98833a3d153f511bae'
+input-fingerprint = 'sha256:63d7b30ccb0b469da0c3dce3a6bb24e54455422700be957bda00393d90fe265c'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/locks/xdp-tools.lock
+++ b/locks/xdp-tools.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'ae532702aa4eac0be2dfb4719d4b7063dbc7768e'
 upstream-commit = 'ae532702aa4eac0be2dfb4719d4b7063dbc7768e'
-input-fingerprint = 'sha256:c72336e27d5adf04ba84a34f6ab0eb23782c2b870487bfac26e951be0277b1e1'
+input-fingerprint = 'sha256:e1b4fedfe55045e0f4b961e1529ff20b50db7e00f30c49fbfaea795692d166fe'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/c/criu/0001-rseq-use-kernel-rseq.h-when-glibc-detects-it.patch
+++ b/specs/c/criu/0001-rseq-use-kernel-rseq.h-when-glibc-detects-it.patch
@@ -1,0 +1,47 @@
+From 95531dcc36c2453b9242e0de17b8fedb20ce48ca Mon Sep 17 00:00:00 2001
+From: Adrian Reber <areber@redhat.com>
+Date: Tue, 3 Mar 2026 06:29:53 +0000
+Subject: [PATCH] rseq: use kernel rseq.h when glibc detects it
+
+Recent glibc conditionally includes the kernel's linux/rseq.h when
+__GLIBC_HAVE_KERNEL_RSEQ is defined, but CRIU's own definitions conflict
+with that newer kernel header. Use the kernel definitions when glibc has
+detected them, and otherwise retain CRIU's fallback definitions.
+
+Signed-off-by: Adrian Reber <areber@redhat.com>
+---
+ criu/include/linux/rseq.h | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/criu/include/linux/rseq.h b/criu/include/linux/rseq.h
+index 5ceefbf8e..d7f81e9a2 100644
+--- a/criu/include/linux/rseq.h
++++ b/criu/include/linux/rseq.h
+@@ -14,6 +14,16 @@
+ 
+ #include "common/config.h"
+ 
++/*
++ * If glibc detected that the kernel rseq.h header exists, include
++ * it directly using angle brackets (which bypasses -iquote and finds
++ * the real kernel header). Otherwise fall back to our own copy of
++ * the definitions.
++ */
++#ifdef __GLIBC_HAVE_KERNEL_RSEQ
++#include <linux/rseq.h>
++#else /* !__GLIBC_HAVE_KERNEL_RSEQ */
++
+ #ifdef CONFIG_HAS_NO_LIBC_RSEQ_DEFS
+ /*
+  * linux/rseq.h
+@@ -45,6 +55,8 @@ enum rseq_cs_flags {
+ };
+ #endif /* CONFIG_HAS_NO_LIBC_RSEQ_DEFS */
+ 
++#endif /* !__GLIBC_HAVE_KERNEL_RSEQ */
++
+ /*
+  * Let's use our own definition of struct rseq_cs because some distros
+  * (for example Mariner GNU/Linux) declares this structure their-own way.
+-- 
+2.51.1

--- a/specs/c/criu/criu.spec
+++ b/specs/c/criu/criu.spec
@@ -15,7 +15,7 @@
 
 Name: criu
 Version: 4.2
-Release: 12%{?dist}
+Release: 13%{?dist}
 Summary: Tool for Checkpoint/Restore in User-space
 License: GPL-2.0-only AND LGPL-2.1-only AND MIT
 URL: http://criu.org/
@@ -55,6 +55,7 @@ BuildRequires: make
 # https://bugzilla.redhat.com/show_bug.cgi?id=902875
 ExclusiveArch: x86_64 %{arm} ppc64le aarch64 s390x riscv64
 
+Patch100: 0001-rseq-use-kernel-rseq.h-when-glibc-detects-it.patch
 %description
 criu is the user-space part of Checkpoint/Restore in User-space
 (CRIU), a project to implement checkpoint/restore functionality for
@@ -118,6 +119,7 @@ This script can help to workaround the so called "PID mismatch" problem.
 %setup -q
 %patch -P 99 -p1
 
+%patch -P 100 -p1
 %build
 # This package calls LD directly without specifying the LTO plugins.  Until
 # that is fixed, disable LTO.

--- a/specs/g/glibc/glibc-open-tree-guards.patch
+++ b/specs/g/glibc/glibc-open-tree-guards.patch
@@ -1,0 +1,38 @@
+From 3ecfa68561d723564a1fb565366182eb4acb3e8f Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Wed, 4 Mar 2026 18:32:36 +0100
+Subject: [PATCH] Linux: Only define OPEN_TREE_* macros in <sys/mount.h> if
+ undefined (bug 33921)
+
+There is a conditional inclusion of <linux/mount.h> earlier in the file.
+If that defines the macros, do not redefine them.  This addresses build
+problems as the token sequence used by the UAPI macro definitions changes
+between Linux versions.
+
+Adapted to the glibc snapshot used by Azure Linux.
+Backport-of: 3ecfa68561d723564a1fb565366182eb4acb3e8f
+---
+ sysdeps/unix/sysv/linux/sys/mount.h | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/sysdeps/unix/sysv/linux/sys/mount.h b/sysdeps/unix/sysv/linux/sys/mount.h
+index 365da1c..dbf31e9 100644
+--- a/sysdeps/unix/sysv/linux/sys/mount.h
++++ b/sysdeps/unix/sysv/linux/sys/mount.h
+@@ -264,8 +264,12 @@ enum fsconfig_command
+ #define FSOPEN_CLOEXEC          0x00000001
+ 
+ /* open_tree flags.  */
+-#define OPEN_TREE_CLONE    1         /* Clone the target tree and attach the clone */
+-#define OPEN_TREE_CLOEXEC  O_CLOEXEC /* Close the file on execve() */
++#ifndef OPEN_TREE_CLONE
++# define OPEN_TREE_CLONE    1 /* Clone the target tree and attach the clone */
++#endif
++#ifndef OPEN_TREE_CLOEXEC
++# define OPEN_TREE_CLOEXEC  O_CLOEXEC /* Close the file on execve() */
++#endif
+ 
+ 
+ __BEGIN_DECLS
+-- 
+2.51.0

--- a/specs/g/glibc/glibc.spec
+++ b/specs/g/glibc/glibc.spec
@@ -155,7 +155,7 @@ Version: %{glibcversion}
 # - It allows using the Release number without the %%dist tag in the dependency
 #   generator to make the generated requires interchangeable between Rawhide
 #   and ELN (.elnYY < .fcXX).
-%global baserelease 10
+%global baserelease 11
 Release: %{baserelease}%{?dist}
 
 # Licenses:
@@ -497,6 +497,7 @@ Recommends: glibc-gconv-extra%{_isa} = %{version}-%{release}
 # unconditionally pull in glibc-gconv-extra in that case.
 Requires: (glibc-gconv-extra%{_isa} = %{version}-%{release} if redhat-rpm-config)
 
+Patch25: glibc-open-tree-guards.patch
 %description
 The glibc package contains standard libraries which are used by
 multiple programs on the system. In order to save disk space and

--- a/specs/x/xdp-tools/xdp-tools-include-limits.patch
+++ b/specs/x/xdp-tools/xdp-tools-include-limits.patch
@@ -1,0 +1,27 @@
+From 5f5a7c78f42713db3ac6fe95c0445f0ff1f78968 Mon Sep 17 00:00:00 2001
+From: nucleo <nucleo@fedoraproject.org>
+Date: Thu, 26 Feb 2026 15:57:47 +0200
+Subject: [PATCH] xdpdump: include <limits.h> removed from linux/ethtool.h
+
+Removing <limits.h> from linux/ethtool.h exposed undeclared UINT_MAX and
+ULONG_MAX uses in xdpdump. Include the defining standard header directly.
+
+Signed-off-by: nucleo <nucleo@fedoraproject.org>
+---
+ xdp-dump/xdpdump.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xdp-dump/xdpdump.c b/xdp-dump/xdpdump.c
+index 19d51e4e..fa3aeb32 100644
+--- a/xdp-dump/xdpdump.c
++++ b/xdp-dump/xdpdump.c
+@@ -7,6 +7,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <inttypes.h>
++#include <limits.h>
+ #include <signal.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+-- 
+2.51.0

--- a/specs/x/xdp-tools/xdp-tools.spec
+++ b/specs/x/xdp-tools/xdp-tools.spec
@@ -3,7 +3,7 @@
 
 Name:             xdp-tools
 Version:          1.5.8
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary:          Utilities and example programs for use with XDP
 %global _soversion 1.5.0
 
@@ -35,6 +35,7 @@ Requires:         libxdp = %{version}-%{release}
 
 %global _hardened_build 1
 
+Patch0: xdp-tools-include-limits.patch
 %description
 Utilities and example programs for use with XDP
 


### PR DESCRIPTION
Backport three targeted fixes needed to build the existing glibc, CRIU, and xdp-tools snapshots against the newer Linux UAPI exposed by the Fedora 43 stage-1 buildroot.

These changes retain the existing upstream package versions and minimize divergence by applying the corresponding upstream or Fedora fixes.

**Change list**: 

- glibc: Guard `OPEN_TREE_CLONE` and `OPEN_TREE_CLOEXEC` definitions when they are already provided by newer Linux headers. 
- CRIU: Use kernel rseq definitions when glibc exposes them, avoiding conflicting `rseq_flags` and `rseq_cs_flags` enum definitions.
- xdp-tools: Include `<limits.h>` directly in xdpdump after `<linux/ethtool.h>` stopped providing `UINT_MAX` and `ULONG_MAX`
  transitively.

**Validation**:
- Local full stage-1 build and %check passed
- AME azl4-bootstrap scratch builds passed