### PR TITLE
fix(qt5-qtwebkit): make GStreamer MPEG-TS optional

### DIFF
--- a/base/comps/qt5-qtwebkit/overlays/0001-make-gstreamer-mpegts-optional.overlay.toml
+++ b/base/comps/qt5-qtwebkit/overlays/0001-make-gstreamer-mpegts-optional.overlay.toml
@@ -1,0 +1,17 @@
+# Fedora ships gstreamer1-plugins-bad-free-devel, which provides the MPEG-TS
+# API. Azure Linux omits that package. QtWebKit's MPEG-TS source and linkage
+# are already gated by USE_GSTREAMER_MPEGTS, which is disabled by default.
+[metadata]
+category = "azl-platform-adaptation"
+upstream-status = "upstreamable"
+
+[[overlays]]
+description = "Remove unavailable GStreamer MPEG-TS build dependency"
+type = "spec-remove-tag"
+tag = "BuildRequires"
+value = "pkgconfig(gstreamer-mpegts-1.0)"
+
+[[overlays]]
+description = "Do not require the disabled GStreamer MPEG-TS integration"
+type = "patch-add"
+source = "qtwebkit-optional-gstreamer-mpegts.patch"

--- a/base/comps/qt5-qtwebkit/overlays/qtwebkit-optional-gstreamer-mpegts.patch
+++ b/base/comps/qt5-qtwebkit/overlays/qtwebkit-optional-gstreamer-mpegts.patch
@@ -1,0 +1,25 @@
+From e76e13acac38658e132f1a03383869b2530151c1 Mon Sep 17 00:00:00 2001
+From: Mitch Zhu <mitchzhu@microsoft.com>
+Date: Tue, 4 Aug 2026 20:57:42 +0000
+Subject: [PATCH] cmake: make GStreamer MPEG-TS optional for Qt
+
+The Qt port requires the MPEG-TS component whenever video is enabled,
+even though MPEG-TS sources and linkage are guarded by
+USE_GSTREAMER_MPEGTS.
+
+Do not require MPEG-TS for generic GStreamer video support.
+
+Signed-off-by: Mitch Zhu <mitchzhu@microsoft.com>
+---
+ Source/cmake/OptionsQt.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/cmake/OptionsQt.cmake b/Source/cmake/OptionsQt.cmake
+index 1ee60b77710..b9c7ab39861 100644
+--- a/Source/cmake/OptionsQt.cmake
++++ b/Source/cmake/OptionsQt.cmake
+@@ -804,3 +804,3 @@ if (USE_GSTREAMER)
+     if (ENABLE_VIDEO)
+-        list(APPEND GSTREAMER_COMPONENTS video mpegts tag gl)
++        list(APPEND GSTREAMER_COMPONENTS video tag gl)
+     endif ()

--- a/base/comps/qt5-qtwebkit/qt5-qtwebkit.comp.toml
+++ b/base/comps/qt5-qtwebkit/qt5-qtwebkit.comp.toml
@@ -1,3 +1,9 @@
 [components.qt5-qtwebkit]
-# Release: 0.95%{?prerel}%{?dist}
+# Release: 0.96%{?prerel}%{?dist}
 release = { calculation = "manual" }
+
+[[components.qt5-qtwebkit.overlays]]
+description = "Bump release for the GStreamer MPEG-TS dependency fix"
+type = "spec-update-tag"
+tag = "Release"
+value = "0.96%{?prerel}%{?dist}"

--- a/locks/qt5-qtwebkit.lock
+++ b/locks/qt5-qtwebkit.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '2058f51438cbeb0d2b37e63efcf6e6fad89560a7'
 upstream-commit = '2058f51438cbeb0d2b37e63efcf6e6fad89560a7'
