### PR TITLE
fix(libgcrypt): pin f43 1.11.1-4 to fix annocheck %check failure

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -1735,7 +1735,6 @@ includes = ["**/*.comp.toml", "component-bootstrap-uucore-pin.toml", "component-
 [components.libfontenc]
 [components.libftdi]
 [components.libfyaml]
-[components.libgcrypt]
 [components.libgdata]
 [components.libgdiplus]
 [components.libgdither]

--- a/base/comps/libgcrypt/libgcrypt.comp.toml
+++ b/base/comps/libgcrypt/libgcrypt.comp.toml
@@ -1,0 +1,9 @@
+[components.libgcrypt]
+# Pin to f43 1.11.1-4, which disables the annocheck %check step and fixes
+# CVE-2026-41989. The default AZL4 Fedora 43 snapshot (2026-02-24) predates
+# this commit (2026-04-27), so without this pin the build fails in %check with
+# "annocheck: Overall: FAIL (due to MAYB results)".
+# https://src.fedoraproject.org/rpms/libgcrypt/c/87da1ac2a755f3b2b2cf368397ad29fade89c038?branch=f43
+# TODO: Drop this override once the default Fedora 43 snapshot in
+# distro/azurelinux.distro.toml advances past 2026-04-27.
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "87da1ac2a755f3b2b2cf368397ad29fade89c038" }

--- a/locks/libgcrypt.lock
+++ b/locks/libgcrypt.lock
@@ -1,6 +1,6 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 import-commit = '191749b6956a7d5d88d1ce62a13bd40cb6824f6e'
-upstream-commit = '191749b6956a7d5d88d1ce62a13bd40cb6824f6e'
-input-fingerprint = 'sha256:5cebf1d3306752f9ca396b3a0031742a209112b42eb34486927875fbebd04489'
-resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'
+upstream-commit = '87da1ac2a755f3b2b2cf368397ad29fade89c038'
+input-fingerprint = 'sha256:cb9ae7364d9aea6accf828fb0339c0c6bed928e178d30ec2cabccd82b4a0d589'
+resolution-input-hash = 'sha256:0c9fcfa1d2d7d9bc6140ec0b5ccebd4c8e76f6c7bfa9cce61ba067cb03d195b9'

