### PR TITLE
fix(python-blivet): support CPE 2.3 distro detection

### DIFF
--- a/base/comps/python-blivet/bb696202-fix-cpe-2.3-version-parsing.patch
+++ b/base/comps/python-blivet/bb696202-fix-cpe-2.3-version-parsing.patch
@@ -1,0 +1,33 @@
+From bb696202fa44b7d516f5cdff7a699e32edc982df Mon Sep 17 00:00:00 2001
+From: Vojtech Trefny <vtrefny@redhat.com>
+Date: Thu, 3 Jul 2025 11:20:44 +0200
+Subject: [PATCH] tests: Fix reading distro and version from CPE version 2.3
+
+---
+ tests/run_tests.py | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/tests/run_tests.py b/tests/run_tests.py
+index 40f9a0ec..78c95ce3 100644
+--- a/tests/run_tests.py
++++ b/tests/run_tests.py
+@@ -63,8 +63,14 @@ def get_version_from_cpe(cpe):
+          - "cpe:/o:fedoraproject:fedora:39"
+          - "cpe:/o:redhat:enterprise_linux:7.3:GA:server
+     """
+-    # 2nd to 4th fields from e.g. "cpe:/o:fedoraproject:fedora:25" or "cpe:/o:redhat:enterprise_linux:7.3:GA:server"
+-    _project, distro, version = tuple(cpe.split(":")[2:5])
++    if cpe.startswith("cpe:2.3"):
++        # version 2.3 of CPE standard
++        # 3th to 6th fields from "cpe:<cpe_version>:<part>:<vendor>:<product>:<version>:<update>:<edition>:"
++        _project, distro, version = tuple(cpe.split(":")[3:6])
++    else:
++        # older version of CPE standard
++        # 2nd to 4th fields from e.g. "cpe:/o:fedoraproject:fedora:25" or "cpe:/o:redhat:enterprise_linux:7.3:GA:server"
++        _project, distro, version = tuple(cpe.split(":")[2:5])
+     version = str(int(float(version)))
+     return (distro, version)
+ 
+-- 
+2.53.0
+

--- a/base/comps/python-blivet/overlays/0001-fix-cpe-2.3-version-parsing.overlay.toml
+++ b/base/comps/python-blivet/overlays/0001-fix-cpe-2.3-version-parsing.overlay.toml
@@ -1,0 +1,12 @@
+# Blivet 3.12.1 parses CPE 2.3 fields as CPE 2.2, causing Azure Linux's
+# `azure_linux` product identifier to be interpreted as a numeric version.
+[metadata]
+category = "upstream-backport"
+upstream-status = "upstreamed"
+commits = [{ url = "https://github.com/storaged-project/blivet/commit/bb696202fa44b7d516f5cdff7a699e32edc982df" }]
+
+[[overlays]]
+description = "Backport CPE 2.3 distro version parsing fix"
+type = "patch-add"
+file = "bb696202-fix-cpe-2.3-version-parsing.patch"
+source = "../bb696202-fix-cpe-2.3-version-parsing.patch"

--- a/base/comps/python-blivet/python-blivet.comp.toml
+++ b/base/comps/python-blivet/python-blivet.comp.toml
@@ -1,3 +1,9 @@
 [components.python-blivet]
-# Release: 9%{?prerelease}%{?dist}
+# Release: 10%{?prerelease}%{?dist}
 release = { calculation = "manual" }
+
+[[components.python-blivet.overlays]]
+description = "Bump release for CPE 2.3 parser backport"
+type = "spec-update-tag"
+tag = "Release"
+value = "10%{?prerelease}%{?dist}"

--- a/locks/python-blivet.lock
+++ b/locks/python-blivet.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '330d0d9977fe371ec4c14f03d693c6943d023586'
 upstream-commit = '330d0d9977fe371ec4c14f03d693c6943d023586'
-input-fingerprint = 'sha256:3c05598063c9d513e2c50ee5f6260ccb666305ea21abf44ab4516c1d334e5243'
+input-fingerprint = 'sha256:e8a98c8e5f433e2820ea1ca2c377f5e24526cfd1da4dab754b307cd94f44ffdd'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/p/python-blivet/bb696202-fix-cpe-2.3-version-parsing.patch
+++ b/specs/p/python-blivet/bb696202-fix-cpe-2.3-version-parsing.patch
@@ -1,0 +1,33 @@
+From bb696202fa44b7d516f5cdff7a699e32edc982df Mon Sep 17 00:00:00 2001
+From: Vojtech Trefny <vtrefny@redhat.com>
+Date: Thu, 3 Jul 2025 11:20:44 +0200
+Subject: [PATCH] tests: Fix reading distro and version from CPE version 2.3
+
+---
+ tests/run_tests.py | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/tests/run_tests.py b/tests/run_tests.py
+index 40f9a0ec..78c95ce3 100644
+--- a/tests/run_tests.py
++++ b/tests/run_tests.py
+@@ -63,8 +63,14 @@ def get_version_from_cpe(cpe):
+          - "cpe:/o:fedoraproject:fedora:39"
+          - "cpe:/o:redhat:enterprise_linux:7.3:GA:server
+     """
+-    # 2nd to 4th fields from e.g. "cpe:/o:fedoraproject:fedora:25" or "cpe:/o:redhat:enterprise_linux:7.3:GA:server"
+-    _project, distro, version = tuple(cpe.split(":")[2:5])
++    if cpe.startswith("cpe:2.3"):
++        # version 2.3 of CPE standard
++        # 3th to 6th fields from "cpe:<cpe_version>:<part>:<vendor>:<product>:<version>:<update>:<edition>:"
++        _project, distro, version = tuple(cpe.split(":")[3:6])
++    else:
++        # older version of CPE standard
++        # 2nd to 4th fields from e.g. "cpe:/o:fedoraproject:fedora:25" or "cpe:/o:redhat:enterprise_linux:7.3:GA:server"
++        _project, distro, version = tuple(cpe.split(":")[2:5])
+     version = str(int(float(version)))
+     return (distro, version)
+ 
+-- 
+2.53.0
+

