### PR TITLE
[MANUAL CHERRYPICK] Upgrade nodejs to 24.18.0 for CVE-2026-45149 (#18069) - branch 3.0-dev

### DIFF
--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -3,6 +3,6 @@
   "btest402.js": "fabaf4dacc13e93d54f825b87ffde18573214b149388a5f96176236dd31d7768",
   "icu4c-78.3-data-bin-b.zip": "cb751fc5d46e218b6c71d69d9dea7ba98da937e2e41b662ad8313c9363d8b7e2",
   "icu4c-78.3-data-bin-l.zip": "982619632b78887f1895b063e96e8c3cc7f99283337c8abbd05aa71635de613c",
-  "node-v24.17.0.tar.xz": "d7e5c0b8b371d0378af9d44629c151c0f1880a4c536e77c6779edbde16904f80"
+  "node-v24.18.0.tar.xz": "119ecda53ccdfbb6c1c64f449e3c0d25b55b6b25feec2e1e1db8853fc123d93b"
  }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -1,5 +1,5 @@
 # Retrieved from 'deps/npm/package.json' inside the sources tarball.
-%define npm_version 11.13.0
+%define npm_version 11.16.0
 
 %global nodejs_datadir %{_datarootdir}/nodejs
 
@@ -15,8 +15,8 @@ Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-Version:        24.17.0
-Release:        2%{?dist}
+Version:        24.18.0
+Release:        1%{?dist}
 License:        BSD AND MIT AND Public Domain AND NAIST-2003 AND Artistic-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -194,6 +194,10 @@ make cctest
 %{_prefix}/lib/node_modules/*
 
 %changelog
+* Tue Jul 21 2026 Sumit Jena <sumitjena@microsoft.com> - 24.18.0-1
+- Upgrade to 24.18.0 (bundled npm 11.16.0).
+- Fixes CVE-2026-45149
+
 * Tue Jun 30 2026 Aditya Singh <v-aditysing@microsoft.com> - 24.17.0-2
 - Patch for CVE-2026-12151 and CVE-2026-9679
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14602,8 +14602,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "24.17.0",
-          "downloadUrl": "https://nodejs.org/download/release/v24.17.0/node-v24.17.0.tar.xz"
+          "version": "24.18.0",
+          "downloadUrl": "https://nodejs.org/download/release/v24.18.0/node-v24.18.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
Manual cherry-pick of #18069 (commit 28e76f7d97) from `fasttrack/3.0`.

The `FastTrack-CherryPickToStaging` pipeline (def 2345) has been failing since 2026-07-20 due to an expired PAT; catching up backlog by hand. Applied cleanly (version bump, no patch conflicts).