### PR TITLE
[CP] Upgrade `nodejs` to version `24.18.1` to fix CVE-2026-56846, CVE-2026-56848, CVE-2026-58043, CVE-2026-56850, CVE-2026-58040, CVE-2026-58041, CVE-2026-58042, CVE-2026-58045, CVE-2026-56847, CVE-2026-58039, CVE-2026-58044 (#18259)

### DIFF
--- a/SPECS/nodejs/CVE-2025-27516.patch
+++ b/SPECS/nodejs/CVE-2025-27516.patch
@@ -4,14 +4,14 @@ Date: Wed, 5 Mar 2025 10:08:48 -0800
 Subject: [PATCH] attr filter uses env.getattr
 
 ---
- deps/v8/third_party/jinja2/filters.py  | 37 ++++++++++++++++---------------------
- 3 files changed, 30 insertions(+), 21 deletions(-)
+ deps/v8/third_party/jinja2/filters.py | 37 ++++++++++++---------------
+ 1 file changed, 16 insertions(+), 21 deletions(-)
 
 diff --git a/deps/v8/third_party/jinja2/filters.py b/deps/v8/third_party/jinja2/filters.py
-index e5b5a00c5..2bcba4fbd 100644
+index eace6ed8..5a6eef37 100644
 --- a/deps/v8/third_party/jinja2/filters.py
 +++ b/deps/v8/third_party/jinja2/filters.py
-@@ -6,6 +6,7 @@
+@@ -5,6 +5,7 @@ import re
  import typing
  import typing as t
  from collections import abc
@@ -19,7 +19,7 @@ index e5b5a00c5..2bcba4fbd 100644
  from itertools import chain
  from itertools import groupby
  
-@@ -1411,31 +1412,25 @@ def do_reverse(value: t.Union[str, t.Iterable[V]]) -> t.Union[str, t.Iterable[V]
+@@ -1401,31 +1402,25 @@ def do_reverse(value: t.Union[str, t.Iterable[V]]) -> t.Union[str, t.Iterable[V]
  def do_attr(
      environment: "Environment", obj: t.Any, name: str
  ) -> t.Union[Undefined, t.Any]:
@@ -66,3 +66,6 @@ index e5b5a00c5..2bcba4fbd 100644
  
  
  @typing.overload
+--
+2.45.4
+

--- a/SPECS/nodejs/disable-tlsv1-tlsv1-1.patch
+++ b/SPECS/nodejs/disable-tlsv1-tlsv1-1.patch
@@ -1,7 +1,8 @@
-diff -ru node-v16.14.0-orig/src/crypto/crypto_context.cc node-v16.14.0/src/crypto/crypto_context.cc
---- node-v16.14.0-orig/src/crypto/crypto_context.cc	2022-02-08 04:37:50.000000000 -0800
-+++ node-v16.14.0/src/crypto/crypto_context.cc	2022-02-25 09:17:21.964960342 -0800
-@@ -467,28 +467,16 @@
+diff --git a/src/crypto/crypto_context.cc b/src/crypto/crypto_context.cc
+index 3513afc5..146bed1b 100644
+--- a/src/crypto/crypto_context.cc
++++ b/src/crypto/crypto_context.cc
+@@ -1506,28 +1506,16 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
        min_version = 0;
        max_version = kMaxSupportedVersion;
        method = TLS_client_method();

--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -3,6 +3,6 @@
   "btest402.js": "fabaf4dacc13e93d54f825b87ffde18573214b149388a5f96176236dd31d7768",
   "icu4c-78.3-data-bin-b.zip": "cb751fc5d46e218b6c71d69d9dea7ba98da937e2e41b662ad8313c9363d8b7e2",
   "icu4c-78.3-data-bin-l.zip": "982619632b78887f1895b063e96e8c3cc7f99283337c8abbd05aa71635de613c",
-  "node-v24.18.0.tar.xz": "119ecda53ccdfbb6c1c64f449e3c0d25b55b6b25feec2e1e1db8853fc123d93b"
+  "node-v24.18.1.tar.xz": "353af024d6716de3962b7d0713f9a4d890d7337dfb8eb4e2fa7b2fbfea2f40f7"
  }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -15,7 +15,7 @@ Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-Version:        24.18.0
+Version:        24.18.1
 Release:        1%{?dist}
 License:        BSD AND MIT AND Public Domain AND NAIST-2003 AND Artistic-2.0
 Vendor:         Microsoft Corporation
@@ -194,6 +194,12 @@ make cctest
 %{_prefix}/lib/node_modules/*
 
 %changelog
+* Thu Jul 30 2026 Aditya Singh <v-aditysing@microsoft.com> - 24.18.1-1
+- Upgrade to 24.18.1 'Krypton' (LTS) (bundled npm 11.16.0).
+- This upgrade fixes CVE-2026-56846, CVE-2026-56848, CVE-2026-58043, CVE-2026-56850, CVE-2026-58040,
+  CVE-2026-58041, CVE-2026-58042, CVE-2026-58045, CVE-2026-56847, CVE-2026-58039, CVE-2026-58044
+- This upgrade also updates dependencies: llhttp to 9.4.3, undici to 7.29.0
+
 * Tue Jul 21 2026 Sumit Jena <sumitjena@microsoft.com> - 24.18.0-1
 - Upgrade to 24.18.0 (bundled npm 11.16.0).
 - Fixes CVE-2026-45149

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14602,8 +14602,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "24.18.0",
-          "downloadUrl": "https://nodejs.org/download/release/v24.18.0/node-v24.18.0.tar.xz"
+          "version": "24.18.1",
+          "downloadUrl": "https://nodejs.org/download/release/v24.18.1/node-v24.18.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION
cherry-pick https://github.com/microsoft/azurelinux/pull/18259