### PR TITLE
Upgrade `thrift` module in vendor tarball of `telegraf`

### DIFF
--- a/SPECS/telegraf/CVE-2026-41602.patch
+++ b/SPECS/telegraf/CVE-2026-41602.patch
@@ -1,55 +1,49 @@
-From 17ad5616555d45b546429e4c030e4a47f793392e Mon Sep 17 00:00:00 2001
-From: Jens Geyer <jensg@apache.org>
-Date: Wed, 8 Apr 2026 23:06:45 +0200
-Subject: [PATCH] added int range checks
+From 014e14050b309750f09c2b446e64ba88d22e7938 Mon Sep 17 00:00:00 2001
+From: Kanishk Bansal <kanbansal@microsoft.com>
+Date: Mon, 3 Aug 2026 06:01:28 +0000
+Subject: [PATCH] upgrade thrift to v0.24.0
 
-Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
-Upstream-reference: https://github.com/apache/thrift/commit/630d66c633a88bbae4a2a090fcb41f72dd1adc6a.patch
 ---
- .../thrift/lib/go/thrift/framed_transport.go       | 14 ++++++++++++--
- 1 file changed, 12 insertions(+), 2 deletions(-)
+ go.mod | 4 ++--
+ go.sum | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/vendor/github.com/apache/thrift/lib/go/thrift/framed_transport.go b/vendor/github.com/apache/thrift/lib/go/thrift/framed_transport.go
-index e3c323af..00f277e1 100644
---- a/vendor/github.com/apache/thrift/lib/go/thrift/framed_transport.go
-+++ b/vendor/github.com/apache/thrift/lib/go/thrift/framed_transport.go
-@@ -26,6 +26,7 @@ import (
- 	"encoding/binary"
- 	"fmt"
- 	"io"
-+	"math"
- )
+diff --git a/go.mod b/go.mod
+index 412d7a0..03c7aad 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/influxdata/telegraf
  
