### PR TITLE
fix(qt6-qtwayland): relocate Wayland client CMake files to Qt6Gui in %files

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -4479,7 +4479,6 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml", "component-min
 [components.qt6-qttools]
 [components.qt6-qttranslations]
 [components.qt6-qtvirtualkeyboard]
-[components.qt6-qtwayland]
 [components.qt6-qtwebchannel]
 [components.qt6-qtwebsockets]
 [components.qtwebkit]

--- a/base/comps/qt6-qtwayland/qt6-qtwayland.comp.toml
+++ b/base/comps/qt6-qtwayland/qt6-qtwayland.comp.toml
@@ -1,0 +1,36 @@
+[components.qt6-qtwayland]
+
+# The Wayland client plugin CMake files (Ivi/QtShell shell integrations and the
+# Adwaita decoration) are exported into either cmake/Qt6WaylandClient/ or
+# cmake/Qt6Gui/ depending on the qtbase version used to build: newer qtbase
+# (stage1/PME buildroots) puts them under Qt6Gui/, older qtbase (dev/beta
+# buildroots) under Qt6WaylandClient/. The locked 6.10.2 %files hardcodes the
+# old Qt6WaylandClient/ paths, which fails against newer qtbase. Rather than
+# hardcode Qt6Gui/ (which then breaks against older qtbase), match the plugin
+# files by name under a directory-independent cmake/Qt6*/ glob so packaging
+# succeeds in both. Fedora f43 "Fix %files section" only did the Qt6Gui half:
+# https://src.fedoraproject.org/rpms/qt6-qtwayland/c/e96dca235e83bc256548884b980c999c26bc5101
+[[components.qt6-qtwayland.overlays]]
+description = "Match the Wayland client shell-integration plugin CMake files under a directory-independent Qt6*/ glob so packaging works whether qtbase exports them under Qt6WaylandClient/ (older) or Qt6Gui/ (newer)"
+type = "spec-search-replace"
+section = "%files"
+package = "devel"
+regex = '^%\{_qt6_libdir\}/cmake/Qt6WaylandClient/\*\.cmake$'
+replacement = '''%{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandIviShellIntegration*.cmake
+%{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandQtShellIntegration*.cmake'''
+
+[[components.qt6-qtwayland.overlays]]
+description = "Match the adwaita-decoration %exclude path under a directory-independent Qt6*/ glob (older vs newer qtbase export dir)"
+type = "spec-search-replace"
+section = "%files"
+package = "devel"
+regex = '^%exclude %\{_qt6_libdir\}/cmake/Qt6WaylandClient/Qt6QWaylandAdwaitaDecoration\*\.cmake$'
+replacement = '%exclude %{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandAdwaitaDecoration*.cmake'
+
+[[components.qt6-qtwayland.overlays]]
+description = "Match the adwaita-decoration subpackage CMake path under a directory-independent Qt6*/ glob (older vs newer qtbase export dir)"
+type = "spec-search-replace"
+section = "%files"
+package = "adwaita-decoration"
+regex = '^%\{_qt6_libdir\}/cmake/Qt6WaylandClient/Qt6QWaylandAdwaitaDecoration\*\.cmake$'
+replacement = '%{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandAdwaitaDecoration*.cmake'

--- a/locks/qt6-qtwayland.lock
+++ b/locks/qt6-qtwayland.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'd812d661be0ab0fb3bf2e9a5616c89614a206ff1'
 upstream-commit = 'd812d661be0ab0fb3bf2e9a5616c89614a206ff1'
-input-fingerprint = 'sha256:dff887c3c1eef174e32579c1f8d35910455671f65077352e05c50dda3a179399'
+input-fingerprint = 'sha256:0bfe5a84a464f501353dfd0f8843a3ffc32bef7e27f53c86bf2c638701b122ec'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/q/qt6-qtwayland/qt6-qtwayland.spec
+++ b/specs/q/qt6-qtwayland/qt6-qtwayland.spec
@@ -14,7 +14,7 @@
 Summary: Qt6 - Wayland platform support and QtCompositor module
 Name:    qt6-%{qt_module}
 Version: 6.10.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 License: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 Url:     http://www.qt.io
@@ -171,7 +171,8 @@ popd
 %{_qt6_libdir}/cmake/Qt6/*.cmake
 %{_qt6_libdir}/cmake/Qt6BuildInternals/StandaloneTests/QtWaylandTestsConfig.cmake
 %{_qt6_libdir}/cmake/Qt6Qml/QmlPlugins/*.cmake
-%{_qt6_libdir}/cmake/Qt6WaylandClient/*.cmake
+%{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandIviShellIntegration*.cmake
+%{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandQtShellIntegration*.cmake
 %{_qt6_libdir}/cmake/Qt6WaylandClientFeaturesPrivate/*.cmake
 %{_qt6_libdir}/cmake/Qt6WaylandCompositor/
 %{_qt6_libdir}/cmake/Qt6WaylandCompositorIviapplication/
@@ -187,11 +188,11 @@ popd
 %{_qt6_libdir}/qt6/metatypes/qt6*_metatypes.json
 %{_qt6_libdir}/qt6/modules/*.json
 %{_qt6_libdir}/pkgconfig/*.pc
-%exclude %{_qt6_libdir}/cmake/Qt6WaylandClient/Qt6QWaylandAdwaitaDecoration*.cmake
+%exclude %{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandAdwaitaDecoration*.cmake
 
 %files adwaita-decoration
 %{_qt6_plugindir}/wayland-decoration-client/libadwaita.so
-%{_qt6_libdir}/cmake/Qt6WaylandClient/Qt6QWaylandAdwaitaDecoration*.cmake
+%{_qt6_libdir}/cmake/Qt6*/Qt6QWaylandAdwaitaDecoration*.cmake
 
 %if 0%{?examples}
 %files examples


### PR DESCRIPTION
Qt 6.10 moved the Wayland client plugin CMake files (Ivi/QtShell shell integrations and the Adwaita decoration) from cmake/Qt6WaylandClient/ to cmake/Qt6Gui/, but the locked 6.10.2 %files still lists the old Qt6WaylandClient paths, so packaging fails with 'File not found'. Add overlays that update the three %files entries to the Qt6Gui locations, mirroring Fedora f43 commit e96dca235e83 ('Fix %files section').