### PR TITLE
Cherry-pick #18033 + #18034 (container-publishing fixes) to 3.0-dev

### DIFF
--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -133,8 +133,12 @@ function oras_attach {
 function oras_detach {
     local image_name=$1
     local lifecycle_manifests
+    # NOTE: keep `-o json`; on the oras version installed on the publish
+    # agent, `--format json` does not emit the schema jq expects below and
+    # causes `parse error: Invalid numeric literal`. The deprecation
+    # warning from `-o` is harmless.
     if ! lifecycle_manifests=$(retry_registry_op "discover lifecycle manifests for $image_name" \
-                                oras discover --format json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
+                                oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
         echo "+++ Warning: could not discover lifecycle manifests for $image_name; skipping detach"
         return
     fi

--- a/.pipelines/containerSourceData/scripts/PublishContainers.sh
+++ b/.pipelines/containerSourceData/scripts/PublishContainers.sh
@@ -101,17 +101,17 @@ function retry_registry_op {
     local backoff=5
 
     while [ $retry_count -lt $max_retries ]; do
-        echo "+++ $desc (attempt $((retry_count + 1))/$max_retries)"
+        echo "+++ $desc (attempt $((retry_count + 1))/$max_retries)" >&2
         if "$@"; then
             return 0
         fi
         retry_count=$((retry_count + 1))
         if [ $retry_count -lt $max_retries ]; then
-            echo "+++ $desc failed; retrying in ${backoff}s..."
+            echo "+++ $desc failed; retrying in ${backoff}s..." >&2
             sleep $backoff
             backoff=$((backoff * 2))
         else
-            echo "+++ $desc failed after $max_retries attempts"
+            echo "+++ $desc failed after $max_retries attempts" >&2
             return 1
         fi
     done
@@ -133,12 +133,8 @@ function oras_attach {
 function oras_detach {
     local image_name=$1
     local lifecycle_manifests
-    # NOTE: keep `-o json`; on the oras version installed on the publish
-    # agent, `--format json` does not emit the schema jq expects below and
-    # causes `parse error: Invalid numeric literal`. The deprecation
-    # warning from `-o` is harmless.
     if ! lifecycle_manifests=$(retry_registry_op "discover lifecycle manifests for $image_name" \
-                                oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
+                                oras discover --format json --artifact-type "application/vnd.microsoft.artifact.lifecycle" "$image_name"); then
         echo "+++ Warning: could not discover lifecycle manifests for $image_name; skipping detach"
         return
     fi


### PR DESCRIPTION
Manual cherry-pick of two PRs that landed on `fasttrack/3.0` on 7/16 but never auto-forward-picked into `3.0-dev`:

- #18033 — `PublishContainers.sh: revert 'oras discover' to -o json`
- #18034 — `container-publishing: fix retry helper stdout pollution + use --format json`

Both PRs are follow-up fixes on top of #18026 (which merged directly to `3.0-dev`). They touch only `.pipelines/containerSourceData/scripts/PublishContainers.sh`.

Verified with `git diff origin/fasttrack/3.0..HEAD -- .pipelines/containerSourceData/scripts/PublishContainers.sh` → empty (file state matches `fasttrack/3.0` exactly).

Cherry-picks applied cleanly with `git cherry-pick -x`, no conflicts. Each original PR is preserved as its own commit — **please do not squash-merge**.