### PR TITLE
[MANUAL CHERRYPICK] [AutoPR- Security] Patch libsolv for CVE-2026-48863 [HIGH] (#18035) - branch 3.0-dev

### DIFF
--- a/SPECS/libsolv/CVE-2026-48863.patch
+++ b/SPECS/libsolv/CVE-2026-48863.patch
@@ -1,0 +1,27 @@
+From 95634be68a02db261bfdb4ae9e4848430fcc7e2a Mon Sep 17 00:00:00 2001
+From: Michael Schroeder <mls@suse.de>
+Date: Tue, 26 May 2026 10:30:31 +0200
+Subject: [PATCH] Fix wrong variable being used in solv_pgpvrfy
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/openSUSE/libsolv/commit/44f8c085045b1f771641091bbb2b810d12cff9e8.patch
+---
+ ext/solv_pgpvrfy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ext/solv_pgpvrfy.c b/ext/solv_pgpvrfy.c
+index 8fec835..7e6e31e 100644
+--- a/ext/solv_pgpvrfy.c
++++ b/ext/solv_pgpvrfy.c
+@@ -589,7 +589,7 @@ solv_pgpvrfy(const unsigned char *pub, int publ, const unsigned char *sig, int s
+ 	if (rlen)
+ 	  memcpy(sigdata + 32 - rlen, r, rlen);
+ 	if (slen)
+-	  memcpy(sigdata + 64 - slen, s, rlen);
++	  memcpy(sigdata + 64 - slen, s, slen);
+ 	res = mped25519(pub + 1 + 10 + 2 + 1, sigdata, sig + 2, hashl);
+ 	break;
+       }
+-- 
+2.45.4
+

--- a/SPECS/libsolv/libsolv.spec
+++ b/SPECS/libsolv/libsolv.spec
@@ -1,12 +1,13 @@
 Summary:        A free package dependency solver
 Name:           libsolv
 Version:        0.7.28
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        BSD
 URL:            https://github.com/openSUSE/libsolv
 Source0:        https://github.com/openSUSE/libsolv/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Patch0:         CVE-2026-9149.patch
 Patch1:         CVE-2026-9150.patch
+Patch2:         CVE-2026-48863.patch
 Group:          Development/Tools
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -82,6 +83,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_mandir}/man1/*
 
 %changelog
+* Thu Jul 16 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.7.28-5
+- Patch for CVE-2026-48863
+
 * Wed May 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.7.28-4
 - Patch for CVE-2026-9150, CVE-2026-9149
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -191,8 +191,8 @@ cpio-lang-2.14-1.azl3.aarch64.rpm
 e2fsprogs-libs-1.47.0-2.azl3.aarch64.rpm
 e2fsprogs-1.47.0-2.azl3.aarch64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.aarch64.rpm
-libsolv-0.7.28-4.azl3.aarch64.rpm
-libsolv-devel-0.7.28-4.azl3.aarch64.rpm
+libsolv-0.7.28-5.azl3.aarch64.rpm
+libsolv-devel-0.7.28-5.azl3.aarch64.rpm
 libssh2-1.11.1-4.azl3.aarch64.rpm
 libssh2-devel-1.11.1-4.azl3.aarch64.rpm
 krb5-1.21.3-5.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -191,8 +191,8 @@ cpio-lang-2.14-1.azl3.x86_64.rpm
 e2fsprogs-libs-1.47.0-2.azl3.x86_64.rpm
 e2fsprogs-1.47.0-2.azl3.x86_64.rpm
 e2fsprogs-devel-1.47.0-2.azl3.x86_64.rpm
-libsolv-0.7.28-4.azl3.x86_64.rpm
-libsolv-devel-0.7.28-4.azl3.x86_64.rpm
+libsolv-0.7.28-5.azl3.x86_64.rpm
+libsolv-devel-0.7.28-5.azl3.x86_64.rpm
 libssh2-1.11.1-4.azl3.x86_64.rpm
 libssh2-devel-1.11.1-4.azl3.x86_64.rpm
 krb5-1.21.3-5.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -225,10 +225,10 @@ libselinux-utils-3.6-4.azl3.aarch64.rpm
 libsepol-3.6-2.azl3.aarch64.rpm
 libsepol-debuginfo-3.6-2.azl3.aarch64.rpm
 libsepol-devel-3.6-2.azl3.aarch64.rpm
-libsolv-0.7.28-4.azl3.aarch64.rpm
-libsolv-debuginfo-0.7.28-4.azl3.aarch64.rpm
-libsolv-devel-0.7.28-4.azl3.aarch64.rpm
-libsolv-tools-0.7.28-4.azl3.aarch64.rpm
+libsolv-0.7.28-5.azl3.aarch64.rpm
+libsolv-debuginfo-0.7.28-5.azl3.aarch64.rpm
+libsolv-devel-0.7.28-5.azl3.aarch64.rpm
+libsolv-tools-0.7.28-5.azl3.aarch64.rpm
 libssh2-1.11.1-4.azl3.aarch64.rpm
 libssh2-debuginfo-1.11.1-4.azl3.aarch64.rpm
 libssh2-devel-1.11.1-4.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -233,10 +233,10 @@ libselinux-utils-3.6-4.azl3.x86_64.rpm
 libsepol-3.6-2.azl3.x86_64.rpm
 libsepol-debuginfo-3.6-2.azl3.x86_64.rpm
 libsepol-devel-3.6-2.azl3.x86_64.rpm
-libsolv-0.7.28-4.azl3.x86_64.rpm
-libsolv-debuginfo-0.7.28-4.azl3.x86_64.rpm
-libsolv-devel-0.7.28-4.azl3.x86_64.rpm
-libsolv-tools-0.7.28-4.azl3.x86_64.rpm
+libsolv-0.7.28-5.azl3.x86_64.rpm
+libsolv-debuginfo-0.7.28-5.azl3.x86_64.rpm
+libsolv-devel-0.7.28-5.azl3.x86_64.rpm
+libsolv-tools-0.7.28-5.azl3.x86_64.rpm
 libssh2-1.11.1-4.azl3.x86_64.rpm
 libssh2-debuginfo-1.11.1-4.azl3.x86_64.rpm
 libssh2-devel-1.11.1-4.azl3.x86_64.rpm


### PR DESCRIPTION
Manual cherry-pick of #18035 (commit ae7e1bb1bf) from `fasttrack/3.0`.

The `FastTrack-CherryPickToStaging` pipeline (def 2345) has been failing since 2026-07-20 due to an expired PAT; catching up backlog by hand.

Cherry-pick applied cleanly; toolchain manifest EOLs normalized to LF.