### PR TITLE
feat(grub2): add AZL SBAT line, keep upstream provenance

### DIFF
--- a/base/comps/grub2/grub2.comp.toml
+++ b/base/comps/grub2/grub2.comp.toml
@@ -64,3 +64,41 @@ replacement = '''Patch0382: 0382-Set-correctly-the-memory-attributes-for-the-ker
 Patch0383: 0383-Revert-Revert-templates-Disable-the-os-prober-by-default.patch
 Patch0384: 0384-Revert-Revert-templates-Properly-disable-the-os-prober-by-d.patch
 Patch0385: 0385-Revert-Revert-templates-Fix-user-facing-typo-with-an.patch'''
+
+# SBAT: edit the upstream sbat.csv.in in place. Swap grub.rh to the
+# @@UPSTREAM_VERSION_RELEASE@@ placeholder and append the grub.azurelinux vendor line.
+# The placeholder is substituted at build time from an interim spec macro pinned to
+# the Fedora grub2 NEVR; swap that macro for the azldev EVR macro when bug 21798 lands.
+
+[[components.grub2.overlays]]
+description = "SBAT: point the upstream grub.rh line at the upstream-Fedora NEVR placeholder"
+type = "file-search-replace"
+file = "sbat.csv.in"
+regex = 'Red Hat,grub2,@@VERSION_RELEASE@@'
+replacement = 'Red Hat,grub2,@@UPSTREAM_VERSION_RELEASE@@'
+
+[[components.grub2.overlays]]
+description = "SBAT: append the Azure Linux grub vendor entry to the end of sbat.csv.in"
+type = "file-search-replace"
+file = "sbat.csv.in"
+regex = '\n\z'
+replacement = "\ngrub.azurelinux,3,Microsoft,grub2,@@VERSION_RELEASE@@,https://github.com/microsoft/azurelinux/issues\n"
+
+[[components.grub2.overlays]]
+description = "SBAT: define interim upstream-EVR spec macro (pinned Fedora grub2 NEVR); replaced by the azldev EVR macro from bug 21798"
+type = "spec-prepend-lines"
+lines = ["%global upstream_version_release 2.12-40.fc43", ""]
+
+[[components.grub2.overlays]]
+description = "SBAT: substitute @@UPSTREAM_VERSION_RELEASE@@ in generated SBAT templates without masking sed failures"
+type = "spec-search-replace"
+section = "%prep"
+regex = '^sed -e "s,@@VERSION@@,%\{version\},g" -e "s,@@VERSION_RELEASE@@,%\{version\}-%\{release\},g" \\$'
+replacement = 'sed -e "s,@@VERSION@@,%{version},g" -e "s,@@VERSION_RELEASE@@,%{version}-%{release},g" -e "s,@@UPSTREAM_VERSION_RELEASE@@,%{upstream_version_release},g" \'
+
+[[components.grub2.overlays]]
+description = "SBAT: correct the missing scheme separator in the upstream GNU GRUB URL"
+type = "file-search-replace"
+file = "sbat.csv.in"
+regex = 'https//www.gnu.org/software/grub/'
+replacement = 'https://www.gnu.org/software/grub/'

--- a/locks/grub2.lock
+++ b/locks/grub2.lock
@@ -3,5 +3,5 @@ version = 1
 import-commit = '354c77b195316a4aa09979793a73ea4485217769'
 upstream-commit = '354c77b195316a4aa09979793a73ea4485217769'
 manual-bump = 1
-input-fingerprint = 'sha256:696727eb72078e8299e033cf6f3831acaf4b8db09db369bbfe47cd5b1e23b114'
+input-fingerprint = 'sha256:74d1be7a320c170cab50262d88e5dd80a13d0b5fb869e3494f4deeb36d551955'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/grub2/grub2.spec
+++ b/specs/g/grub2/grub2.spec
@@ -1,6 +1,8 @@
 # This spec file has been modified by azldev to include build configuration overlays.
 # Do not edit manually; changes may be overwritten.
 
+%global upstream_version_release 2.12-40.fc43
+
 # This package calls binutils components directly and would need to pass
 # in flags to enable the LTO plugins
 # Disable LTO
@@ -20,7 +22,7 @@
 Name:		grub2
 Epoch:		1
 Version:	2.12
-Release: 45%{?dist}
+Release: 46%{?dist}
 Summary:	Bootloader with support for Linux, Multiboot and more
 License:	GPL-3.0-or-later
 URL:		http://www.gnu.org/software/grub/
@@ -196,7 +198,7 @@ This subpackage provides the GRUB user-space emulation modules.
 mkdir grub-%{grubefiarch}-%{tarversion}
 grep -A100000 '# stuff "make" creates' .gitignore > grub-%{grubefiarch}-%{tarversion}/.gitignore
 cp %{SOURCE4} grub-%{grubefiarch}-%{tarversion}/unifont.pcf.gz
