### PR TITLE
fix(qt5-qtmultimedia): drop gstreamer-plugins-bad BuildRequires

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -4426,7 +4426,6 @@ includes = ["**/*.comp.toml", "component-bootstrap-uucore-pin.toml", "component-
 [components.qt5-qtdeclarative]
 [components.qt5-qtgraphicaleffects]
 [components.qt5-qtlocation]
-[components.qt5-qtmultimedia]
 [components.qt5-qtquickcontrols]
 [components.qt5-qtquickcontrols2]
 [components.qt5-qtscript]

--- a/base/comps/qt5-qtmultimedia/qt5-qtmultimedia.comp.toml
+++ b/base/comps/qt5-qtmultimedia/qt5-qtmultimedia.comp.toml
@@ -1,0 +1,11 @@
+[components.qt5-qtmultimedia]
+
+[[components.qt5-qtmultimedia.overlays]]
+description = "Drop gstreamer-plugins-bad BuildRequires — Azure Linux does not ship gstreamer1-plugins-bad-free; qtmultimedia auto-detects it and only loses the optional GStreamer photography/camerabin backend"
+type = "spec-remove-tag"
+tag = "BuildRequires"
+value = "pkgconfig(gstreamer-plugins-bad-%{gst})"
+
+[components.qt5-qtmultimedia.overlays.metadata]
+category = "azl-pruning"
+upstream-status = "inapplicable"

--- a/locks/qt5-qtmultimedia.lock
+++ b/locks/qt5-qtmultimedia.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '39d0bc1531af5d52a27034438d45d860c20eea8f'
 upstream-commit = '39d0bc1531af5d52a27034438d45d860c20eea8f'
-input-fingerprint = 'sha256:a4ec869591990b7ed52a1d591443fe7545334f63f5892585bd80890c1cd7b87a'
+input-fingerprint = 'sha256:228903cad79303ede62058da29ea91a3a9666580207eceaa64b3d0c24a33cf99'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/q/qt5-qtmultimedia/qt5-qtmultimedia.spec
+++ b/specs/q/qt5-qtmultimedia/qt5-qtmultimedia.spec
@@ -13,7 +13,7 @@
 Summary: Qt5 - Multimedia support
 Name:    qt5-%{qt_module}
 Version: 5.15.18
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 # See LGPL_EXCEPTIONS.txt, LICENSE.GPL3, respectively, for exception details
 License: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
@@ -49,7 +49,6 @@ BuildRequires: pkgconfig(gstreamer-app-%{gst})
 BuildRequires: pkgconfig(gstreamer-audio-%{gst})
 BuildRequires: pkgconfig(gstreamer-base-%{gst})
 BuildRequires: pkgconfig(gstreamer-pbutils-%{gst})
-BuildRequires: pkgconfig(gstreamer-plugins-bad-%{gst})
 BuildRequires: pkgconfig(gstreamer-video-%{gst})
 BuildRequires: pkgconfig(libpulse) pkgconfig(libpulse-mainloop-glib)
 %if 0%{?openal}


### PR DESCRIPTION
Azure Linux 4.0 does not ship gstreamer1-plugins-bad-free, so pkgconfig(gstreamer-plugins-bad-1.0) is unresolvable and the build fails at dependency resolution.

qtmultimedia auto-detects the GStreamer photography interface, so dropping the BuildRequires only disables that optional backend. All mediaservice, audio and playlistformats plugins still build and load.

Fixes: [AB#20326](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20326)