### PR TITLE
Upgrade `perl-HTTP-Daemon` to 6.17 for CVE-2026-8450 [CRITICAL]

### DIFF
--- a/SPECS/perl-HTTP-Daemon/perl-HTTP-Daemon.signatures.json
+++ b/SPECS/perl-HTTP-Daemon/perl-HTTP-Daemon.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "perl-HTTP-Daemon-6.16.tar.gz": "b38d092725e6fa4e0c4dc2a47e157070491bafa0dbe16c78a358e806aa7e173d"
- }
+  "Signatures": {
+    "perl-HTTP-Daemon-6.17.tar.gz": "16281580c40e23108d028434698b5d7d53637bf904c9df822481e253cbec920c"
+  }
 }

--- a/SPECS/perl-HTTP-Daemon/perl-HTTP-Daemon.spec
+++ b/SPECS/perl-HTTP-Daemon/perl-HTTP-Daemon.spec
@@ -1,5 +1,5 @@
 Name:           perl-HTTP-Daemon
-Version:        6.16
+Version:        6.17
 Release:        1%{?dist}
 Summary:        Simple HTTP server class
 License:        GPL+ or Artistic
@@ -116,6 +116,9 @@ make test
 %{_libexecdir}/%{name}
 
 %changelog
+* Thu Jul 23 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.17-1
+- Auto-upgrade to 6.17 - for CVE-2026-8450
+
 * Wed Mar 27 2024 Sam Meluch <sammeluch@microsoft.com> - 6.16-1
 - Upgrade to version 6.16 for Azure Linux 3.0
 - Add tests package

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -18173,8 +18173,8 @@
         "type": "other",
         "other": {
           "name": "perl-HTTP-Daemon",
-          "version": "6.16",
-          "downloadUrl": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Daemon-6.16.tar.gz"
+          "version": "6.17",
+          "downloadUrl": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Daemon-6.17.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Upgrade `perl-HTTP-Daemon` to 6.17 for CVE-2026-8450 [CRITICAL]
Commit having CVE fix https://github.com/libwww-perl/HTTP-Daemon/commit/945d35141d94490f749640bd4390acd6a2193995