### PR TITLE
fix(azurelinux-release): set canonical URL defaults

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -273,15 +273,17 @@ ln -s azurelinux-release %{buildroot}%{_sysconfdir}/system-release
 
 # URL of the homepage of the distribution
 # Example: gstreamer1-plugins-base.spec
-%global dist_home_url https://aka.ms/azurelinux
+%global dist_home_url https://azure.microsoft.com/products/azure-linux
 
 # Bugzilla / bug reporting URLs shown to users.
 # Examples: gcc.spec
-%global dist_bug_report_url https://aka.ms/azurelinux
+%global dist_bug_report_url https://github.com/microsoft/azurelinux/issues
 
-# debuginfod server, as used in elfutils.spec.
-# TODO(azl): review
-%global dist_debuginfod_url ima:enforcing https://debuginfod.microsoft.com/ ima:ignore
+# Azure Linux has no public debuginfod server yet, so do not configure a
+# default. When a server is available, set its URL here and rebuild both
+# azurelinux-release (which publishes this macro) and elfutils (which consumes
+# it at build time to generate the debuginfod client configuration).
+%global dist_debuginfod_url %{nil}
 # -------------------------------------------------------------------------
 
 # TODO(azl): review; dynamically generate RELEASE_TYPE from release_type macro
@@ -299,8 +301,8 @@ LOGO=azurelinux-logo-icon
 CPE_NAME="cpe:2.3:o:microsoft:azure_linux:%{dist_version}:*:*:*:*:*:*:*"
 DEFAULT_HOSTNAME="azurelinux"
 HOME_URL="%{dist_home_url}"
-DOCUMENTATION_URL="https://aka.ms/azurelinux"
-SUPPORT_URL="https://aka.ms/azurelinux"
+DOCUMENTATION_URL="https://learn.microsoft.com/azure/azure-linux"
+SUPPORT_URL="https://azure.microsoft.com/support"
 BUG_REPORT_URL="%{dist_bug_report_url}"
 EOF
 
@@ -385,8 +387,12 @@ cat >> %{buildroot}%{_rpmconfigdir}/macros.d/macros.dist << EOF
 %%dist_purl_namespace %{dist_purl_namespace}
 %%dist_home_url       %{dist_home_url}
 %%dist_bug_report_url %{dist_bug_report_url}
+EOF
+%if "%{?dist_debuginfod_url}"
+cat >> %{buildroot}%{_rpmconfigdir}/macros.d/macros.dist << EOF
 %%dist_debuginfod_url %{dist_debuginfod_url}
 EOF
+%endif
 
 # Install licenses
 install -pm 0644 %{SOURCE1} licenses/LICENSE
@@ -479,6 +485,10 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Thu Jul 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-21
+- Set canonical product, documentation, support, and issue-reporting URLs
+- Remove the inactive default debuginfod server configuration
+
 * Wed Jul 08 2026 Mitch Zhu <mitchzhu@microsoft.com> - 4.0-20
 - Add cloud-init Azure KVP telemetry config to the cloud identity package
 

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:93eeecefaa1eabd161cd6eaa514fbad9f3e2ad1eb8c90c964b13d50a7e1e2b6f'
+input-fingerprint = 'sha256:d1cc028f962349cd61ec32c56584dbb890aebb6120c0ff641cecdfd4117b31e2'

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -276,15 +276,17 @@ ln -s azurelinux-release %{buildroot}%{_sysconfdir}/system-release
 
 # URL of the homepage of the distribution
 # Example: gstreamer1-plugins-base.spec
-%global dist_home_url https://aka.ms/azurelinux
+%global dist_home_url https://azure.microsoft.com/products/azure-linux
 
 # Bugzilla / bug reporting URLs shown to users.
 # Examples: gcc.spec
-%global dist_bug_report_url https://aka.ms/azurelinux
+%global dist_bug_report_url https://github.com/microsoft/azurelinux/issues
 
-# debuginfod server, as used in elfutils.spec.
-# TODO(azl): review
-%global dist_debuginfod_url ima:enforcing https://debuginfod.microsoft.com/ ima:ignore
+# Azure Linux has no public debuginfod server yet, so do not configure a
+# default. When a server is available, set its URL here and rebuild both
+# azurelinux-release (which publishes this macro) and elfutils (which consumes
+# it at build time to generate the debuginfod client configuration).
+%global dist_debuginfod_url %{nil}
 # -------------------------------------------------------------------------
 
 # TODO(azl): review; dynamically generate RELEASE_TYPE from release_type macro
@@ -302,8 +304,8 @@ LOGO=azurelinux-logo-icon
 CPE_NAME="cpe:2.3:o:microsoft:azure_linux:%{dist_version}:*:*:*:*:*:*:*"
 DEFAULT_HOSTNAME="azurelinux"
 HOME_URL="%{dist_home_url}"
-DOCUMENTATION_URL="https://aka.ms/azurelinux"
-SUPPORT_URL="https://aka.ms/azurelinux"
+DOCUMENTATION_URL="https://learn.microsoft.com/azure/azure-linux"
+SUPPORT_URL="https://azure.microsoft.com/support"
 BUG_REPORT_URL="%{dist_bug_report_url}"
 EOF
 
@@ -388,8 +390,12 @@ cat >> %{buildroot}%{_rpmconfigdir}/macros.d/macros.dist << EOF
 %%dist_purl_namespace %{dist_purl_namespace}
 %%dist_home_url       %{dist_home_url}
 %%dist_bug_report_url %{dist_bug_report_url}
+EOF
+%if "%{?dist_debuginfod_url}"
+cat >> %{buildroot}%{_rpmconfigdir}/macros.d/macros.dist << EOF
 %%dist_debuginfod_url %{dist_debuginfod_url}
 EOF
+%endif
 
 # Install licenses
 install -pm 0644 %{SOURCE1} licenses/LICENSE
@@ -482,6 +488,10 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Thu Jul 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-21
+- Set canonical product, documentation, support, and issue-reporting URLs
+- Remove the inactive default debuginfod server configuration
+
 * Wed Jul 08 2026 Mitch Zhu <mitchzhu@microsoft.com> - 4.0-20
 - Add cloud-init Azure KVP telemetry config to the cloud identity package
 


### PR DESCRIPTION
### Summary

Update Azure Linux release metadata with canonical public URLs:

- Home: `https://azure.microsoft.com/products/azure-linux`
- Documentation: `https://learn.microsoft.com/azure/azure-linux`
- Support: `https://azure.microsoft.com/support`
- Bug reports: `https://github.com/microsoft/azurelinux/issues`

Also stop publishing a default `dist_debuginfod_url`. Azure Linux has no
distro-operated debuginfod endpoint, so `macros.dist` omits the macro instead
of defining it with an empty value.

Fixes [AB#22371](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22371)

### Validation

- Successful Koji scratch build
- Verified `azurelinux-release-common` has no `dist_debuginfod_url` in
  `macros.dist`.
- Verified the basic identity package contains the expected `os-release` URLs.
- Rebuilt elfutils against `azurelinux-release-4.0-21` in a fresh,
  cache-disabled Mock root; `%check` passed and the resulting client RPM has
  no default debuginfod URL configuration.
