### PR TITLE
[MANUAL CHERRYPICK] [AutoPR- Security] Patch nginx for CVE-2026-56434, CVE-2026-42533 [CRITICAL] (#18057) - branch 3.0-dev

### DIFF
--- a/SPECS/nginx/CVE-2026-42533.patch
+++ b/SPECS/nginx/CVE-2026-42533.patch
@@ -1,0 +1,1082 @@
+From ea47fabf55e2bc9192ddc27f52486b4e58d5e007 Mon Sep 17 00:00:00 2001
+From: Maxim Dounin <mdounin@mdounin.ru>
+Date: Fri, 19 Jun 2026 22:54:19 +0300
+Subject: [PATCH 1/3] Script: simplified copy capture codes
+
+Signed-off-by: Roman Arutyunyan <arut@nginx.com>
+Origin: <https://freenginx.org/hg/nginx/rev/0fd5e6155817>
+
+Upstream Patch Reference: https://github.com/nginx/nginx/commit/ea47fabf55e2bc9192ddc27f52486b4e58d5e007.patch
+---
+ src/http/ngx_http_script.c     | 22 ++++++++++++----------
+ src/stream/ngx_stream_script.c | 10 +++++++---
+ 2 files changed, 19 insertions(+), 13 deletions(-)
+
+diff --git a/src/http/ngx_http_script.c b/src/http/ngx_http_script.c
+index 8a28e23..6b33d01 100644
+--- a/src/http/ngx_http_script.c
++++ b/src/http/ngx_http_script.c
+@@ -1343,6 +1343,7 @@ ngx_http_script_copy_capture_len_code(ngx_http_script_engine_t *e)
+ {
+     int                                  *cap;
+     u_char                               *p;
++    size_t                                len;
+     ngx_uint_t                            n;
+     ngx_http_request_t                   *r;
+     ngx_http_script_copy_capture_code_t  *code;
+@@ -1358,17 +1359,17 @@ ngx_http_script_copy_capture_len_code(ngx_http_script_engine_t *e)
+     if (n < r->ncaptures) {
+ 
+         cap = r->captures;
++        len = cap[n + 1] - cap[n];
+ 
+         if ((e->is_args || e->quote)
+             && (e->request->quoted_uri || e->request->plus_in_uri))
+         {
+-            p = r->captures_data;
++            p = r->captures_data + cap[n];
++
++            return len + 2 * ngx_escape_uri(NULL, p, len, NGX_ESCAPE_ARGS);
+ 
+-            return cap[n + 1] - cap[n]
+-                   + 2 * ngx_escape_uri(NULL, &p[cap[n]], cap[n + 1] - cap[n],
+-                                        NGX_ESCAPE_ARGS);
+         } else {
+-            return cap[n + 1] - cap[n];
++            return len;
+         }
+     }
+ 
+@@ -1381,6 +1382,7 @@ ngx_http_script_copy_capture_code(ngx_http_script_engine_t *e)
+ {
+     int                                  *cap;
+     u_char                               *p, *pos;
++    size_t                                len;
+     ngx_uint_t                            n;
+     ngx_http_request_t                   *r;
+     ngx_http_script_copy_capture_code_t  *code;
+@@ -1398,16 +1400,16 @@ ngx_http_script_copy_capture_code(ngx_http_script_engine_t *e)
+     if (n < r->ncaptures) {
+ 
+         cap = r->captures;
+-        p = r->captures_data;
++        len = cap[n + 1] - cap[n];
++        p = r->captures_data + cap[n];
+ 
+         if ((e->is_args || e->quote)
+             && (e->request->quoted_uri || e->request->plus_in_uri))
+         {
+-            e->pos = (u_char *) ngx_escape_uri(pos, &p[cap[n]],
+-                                               cap[n + 1] - cap[n],
+-                                               NGX_ESCAPE_ARGS);
++            e->pos = (u_char *) ngx_escape_uri(pos, p, len, NGX_ESCAPE_ARGS);
++
+         } else {
+-            e->pos = ngx_copy(pos, &p[cap[n]], cap[n + 1] - cap[n]);
++            e->pos = ngx_copy(pos, p, len);
+         }
+     }
+ 
+diff --git a/src/stream/ngx_stream_script.c b/src/stream/ngx_stream_script.c
+index c447e15..2cd8b08 100644
+--- a/src/stream/ngx_stream_script.c
++++ b/src/stream/ngx_stream_script.c
+@@ -894,6 +894,7 @@ size_t
+ ngx_stream_script_copy_capture_len_code(ngx_stream_script_engine_t *e)
+ {
+     int                                    *cap;
++    size_t                                  len;
+     ngx_uint_t                              n;
+     ngx_stream_session_t                   *s;
+     ngx_stream_script_copy_capture_code_t  *code;
+@@ -908,7 +909,8 @@ ngx_stream_script_copy_capture_len_code(ngx_stream_script_engine_t *e)
+ 
+     if (n < s->ncaptures) {
+         cap = s->captures;
+-        return cap[n + 1] - cap[n];
++        len = cap[n + 1] - cap[n];
++        return len;
+     }
+ 
+     return 0;
+@@ -920,6 +922,7 @@ ngx_stream_script_copy_capture_code(ngx_stream_script_engine_t *e)
+ {
+     int                                    *cap;
+     u_char                                 *p, *pos;
++    size_t                                  len;
+     ngx_uint_t                              n;
+     ngx_stream_session_t                   *s;
+     ngx_stream_script_copy_capture_code_t  *code;
+@@ -936,8 +939,9 @@ ngx_stream_script_copy_capture_code(ngx_stream_script_engine_t *e)
+ 
+     if (n < s->ncaptures) {
+         cap = s->captures;
+-        p = s->captures_data;
+-        e->pos = ngx_copy(pos, &p[cap[n]], cap[n + 1] - cap[n]);
++        len = cap[n + 1] - cap[n];
++        p = s->captures_data + cap[n];
++        e->pos = ngx_copy(pos, p, len);
+     }
+ 
+     ngx_log_debug2(NGX_LOG_DEBUG_STREAM, e->session->connection->log, 0,
+-- 
+2.45.4
+
+From 7ac67898bdfed2140a1bedcda252074cca11f494 Mon Sep 17 00:00:00 2001
+From: Maxim Dounin <mdounin@mdounin.ru>
+Date: Fri, 19 Jun 2026 22:54:27 +0300
+Subject: [PATCH 2/3] Script: buffer overrun protection
+
+With this change, all script copy operations now check if there is
+enough room in the buffer.  To do so, the script engine now provides the
+e->end pointer, which specifies expected buffer end, and each copy
+operation is checked against it with the ngx_http_script_check_length()
+function.
+
+The e->end pointer is optional and only checked when set, thus
+introducing no incompatible API changes.  All standard functions were
+updated to use it, notably ngx_http_complex_value(), ngx_http_script_run(),
+ngx_http_script_regex_start_code(), ngx_http_script_complex_value_code().
+Direct script evaluation in the proxy, fastcgi, scgi, uwsgi, grpc proxy,
+index, and try_files modules will be updated by a separate patch.
+
+In particular, this catches issues as observed when evaluating variables
+with side effects, such as in the following configuration:
+
+    map $uri $map {
+        ~(?<capture>.*) $capture;
+    }
+
+    set $capture "";
+    set $temp "$capture $map";
+
+As well as when evaluating non-cacheable variables, where length of a
+variable might change between length and copy codes, such as in the
+following configuration:
+
+    map prefix:$capture $map_volatile {
+        volatile;
+        ~(?<capture>.*) $capture;
+    }
+
+    set $capture "";
+    set $temp "$map_volatile";
+
+Similar changes were made in the stream module.
+
+Signed-off-by: Roman Arutyunyan <arut@nginx.com>
+Origin: <https://freenginx.org/hg/nginx/rev/d172f506ab5f>
+
+Upstream Patch Reference: https://github.com/nginx/nginx/commit/7ac67898bdfed2140a1bedcda252074cca11f494.patch
+---
+ src/http/ngx_http_script.c     | 63 ++++++++++++++++++++++++++++++++++
+ src/http/ngx_http_script.h     |  4 +++
+ src/stream/ngx_stream_script.c | 45 ++++++++++++++++++++++++
+ src/stream/ngx_stream_script.h |  5 +++
+ 4 files changed, 117 insertions(+)
+
+diff --git a/src/http/ngx_http_script.c b/src/http/ngx_http_script.c
+index 6b33d01..d3af440 100644
+--- a/src/http/ngx_http_script.c
++++ b/src/http/ngx_http_script.c
+@@ -92,12 +92,17 @@ ngx_http_complex_value(ngx_http_request_t *r, ngx_http_complex_value_t *val,
+     e.ip = val->values;
+     e.pos = value->data;
+     e.buf = *value;
++    e.end = value->data + len;
+ 
+     while (*(uintptr_t *) e.ip) {
+         code = *(ngx_http_script_code_pt *) e.ip;
+         code((ngx_http_script_engine_t *) &e);
+     }
+ 
++    if (e.status) {
++        return NGX_ERROR;
++    }
++
+     *value = e.buf;
+ 
+     return NGX_OK;
+@@ -650,12 +655,17 @@ ngx_http_script_run(ngx_http_request_t *r, ngx_str_t *value,
+ 
+     e.ip = code_values;
+     e.pos = value->data;
++    e.end = value->data + len;
+ 
+     while (*(uintptr_t *) e.ip) {
+         code = *(ngx_http_script_code_pt *) e.ip;
+         code((ngx_http_script_engine_t *) &e);
+     }
+ 
++    if (e.status) {
++        return NULL;
++    }
++
+     return e.pos;
+ }
+ 
+@@ -805,6 +815,25 @@ ngx_http_script_add_code(ngx_array_t *codes, size_t size, void *code)
+ }
+ 
+ 
++ngx_int_t
++ngx_http_script_check_length(ngx_http_script_engine_t *e, size_t len)
++{
++    if (e->end == NULL) {
++        return NGX_OK;
++    }
++
++    if (e->end - e->pos < (ssize_t) len) {
++        ngx_log_error(NGX_LOG_ALERT, e->request->connection->log, 0,
++                      "no buffer space in script copy");
++        e->ip = ngx_http_script_exit;
++        e->status = NGX_HTTP_INTERNAL_SERVER_ERROR;
++        return NGX_ERROR;
++    }
++
++    return NGX_OK;
++}
++
++
+ static ngx_int_t
+ ngx_http_script_add_copy_code(ngx_http_script_compile_t *sc, ngx_str_t *value,
+     ngx_uint_t last)
+@@ -873,6 +902,11 @@ ngx_http_script_copy_code(ngx_http_script_engine_t *e)
+     p = e->pos;
+ 
+     if (!e->skip) {
++
++        if (ngx_http_script_check_length(e, code->len) != NGX_OK) {
++            return;
++        }
++
+         e->pos = ngx_copy(p, e->ip + sizeof(ngx_http_script_copy_code_t),
+                           code->len);
+     }
+@@ -976,6 +1010,11 @@ ngx_http_script_copy_var_code(ngx_http_script_engine_t *e)
+         }
+ 
+         if (value && !value->not_found) {
++
++            if (ngx_http_script_check_length(e, value->len) != NGX_OK) {
++                return;
++            }
++
+             p = e->pos;
+             e->pos = ngx_copy(p, value->data, value->len);
+ 
+@@ -1192,6 +1231,7 @@ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
+     e->quote = code->redirect;
+ 
+     e->pos = e->buf.data;
++    e->end = e->buf.data + e->buf.len;
+ 
+     e->ip += sizeof(ngx_http_script_regex_code_t);
+ }
+@@ -1229,6 +1269,11 @@ ngx_http_script_regex_end_code(ngx_http_script_engine_t *e)
+         e->pos = dst;
+ 
+         if (code->add_args && r->args.len) {
++
++            if (ngx_http_script_check_length(e, r->args.len + 1) != NGX_OK) {
++                return;
++            }
++
+             *e->pos++ = (u_char) (code->args ? '&' : '?');
+             e->pos = ngx_copy(e->pos, r->args.data, r->args.len);
+         }
+@@ -1262,6 +1307,11 @@ ngx_http_script_regex_end_code(ngx_http_script_engine_t *e)
+         e->buf.len = e->args - e->buf.data;
+ 
+         if (code->add_args && r->args.len) {
++
++            if (ngx_http_script_check_length(e, r->args.len + 1) != NGX_OK) {
++                return;
++            }
++
+             *e->pos++ = '&';
+             e->pos = ngx_copy(e->pos, r->args.data, r->args.len);
+         }
+@@ -1383,6 +1433,7 @@ ngx_http_script_copy_capture_code(ngx_http_script_engine_t *e)
+     int                                  *cap;
+     u_char                               *p, *pos;
+     size_t                                len;
++    uintptr_t                             escape;
+     ngx_uint_t                            n;
+     ngx_http_request_t                   *r;
+     ngx_http_script_copy_capture_code_t  *code;
+@@ -1406,9 +1457,20 @@ ngx_http_script_copy_capture_code(ngx_http_script_engine_t *e)
+         if ((e->is_args || e->quote)
+             && (e->request->quoted_uri || e->request->plus_in_uri))
+         {
++            escape = 2 * ngx_escape_uri(NULL, p, len, NGX_ESCAPE_ARGS);
++
++            if (ngx_http_script_check_length(e, len + escape) != NGX_OK) {
++                return;
++            }
++
+             e->pos = (u_char *) ngx_escape_uri(pos, p, len, NGX_ESCAPE_ARGS);
+ 
+         } else {
++
++            if (ngx_http_script_check_length(e, len) != NGX_OK) {
++                return;
++            }
++
+             e->pos = ngx_copy(pos, p, len);
+         }
+     }
+@@ -1792,6 +1854,7 @@ ngx_http_script_complex_value_code(ngx_http_script_engine_t *e)
+     }
+ 
+     e->pos = e->buf.data;
++    e->end = e->buf.data + len;
+ 
+     e->sp->len = e->buf.len;
+     e->sp->data = e->buf.data;
+diff --git a/src/http/ngx_http_script.h b/src/http/ngx_http_script.h
+index 4360038..b086b26 100644
+--- a/src/http/ngx_http_script.h
++++ b/src/http/ngx_http_script.h
+@@ -17,6 +17,7 @@
+ typedef struct {
+     u_char                     *ip;
+     u_char                     *pos;
++    u_char                     *end;
+     ngx_http_variable_value_t  *sp;
+ 
+     ngx_str_t                   buf;
+@@ -240,6 +241,9 @@ void *ngx_http_script_start_code(ngx_pool_t *pool, ngx_array_t **codes,
+     size_t size);
+ void *ngx_http_script_add_code(ngx_array_t *codes, size_t size, void *code);
+ 
++ngx_int_t ngx_http_script_check_length(ngx_http_script_engine_t *e,
++    size_t len);
++
+ size_t ngx_http_script_copy_len_code(ngx_http_script_engine_t *e);
+ void ngx_http_script_copy_code(ngx_http_script_engine_t *e);
+ size_t ngx_http_script_copy_var_len_code(ngx_http_script_engine_t *e);
+diff --git a/src/stream/ngx_stream_script.c b/src/stream/ngx_stream_script.c
+index 2cd8b08..2e31102 100644
+--- a/src/stream/ngx_stream_script.c
++++ b/src/stream/ngx_stream_script.c
+@@ -92,6 +92,7 @@ ngx_stream_complex_value(ngx_stream_session_t *s,
+ 
+     e.ip = val->values;
+     e.pos = value->data;
++    e.end = value->data + len;
+     e.buf = *value;
+ 
+     while (*(uintptr_t *) e.ip) {
+@@ -99,6 +100,10 @@ ngx_stream_complex_value(ngx_stream_session_t *s,
+         code((ngx_stream_script_engine_t *) &e);
+     }
+ 
++    if (e.status) {
++        return NGX_ERROR;
++    }
++
+     *value = e.buf;
+ 
+     return NGX_OK;
+@@ -526,12 +531,17 @@ ngx_stream_script_run(ngx_stream_session_t *s, ngx_str_t *value,
+ 
+     e.ip = code_values;
+     e.pos = value->data;
++    e.end = value->data + len;
+ 
+     while (*(uintptr_t *) e.ip) {
+         code = *(ngx_stream_script_code_pt *) e.ip;
+         code((ngx_stream_script_engine_t *) &e);
+     }
+ 
++    if (e.status) {
++        return NULL;
++    }
++
+     return e.pos;
+ }
+ 
+@@ -668,6 +678,25 @@ ngx_stream_script_add_code(ngx_array_t *codes, size_t size, void *code)
+ }
+ 
+ 
++ngx_int_t
++ngx_stream_script_check_length(ngx_stream_script_engine_t *e, size_t len)
++{
++    if (e->end == NULL) {
++        return NGX_OK;
++    }
++
++    if (e->end - e->pos < (ssize_t) len) {
++        ngx_log_error(NGX_LOG_ALERT, e->session->connection->log, 0,
++                      "no buffer space in script copy");
++        e->ip = ngx_stream_script_exit;
++        e->status = NGX_STREAM_INTERNAL_SERVER_ERROR;
++        return NGX_ERROR;
++    }
++
++    return NGX_OK;
++}
++
++
+ static ngx_int_t
+ ngx_stream_script_add_copy_code(ngx_stream_script_compile_t *sc,
+     ngx_str_t *value, ngx_uint_t last)
+@@ -737,6 +766,11 @@ ngx_stream_script_copy_code(ngx_stream_script_engine_t *e)
+     p = e->pos;
+ 
+     if (!e->skip) {
++
++        if (ngx_stream_script_check_length(e, code->len) != NGX_OK) {
++            return;
++        }
++
+         e->pos = ngx_copy(p, e->ip + sizeof(ngx_stream_script_copy_code_t),
+                           code->len);
+     }
+@@ -841,6 +875,11 @@ ngx_stream_script_copy_var_code(ngx_stream_script_engine_t *e)
+         }
+ 
+         if (value && !value->not_found) {
++
++            if (ngx_stream_script_check_length(e, value->len) != NGX_OK) {
++                return;
++            }
++
+             p = e->pos;
+             e->pos = ngx_copy(p, value->data, value->len);
+ 
+@@ -941,6 +980,11 @@ ngx_stream_script_copy_capture_code(ngx_stream_script_engine_t *e)
+         cap = s->captures;
+         len = cap[n + 1] - cap[n];
+         p = s->captures_data + cap[n];
++
++        if (ngx_stream_script_check_length(e, len) != NGX_OK) {
++            return;
++        }
++
+         e->pos = ngx_copy(pos, p, len);
+     }
+ 
+@@ -1013,6 +1057,7 @@ ngx_stream_script_full_name_code(ngx_stream_script_engine_t *e)
+         != NGX_OK)
+     {
+         e->ip = ngx_stream_script_exit;
++        e->status = NGX_STREAM_INTERNAL_SERVER_ERROR;
+         return;
+     }
+ 
+diff --git a/src/stream/ngx_stream_script.h b/src/stream/ngx_stream_script.h
+index d8f3740..dc6de9c 100644
+--- a/src/stream/ngx_stream_script.h
++++ b/src/stream/ngx_stream_script.h
+@@ -17,6 +17,7 @@
+ typedef struct {
+     u_char                       *ip;
+     u_char                       *pos;
++    u_char                       *end;
+     ngx_stream_variable_value_t  *sp;
+ 
+     ngx_str_t                     buf;
+@@ -25,6 +26,7 @@ typedef struct {
+     unsigned                      flushed:1;
+     unsigned                      skip:1;
+ 
++    ngx_int_t                     status;
+     ngx_stream_session_t         *session;
+ } ngx_stream_script_engine_t;
+ 
+@@ -127,6 +129,9 @@ void ngx_stream_script_flush_no_cacheable_variables(ngx_stream_session_t *s,
+ 
+ void *ngx_stream_script_add_code(ngx_array_t *codes, size_t size, void *code);
+ 
++ngx_int_t ngx_stream_script_check_length(ngx_stream_script_engine_t *e,
++    size_t len);
++
+ size_t ngx_stream_script_copy_len_code(ngx_stream_script_engine_t *e);
+ void ngx_stream_script_copy_code(ngx_stream_script_engine_t *e);
+ size_t ngx_stream_script_copy_var_len_code(ngx_stream_script_engine_t *e);
+-- 
+2.45.4
+
+From 326b17b0038321c29252e79bf4c53d4773fcb8b5 Mon Sep 17 00:00:00 2001
+From: Maxim Dounin <mdounin@mdounin.ru>
+Date: Fri, 19 Jun 2026 22:54:46 +0300
+Subject: [PATCH 3/3] Script: buffer overrun protection in direct script usage
+
+Following the previous change, this change adds script overrun
+protection to direct script evaluation in the proxy, fastcgi, scgi,
+uwsgi, grpc proxy, index, and try_files modules.
+
+This change is a modified version of a patch by Maxim Dounin.  The
+modifications include ngx_http_proxy_v2_module and hardened size checks.
+
+Signed-off-by: Roman Arutyunyan <arut@nginx.com>
+Origin: <https://freenginx.org/hg/nginx/rev/7e4d7feb4c77>
+
+Upstream Patch Reference: https://github.com/nginx/nginx/commit/326b17b0038321c29252e79bf4c53d4773fcb8b5.patch
+---
+ src/http/modules/ngx_http_fastcgi_module.c   | 26 ++++++++--
+ src/http/modules/ngx_http_grpc_module.c      | 52 ++++++++++++++++++--
+ src/http/modules/ngx_http_index_module.c     | 13 ++++-
+ src/http/modules/ngx_http_proxy_module.c     | 31 ++++++++++--
+ src/http/modules/ngx_http_scgi_module.c      | 27 +++++++++-
+ src/http/modules/ngx_http_try_files_module.c | 17 ++++++-
+ src/http/modules/ngx_http_uwsgi_module.c     | 30 ++++++++++-
+ 7 files changed, 180 insertions(+), 16 deletions(-)
+
+diff --git a/src/http/modules/ngx_http_fastcgi_module.c b/src/http/modules/ngx_http_fastcgi_module.c
+index 6b19773..ea8542c 100644
+--- a/src/http/modules/ngx_http_fastcgi_module.c
++++ b/src/http/modules/ngx_http_fastcgi_module.c
+@@ -836,8 +836,8 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
+ {
+     off_t                         file_pos;
+     u_char                        ch, sep, *pos, *lowcase_key;
+-    size_t                        size, len, key_len, val_len, padding,
+-                                  allocated;
++    size_t                        size, len, params_len,
++                                  key_len, val_len, padding, allocated;
+     ngx_uint_t                    i, n, next, hash, skip_empty, header_params;
+     ngx_buf_t                    *b;
+     ngx_chain_t                  *cl, *body;
+@@ -852,6 +852,7 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
+     ngx_http_script_len_code_pt   lcode;
+ 
+     len = 0;
++    params_len = 0;
+     header_params = 0;
+     ignored = NULL;
+ 
+@@ -891,8 +892,10 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
+                 continue;
+             }
+ 
+-            len += 1 + key_len + ((val_len > 127) ? 4 : 1) + val_len;
++            params_len += 1 + key_len + ((val_len > 127) ? 4 : 1) + val_len;
+         }
++
++        len += params_len;
+     }
+ 
+     if (flcf->upstream.pass_request_headers) {
+@@ -1048,6 +1051,7 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
+ 
+         e.ip = params->values->elts;
+         e.pos = b->last;
++        e.end = b->last + params_len;
+         e.request = r;
+         e.flushed = 1;
+ 
+@@ -1080,6 +1084,12 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
+                 continue;
+             }
+ 
++            if (ngx_http_script_check_length(&e, 1 + ((val_len > 127) ? 4 : 1))
++                != NGX_OK)
++            {
++                return NGX_ERROR;
++            }
++
+             *e.pos++ = (u_char) key_len;
+ 
+             if (val_len > 127) {
+@@ -1098,12 +1108,22 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
+             }
+             e.ip += sizeof(uintptr_t);
+ 
++            if (e.status) {
++                return NGX_ERROR;
++            }
++
+             ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                            "fastcgi param: \"%*s: %*s\"",
+                            key_len, e.pos - (key_len + val_len),
+                            val_len, e.pos - val_len);
+         }
+ 
++        if (e.pos != e.end) {
++            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                          "fastcgi request length mismatch");
++            return NGX_ERROR;
++        }
++
+         b->last = e.pos;
+     }
+ 
+diff --git a/src/http/modules/ngx_http_grpc_module.c b/src/http/modules/ngx_http_grpc_module.c
+index da6970d..b9d80f0 100644
+--- a/src/http/modules/ngx_http_grpc_module.c
++++ b/src/http/modules/ngx_http_grpc_module.c
+@@ -717,8 +717,10 @@ ngx_http_grpc_eval(ngx_http_request_t *r, ngx_http_grpc_ctx_t *ctx,
+ static ngx_int_t
+ ngx_http_grpc_create_request(ngx_http_request_t *r)
+ {
+-    u_char                       *p, *tmp, *key_tmp, *val_tmp, *headers_frame;
+-    size_t                        len, tmp_len, key_len, val_len, uri_len;
++    u_char                       *p, *tmp, *key_tmp, *val_tmp, *headers_frame,
++                                 *headers_end;
++    size_t                        len, headers_len, tmp_len,
++                                  key_len, val_len, uri_len;
+     uintptr_t                     escape;
+     ngx_buf_t                    *b;
+     ngx_uint_t                    i, next;
+@@ -742,6 +744,8 @@ ngx_http_grpc_create_request(ngx_http_request_t *r)
+     len = sizeof(ngx_http_grpc_connection_start) - 1
+           + sizeof(ngx_http_grpc_frame_t);             /* headers frame */
+ 
++    headers_len = 0;
++
+     /* :method header */
+ 
+     if (r->method == NGX_HTTP_GET || r->method == NGX_HTTP_POST) {
+@@ -838,8 +842,8 @@ ngx_http_grpc_create_request(ngx_http_request_t *r)
+             return NGX_ERROR;
+         }
+ 
+-        len += 1 + NGX_HTTP_V2_INT_OCTETS + key_len
+-                 + NGX_HTTP_V2_INT_OCTETS + val_len;
++        headers_len += 1 + NGX_HTTP_V2_INT_OCTETS + key_len
++                         + NGX_HTTP_V2_INT_OCTETS + val_len;
+ 
+         if (tmp_len < key_len) {
+             tmp_len = key_len;
+@@ -850,6 +854,8 @@ ngx_http_grpc_create_request(ngx_http_request_t *r)
+         }
+     }
+ 
++    len += headers_len;
++
+     if (glcf->upstream.pass_request_headers) {
+         part = &r->headers_in.headers.part;
+         header = part->elts;
+@@ -1046,6 +1052,8 @@ ngx_http_grpc_create_request(ngx_http_request_t *r)
+ 
+     le.ip = glcf->headers.lengths->elts;
+ 
++    headers_end = b->last + headers_len;
++
+     while (*(uintptr_t *) le.ip) {
+ 
+         lcode = *(ngx_http_script_len_code_pt *) le.ip;
+@@ -1070,16 +1078,38 @@ ngx_http_grpc_create_request(ngx_http_request_t *r)
+             continue;
+         }
+ 
++        if (headers_end - b->last < 1) {
++            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                          "no buffer space in grpc create request");
++            return NGX_ERROR;
++        }
++
+         *b->last++ = 0;
+ 
+         e.pos = key_tmp;
++        e.end = key_tmp + tmp_len;
+ 
+         code = *(ngx_http_script_code_pt *) e.ip;
+         code((ngx_http_script_engine_t *) &e);
+ 
++        if (e.status) {
++            return NGX_ERROR;
++        }
++
++        key_len = e.pos - key_tmp;
++
++        if (headers_end - b->last
++            < (ssize_t) (NGX_HTTP_V2_INT_OCTETS + key_len))
++        {
++            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                          "no buffer space in grpc create request");
++            return NGX_ERROR;
++        }
++
+         b->last = ngx_http_v2_write_name(b->last, key_tmp, key_len, tmp);
+ 
+         e.pos = val_tmp;
++        e.end = val_tmp + tmp_len;
+ 
+         while (*(uintptr_t *) e.ip) {
+             code = *(ngx_http_script_code_pt *) e.ip;
+@@ -1087,6 +1117,20 @@ ngx_http_grpc_create_request(ngx_http_request_t *r)
+         }
+         e.ip += sizeof(uintptr_t);
+ 
++        if (e.status) {
++            return NGX_ERROR;
++        }
++
++        val_len = e.pos - val_tmp;
++
++        if (headers_end - b->last
++            < (ssize_t) (NGX_HTTP_V2_INT_OCTETS + val_len))
++        {
++            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                          "no buffer space in grpc create request");
++            return NGX_ERROR;
++        }
++
+         b->last = ngx_http_v2_write_value(b->last, val_tmp, val_len, tmp);
+ 
+ #if (NGX_DEBUG)
+diff --git a/src/http/modules/ngx_http_index_module.c b/src/http/modules/ngx_http_index_module.c
+index 18e7049..149b447 100644
+--- a/src/http/modules/ngx_http_index_module.c
++++ b/src/http/modules/ngx_http_index_module.c
+@@ -126,6 +126,7 @@ ngx_http_index_handler(ngx_http_request_t *r)
+     name = NULL;
+     /* suppress MSVC warning */
+     path.data = NULL;
++    e.status = 0;
+ 
+     index = ilcf->indices->elts;
+     for (i = 0; i < ilcf->indices->nelts; i++) {
+@@ -180,18 +181,28 @@ ngx_http_index_handler(ngx_http_request_t *r)
+         } else {
+             e.ip = index[i].values->elts;
+             e.pos = name;
++            e.end = name + allocated;
+ 
+             while (*(uintptr_t *) e.ip) {
+                 code = *(ngx_http_script_code_pt *) e.ip;
+                 code((ngx_http_script_engine_t *) &e);
+             }
+ 
++            if (e.status) {
++                return NGX_HTTP_INTERNAL_SERVER_ERROR;
++            }
++
++            if (ngx_http_script_check_length(&e, 1) != NGX_OK) {
++                return NGX_ERROR;
++            }
++
+             if (*name == '/') {
+-                uri.len = len - 1;
++                uri.len = e.pos - name;
+                 uri.data = name;
+                 return ngx_http_internal_redirect(r, &uri, &r->args);
+             }
+ 
++            len = e.pos - name + 1;
+             path.len = e.pos - path.data;
+ 
+             *e.pos = '\0';
+diff --git a/src/http/modules/ngx_http_proxy_module.c b/src/http/modules/ngx_http_proxy_module.c
+index 44a31e4..d77cb2e 100644
+--- a/src/http/modules/ngx_http_proxy_module.c
++++ b/src/http/modules/ngx_http_proxy_module.c
+@@ -1256,7 +1256,7 @@ ngx_http_proxy_create_key(ngx_http_request_t *r)
+ static ngx_int_t
+ ngx_http_proxy_create_request(ngx_http_request_t *r)
+ {
+-    size_t                        len, uri_len, loc_len, body_len,
++    size_t                        len, uri_len, loc_len, body_len, headers_len,
+                                   key_len, val_len;
+     uintptr_t                     escape;
+     ngx_buf_t                    *b;
+@@ -1310,6 +1310,8 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+     escape = 0;
+     loc_len = 0;
+     unparsed_uri = 0;
++    body_len = 0;
++    headers_len = 0;
+ 
+     if (plcf->proxy_lengths && ctx->vars.uri.len) {
+         uri_len = ctx->vars.uri.len;
+@@ -1348,7 +1350,6 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+         le.ip = plcf->body_lengths->elts;
+         le.request = r;
+         le.flushed = 1;
+-        body_len = 0;
+ 
+         while (*(uintptr_t *) le.ip) {
+             lcode = *(ngx_http_script_len_code_pt *) le.ip;
+@@ -1384,9 +1385,11 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+             continue;
+         }
+ 
+-        len += key_len + sizeof(": ") - 1 + val_len + sizeof(CRLF) - 1;
++        headers_len += key_len + sizeof(": ") - 1 + val_len + sizeof(CRLF) - 1;
+     }
+ 
++    len += headers_len;
++
+ 
+     if (plcf->upstream.pass_request_headers) {
+         part = &r->headers_in.headers.part;
+@@ -1478,6 +1481,7 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+ 
+     e.ip = headers->values->elts;
+     e.pos = b->last;
++    e.end = b->last + headers_len;
+     e.request = r;
+     e.flushed = 1;
+ 
+@@ -1510,6 +1514,14 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+         code = *(ngx_http_script_code_pt *) e.ip;
+         code((ngx_http_script_engine_t *) &e);
+ 
++        if (e.status) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_http_script_check_length(&e, 2) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
+         *e.pos++ = ':'; *e.pos++ = ' ';
+ 
+         while (*(uintptr_t *) e.ip) {
+@@ -1518,6 +1530,14 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+         }
+         e.ip += sizeof(uintptr_t);
+ 
++        if (e.status) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_http_script_check_length(&e, 2) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
+         *e.pos++ = CR; *e.pos++ = LF;
+     }
+ 
+@@ -1568,6 +1588,7 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+     if (plcf->body_values) {
+         e.ip = plcf->body_values->elts;
+         e.pos = b->last;
++        e.end = b->last + body_len;
+         e.skip = 0;
+ 
+         while (*(uintptr_t *) e.ip) {
+@@ -1575,6 +1596,10 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
+             code((ngx_http_script_engine_t *) &e);
+         }
+ 
++        if (e.status) {
++            return NGX_ERROR;
++        }
++
+         b->last = e.pos;
+     }
+ 
+diff --git a/src/http/modules/ngx_http_scgi_module.c b/src/http/modules/ngx_http_scgi_module.c
+index 7477df3..1f0ebb4 100644
+--- a/src/http/modules/ngx_http_scgi_module.c
++++ b/src/http/modules/ngx_http_scgi_module.c
+@@ -634,7 +634,7 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
+ {
+     off_t                         content_length_n;
+     u_char                        ch, sep, *key, *val, *lowcase_key;
+-    size_t                        len, key_len, val_len, allocated;
++    size_t                        len, params_len, key_len, val_len, allocated;
+     ngx_buf_t                    *b;
+     ngx_str_t                     content_length;
+     ngx_uint_t                    i, n, hash, skip_empty, header_params;
+@@ -661,6 +661,7 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
+ 
+     len = sizeof("CONTENT_LENGTH") + content_length.len + 1;
+ 
++    params_len = 0;
+     header_params = 0;
+     ignored = NULL;
+ 
+@@ -698,8 +699,10 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
+                 continue;
+             }
+ 
+-            len += key_len + val_len + 1;
++            params_len += key_len + val_len + 1;
+         }
++
++        len += params_len;
+     }
+ 
+     if (scf->upstream.pass_request_headers) {
+@@ -814,6 +817,7 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
+ 
+         e.ip = params->values->elts;
+         e.pos = b->last;
++        e.end = b->last + params_len;
+         e.request = r;
+         e.flushed = 1;
+ 
+@@ -852,6 +856,10 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
+             code = *(ngx_http_script_code_pt *) e.ip;
+             code((ngx_http_script_engine_t *) &e);
+ 
++            if (e.status) {
++                return NGX_ERROR;
++            }
++
+ #if (NGX_DEBUG)
+             val = e.pos;
+ #endif
+@@ -859,6 +867,15 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
+                 code = *(ngx_http_script_code_pt *) e.ip;
+                 code((ngx_http_script_engine_t *) &e);
+             }
++
++            if (e.status) {
++                return NGX_ERROR;
++            }
++
++            if (ngx_http_script_check_length(&e, 1) != NGX_OK) {
++                return NGX_ERROR;
++            }
++
+             *e.pos++ = '\0';
+             e.ip += sizeof(uintptr_t);
+ 
+@@ -866,6 +883,12 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
+                            "scgi param: \"%s: %s\"", key, val);
+         }
+ 
++        if (e.pos != e.end) {
++            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                          "scgi request length mismatch");
++            return NGX_ERROR;
++        }
++
+         b->last = e.pos;
+     }
+ 
+diff --git a/src/http/modules/ngx_http_try_files_module.c b/src/http/modules/ngx_http_try_files_module.c
+index ce783a2..bbdab85 100644
+--- a/src/http/modules/ngx_http_try_files_module.c
++++ b/src/http/modules/ngx_http_try_files_module.c
+@@ -78,7 +78,7 @@ ngx_module_t  ngx_http_try_files_module = {
+ static ngx_int_t
+ ngx_http_try_files_handler(ngx_http_request_t *r)
+ {
+-    size_t                          len, root, alias, reserve, allocated;
++    size_t                          len, root, alias, reserve, allocated, n;
+     u_char                         *p, *name;
+     ngx_str_t                       path, args;
+     ngx_uint_t                      test_dir;
+@@ -162,8 +162,15 @@ ngx_http_try_files_handler(ngx_http_request_t *r)
+             path.len = (name + tf->name.len - 1) - path.data;
+ 
+         } else {
++            n = allocated;
++
++            if (alias != NGX_MAX_SIZE_T_VALUE) {
++                n += (r->uri.len - alias);
++            }
++
+             e.ip = tf->values->elts;
+             e.pos = name;
++            e.end = name + n;
+             e.flushed = 1;
+ 
+             while (*(uintptr_t *) e.ip) {
+@@ -171,6 +178,14 @@ ngx_http_try_files_handler(ngx_http_request_t *r)
+                 code((ngx_http_script_engine_t *) &e);
+             }
+ 
++            if (e.status) {
++                return NGX_HTTP_INTERNAL_SERVER_ERROR;
++            }
++
++            if (ngx_http_script_check_length(&e, 1) != NGX_OK) {
++                return NGX_ERROR;
++            }
++
+             path.len = e.pos - path.data;
+ 
+             *e.pos = '\0';
+diff --git a/src/http/modules/ngx_http_uwsgi_module.c b/src/http/modules/ngx_http_uwsgi_module.c
+index 21b2fc3..6d865c2 100644
+--- a/src/http/modules/ngx_http_uwsgi_module.c
++++ b/src/http/modules/ngx_http_uwsgi_module.c
+@@ -857,7 +857,7 @@ static ngx_int_t
+ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
+ {
+     u_char                        ch, sep, *lowcase_key;
+-    size_t                        key_len, val_len, len, allocated;
++    size_t                        key_len, val_len, len, params_len, allocated;
+     ngx_uint_t                    i, n, hash, skip_empty, header_params;
+     ngx_buf_t                    *b;
+     ngx_chain_t                  *cl, *body;
+@@ -870,6 +870,7 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
+     ngx_http_script_len_code_pt   lcode;
+ 
+     len = 0;
++    params_len = 0;
+     header_params = 0;
+     ignored = NULL;
+ 
+@@ -907,8 +908,10 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
+                 continue;
+             }
+ 
+-            len += 2 + key_len + 2 + val_len;
++            params_len += 2 + key_len + 2 + val_len;
+         }
++
++        len += params_len;
+     }
+ 
+     if (uwcf->upstream.pass_request_headers) {
+@@ -1040,6 +1043,7 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
+ 
+         e.ip = params->values->elts;
+         e.pos = b->last;
++        e.end = b->last + params_len;
+         e.request = r;
+         e.flushed = 1;
+ 
+@@ -1072,12 +1076,24 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
+                 continue;
+             }
+ 
++            if (ngx_http_script_check_length(&e, 2) != NGX_OK) {
++                return NGX_ERROR;
++            }
++
+             *e.pos++ = (u_char) (key_len & 0xff);
+             *e.pos++ = (u_char) ((key_len >> 8) & 0xff);
+ 
+             code = *(ngx_http_script_code_pt *) e.ip;
+             code((ngx_http_script_engine_t *) &e);
+ 
++            if (e.status) {
++                return NGX_ERROR;
++            }
++
++            if (ngx_http_script_check_length(&e, 2) != NGX_OK) {
++                return NGX_ERROR;
++            }
++
+             *e.pos++ = (u_char) (val_len & 0xff);
+             *e.pos++ = (u_char) ((val_len >> 8) & 0xff);
+ 
+@@ -1086,6 +1102,10 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
+                 code((ngx_http_script_engine_t *) &e);
+             }
+ 
++            if (e.status) {
++                return NGX_ERROR;
++            }
++
+             e.ip += sizeof(uintptr_t);
+ 
+             ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+@@ -1094,6 +1114,12 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
+                            val_len, e.pos - val_len);
+         }
+ 
++        if (e.pos != e.end) {
++            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                          "uwsgi request length mismatch");
++            return NGX_ERROR;
++        }
++
+         b->last = e.pos;
+     }
+ 
+-- 
+2.45.4
+

