### PR TITLE
[MANUAL CHERRYPICK] [AutoPR- Security] Patch busybox for CVE-2026-38755, CVE-2026-38754 [HIGH] (#18056) - branch 3.0-dev

### DIFF
--- a/SPECS/busybox/CVE-2026-38754.patch
+++ b/SPECS/busybox/CVE-2026-38754.patch
@@ -1,0 +1,102 @@
+From fc3c48fa3599e152caccc3c7e9e2f349750cdede Mon Sep 17 00:00:00 2001
+From: Sanghyun Park <sanghyun.park.cnu@gmail.com>
+Date: Mon, 20 Jul 2026 06:28:02 +0000
+Subject: [PATCH] CVE-2026-38754 ifsbreakup() skips over CTLESC before testing
+ the following byte against
+
+IFS. If CTLESC is the last byte in the recorded region, the scan
+advances to the region end and can dereference one byte past it.
+
+The recorded region can also be stale after error unwinding, so cap each
+scan to the current stack block before walking it and make the final
+empty-string check respect the same bound.
+
+Signed-off-by: Sanghyun Park <sanghyun.park.cnu@gmail.com>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://lists.busybox.net/pipermail/busybox/2026-June/092353.html
+---
+ shell/ash.c | 30 +++++++++++++++++++++++++-----
+ 1 file changed, 25 insertions(+), 5 deletions(-)
+
+diff --git a/shell/ash.c b/shell/ash.c
+index 9344e4d..7bdd5f0 100644
+--- a/shell/ash.c
++++ b/shell/ash.c
+@@ -6136,13 +6136,16 @@ ifsbreakup(char *string, struct arglist *arglist)
+ 	struct ifsregion *ifsp;
+ 	struct strlist *sp;
+ 	char *start;
++	char *end;
+ 	char *p;
+ 	char *q;
++	char *stack_end;
+ 	const char *ifs, *realifs;
+ 	int ifsspc;
+ 	int nulonly;
+ 
+ 	start = string;
++	stack_end = (char *)stackblock() + stackblocksize();
+ 	if (ifslastp != NULL) {
+ 		ifsspc = 0;
+ 		nulonly = 0;
+@@ -6152,14 +6155,26 @@ ifsbreakup(char *string, struct arglist *arglist)
+ 			int afternul;
+ 
+ 			p = string + ifsp->begoff;
++			end = string + ifsp->endoff;
++			if (end > stack_end)
++				end = stack_end;
++			if (p >= end) {
++				ifsp = ifsp->next;
++				continue;
++			}
+ 			afternul = nulonly;
+ 			nulonly = ifsp->nulonly;
+ 			ifs = nulonly ? nullstr : realifs;
+ 			ifsspc = 0;
+-			while (p < string + ifsp->endoff) {
++			while (p < end) {
+ 				q = p;
+-				if ((unsigned char)*p == CTLESC)
++				if ((unsigned char)*p == CTLESC) {
+ 					p++;
++					if (p >= end) {
++						p = q;
++						break;
++					}
++				}
+ 				if (!strchr(ifs, *p)) {
+ 					p++;
+ 					continue;
+@@ -6180,12 +6195,17 @@ ifsbreakup(char *string, struct arglist *arglist)
+ 				p++;
+ 				if (!nulonly) {
+ 					for (;;) {
+-						if (p >= string + ifsp->endoff) {
++						if (p >= end) {
+ 							break;
+ 						}
+ 						q = p;
+-						if ((unsigned char)*p == CTLESC)
++						if ((unsigned char)*p == CTLESC) {
+ 							p++;
++							if (p >= end) {
++								p = q;
++								break;
++							}
++						}
+ 						if (strchr(ifs, *p) == NULL) {
+ 							p = q;
+ 							break;
+@@ -6210,7 +6230,7 @@ ifsbreakup(char *string, struct arglist *arglist)
+ 			goto add;
+ 	}
+ 
+-	if (!*start)
++	if (start >= stack_end || !*start)
+ 		return;
+ 
+  add:
+-- 
+2.45.4
+

--- a/SPECS/busybox/CVE-2026-38755.patch
+++ b/SPECS/busybox/CVE-2026-38755.patch
@@ -1,0 +1,69 @@
+From 46496da2ec13ac56b7aa687832f0a3bb355361ab Mon Sep 17 00:00:00 2001
+From: Sanghyun Park <sanghyun.park.cnu@gmail.com>
+Date: Mon, 20 Jul 2026 06:28:50 +0000
+Subject: [PATCH] CVE-2026-38755
+
+Recursive shell functions can repeatedly enter evalfun() until the
+process stack is exhausted. Track active shell function calls and raise a
+normal shell error when the recursion limit is reached.
+
+The counter is decremented through the existing funcdone cleanup path so
+errors raised from inside the function body unwind it correctly.
+
+Signed-off-by: Sanghyun Park <sanghyun.park.cnu@gmail.com>
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://lists.busybox.net/pipermail/busybox/2026-June/092354.html
+---
+ shell/ash.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/shell/ash.c b/shell/ash.c
+index 7bdd5f0..974fb57 100644
+--- a/shell/ash.c
++++ b/shell/ash.c
+@@ -402,6 +402,7 @@ struct globals_misc {
+ 	int shlvl;
+ #define rootshell (!shlvl)
+ 	int errlinno;
++	unsigned func_depth;
+ 
+ 	char *minusc;  /* argument to -c option */
+ 
+@@ -489,6 +490,7 @@ extern struct globals_misc *BB_GLOBAL_CONST ash_ptr_to_globals_misc;
+ #define rootpid     (G_misc.rootpid    )
+ #define shlvl       (G_misc.shlvl      )
+ #define errlinno    (G_misc.errlinno   )
++#define func_depth  (G_misc.func_depth )
+ #define minusc      (G_misc.minusc     )
+ #define curdir      (G_misc.curdir     )
+ #define physdir     (G_misc.physdir    )
+@@ -9930,6 +9932,10 @@ evalfun(struct funcnode *func, int argc, char **argv, int flags)
+ 	int savefuncline;
+ 	char *savefuncname;
+ 	char *savetrap = NULL;
++	enum { MAX_ASH_FUNC_DEPTH = 1000 };
++
++	if (func_depth >= MAX_ASH_FUNC_DEPTH)
++		ash_msg_and_raise_error("function recursion limit exceeded");
+ 
+ 	if (!Eflag) {
+ 		savetrap = trap[NTRAP_ERR];
+@@ -9948,6 +9954,7 @@ evalfun(struct funcnode *func, int argc, char **argv, int flags)
+ 	exception_handler = &jmploc;
+ 	shellparam.malloced = 0;
+ 	func->count++;
++	func_depth++;
+ 	funcname = func->n.ndefun.text;
+ 	funcline = func->n.ndefun.linno;
+ 	INT_ON;
+@@ -9969,6 +9976,7 @@ evalfun(struct funcnode *func, int argc, char **argv, int flags)
+ 	}
+ 	funcline = savefuncline;
+ 	lineno = savelineno;
++	func_depth--;
+ 	freefunc(func);
+ 	freeparam(&shellparam);
+ 	shellparam = saveparam;
+-- 
+2.45.4
+

--- a/SPECS/busybox/busybox.spec
+++ b/SPECS/busybox/busybox.spec
@@ -114,14 +114,11 @@ cd testsuite
 %{_mandir}/man1/busybox.petitboot.1.gz
 
 %changelog
-* Wed Jul 23 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.36.1-26
-- Rebased 3.0-dev CVE patches (CVE-2026-38752, CVE-2026-38753) on top of fasttrack CVE ordering; renumbered as Patch11, Patch12.
+* Tue Jul 21 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.36.1-26
+- Patch for CVE-2026-38753, CVE-2026-38752
 
 * Mon Jul 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.36.1-25
 - Patch for CVE-2026-38755, CVE-2026-38754
-
-* Tue Jul 21 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.36.1-25
-- Patch for CVE-2026-38753, CVE-2026-38752
 
 * Thu May 07 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.36.1-24
 - Bump to rebuild with updated glibc

--- a/SPECS/busybox/busybox.spec
+++ b/SPECS/busybox/busybox.spec
@@ -1,7 +1,7 @@
 Summary:        Statically linked binary providing simplified versions of system commands
 Name:           busybox
 Version:        1.36.1
-Release:        25%{?dist}
+Release:        26%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -19,8 +19,10 @@ Patch5:         CVE-2023-42366.patch
 Patch6:         CVE-2023-39810.patch
 Patch7:         CVE-2022-48174.patch
 Patch8:         CVE-2026-26157.patch
-Patch9:         CVE-2026-38752.patch
-Patch10:        CVE-2026-38753.patch
+Patch9:         CVE-2026-38754.patch
+Patch10:        CVE-2026-38755.patch
+Patch11:        CVE-2026-38752.patch
+Patch12:        CVE-2026-38753.patch
 BuildRequires:  gcc
 BuildRequires:  glibc-static >= 2.38-20%{?dist}
 BuildRequires:  libselinux-devel >= 1.27.7-2
@@ -112,6 +114,12 @@ cd testsuite
 %{_mandir}/man1/busybox.petitboot.1.gz
 
 %changelog
+* Wed Jul 23 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.36.1-26
+- Rebased 3.0-dev CVE patches (CVE-2026-38752, CVE-2026-38753) on top of fasttrack CVE ordering; renumbered as Patch11, Patch12.
+
+* Mon Jul 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.36.1-25
+- Patch for CVE-2026-38755, CVE-2026-38754
+
 * Tue Jul 21 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.36.1-25
 - Patch for CVE-2026-38753, CVE-2026-38752
 


### PR DESCRIPTION
Manual cherry-pick of #18056 (commit 87345f5870) from `fasttrack/3.0`.

The `FastTrack-CherryPickToStaging` pipeline (def 2345) has been failing since 2026-07-20 due to an expired PAT; catching up backlog by hand.

**Conflict resolution:** 3.0-dev already had CVE-2026-38752/38753 as Patch9/10 (Release 25). Re-sequenced the two new CVE patches to Patch11/12 and bumped Release to 26. New changelog entry prepended.