### PR TITLE
fix(rocm-examples): add libpfm-devel BuildRequires for libpfm-enabled google-benchmark

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -4527,7 +4527,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.rocm-bandwidth-test]
 [components.rocm-cmake]
 [components.rocm-core]
-[components.rocm-examples]
 [components.rocm-omp]
 [components.rocm-rpm-macros]
 [components.rocm-rpp]

--- a/base/comps/rocm-examples/rocm-examples.comp.toml
+++ b/base/comps/rocm-examples/rocm-examples.comp.toml
@@ -1,0 +1,13 @@
+[components.rocm-examples]
+
+# System google-benchmark is built with libpfm, so its CMake config
+# (/usr/lib64/cmake/benchmark/benchmarkConfig.cmake) does find_dependency(PFM).
+# Without libpfm-devel, find_package(benchmark) fails: rocm-examples' benchmark
+# CMakeLists then falls back to a github.com FetchContent clone that dies under
+# network isolation. Mirrors the grpc libpfm-devel fix (Fedora rawhide grpc):
+# https://src.fedoraproject.org/rpms/grpc/c/e57bdb01893e49b38eb638f8e316b241dcd7382c
+[[components.rocm-examples.overlays]]
+description = "Add libpfm-devel so libpfm-enabled google-benchmark's CMake config find_dependency(PFM) resolves"
+type = "spec-add-tag"
+tag = "BuildRequires"
+value = "libpfm-devel"

--- a/locks/rocm-examples.lock
+++ b/locks/rocm-examples.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '33e867f3d29a679a6232c94088af2aaf059e10c3'
 upstream-commit = '33e867f3d29a679a6232c94088af2aaf059e10c3'
-input-fingerprint = 'sha256:5e97d3ebb38d42e5cbd16ba3e048297de55cabed3cf9ef8e1a8794e7117cc6ca'
+input-fingerprint = 'sha256:3d4cf0ea916d95067710d82bcb1e0a512792825256b708bae3f4be9cef5b4c7b'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/r/rocm-examples/rocm-examples.spec
+++ b/specs/r/rocm-examples/rocm-examples.spec
@@ -28,7 +28,7 @@
 
 Name:           rocm-examples
 Version:        %{rocm_version}
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary:        A collection of examples for the ROCm software stack
 Url:            https://github.com/ROCm/%{upstreamname}
 License:        MIT AND Apache-2.0
@@ -69,6 +69,7 @@ BuildRequires:  gtest-devel
 # Only x86_64 works right now:
 ExclusiveArch:  x86_64
 
+BuildRequires: libpfm-devel
 %description
 This repository is a collection of examples to enable new users
 to start using ROCm, as well as provide more advanced examples


### PR DESCRIPTION
_Background:_ Upstream F43 changes have since enabled libpfm in google-benchmark; these changes, unfortunately, require consumers of google-benchmark to also enable libpfm-devel. Those compensating changes have been making their way through Rawhide.

_Issue here_: rocm-examples' Tutorials/reduction/benchmark CMakeLists does find_package(benchmark CONFIG QUIET). If the system's google-benchmark package is libpfm-enabled, CMake config runs an unconditional find_dependency(PFM), which fails without libpfm-devel. When this happens, the benchmark is silently not found -- and that causes the build of this package to fall back to network-fetching content from github. That fails in network-isolated koji.

Adding libpfm-devel lets find_package(benchmark) resolve so the packaged benchmark is used and no network fetch is attempted.