### PR TITLE
fix(fido-device-onboard): pin libcryptsetup-rs to 0.13.2

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -431,7 +431,6 @@ includes = ["**/*.comp.toml", "component-bootstrap-uucore-pin.toml", "component-
 [components.festival]
 [components.ffcall]
 [components.fftw]
-[components.fido-device-onboard]
 [components.file]
 [components.filesystem]
 [components.findutils]

--- a/base/comps/fido-device-onboard/fido-device-onboard.comp.toml
+++ b/base/comps/fido-device-onboard/fido-device-onboard.comp.toml
@@ -1,0 +1,10 @@
+[components.fido-device-onboard]
+
+[[components.fido-device-onboard.overlays]]
+description = "Pin libcryptsetup-rs to 0.13.2 because FDO 0.5.5 uses the pre-0.14 CryptParamsReencrypt API"
+type = "patch-add"
+source = "pin-libcryptsetup-rs-0.13.2.patch"
+
+[components.fido-device-onboard.overlays.metadata]
+category = "azl-compatibility"
+upstream-status = "inapplicable"

--- a/base/comps/fido-device-onboard/pin-libcryptsetup-rs-0.13.2.patch
+++ b/base/comps/fido-device-onboard/pin-libcryptsetup-rs-0.13.2.patch
@@ -1,0 +1,11 @@
+diff --git a/client-linuxapp/Cargo.toml b/client-linuxapp/Cargo.toml
+--- a/client-linuxapp/Cargo.toml
++++ b/client-linuxapp/Cargo.toml
+@@ -16,6 +16,6 @@ nix = "0.26"
+ uuid = "1.3"
+ thiserror = "1"
+-libcryptsetup-rs = { version = ">= 0.11.2", features = ["mutex"] }
++libcryptsetup-rs = { version = "=0.13.2", features = ["mutex"] }
+ secrecy = "0.8"
+ devicemapper = "0.34"
+ openssl = "0.10.72"

--- a/locks/fido-device-onboard.lock
+++ b/locks/fido-device-onboard.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '040c998c36848c1ed6cbddc4703e16a823a774b4'
 upstream-commit = '040c998c36848c1ed6cbddc4703e16a823a774b4'
-input-fingerprint = 'sha256:0045e9a7ead4231c13c960779e0955a84d8e4d25358bade387ce7c2915c0622a'
+input-fingerprint = 'sha256:a7284c019a1c1d3019c411c693e76e6664f1b930fc2a7fa239c5e44f0ed62260'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/f/fido-device-onboard/fido-device-onboard.spec
+++ b/specs/f/fido-device-onboard/fido-device-onboard.spec
@@ -7,7 +7,7 @@
 
 Name:           fido-device-onboard
 Version:        0.5.5
-Release: 7%{?dist}
+Release: 8%{?dist}
 Summary:        A rust implementation of the FIDO Device Onboard Specification
 License:        BSD-3-Clause
 
@@ -34,6 +34,7 @@ BuildRequires:  tpm2-tss-devel
 BuildRequires:  sqlite-devel
 BuildRequires:  libpq-devel
 
+Patch2: pin-libcryptsetup-rs-0.13.2.patch
 %description
 %{summary}.
 

--- a/specs/f/fido-device-onboard/pin-libcryptsetup-rs-0.13.2.patch
+++ b/specs/f/fido-device-onboard/pin-libcryptsetup-rs-0.13.2.patch
@@ -1,0 +1,11 @@
+diff --git a/client-linuxapp/Cargo.toml b/client-linuxapp/Cargo.toml
+--- a/client-linuxapp/Cargo.toml
++++ b/client-linuxapp/Cargo.toml
+@@ -16,6 +16,6 @@ nix = "0.26"
+ uuid = "1.3"
+ thiserror = "1"
+-libcryptsetup-rs = { version = ">= 0.11.2", features = ["mutex"] }
++libcryptsetup-rs = { version = "=0.13.2", features = ["mutex"] }
+ secrecy = "0.8"
+ devicemapper = "0.34"
+ openssl = "0.10.72"


### PR DESCRIPTION
Pin `fido-device-onboard` 0.5.5 to `libcryptsetup-rs` 0.13.2 so it builds consistently against both the Fedora 43 stage-1 and Azure Linux DEV buildroots.

Fedora 43 updates provide `libcryptsetup-rs` 0.15.1, which changed `CryptParamsReencrypt::luks2` to an optional value. FDO 0.5.5 still uses the pre-0.14 API. Both buildroots provide 0.13.2, so pin the Cargo dependency rather than modifying the Rust implementation.

Change list:
- Pin the `libcryptsetup-rs` Cargo dependency to 0.13.2.
- Retain the existing FDO 0.5.5 upstream snapshot without Rust source changes.

Validation:

- Local full PROD & DEV stage-1 build passed
- Installed and smoke-tested `fdo-client` in a mock chroot; the client exited successfully.
- PME azl4-bootstrap scratch builds passed