### PR TITLE
fix(kmod-nvidia-open): move driver version from package name into Version field

### DIFF
--- a/base/comps/kernel/kernel.azl.macros
+++ b/base/comps/kernel/kernel.azl.macros
@@ -2,6 +2,6 @@
 # Removed once these defines move directly into kernel.spec.
 %_without_debug 1
 %_without_selftests 1
-%azl_pkgrelease 10
+%azl_pkgrelease 11
 %kextraversion 1
 %nvidia_open_version 595.58.03

--- a/base/comps/kernel/kernel.spec
+++ b/base/comps/kernel/kernel.spec
@@ -4575,6 +4575,9 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Thu Jul 30 2026 Elaheh Dehghani <edehghani@microsoft.com> - 6.18.31-1.11
+- fix(kmod-nvidia-open): move driver version from package name into Version field
+
 * Mon Jul 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.18.31-1.10
 - feat(kernel): enable Broadcom RoCE driver (bnxt_re) as module on x86_64
 

--- a/base/comps/kernel/kmod-nvidia-open.inc
+++ b/base/comps/kernel/kmod-nvidia-open.inc
@@ -14,14 +14,24 @@
 %if "%{_kmod_phase}" == "package" && %{with_up_base}
 
 %ifarch x86_64 aarch64
-%package -n kmod-%{_kmod_name}-%{nvidia_open_version}
+# Snapshot the kernel NVR, then give this subpackage its own Version (the NVIDIA
+# driver version) and Release (the kernel NVR). Setting Version/Release clobbers
+# the global %{version}/%{release} macros at parse time, so restore them right
+# after the tags below — before %{KVERREL} (which expands %{release}) is used in
+# the Requires and %description.
+%global _azl_kver %{version}
+%global _azl_krel %{release}
+%package -n kmod-%{_kmod_name}
 Summary:        NVIDIA open GPU kernel modules (driver %{nvidia_open_version})
+Version:        %{nvidia_open_version}
+Release:        %{_azl_kver}.%{_azl_krel}
+# Restore kernel NVR macros clobbered by the Version/Release tags above.
+%global version %{_azl_kver}
+%global release %{_azl_krel}
 AutoReq:        no
-# NOTE: Version is inherited from kernel (%{version}), NOT nvidia_open_version.
 # Track the actual NVIDIA driver version via Provides for dependency resolution.
 Provides:       nvidia-open-kmod-version = %{nvidia_open_version}
-provides:       nvidia-kmod = %{nvidia_open_version}
-Provides:       kmod-%{_kmod_name} = %{version}-%{release}
+Provides:       nvidia-kmod = %{nvidia_open_version}
 # Mark this kmod as install-only so multiple versions can coexist alongside
 # their matching kernels (dnf/dnf5 default installonlypkgs includes the
 # 'installonlypkg(kernel-module)' token).
@@ -31,18 +41,17 @@ Requires(post): kmod
 Requires(postun): kmod
 Conflicts:      nvidia-closed-kmod
 
-%description -n kmod-%{_kmod_name}-%{nvidia_open_version}
+%description -n kmod-%{_kmod_name}
 Open-source NVIDIA GPU kernel modules (driver version %{nvidia_open_version})
 built from the official NVIDIA/open-gpu-kernel-modules repository for
 kernel %{KVERREL}.
 
 These modules support CUDA workloads on NVIDIA GPUs (Turing and later).
-
 Each kernel version produces a separate kmod package
 (kmod-nvidia-open-<nvidia_driver_version>-<KVERREL>) so that multiple kernel versions
 can coexist with their own NVIDIA modules.
 Use 'Requires: nvidia-open-kmod-version = %{nvidia_open_version}' to depend on a
-specific NVIDIA driver version, or 'Requires: kmod-nvidia-open' for any version.
+specific NVIDIA driver version, or 'Requires: nvidia-kmod = %{nvidia_open_version}'.
 %endif
 
 %endif
@@ -110,10 +119,12 @@ done
 # Install modprobe config to blacklist conflicting modules. Lives under
 # %{_modprobedir} (/usr/lib/modprobe.d) — vendor-supplied config, not
 # admin-editable, so it is owned by the package without %config(noreplace).
-install -D -m 0644 %{SOURCE6001} %{buildroot}%{_modprobedir}/kmod-%{_kmod_name}-%{nvidia_open_version}.conf
-# Install NVIDIA license file
+# Path is keyed by %{KVERREL} (not the driver version) so that per-kernel kmod
+# packages sharing the same driver version can coexist without file conflicts.
+install -D -m 0644 %{SOURCE6001} %{buildroot}%{_modprobedir}/kmod-%{_kmod_name}-%{KVERREL}.conf
+# Install NVIDIA license file (keyed by %{KVERREL} for the same coexistence reason)
 install -D -m 0644 %{_builddir}/open-gpu-kernel-modules-%{nvidia_open_version}/COPYING \