-input-fingerprint = 'sha256:8f9e1e532719f18c7e40af5b30a1fbb138c3d098a26c04b5f18648bd89809945'
+input-fingerprint = 'sha256:698497d4d968a0c789fa958b6ae554c270a4e831fdf0e0c22c33f8c127d31cbe'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/q/qt5-qtwebkit/qt5-qtwebkit.spec
+++ b/specs/q/qt5-qtwebkit/qt5-qtwebkit.spec
@@ -21,7 +21,7 @@
 
 Name:           qt5-%{qt_module}
 Version:        5.212.0
-Release:        0.95%{?prerel}%{?dist}
+Release: 0.96%{?prerel}%{?dist}
 Summary:        Qt5 - QtWebKit components
 
 License:        LGPL-2.0-only AND BSD-3-Clause
@@ -67,7 +67,6 @@ BuildRequires:  pkgconfig(xrender)
 BuildRequires:  pkgconfig(libxslt)
 BuildRequires:  pkgconfig(gl)
 BuildRequires:  pkgconfig(gstreamer-gl-1.0)
-BuildRequires:  pkgconfig(gstreamer-mpegts-1.0)
 BuildRequires:  perl-generators
 BuildRequires:  perl(File::Copy)
 BuildRequires:  python3
@@ -102,6 +101,7 @@ Provides:       bundled(brotli)
 Provides:       bundled(woff2)
 
 
+Patch12: qtwebkit-optional-gstreamer-mpegts.patch
 %description
 %{summary}
 

--- a/specs/q/qt5-qtwebkit/qtwebkit-optional-gstreamer-mpegts.patch
+++ b/specs/q/qt5-qtwebkit/qtwebkit-optional-gstreamer-mpegts.patch
@@ -1,0 +1,25 @@
+From e76e13acac38658e132f1a03383869b2530151c1 Mon Sep 17 00:00:00 2001
+From: Mitch Zhu <mitchzhu@microsoft.com>
+Date: Tue, 4 Aug 2026 20:57:42 +0000
+Subject: [PATCH] cmake: make GStreamer MPEG-TS optional for Qt
+
+The Qt port requires the MPEG-TS component whenever video is enabled,
+even though MPEG-TS sources and linkage are guarded by
+USE_GSTREAMER_MPEGTS.
+
+Do not require MPEG-TS for generic GStreamer video support.
+
+Signed-off-by: Mitch Zhu <mitchzhu@microsoft.com>
+---
+ Source/cmake/OptionsQt.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/cmake/OptionsQt.cmake b/Source/cmake/OptionsQt.cmake
+index 1ee60b77710..b9c7ab39861 100644
+--- a/Source/cmake/OptionsQt.cmake
++++ b/Source/cmake/OptionsQt.cmake
+@@ -804,3 +804,3 @@ if (USE_GSTREAMER)
+     if (ENABLE_VIDEO)
+-        list(APPEND GSTREAMER_COMPONENTS video mpegts tag gl)
++        list(APPEND GSTREAMER_COMPONENTS video tag gl)
+     endif ()


### PR DESCRIPTION
Fixes the QtWebKit Stage 2 buildroot failure caused by the unavailable `pkgconfig(gstreamer-mpegts-1.0)` dependency.

Azure Linux does not provide `gstreamer1-plugins-bad-free-devel`, the package that supplies `pkgconfig(gstreamer-mpegts-1.0)`. QtWebKit nevertheless treats MPEG-TS as a required GStreamer component whenever video support is enabled. That dependency is unnecessary for this build because QtWebKit uses the MPEG-TS source code and libraries only when `USE_GSTREAMER_MPEGTS` is enabled, and that integration is disabled. The fix makes MPEG-TS optional while leaving QtWebKit's general GStreamer audio and video support enabled.

Changes:
- Removes the MPEG-TS build requirement and patches QtWebKit's required GStreamer component list.

Validation:
- The full x86_64 build passed with `ENABLE_VIDEO` and `USE_GSTREAMER` still enabled.
- RPM installation, dependency inspection, and an offscreen `QWebPage` smoke test passed.