### PR TITLE
[MANUAL CHERRYPICK] [AutoPR- Security] Patch qemu for CVE-2026-3842 [HIGH] (#18055) - branch 3.0-dev

### DIFF
--- a/SPECS/qemu/CVE-2026-3842.patch
+++ b/SPECS/qemu/CVE-2026-3842.patch
@@ -1,0 +1,68 @@
+From f52056b4fdf5f43b1513168443617bd479e5233f Mon Sep 17 00:00:00 2001
+From: AllSpark <allspark@microsoft.com>
+Date: Mon, 20 Jul 2026 05:56:28 +0000
+Subject: [PATCH] hyperv/syndbg: check length returned by
+ cpu_physical_memory_map()
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: AI Backport of https://gitlab.com/qemu-project/qemu/-/commit/85af4e937016ed2f20122eb116597d1abb30c5c0.patch
+---
+ hw/hyperv/syndbg.c | 23 +++++++++++------------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/hw/hyperv/syndbg.c b/hw/hyperv/syndbg.c
+index 065e12fb1..9fdec1146 100644
+--- a/hw/hyperv/syndbg.c
++++ b/hw/hyperv/syndbg.c
+@@ -189,7 +189,7 @@ static uint16_t handle_recv_msg(HvSynDbg *syndbg, uint64_t outgpa,
+ {
+     uint16_t ret;
+     uint8_t data_buf[TARGET_PAGE_SIZE - UDP_PKT_HEADER_SIZE];
+-    hwaddr out_len;
++    hwaddr out_len, out_requested_len;
+     void *out_data;
+     ssize_t recv_byte_count;
+ 
+@@ -218,29 +218,28 @@ static uint16_t handle_recv_msg(HvSynDbg *syndbg, uint64_t outgpa,
+     if (is_raw) {
+         out_len += UDP_PKT_HEADER_SIZE;
+     }
++    out_requested_len = out_len;
+     out_data = cpu_physical_memory_map(outgpa, &out_len, 1);
+-    if (!out_data) {
+-        return HV_STATUS_INSUFFICIENT_MEMORY;
++    ret = HV_STATUS_INSUFFICIENT_MEMORY;
++    if (!out_data || out_len < out_requested_len) {
++        goto cleanup_out_data;
+     }
+ 
+     if (is_raw &&
+-        !create_udp_pkt(syndbg, out_data,
+-                        recv_byte_count + UDP_PKT_HEADER_SIZE,
++        !create_udp_pkt(syndbg, out_data, out_len,
+                         data_buf, recv_byte_count)) {
+-        ret = HV_STATUS_INSUFFICIENT_MEMORY;
+         goto cleanup_out_data;
+     } else if (!is_raw) {
+-        memcpy(out_data, data_buf, recv_byte_count);
++        memcpy(out_data, data_buf, out_len);
+     }
+ 
+-    *retrieved_count = recv_byte_count;
+-    if (is_raw) {
+-        *retrieved_count += UDP_PKT_HEADER_SIZE;
+-    }
++    *retrieved_count = out_len;
+     ret = HV_STATUS_SUCCESS;
+ 
+ cleanup_out_data:
+-    cpu_physical_memory_unmap(out_data, out_len, 1, out_len);
++    if (out_data) {
++        cpu_physical_memory_unmap(out_data, out_len, 1, out_len);
++    }
+     return ret;
+ }
+ 
+-- 
+2.43.0
+

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -432,7 +432,7 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 9.1.0
-Release: 10%{?dist}
+Release: 11%{?dist}
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -473,6 +473,7 @@ Patch30:  kvm-migration-Fix-UAF-for-incoming-migration-on-Migratio.patch
 Patch31:  CVE-2026-3195.patch
 Patch32:  CVE-2026-48914.patch
 Patch33:  CVE-2026-3196.patch
+Patch34:  CVE-2026-3842.patch
 
 Source10: qemu-guest-agent.service
 Source11: 99-qemu-guest-agent.rules
@@ -3522,6 +3523,9 @@ fi
 # endif !tools_only
 %endif
 %changelog
+* Mon Jul 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 9.1.0-11
+- Patch for CVE-2026-3842
+
 * Wed Jul 01 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 9.1.0-10
 - Patch for CVE-2026-3196
 


### PR DESCRIPTION
Manual cherry-pick of #18055 (commit 66ba569a8b) from `fasttrack/3.0`.

The `FastTrack-CherryPickToStaging` pipeline (def 2345) has been failing since 2026-07-20 due to an expired PAT; catching up backlog by hand. Applied cleanly.