### PR TITLE
distroless: fallback to marinara:3.0 when date-matched tag missing

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -82,6 +82,16 @@ function create_distroless_container {
     MARINARA_IMAGE=${BASE_IMAGE_NAME_FULL/base\/core/$marinara}
     echo "MARINARA_IMAGE -> $MARINARA_IMAGE"
 
+    # Marinara is published to MCR by Stage 6 alongside base/core, but as an independent push.
+    # If the date-matched marinara tag is missing from MCR (rare — publish hiccup, GC, etc.), fall
+    # back to the floating :3.0 tag. Marinara is used only as a *builder* image whose contents don't
+    # ship in the final distroless image, so any recent 3.0 marinara is functionally equivalent.
+    marinaraFallback="mcr.microsoft.com/azurelinux/marinara:3.0"
+    if ! docker manifest inspect "$MARINARA_IMAGE" > /dev/null 2>&1; then
+        echo "WARNING: $MARINARA_IMAGE not found on registry; falling back to $marinaraFallback"
+        MARINARA_IMAGE="$marinaraFallback"
+    fi
+
     sed -E "s|^FROM .*builder$|FROM $MARINARA_IMAGE as builder|g" -i "$marinaraSrcDir/dockerfiles/dockerfile-new-image"
 
     # WORK_DIR has a directory named 'Stage' which created inside prepare_docker_directory function


### PR DESCRIPTION
Marinara is published to MCR by Stage 6 (`BuildBaseContainers.sh`) alongside `base/core`, but as an independent push. The current substitution in `BuildGoldenDistrolessContainer.sh` forces marinara to use the exact same tag as base/core with no way to recover if marinara publishing hiccups on a given date:

```bash
MARINARA_IMAGE=${BASE_IMAGE_NAME_FULL/base\/core/$marinara}
```

If marinara's date-matched tag is ever missing from MCR while base/core succeeds, every subsequent Stage 7 distroless golden build breaks with `manifest not found` until Stage 6 is re-run. This is the same class of failure that motivated the `baseImageOverride` parameter in ADO PR #28408.

## Change

Add a `docker manifest inspect` probe after the substitution. If the date-matched marinara tag is missing, fall back to `mcr.microsoft.com/azurelinux/marinara:3.0` (floating) and log a warning.

## Rationale

Marinara is used **only** as a builder image (`FROM marinara AS builder`) — its contents don't ship in the final `FROM scratch` distroless image. Any recent 3.0 marinara is functionally equivalent for staging RPMs into `/staging`. The `:3.0` floating tag is empirically published on MCR today.

## Refs

- ADO Task #22512
- ADO PR #28408 (adds `baseImageOverride=latest` in CBL-Mariner-Pipelines to work around the parallel 20260712 base/core MCR-publish miss)

## Testing

DEV Stage 4 (defs 2733/2734) and PROD Stage 7 (defs 2902/2905) test runs are in flight against the `baseImageOverride` PR. Once those complete cleanly, this PR can be validated by intentionally targeting a date where marinara doesn't exist (or by manual verification that `docker manifest inspect` on the current happy-path tag returns success in the pipeline environment).