### PR TITLE
fix: mask systemd units discouraged in WSL images

### DIFF
--- a/base/images/wsl/config.sh
+++ b/base/images/wsl/config.sh
@@ -24,5 +24,7 @@ systemctl mask \
     systemd-vconsole-setup.service \
     getty@tty1.service \
     tmp.mount \
+    systemd-tmpfiles-clean.service \
+    systemd-tmpfiles-clean.timer
     systemd-tmpfiles-setup-dev.service \
     systemd-tmpfiles-setup-dev-early.service

--- a/base/images/wsl/config.sh
+++ b/base/images/wsl/config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# config.sh — Kiwi config.sh hook for the Azure Linux WSL image.
+#
+# WSL owns networking, DNS resolution, the console/TTY, /tmp and early /dev
+# setup on behalf of the distribution. systemd units that duplicate that
+# management cause DNS/boot breakage, and console units (systemd-vconsole-setup,
+# getty@tty1) fail when several distros try to claim the TTY in parallel. WSL's
+# distribution validator rejects some of these (validate-modern.py:
+# DISCOURAGED_SYSTEM_UNITS) and WSL maintainers flagged the rest. Mask them, per
+# the WSL systemd recommendations:
+#   https://learn.microsoft.com/windows/wsl/build-custom-distro#systemd-recommendations
+#
+# systemd-tmpfiles-setup.service is intentionally left enabled: wsl-setup relies
+# on it to materialize the WSLg X11/Wayland/PulseAudio socket links, so masking
+# it would break GUI application support.
+set -euo pipefail
+
+echo "config.sh: masking systemd units discouraged in WSL"
+
+systemctl mask \
+    systemd-networkd.service \
+    systemd-networkd-wait-online.service \
+    systemd-resolved.service \
+    systemd-vconsole-setup.service \
+    getty@tty1.service \
+    tmp.mount \
+    systemd-tmpfiles-setup-dev.service \
+    systemd-tmpfiles-setup-dev-early.service

--- a/base/images/wsl/config.sh
+++ b/base/images/wsl/config.sh
@@ -25,6 +25,6 @@ systemctl mask \
     getty@tty1.service \
     tmp.mount \
     systemd-tmpfiles-clean.service \
-    systemd-tmpfiles-clean.timer
+    systemd-tmpfiles-clean.timer \
     systemd-tmpfiles-setup-dev.service \
     systemd-tmpfiles-setup-dev-early.service

--- a/base/images/wsl/wsl.kiwi
+++ b/base/images/wsl/wsl.kiwi
@@ -67,9 +67,7 @@
         <package name="shadow-utils"/>
         <package name="sudo"/>
         <package name="symlinks"/>
-        <package name="systemd-networkd"/>
         <package name="systemd-udev"/>
-        <package name="systemd-resolved"/>
         <package name="tar"/>
         <package name="tcpdump"/>
         <package name="time"/>


### PR DESCRIPTION
WSL manages networking, DNS resolution, the console/TTY, /tmp and early
/dev setup on behalf of the distribution. systemd units that duplicate
that management cause DNS/boot breakage under WSL and are flagged by WSL's
distribution validator (validate-modern.py: DISCOURAGED_SYSTEM_UNITS), as
seen on the "Validate tar based distributions changes" check for the WSL
registration PR. WSL maintainers additionally called out the console units
in review.

Add a Kiwi config.sh hook that masks the discouraged units so they resolve
to /dev/null:
  - systemd-networkd.service
  - systemd-networkd-wait-online.service
  - systemd-resolved.service
  - systemd-vconsole-setup.service
  - getty@tty1.service
  - tmp.mount
  - systemd-tmpfiles-setup-dev.service
  - systemd-tmpfiles-setup-dev-early.service

systemd-vconsole-setup.service and getty@tty1.service are masked because
WSL configures the TTY itself; both fail when several distros try to claim
the console in parallel, and tty1 is unreachable under WSL.

Masking (not delisting) is required for the networking/DNS daemons:
azurelinux-release defines %fedora=43, so systemd.spec's
%{?fedora:Recommends: systemd-networkd/resolved} are active and the image's
patternType="plusRecommended" pulls them in as weak deps regardless of the
explicit package list. The two explicit package lines are dropped as well
to reflect intent, but masking is what actually neutralizes the units.

systemd-tmpfiles-setup.service is intentionally left enabled: wsl-setup
relies on it to materialize the WSLg X11/Wayland/PulseAudio socket links,
so masking it would break GUI application support.

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