--- a/specs/l/libgcrypt/libgcrypt-1.11.1-ecc-montgomery.patch
+++ b/specs/l/libgcrypt/libgcrypt-1.11.1-ecc-montgomery.patch
@@ -1,0 +1,40 @@
+From 8b3612d62a74ddd4dc2485e5952d955c52745aec Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Fri, 10 Apr 2026 16:58:57 +0900
+Subject: [PATCH] cipher:ecc: Fix decoding a point on Montgomery curve.
+
+* cipher/ecc-misc.c (_gcry_ecc_mont_decodepoint): Fix the padding
+mistake and add updating RAWMPILEN.
+
+--
+
+Reported by Calif.io in collaboration with Claude and Anthropic
+Research.
+
+GnuPG-bug-id: 8211
+Fixes-commit: bbe15758c893dbf546416c1a6bccdad1ab000ad7
+Suggested-by: Bronson Yen <bronson@calif.io>
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+---
+ cipher/ecc-misc.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/cipher/ecc-misc.c b/cipher/ecc-misc.c
+index 6796ba2c..fd429a08 100644
+--- a/cipher/ecc-misc.c
++++ b/cipher/ecc-misc.c
+@@ -438,7 +438,10 @@ _gcry_ecc_mont_decodepoint (gcry_mpi_t pk, mpi_ec_t ec, mpi_point_t result)
+         *--p = *buf++;
+ 
+       if (rawmpilen < nbytes)
+-        memset (rawmpi + nbytes - rawmpilen, 0, nbytes - rawmpilen);
++        {
++          memset (rawmpi + rawmpilen, 0, nbytes - rawmpilen);
++          rawmpilen = nbytes;
++        }
+     }
+   else
+     {
+-- 
+2.53.0
+

--- a/specs/l/libgcrypt/libgcrypt.spec
+++ b/specs/l/libgcrypt/libgcrypt.spec
@@ -18,7 +18,7 @@ print(string.sub(hash, 0, 16))
 
 Name: libgcrypt
 Version: 1.11.1
-Release: 4%{?dist}
+Release: 6%{?dist}
 URL: https://www.gnupg.org/
 Source0: https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-%{version}.tar.bz2
 Source1: https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-%{version}.tar.bz2.sig
@@ -30,6 +30,7 @@ Patch5: libgcrypt-1.11.0-marvin.patch
 # Part of 1.11.2 release
 Patch6: 0001-Fix-missing-simd-common-riscv.h-in-libgcrypt-tarball.patch
 Patch7: 0001-Add-missing-simd-common-riscv.h.patch
+Patch8: libgcrypt-1.11.1-ecc-montgomery.patch
 
 %global gcrylibdir %{_libdir}
 %global gcrysoname libgcrypt.so.20
@@ -68,6 +69,7 @@ applications using libgcrypt.
 %patch 5 -p1
 %patch 6 -p1
 %patch 7 -p1
+%patch 8 -p1
 
 %build
 # should be all algorithms except SM3 and SM4, aria
@@ -100,7 +102,10 @@ LIBGCRYPT_FORCE_FIPS_MODE=1 make check
 
 %define libpath $RPM_BUILD_ROOT%{gcrylibdir}/%{gcrysoname}.?.?
 
-PROFILE=%{?dist} annocheck --ignore-unknown --verbose --profile=${PROFILE:1} %{libpath}
+# Disabled now due to failing in F44
+# https://github.com/rpminspect/rpminspect/issues/1546
+# export PROFILE=%{?dist}
+# annocheck --ignore-unknown --verbose --profile=${PROFILE:1} %{libpath}
 
 # Add generation of HMAC checksums of the final stripped binaries 
 %define __spec_install_post \
@@ -182,6 +187,10 @@ mkdir -p -m 755 $RPM_BUILD_ROOT/etc/gcrypt
 %license COPYING
 
 %changelog
+* Mon Apr 27 2026 Jakub Jelen <jjelen@redhat.com> - 1.11.1-4
+- Fix CVE-2026-41989 (#2461782)
+- Skip annochecks
+
 * Wed Nov 26 2025 Marcin Juszkiewicz <mjuszkiewicz@redhat.com> - 1.11.1-3
 - Fix missing header on RISC-V
 


### PR DESCRIPTION
## Summary
The AZL4 `libgcrypt` `%check` build fails with `annocheck: Overall: FAIL (due to MAYB results)`.

The global Fedora 43 snapshot is frozen at **2026-02-24**, so `azldev comp update` alone reports `upToDate` and never picks up the upstream fix (which landed **2026-04-27**). This pins **libgcrypt** to Fedora f43 `87da1ac` (1.11.1-4) via `spec.upstream-commit` (takes priority over the snapshot), matching the existing per-component pin pattern (golang, rust-cipher, ImageMagick).

## What f43 1.11.1-4 brings
- Comments out the failing annocheck `%check` invocation.
- Adds the `ecc-montgomery` patch and fixes **CVE-2026-41989**.

## Changes
- New `base/comps/libgcrypt/libgcrypt.comp.toml` pinning `upstream-commit = 87da1ac…`, with rationale and a `# TODO:` to drop the pin once the global snapshot advances past 2026-04-27 (same convention as `golang.comp.toml`).
- Removed the inline `[components.libgcrypt]` entry from `components.toml`.
- Regenerated `locks/libgcrypt.lock` and rendered `specs/l/libgcrypt/` (spec Release 4→6, new patch, annocheck disabled).

## Validation
- `azldev comp update` → `changed=0 upToDate=1`; `render` → `CHANGED=false` (CI-consistent).
- Rebuilt locally: annocheck **no longer invoked**, all **38 tests pass**.
- Mock smoke test: libraries resolve.