- // Deprecated: Use DEFAULT_MAX_FRAME_SIZE instead.
-@@ -60,8 +61,13 @@ func NewTFramedTransportFactory(factory TTransportFactory) TTransportFactory {
+-go 1.22.0
++go 1.25
  
- // Deprecated: Use NewTFramedTransportFactoryConf instead.
- func NewTFramedTransportFactoryMaxLength(factory TTransportFactory, maxLength uint32) TTransportFactory {
-+	safeMax := maxLength
-+	if safeMax > math.MaxInt32 {
-+		safeMax = math.MaxInt32
-+	}
-+
- 	return NewTFramedTransportFactoryConf(factory, &TConfiguration{
--		MaxFrameSize: int32(maxLength),
-+		MaxFrameSize: int32(safeMax),
- 
- 		noPropagation: true,
- 	})
-@@ -196,8 +202,12 @@ func (p *TFramedTransport) WriteString(s string) (n int, err error) {
- }
- 
- func (p *TFramedTransport) Flush(ctx context.Context) error {
--	defer bufPool.put(&p.writeBuf)
- 	size := p.writeBuf.Len()
-+	if size > math.MaxUint32 {
-+		return NewTTransportException(UNKNOWN_TRANSPORT_EXCEPTION, fmt.Sprintf("frame too large: %d bytes exceeds uint32 max",size))
-+	}
-+
-+	defer bufPool.put(&p.writeBuf)
- 	buf := p.buffer[:4]
- 	binary.BigEndian.PutUint32(buf, uint32(size))
- 	_, err := p.transport.Write(buf)
+ require (
+ 	cloud.google.com/go/bigquery v1.61.0
+@@ -37,7 +37,7 @@ require (
+ 	github.com/apache/arrow/go/v13 v13.0.0
+ 	github.com/apache/arrow/go/v16 v16.0.0-20240319161736-1ee3da0064a0
+ 	github.com/apache/iotdb-client-go v1.2.0-tsbs
+-	github.com/apache/thrift v0.19.0
++	github.com/apache/thrift v0.24.0
+ 	github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740
+ 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
+ 	github.com/awnumar/memguard v0.22.5
+diff --git a/go.sum b/go.sum
+index 60b357d..245dae3 100644
+--- a/go.sum
++++ b/go.sum
+@@ -808,8 +808,8 @@ github.com/apache/iotdb-client-go v1.2.0-tsbs h1:hezGUydAkDSceCvsetYorI87S2e8HZ4
+ github.com/apache/iotdb-client-go v1.2.0-tsbs/go.mod h1:3D6QYkqRmASS/4HsjU+U/3fscyc5M9xKRfywZsKuoZY=
+ github.com/apache/thrift v0.15.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+ github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+-github.com/apache/thrift v0.19.0 h1:sOqkWPzMj7w6XaYbJQG7m4sGqVolaW/0D28Ln7yPzMk=
+-github.com/apache/thrift v0.19.0/go.mod h1:SUALL216IiaOw2Oy+5Vs9lboJ/t9g40C+G07Dc0QC1I=
++github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
++github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
+ github.com/apex/log v1.6.0/go.mod h1:x7s+P9VtvFBXge9Vbn+8TrqKmuzmD35TTkeBHul8UtY=
+ github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
+ github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 -- 
 2.45.4
 

--- a/SPECS/telegraf/telegraf.signatures.json
+++ b/SPECS/telegraf/telegraf.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
     "telegraf-1.31.0.tar.gz": "c7a4725aefaf6cab4a354c577e06032187ce1c428337c795e48bbe7d7054d489",
-    "telegraf-1.31.0-vendor.tar.gz": "582012893525873ef2b93b95714ea87b002405a1425806a0392ac50e235d3ed0"
+    "telegraf-1.31.0-v1-vendor.tar.gz": "e2a1f51ade0483b61757a7f61ff223f45d3b9874cda91e066e3bee3d64b0b234"
   }
 }

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.31.0
-Release:        25%{?dist}
+Release:        26%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -9,7 +9,7 @@ Group:          Development/Tools
 URL:            https://github.com/influxdata/telegraf
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Use the generate_source_tarbbal.sh script to get the vendored sources.
-Source1:        %{name}-%{version}-vendor.tar.gz
+Source1:        %{name}-%{version}-v1-vendor.tar.gz
 
 Patch0:         CVE-2024-35255.patch
 Patch1:         CVE-2024-37298.patch
@@ -130,6 +130,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Mon Aug 03 2026 Kanishk Bansal <kanbansal@microsoft.com> - 1.31.0-26
+- Upgrade thrift module to 0.24.0
+
 * Tue Jul 28 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.31.0-25
 - Patch for CVE-2026-56852
 


### PR DESCRIPTION
Upgrade `thrift` module in vendor tarball of `telegraf`
Buddy Build - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1174165&view=results
as 0.24.0 having fix for multiple CVEs, Hence it is better to go with the internal dependency upgrade solution instead of adding 20+ patches.

CVEs fixed in Thrift 0.24.0
CVE-2026-55971 — C++ heap buffer overflow (write) in THeaderTransport::untransform() — 9.3 Critical
CVE-2026-48144 — c_glib TLS client missing hostname verification — 9.1 Critical
CVE-2026-58662 — C++ THeaderTransport::readString() bounds bypass → OOB read — 9.1 Critical
CVE-2026-55969 — Integer overflow in TProtocol::checkReadBytesAvailable() (C++, c_glib, Go, netstd, Delphi, Haxe) — 8.7 High
CVE-2026-43871 — Infinite loop DoS (Python, Go, PHP, Java) — 8.7 High
CVE-2026-48145 — C++ TSSLSocket matchName() RFC 6125 wildcard bypass → MITM — 8.2 High
CVE-2026-55968 — Node.js quadratic-time DoS in server receive transports — 7.5 High
CVE-2026-41608 — Python zlib data amplification DoS — 7.5 High
CVE-2026-49158 — Ruby data amplification (highly compressed data) — 7.5 High
CVE-2026-48586 — TZlibTransport missing decompression size limit (C++, Java, Python, Go, D, c_glib) — High
CVE-2026-58389 — Rust allocation without limits/throttling — unrated
CVE-2026-45112 — Java unbounded read DoS (only 0.19.0 → <0.24.0) — 6.9 Medium
CVE-2026-58023 — c_glib heap OOB read in transport leftover-bytes path — 6.5 Medium
CVE-2026-55970 — C++ buffer over-read — 6.5 Medium
CVE-2026-66053 — Python cert host mismatch (replaces rejected CVE-2026-41603) — 5.9 Medium