### PR TITLE
tracelogging: migrate test suite to Catch2 v3 API

### DIFF
--- a/SPECS/tracelogging/tracelogging-migrate-catch2-v3.patch
+++ b/SPECS/tracelogging/tracelogging-migrate-catch2-v3.patch
@@ -1,0 +1,57 @@
+From bff34851d19f7d6ad6d96cde39782ea1f6eefdbb Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Mon, 27 Jul 2026 00:00:00 +0000
+Subject: [PATCH] tracelogging: migrate test suite from Catch2 v2 to v3 API
+
+Azure Linux ships Catch2 3.x, which removed the v2 single-header
+<catch2/catch.hpp> and no longer provides main() via CATCH_CONFIG_MAIN.
+
+Link the tests against Catch2::Catch2WithMain for the entry point and
+switch the includes to the split <catch2/catch_all.hpp> header so the
+%check build compiles against the shipped Catch2.
+---
+ test/CMakeLists.txt       | 2 +-
+ test/CatchMain.cpp        | 3 +--
+ test/TestTraceLogging.cpp | 2 +-
+ 3 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 7d46ad3..8ed0da6 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -11,7 +11,7 @@ target_link_libraries(
+     PRIVATE
+     tracelogging
+     # lttng-ust-common # Needed for LTTNG 2.13+
+-    Catch2::Catch2)
++    Catch2::Catch2WithMain)
+ 
+ include(CTest)
+ include(Catch)
+diff --git a/test/CatchMain.cpp b/test/CatchMain.cpp
+index 9909381..a3d1a2c 100644
+--- a/test/CatchMain.cpp
++++ b/test/CatchMain.cpp
+@@ -1,5 +1,4 @@
+ // Copyright (c) Microsoft Corporation. All rights reserved.
+ // Licensed under the MIT License.
+ 
+-#define CATCH_CONFIG_MAIN
+-#include <catch2/catch.hpp>
++// Catch2 v3: main() is provided by linking against Catch2::Catch2WithMain.
+diff --git a/test/TestTraceLogging.cpp b/test/TestTraceLogging.cpp
+index 3484db9..1325a73 100644
+--- a/test/TestTraceLogging.cpp
++++ b/test/TestTraceLogging.cpp
+@@ -119,7 +119,7 @@ bool TestCpp()
+     return ok && err == 0;
+ }
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ TEST_CASE("TraceLogging workflow builds", "[tracelogging]") {
+   REQUIRE(TestC());
+-- 
+2.53.0
+

--- a/SPECS/tracelogging/tracelogging.spec
+++ b/SPECS/tracelogging/tracelogging.spec
@@ -1,13 +1,15 @@
 Summary:        tracelogging one-line structure logging API on top of LTTNG
 Name:           tracelogging
 Version:        0.3.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System Environment
 URL:            https://github.com/microsoft/tracelogging
 Source0:        https://github.com/microsoft/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Migrate the test suite from Catch2 v2 to the Catch2 v3 API shipped by Azure Linux.
+Patch0:         tracelogging-migrate-catch2-v3.patch
 BuildRequires:  cmake >= 3.6
 BuildRequires:  gcc
 BuildRequires:  lttng-ust-devel >= 2.13
@@ -30,7 +32,7 @@ This package contains the headers and symlinks for instrumenting
 applications and libraries with tracelogging.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 mkdir build && cd build
@@ -65,6 +67,9 @@ mkdir build && cd build
 %{_libdir}/cmake/tracelogging
 
 %changelog
+* Mon Jul 27 2026 Kshitiz Godara <kgodara@microsoft.com> - 0.3.1-2
+- Migrate test suite from Catch2 v2 to Catch2 v3 API to fix test build.
+
 * Wed Feb 09 2022 Francisco Huelsz Prince <frhuelsz@microsoft.com> - 0.3.1-1
 - Upgrade to 0.3.1 for lttng-ust 2.13 compatibility & fixes.
 


### PR DESCRIPTION
Azure Linux ships Catch2 3.x, whose split headers replace the v2 single header. Add a patch migrating the test sources to the Catch2 v3 API and apply it with %autosetup -p1 so the %check build compiles again. Bump release to 2.