-sed -e "s,@@VERSION@@,%{version},g" -e "s,@@VERSION_RELEASE@@,%{version}-%{release},g" \
+sed -e "s,@@VERSION@@,%{version},g" -e "s,@@VERSION_RELEASE@@,%{version}-%{release},g" -e "s,@@UPSTREAM_VERSION_RELEASE@@,%{upstream_version_release},g" \
     %{SOURCE12} > grub-%{grubefiarch}-%{tarversion}/sbat.csv
 git add grub-%{grubefiarch}-%{tarversion}
 %endif
@@ -222,7 +224,7 @@ git add grub-emu-%{tarversion}
 mkdir grub-%{grubxenarch}-%{tarversion}
 grep -A100000 '# stuff "make" creates' .gitignore > grub-%{grubxenarch}-%{tarversion}/.gitignore
 cp %{SOURCE4} grub-%{grubxenarch}-%{tarversion}/unifont.pcf.gz
-sed -e "s,@@VERSION@@,%{version},g" -e "s,@@VERSION_RELEASE@@,%{version}-%{release},g" \
+sed -e "s,@@VERSION@@,%{version},g" -e "s,@@VERSION_RELEASE@@,%{version}-%{release},g" -e "s,@@UPSTREAM_VERSION_RELEASE@@,%{upstream_version_release},g" \
     %{SOURCE12} > grub-%{grubxenarch}-%{tarversion}/sbat.csv
 git add grub-%{grubxenarch}-%{tarversion}
 %endif
@@ -230,7 +232,7 @@ git add grub-%{grubxenarch}-%{tarversion}
 mkdir grub-%{grubxenpvharch}-%{tarversion}
 grep -A100000 '# stuff "make" creates' .gitignore > grub-%{grubxenpvharch}-%{tarversion}/.gitignore
 cp %{SOURCE4} grub-%{grubxenpvharch}-%{tarversion}/unifont.pcf.gz
-sed -e "s,@@VERSION@@,%{version},g" -e "s,@@VERSION_RELEASE@@,%{version}-%{release},g" \
+sed -e "s,@@VERSION@@,%{version},g" -e "s,@@VERSION_RELEASE@@,%{version}-%{release},g" -e "s,@@UPSTREAM_VERSION_RELEASE@@,%{upstream_version_release},g" \
     %{SOURCE12} > grub-%{grubxenpvharch}-%{tarversion}/sbat.csv
 git add grub-%{grubxenpvharch}-%{tarversion}
 %endif

--- a/specs/g/grub2/sbat.csv.in
+++ b/specs/g/grub2/sbat.csv.in
@@ -1,3 +1,4 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,5,Free Software Foundation,grub,@@VERSION@@,https//www.gnu.org/software/grub/
-grub.rh,2,Red Hat,grub2,@@VERSION_RELEASE@@,mailto:secalert@redhat.com
+grub,5,Free Software Foundation,grub,@@VERSION@@,https://www.gnu.org/software/grub/
+grub.rh,2,Red Hat,grub2,@@UPSTREAM_VERSION_RELEASE@@,mailto:secalert@redhat.com
+grub.azurelinux,3,Microsoft,grub2,@@VERSION_RELEASE@@,https://github.com/microsoft/azurelinux/issues


### PR DESCRIPTION
## Summary

Adds Azure Linux SBAT metadata to GRUB EFI binaries.

- Adds `grub.azurelinux,3` for the Azure Linux distributor identity. Generation 3 matches the existing Azure Linux 3.0 SBAT record.
- Preserves the imported Fedora provenance on `grub.rh` with its upstream EVR, `2.12-40.fc43`, rather than substituting the Azure Linux release.
- Points the Azure Linux contact URL to the GitHub issues page.
- Corrects the inherited GNU GRUB SBAT URL typo (`https//` → `https://`).

## Implementation notes

The Fedora provenance EVR is temporarily defined in the component overlay. Azure Linux 4.0 does not yet include the azldev upstream-EVR macros from [azure-linux-dev-tools#290](https://github.com/microsoft/azure-linux-dev-tools/pull/290). Replace the local macro once that work is available in 4.0.

## Validation

- Local and koji builds
- Extracted the `.sbat` section from `grubx64.efi`:

```
$ objcopy --dump-section .sbat=/dev/stdout    boot/efi/EFI/azurelinux/grubx64.efi
sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
grub,5,Free Software Foundation,grub,2.12,https://www.gnu.org/software/grub/
grub.rh,2,Red Hat,grub2,2.12-40.fc43,mailto:secalert@redhat.com
grub.azurelinux,3,Microsoft,grub2,2.12-46.azl4,https://github.com/microsoft/azurelinux/issues
```