### PR TITLE
Azaugg/3.0/rasdaemon 0.8.1

### DIFF
--- a/SPECS/rasdaemon/rasdaemon.signatures.json
+++ b/SPECS/rasdaemon/rasdaemon.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "rasdaemon-0.8.0.tar.bz2": "ef0b8df430746b3907f8d0808e7fdd1f8bf2ebdfa098a4f8db1edbf89a760349"
+  "rasdaemon-0.8.1.tar.bz2": "3cb5bbb2091cd278a394674259256bb7ff8f1eba8f2462c67e5172dccda0bebe"
  }
 }

--- a/SPECS/rasdaemon/rasdaemon.spec
+++ b/SPECS/rasdaemon/rasdaemon.spec
@@ -1,7 +1,7 @@
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Name:			rasdaemon
-Version:		0.8.0
+Version:		0.8.1
 Release:		1%{?dist}
 Summary:		Utility to receive RAS error tracings
 License:		GPLv2
@@ -75,6 +75,9 @@ rm INSTALL %{buildroot}/usr/include/*.h
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 
 %changelog
+* Wed Aug 05 2026 Andy Zaugg <azaugg@linkedin.com> - 0.8.1-1
+- Update to version 0.8.1. License verified.
+
 * Wed May 22 2024 Chris Co <chrco@microsoft.com> - 0.8.0-1
 - Update to version 0.8.0. From Fedora 40. License verified.
 

--- a/SPECS/rasdaemon/rasdaemon.spec
+++ b/SPECS/rasdaemon/rasdaemon.spec
@@ -72,6 +72,8 @@ rm INSTALL %{buildroot}/usr/include/*.h
 %{_mandir}/*/*
 %{_unitdir}/*.service
 %{_sysconfdir}/ras/dimm_labels.d
+%{_sysconfdir}/ras/triggers/mc_event_trigger
+%{_sysconfdir}/ras/triggers/mem_fail_trigger
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 
 %changelog

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -26303,8 +26303,8 @@
         "type": "other",
         "other": {
           "name": "rasdaemon",
-          "version": "0.8.0",
-          "downloadUrl": "http://www.infradead.org/~mchehab/rasdaemon/rasdaemon-0.8.0.tar.bz2"
+          "version": "0.8.1",
+          "downloadUrl": "http://www.infradead.org/~mchehab/rasdaemon/rasdaemon-0.8.1.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
Need to bump rasdaemon for AMD workloads due to a included fix that corrects SMCA memory-controller bank-type decoding on dual-socket AMD systems. Without this fix, corrected-error records raised on socket 1 are decoded into the wrong memory location, which misattributes DIMM corrected errors to the wrong physical slot.

0.8.1  includes a fix by AMD in rasdaemon commit `b6a64416` — "rasdaemon: Fix SMCA bank type decoding", 2023-08-31. The commit message names the exact mechanism:


Built
```
sudo make build-packages -j$(nproc)       REBUILD_TOOLS=n       SRPM_PACK_LIST="rasdaemon"       PACKAGE_BUILD_LIST="rasdaemon"        SPECS_DIR="../SPECS"  SRPM_FILE_SIGNATURE_HANDLING=update; 

..
..
..
        --timeout="8h" \
        --log-file=/home/azaugg/azurelinux/build/logs/pkggen/workplan/build-rpms.flag.log --log-level=info --log-color=auto && \
touch /home/azaugg/azurelinux/build/make_status/build-rpms.flag
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/azurelinux/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/azurelinux/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Successfully created solvable subgraph
INFO[0000][scheduler] Building 26 nodes with 16 workers
INFO[0000][scheduler] Building: rasdaemon-0.8.1-1.azl3.src.rpm
INFO[0032][scheduler] Built: rasdaemon-0.8.1-1.azl3.src.rpm -> [/home/azaugg/azurelinux/out/RPMS/x86_64/rasdaemon-0.8.1-1.azl3.x86_64.rpm /home/azaugg/azurelinux/out/RPMS/x86_64/rasdaemon-debuginfo-0.8.1-1.azl3.x86_64.rpm]
INFO[0032][scheduler] 0 currently active build(s): [].
INFO[0032][scheduler] All packages built
INFO[0033][scheduler] ---------------------------
INFO[0033][scheduler] --------- Summary ---------
INFO[0033][scheduler] ---------------------------
INFO[0033][scheduler] Number of prebuilt SRPMs:              0
INFO[0033][scheduler] Number of prebuilt delta SRPMs:        0
INFO[0033][scheduler] Number of skipped SRPMs tests:         0
INFO[0033][scheduler] Number of built SRPMs:                 1
INFO[0033][scheduler] Number of passed SRPMs tests:          0
INFO[0033][scheduler] Number of unresolved dependencies:     0
INFO[0033][scheduler] Number of blocked SRPMs:               0
INFO[0033][scheduler] Number of blocked SRPMs tests:         0
INFO[0033][scheduler] Number of failed SRPMs:                0
INFO[0033][scheduler] Number of failed SRPMs tests:          0
INFO[0033][scheduler] Number of SRPMs with license errors:   0
INFO[0033][scheduler] Number of SRPMs with license warnings: 0
INFO[0033][scheduler] Number of toolchain RPM conflicts:     0
INFO[0033][scheduler] Number of toolchain SRPM conflicts:    0
INFO[0033][scheduler] Built SRPMs:
INFO[0033][scheduler] --> rasdaemon-0.8.1-1.azl3.src.rpm
INFO[0033][scheduler] ---------------------------
INFO[0033][scheduler] --------- Summary ---------
INFO[0033][scheduler] ---------------------------
INFO[0033][scheduler] Number of prebuilt SRPMs:              0
INFO[0033][scheduler] Number of prebuilt delta SRPMs:        0
INFO[0033][scheduler] Number of skipped SRPMs tests:         0
INFO[0033][scheduler] Number of built SRPMs:                 1
INFO[0033][scheduler] Number of passed SRPMs tests:          0
INFO[0033][scheduler] Number of unresolved dependencies:     0
INFO[0033][scheduler] Number of blocked SRPMs:               0
INFO[0033][scheduler] Number of blocked SRPMs tests:         0
INFO[0033][scheduler] Number of failed SRPMs:                0
INFO[0033][scheduler] Number of failed SRPMs tests:          0
INFO[0033][scheduler] Number of SRPMs with license errors:   0
INFO[0033][scheduler] Number of SRPMs with license warnings: 0
INFO[0033][scheduler] Number of toolchain RPM conflicts:     0
INFO[0033][scheduler] Number of toolchain SRPM conflicts:    0
```