### PR TITLE
[MANUAL CHERRYPICK] Auto-upgrade perl-DBI to 1.651 [CRITICAL] (#18038) - branch 3.0-dev

### DIFF
--- a/SPECS/perl-DBI/perl-DBI.signatures.json
+++ b/SPECS/perl-DBI/perl-DBI.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "DBI-1.650.tgz": "a807b817c1cfb0fe6ecccff1d9ddeb293c317d518f5ab2007dfb9d3bccdbcf83"
- }
+  "Signatures": {
+    "DBI-1.651.tgz": "da621a23fa68e1e04fac824cfd3d41e8ffbab2ab3eba642a12499242e8be5253"
+  }
 }

--- a/SPECS/perl-DBI/perl-DBI.spec
+++ b/SPECS/perl-DBI/perl-DBI.spec
@@ -4,7 +4,7 @@
 
 Summary:        A database access API for perl
 Name:           perl-DBI
-Version:        1.650
+Version:        1.651
 Release:        1%{?dist}
 Group:          Development/Libraries
 License:        GPL+ or Artistic
@@ -162,6 +162,9 @@ make test
 %{_mandir}/man3/*.3*
 
 %changelog
+* Thu Jul 16 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.651-1
+- Auto-upgrade to 1.651 - for CVE-2026-15043, CVE-2026-15392, CVE-2026-60081, CVE-2026-60082
+
 * Sat Jul 11 2026 Kanishk Bansal <kanbansal@microsoft.com> - 1.650-1
 - Upgrade to 1.650 for CVE-2026-14380, CVE-2026-14739 & CVE-2026-14740
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -17323,8 +17323,8 @@
         "type": "other",
         "other": {
           "name": "perl-DBI",
-          "version": "1.650",
-          "downloadUrl": "https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.650.tgz"
+          "version": "1.651",
+          "downloadUrl": "https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.651.tgz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -336,8 +336,8 @@ perl-CPAN-Meta-YAML-0.018-513.azl3.noarch.rpm
 perl-Data-Dumper-2.188-513.azl3.aarch64.rpm
 perl-DBD-SQLite-1.74-2.azl3.aarch64.rpm
 perl-DBD-SQLite-debuginfo-1.74-2.azl3.aarch64.rpm
-perl-DBI-1.650-1.azl3.aarch64.rpm
-perl-DBI-debuginfo-1.650-1.azl3.aarch64.rpm
+perl-DBI-1.651-1.azl3.aarch64.rpm
+perl-DBI-debuginfo-1.651-1.azl3.aarch64.rpm
 perl-DBIx-Simple-1.37-7.azl3.noarch.rpm
 perl-DBM_Filter-0.06-513.azl3.noarch.rpm
 perl-debugger-1.60-513.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -344,8 +344,8 @@ perl-CPAN-Meta-YAML-0.018-513.azl3.noarch.rpm
 perl-Data-Dumper-2.188-513.azl3.x86_64.rpm
 perl-DBD-SQLite-1.74-2.azl3.x86_64.rpm
 perl-DBD-SQLite-debuginfo-1.74-2.azl3.x86_64.rpm
-perl-DBI-1.650-1.azl3.x86_64.rpm
-perl-DBI-debuginfo-1.650-1.azl3.x86_64.rpm
+perl-DBI-1.651-1.azl3.x86_64.rpm
+perl-DBI-debuginfo-1.651-1.azl3.x86_64.rpm
 perl-DBIx-Simple-1.37-7.azl3.noarch.rpm
 perl-DBM_Filter-0.06-513.azl3.noarch.rpm
 perl-debugger-1.60-513.azl3.noarch.rpm


### PR DESCRIPTION
Manual cherry-pick of #18038 (commit 4d35edc2bb) from `fasttrack/3.0`.

The `FastTrack-CherryPickToStaging` pipeline (def 2345) has been failing since 2026-07-20 due to an expired PAT; catching up backlog by hand.

Cherry-pick applied cleanly; toolchain manifest EOLs normalized to LF.