-    %{buildroot}%{_datadir}/licenses/kmod-%{_kmod_name}-%{nvidia_open_version}/COPYING
+    %{buildroot}%{_datadir}/licenses/kmod-%{_kmod_name}-%{KVERREL}/COPYING
 %endif
 
 %endif
@@ -124,20 +135,20 @@ install -D -m 0644 %{_builddir}/open-gpu-kernel-modules-%{nvidia_open_version}/C
 %if "%{_kmod_phase}" == "files" && %{with_up_base}
 
 %ifarch x86_64 aarch64
-%post -n kmod-%{_kmod_name}-%{nvidia_open_version}
+%post -n kmod-%{_kmod_name}
 %{_sbindir}/depmod -a %{KVERREL} || :
 
-%postun -n kmod-%{_kmod_name}-%{nvidia_open_version}
+%postun -n kmod-%{_kmod_name}
 %{_sbindir}/depmod -a %{KVERREL} || :
 
-%files -n kmod-%{_kmod_name}-%{nvidia_open_version}
-%license %{_datadir}/licenses/kmod-%{_kmod_name}-%{nvidia_open_version}/COPYING
+%files -n kmod-%{_kmod_name}
+%license %{_datadir}/licenses/kmod-%{_kmod_name}-%{KVERREL}/COPYING
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-modeset.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-drm.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-uvm.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-peermem.ko.%{compext}
-%{_modprobedir}/kmod-%{_kmod_name}-%{nvidia_open_version}.conf
+%{_modprobedir}/kmod-%{_kmod_name}-%{KVERREL}.conf
 %endif
 
 %endif

--- a/locks/kernel.lock
+++ b/locks/kernel.lock
@@ -1,4 +1,4 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:6ee67ba00fec219ea0720d9864e4507644cee729f05af50604022d12b2be46c4'
+input-fingerprint = 'sha256:66a11bc6b18f36071a7beae396db43de7e723cc207de3a263b75ce33a942683b'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/k/kernel/kernel.azl.macros
+++ b/specs/k/kernel/kernel.azl.macros
@@ -2,6 +2,6 @@
 # Removed once these defines move directly into kernel.spec.
 %_without_debug 1
 %_without_selftests 1
-%azl_pkgrelease 10
+%azl_pkgrelease 11
 %kextraversion 1
 %nvidia_open_version 595.58.03

--- a/specs/k/kernel/kernel.spec
+++ b/specs/k/kernel/kernel.spec
@@ -4578,6 +4578,9 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Thu Jul 30 2026 Elaheh Dehghani <edehghani@microsoft.com> - 6.18.31-1.11
+- fix(kmod-nvidia-open): move driver version from package name into Version field
+
 * Mon Jul 27 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.18.31-1.10
 - feat(kernel): enable Broadcom RoCE driver (bnxt_re) as module on x86_64
 

--- a/specs/k/kernel/kmod-nvidia-open.inc
+++ b/specs/k/kernel/kmod-nvidia-open.inc
@@ -14,14 +14,24 @@
 %if "%{_kmod_phase}" == "package" && %{with_up_base}
 
 %ifarch x86_64 aarch64
-%package -n kmod-%{_kmod_name}-%{nvidia_open_version}
+# Snapshot the kernel NVR, then give this subpackage its own Version (the NVIDIA
+# driver version) and Release (the kernel NVR). Setting Version/Release clobbers
+# the global %{version}/%{release} macros at parse time, so restore them right
+# after the tags below — before %{KVERREL} (which expands %{release}) is used in
+# the Requires and %description.
+%global _azl_kver %{version}
+%global _azl_krel %{release}
+%package -n kmod-%{_kmod_name}
 Summary:        NVIDIA open GPU kernel modules (driver %{nvidia_open_version})
+Version:        %{nvidia_open_version}
+Release:        %{_azl_kver}.%{_azl_krel}
+# Restore kernel NVR macros clobbered by the Version/Release tags above.
+%global version %{_azl_kver}
+%global release %{_azl_krel}
 AutoReq:        no
-# NOTE: Version is inherited from kernel (%{version}), NOT nvidia_open_version.
 # Track the actual NVIDIA driver version via Provides for dependency resolution.
 Provides:       nvidia-open-kmod-version = %{nvidia_open_version}
-provides:       nvidia-kmod = %{nvidia_open_version}
-Provides:       kmod-%{_kmod_name} = %{version}-%{release}
+Provides:       nvidia-kmod = %{nvidia_open_version}
 # Mark this kmod as install-only so multiple versions can coexist alongside
 # their matching kernels (dnf/dnf5 default installonlypkgs includes the
 # 'installonlypkg(kernel-module)' token).
@@ -31,18 +41,17 @@ Requires(post): kmod
 Requires(postun): kmod
 Conflicts:      nvidia-closed-kmod
 
-%description -n kmod-%{_kmod_name}-%{nvidia_open_version}
+%description -n kmod-%{_kmod_name}
 Open-source NVIDIA GPU kernel modules (driver version %{nvidia_open_version})
 built from the official NVIDIA/open-gpu-kernel-modules repository for
 kernel %{KVERREL}.
 
 These modules support CUDA workloads on NVIDIA GPUs (Turing and later).
