### PR TITLE
kata-containers: use smaller vendored tarball

### DIFF
--- a/SPECS/kata-containers/kata-containers.signatures.json
+++ b/SPECS/kata-containers/kata-containers.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "kata-containers-3.32.0.kata1-cargo.tar.gz": "4b33cca659724770d8bcecfa3ed889f9030c6f4e92aea675f4ebc291ac281edf",
-    "kata-containers-3.32.0.kata1.tar.gz": "0852d797c6312a87afd1316be0ff74137ebe5dbfe0b571e8d0ce3949980d96c7"
+    "kata-containers-3.32.0.kata0.tar.gz": "933af57d9678c2ed4772aaa21527a714b017fddd4e8a7e64d127d71a62f800e1",
+    "kata-containers-3.32.0.kata1-cargo.tar.gz": "4b33cca659724770d8bcecfa3ed889f9030c6f4e92aea675f4ebc291ac281edf"
   }
 }

--- a/SPECS/kata-containers/kata-containers.signatures.json
+++ b/SPECS/kata-containers/kata-containers.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "kata-containers-3.32.0.kata0-cargo.tar.gz": "7442807aaeb43bde8f428f8d3a33edc3e8eabf4b23977a3e477294c0279452db",
-    "kata-containers-3.32.0.kata0.tar.gz": "933af57d9678c2ed4772aaa21527a714b017fddd4e8a7e64d127d71a62f800e1"
+    "kata-containers-3.32.0.kata1-cargo.tar.gz": "4b33cca659724770d8bcecfa3ed889f9030c6f4e92aea675f4ebc291ac281edf",
+    "kata-containers-3.32.0.kata1.tar.gz": "0852d797c6312a87afd1316be0ff74137ebe5dbfe0b571e8d0ce3949980d96c7"
   }
 }

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           kata-containers
-Version:        3.32.0.kata0
+Version:        3.32.0.kata1
 Release:        1%{?dist}
 Summary:        Kata Containers package developed for Pod Sandboxing on AKS
 License:        ASL 2.0
@@ -140,6 +140,9 @@ install -m 0644 \
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Tue Aug 04 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.32.0.kata1-1
+- Auto-upgrade to 3.32.0.kata1
+
 * Mon Jul 27 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.32.0.kata0-1
 - Auto-upgrade to 3.32.0.kata0
 - Add preview configurations for VM templating

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -1,15 +1,17 @@
 %global debug_package %{nil}
 
 Name:           kata-containers
-Version:        3.32.0.kata1
-Release:        1%{?dist}
+Version:        3.32.0.kata0
+Release:        2%{?dist}
 Summary:        Kata Containers package developed for Pod Sandboxing on AKS
 License:        ASL 2.0
 URL:            https://github.com/microsoft/kata-containers
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Source0:        https://github.com/microsoft/kata-containers/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Source1:        %{name}-%{version}-cargo.tar.gz
+# Todo: revert back to %{name}-${version}-cargo.tar.gz next release
+# This is a temporary workaround so we can use a newer cargo tarball without having to make a new fork release
+Source1:        %{name}-3.32.0.kata1-cargo.tar.gz
 # Only needed up to Rust 1.93; remove once the Rust toolchain is updated to 1.94 or newer.
 Patch0:         dbs-arch-cpuid-unsafe.patch
 Patch1:         CVE-2025-11065.patch
@@ -140,8 +142,8 @@ install -m 0644 \
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
-* Tue Aug 04 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.32.0.kata1-1
-- Auto-upgrade to 3.32.0.kata1
+* Tue Aug 04 2026 Saul Paredes <saulparedes@microsoft.com>  - 3.32.0.kata0-2
+- Use smaller vendored sources
 
 * Mon Jul 27 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.32.0.kata0-1
 - Auto-upgrade to 3.32.0.kata0

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8281,8 +8281,8 @@
         "type": "other",
         "other": {
           "name": "kata-containers",
-          "version": "3.32.0.kata0",
-          "downloadUrl": "https://github.com/microsoft/kata-containers/archive/refs/tags/3.32.0.kata0.tar.gz"
+          "version": "3.32.0.kata1",
+          "downloadUrl": "https://github.com/microsoft/kata-containers/archive/refs/tags/3.32.0.kata1.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8281,8 +8281,8 @@
         "type": "other",
         "other": {
           "name": "kata-containers",
-          "version": "3.32.0.kata1",
-          "downloadUrl": "https://github.com/microsoft/kata-containers/archive/refs/tags/3.32.0.kata1.tar.gz"
+          "version": "3.32.0.kata0",
+          "downloadUrl": "https://github.com/microsoft/kata-containers/archive/refs/tags/3.32.0.kata0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Current vendored tarball is ~400Mb and causes issues with ESRP singing.

A smaller tarballl (~100Mb) was produced by  [1]:
- deduplicating rust vendored code
- removing windows support

bb: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1175221&view=results
image build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1175379&view=results
conformance: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1175455&view=results
performance: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1175484&view=results

[1] https://dev.azure.com/mariner-org/mariner/_git/CBL-Mariner-Pipelines/pullrequest/26534?path=/spec-auto-patch-update/script/vendorSources.sh&_a=files