--- a/specs/p/python-blivet/python-blivet.spec
+++ b/specs/p/python-blivet/python-blivet.spec
@@ -8,7 +8,7 @@ Version: 3.12.1
 
 #%%global prerelease .b2
 # prerelease, if defined, should be something like .a1, .b1, .b2.dev1, or .c2
-Release: 9%{?prerelease}%{?dist}
+Release: 10%{?prerelease}%{?dist}
 Epoch: 1
 License: LGPL-2.1-or-later
 %global realname blivet
@@ -45,6 +45,7 @@ Patch103: 0003-Fix-setting-mount-options-in-FSTabManager.get_device.patch
 
 BuildArch: noarch
 
+Patch104: bb696202-fix-cpe-2.3-version-parsing.patch
 %description
 The python-blivet package is a python module for examining and modifying
 storage configuration.


### PR DESCRIPTION
Backports Blivet's CPE 2.3 parsing fix so `python-blivet` correctly identifies Azure Linux during `%check`.

Blivet 3.12.1 parses CPE 2.3 using legacy field positions, causing Azure Linux's `azure_linux` product identifier to be interpreted as a numeric version before any unit tests run.

Changes:

- Backports upstream commit [`bb696202`](https://github.com/storaged-project/blivet/commit/bb696202fa44b7d516f5cdff7a699e32edc982df).
- Handles CPE 2.3 and legacy CPE field layouts correctly.
- Bumps the manually managed package release from 9 to 10.

Validation:
- PME Stage 2 build passed with `%check` enabled.
- Full unit suite passed with `OK (skipped=28)`.
- Installed `blivet-data` and `python3-blivet` in a clean Stage 2 mock root. Verified that the packaged `blivet` Python module imports successfully.