### PR TITLE
[MANUAL CHERRYPICK] Upgrade etcd to 3.5.33 for CVE-2026-56852 (#18180) - branch 3.0-dev

### DIFF
--- a/SPECS/etcd/etcd.signatures.json
+++ b/SPECS/etcd/etcd.signatures.json
@@ -1,7 +1,7 @@
 {
   "Signatures": {
-    "etcd.service": "4550a4967ba35670051cbfd9b4edf1fc57c0f1d7a07e51f88351ac44c76d8066",
-    "etcd-3.5.32.tar.gz": "dfcd2fee36f008b2e26deef8b1180e06c7c400f7a4c25951c33044f8af8ab0bd",
-    "etcd-3.5.32-vendor.tar.gz": "5643426f135d66a558bf640797349ae04f494371c00edcdb5a8afd0908cd372c"
+    "etcd-3.5.33-vendor.tar.gz": "937c2b8ab40f555f672209f3cfe8891b223cde99009b7bcd75e5a50475ba0e36",
+    "etcd-3.5.33.tar.gz": "4bd8f588fb65033c23f6fac9b9a5ff4812ae2b6f77359fbe6d0eb2f1803d1d50",
+    "etcd.service": "4550a4967ba35670051cbfd9b4edf1fc57c0f1d7a07e51f88351ac44c76d8066"
   }
 }

--- a/SPECS/etcd/etcd.spec
+++ b/SPECS/etcd/etcd.spec
@@ -1,6 +1,6 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
-Version:        3.5.32
+Version:        3.5.33
 Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
@@ -30,7 +30,7 @@ Source1:        etcd.service
 #       e. create tarball containing 'vendor' folder and 'go.mod' and 'go.sum' files
 #          (same naming rules than described above)
 #       f. repeat above operations for 'etcd-dump-logs' folder
-#   4. create 'etcd-%{version}-vendor.tar.gz' tarball containing all tarballs created above
+#   4. create 'etcd-%%{version}-vendor.tar.gz' tarball containing all tarballs created above
 #
 #   NOTES:
 #       - You require GNU tar version 1.28+.
@@ -42,7 +42,7 @@ Source1:        etcd.service
 #             --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 #             -cJf [tarball name] [folder to tar]
 Source2:        %{name}-%{version}-vendor.tar.gz
-BuildRequires:  golang >= 1.16
+BuildRequires:  golang >= 1.25.12
 
 %description
 A highly-available key value store for shared configuration and service discovery.
@@ -143,6 +143,10 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Mon Jul 27 2026 Aditya Singh <v-aditysing@microsoft.com> - 3.5.33-1
+- Upgrade to version 3.5.33.
+- Fixes CVE-2026-56852 by upgrading vendor package golang.org/x/text from version 0.37.0 => 0.39.0.
+
 * Mon Jul 13 2026 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 3.5.32-1
 - Upgrade to version 3.5.32 (fixes CVE-2026-59818).
 - Drop CVE-2026-29181, CVE-2026-39821, and CVE-2026-33814 patches; these fixes are already included upstream via bundled dependency updates (go.opentelemetry.io/otel 1.43.0, golang.org/x/net 0.55.0).

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3458,8 +3458,8 @@
         "type": "other",
         "other": {
           "name": "etcd",
-          "version": "3.5.32",
-          "downloadUrl": "https://github.com/etcd-io/etcd/archive/v3.5.32.tar.gz"
+          "version": "3.5.33",
+          "downloadUrl": "https://github.com/etcd-io/etcd/archive/v3.5.33.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Manual cherry-pick of Fast-Track PR #18180 (commit `9a1391aad`) to `3.0-dev`.

`3.0-dev` already contains the prerequisite etcd 3.5.32 upgrade from #18002, so this applies only the intended 3.5.33 delta: source/vendor signatures, golang >= 1.25.12, cgmanifest, and changelog.

The resulting etcd SPEC matches `fasttrack/3.0` for the 3.5.33 package content.