### PR TITLE
[MANUAL CHERRYPICK] Auto-upgrade valkey to 8.0.10 for CVE-2026-56684, CVE-2026-63639 (#18077) - branch 3.0-dev

### DIFF
--- a/SPECS/valkey/valkey.signatures.json
+++ b/SPECS/valkey/valkey.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "valkey-8.0.9.tar.gz": "621427980c58c7605384365e82bc83f2b0618bf38d924a0c75606e393643aeb0"
+    "valkey-8.0.10.tar.gz": "3bf957a99d375a0b594db7c52026041c4bfad8ad3711fc00418ccd21dc4632a4"
   }
 }

--- a/SPECS/valkey/valkey.spec
+++ b/SPECS/valkey/valkey.spec
@@ -1,6 +1,6 @@
 Summary:        advanced key-value store
 Name:           valkey
-Version:        8.0.9
+Version:        8.0.10
 Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
@@ -84,6 +84,9 @@ exit 0
 %config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/valkey.conf
 
 %changelog
+* Wed Jul 22 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.0.10-1
+- Auto-upgrade to 8.0.10 - for CVE-2026-56684 CVE-2026-63639
+
 * Wed May 06 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.0.9-1
 - Auto-upgrade to 8.0.9 - for CVE-2026-23479, CVE-2026-25243, CVE-2026-23631
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -30146,8 +30146,8 @@
         "type": "other",
         "other": {
           "name": "valkey",
-          "version": "8.0.9",
-          "downloadUrl": "https://github.com/valkey-io/valkey/archive/refs/tags/8.0.9.tar.gz"
+          "version": "8.0.10",
+          "downloadUrl": "https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Manual cherry-pick of #18077 (commit 536833c581) from `fasttrack/3.0`.

The `FastTrack-CherryPickToStaging` pipeline (def 2345) has been failing since 2026-07-20 due to an expired PAT; catching up backlog by hand. Applied cleanly.