-
 Each kernel version produces a separate kmod package
 (kmod-nvidia-open-<nvidia_driver_version>-<KVERREL>) so that multiple kernel versions
 can coexist with their own NVIDIA modules.
 Use 'Requires: nvidia-open-kmod-version = %{nvidia_open_version}' to depend on a
-specific NVIDIA driver version, or 'Requires: kmod-nvidia-open' for any version.
+specific NVIDIA driver version, or 'Requires: nvidia-kmod = %{nvidia_open_version}'.
 %endif
 
 %endif
@@ -110,10 +119,12 @@ done
 # Install modprobe config to blacklist conflicting modules. Lives under
 # %{_modprobedir} (/usr/lib/modprobe.d) — vendor-supplied config, not
 # admin-editable, so it is owned by the package without %config(noreplace).
-install -D -m 0644 %{SOURCE6001} %{buildroot}%{_modprobedir}/kmod-%{_kmod_name}-%{nvidia_open_version}.conf
-# Install NVIDIA license file
+# Path is keyed by %{KVERREL} (not the driver version) so that per-kernel kmod
+# packages sharing the same driver version can coexist without file conflicts.
+install -D -m 0644 %{SOURCE6001} %{buildroot}%{_modprobedir}/kmod-%{_kmod_name}-%{KVERREL}.conf
+# Install NVIDIA license file (keyed by %{KVERREL} for the same coexistence reason)
 install -D -m 0644 %{_builddir}/open-gpu-kernel-modules-%{nvidia_open_version}/COPYING \
-    %{buildroot}%{_datadir}/licenses/kmod-%{_kmod_name}-%{nvidia_open_version}/COPYING
+    %{buildroot}%{_datadir}/licenses/kmod-%{_kmod_name}-%{KVERREL}/COPYING
 %endif
 
 %endif
@@ -124,20 +135,20 @@ install -D -m 0644 %{_builddir}/open-gpu-kernel-modules-%{nvidia_open_version}/C
 %if "%{_kmod_phase}" == "files" && %{with_up_base}
 
 %ifarch x86_64 aarch64
-%post -n kmod-%{_kmod_name}-%{nvidia_open_version}
+%post -n kmod-%{_kmod_name}
 %{_sbindir}/depmod -a %{KVERREL} || :
 
-%postun -n kmod-%{_kmod_name}-%{nvidia_open_version}
+%postun -n kmod-%{_kmod_name}
 %{_sbindir}/depmod -a %{KVERREL} || :
 
-%files -n kmod-%{_kmod_name}-%{nvidia_open_version}
-%license %{_datadir}/licenses/kmod-%{_kmod_name}-%{nvidia_open_version}/COPYING
+%files -n kmod-%{_kmod_name}
+%license %{_datadir}/licenses/kmod-%{_kmod_name}-%{KVERREL}/COPYING
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-modeset.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-drm.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-uvm.ko.%{compext}
 /lib/modules/%{KVERREL}/extra/nvidia/nvidia-peermem.ko.%{compext}
-%{_modprobedir}/kmod-%{_kmod_name}-%{nvidia_open_version}.conf
+%{_modprobedir}/kmod-%{_kmod_name}-%{KVERREL}.conf
 %endif
 
 %endif


### PR DESCRIPTION
## Summary

Renames the NVIDIA open GPU kmod subpackage from `kmod-nvidia-open-<driver_version>`
to plain `kmod-nvidia-open`, moving the NVIDIA driver version out of the RPM **name**
and into the RPM **Version** field. The kernel NVR is used as the **Release**.

## Why

Encoding the driver version in the package name meant every driver bump created a new
package name (`kmod-nvidia-open-595.58.03` → `kmod-nvidia-open-596.x.y`). This breaks
dnf:

- **No upgrade path** — dnf treats differently-named packages as unrelated, so a driver
  bump isn't seen as an upgrade of the existing kmod.
- **Broken dependency resolution** — consumers had to `Requires: kmod-nvidia-open-595.58.03`,
  a name that disappears on the next driver release, breaking anything that referenced it.

Putting the driver version in `Version:` keeps the name (`kmod-nvidia-open`) stable across
driver updates: dnf sees bumps as normal version upgrades, and consumers depend on the
stable name (or on `Provides: nvidia-open-kmod-version` / `nvidia-kmod` to pin a specific
driver version) without breakage.

## What changed
- `kmod-nvidia-open-%{nvidia_open_version}`  package renamed to `kmod-nvidia-open`.
- Modprobe conf + license paths re-keyed on `%{KVERREL}` (not the driver version)
- Bumped `azl_pkgrelease`, re-rendered spec, refreshed lock.

## Documentation

Follows the out-of-tree kmod packaging strategy documented in microsoft/azurelinux#18064.

CT build: /koji/taskinfo?taskID=3944123