--- a/SPECS/nginx/CVE-2026-56434.patch
+++ b/SPECS/nginx/CVE-2026-56434.patch
@@ -1,0 +1,69 @@
+From 5ef2a7f19e30b3b5b39d811dbe023c851aff7142 Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Mon, 29 Jun 2026 21:49:27 +0400
+Subject: [PATCH] Avoid duplicate subrequest finalization
+
+Previously, if a subrequest was posted twice, it could be finalized in
+both calls, excessively reducing r->main->count and potentially leading
+to a use-after-free.
+
+The fix is to avoid posting a request if it's already posted.  Also,
+as a hardening measure, r->write_event_handler is now reset to a no-op
+handler during active subrequest finalization.
+
+The problem manifests itself in ngx_http_ssi_filter_module during
+unbuffered proxying.  If a subrequest is created for an SSI include
+statement while the main request has some data postponed by another
+include, this subrequest becomes double-posted when the main request
+data is flushed.  The first post comes from ngx_http_subrequest() and
+the second one comes from ngx_http_postpone_filter().  In case of a
+quick subrequest finalization, the above mentioned problem happens.
+
+Reported by P4P3R-HAK.
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/nginx/nginx/commit/ddde692db11ab8238e9ca661007f64c9f6d764d2.patch
+---
+ src/http/ngx_http_request.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
+index 26dae3f..2e4f40a 100644
+--- a/src/http/ngx_http_request.c
++++ b/src/http/ngx_http_request.c
+@@ -2510,6 +2510,14 @@ ngx_http_post_request(ngx_http_request_t *r, ngx_http_posted_request_t *pr)
+ {
+     ngx_http_posted_request_t  **p;
+ 
++    for (p = &r->main->posted_requests; *p; p = &(*p)->next) {
++        if ((*p)->request == r) {
++            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
++                           "http request already posted");
++            return NGX_OK;
++        }
++    }
++
+     if (pr == NULL) {
+         pr = ngx_palloc(r->pool, sizeof(ngx_http_posted_request_t));
+         if (pr == NULL) {
+@@ -2520,8 +2528,6 @@ ngx_http_post_request(ngx_http_request_t *r, ngx_http_posted_request_t *pr)
+     pr->request = r;
+     pr->next = NULL;
+ 
+-    for (p = &r->main->posted_requests; *p; p = &(*p)->next) { /* void */ }
+-
+     *p = pr;
+ 
+     return NGX_OK;
+@@ -2641,6 +2647,8 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+ 
+             r->main->count--;
+ 
++            r->write_event_handler = ngx_http_request_empty_handler;
++
+             if (pr->postponed && pr->postponed->request == r) {
+                 pr->postponed = pr->postponed->next;
+             }
+-- 
+2.45.4
+

--- a/SPECS/nginx/nginx.spec
+++ b/SPECS/nginx/nginx.spec
@@ -6,7 +6,7 @@ Name:           nginx
 # Currently on "stable" version of nginx from https://nginx.org/en/download.html.
 # Note: Stable versions are even (1.20), mainline versions are odd (1.21)
 Version:        1.28.3
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        BSD-2-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -34,6 +34,8 @@ Patch11:        CVE-2026-9256.patch
 Patch12:        CVE-2026-49975.patch
 Patch13:        CVE-2026-48142.patch
 Patch14:        CVE-2026-42055.patch
+Patch15:        CVE-2026-56434.patch
+Patch16:        CVE-2026-42533.patch
 
 # njs patches start at 1001 to keep them separate from nginx patches
 Patch1001:      CVE-2026-8711.patch
@@ -186,6 +188,9 @@ rm -rf nginx-tests
 %dir %{_sysconfdir}/%{name}
 
 %changelog
+* Mon Jul 20 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.28.3-8
+- Patch for CVE-2026-56434 and CVE-2026-42533
+
 * Tue Jun 30 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.28.3-7
 - Patch for CVE-2026-42055
 


### PR DESCRIPTION
Manual cherry-pick of #18057 (commit a18de012c0) from `fasttrack/3.0`.

The `FastTrack-CherryPickToStaging` pipeline (def 2345) has been failing since 2026-07-20 due to an expired PAT; catching up backlog by hand. Applied cleanly.