### PR TITLE
ci: enable PR checks to run scratch package builds against PROD

### DIFF
--- a/.github/workflows/ado/pr-check-ct.yml
+++ b/.github/workflows/ado/pr-check-ct.yml
@@ -3,9 +3,9 @@
 #
 # Wrapper pipeline — passed to ADO as the entry point for the PR Control Tower
 # check. For each configured deployment, it calls Control Tower 'prcheck'
-# (which uploads the changed components' missing lookaside sources). DEV then
-# submits a *scratch* Control Tower build of those components and WAITS for it
-# to finish; STAGING and PROD skip package builds. DEV and PROD API failures
+# (which uploads the changed components' missing lookaside sources). DEV and
+# PROD then submit a *scratch* Control Tower build of those components and
+# WAIT for it to finish; STAGING skips package builds. DEV and PROD API failures
 # fail the check, while STAGING prcheck failures are non-blocking. Deployment
 # jobs run independently in parallel. Package builds run in Control Tower's own
 # sandbox; checkout-controlled pipeline helpers still run on CI agents under
@@ -114,7 +114,7 @@ extends:
               apiBaseAFDUrl: $(ApiBaseAFDUrlProd)
               continueOnError: false
               serviceConnection: CT-Endpoints-Access-ServiceConnection-PROD
-              skipPackageBuilds: true
+              skipPackageBuilds: false
           outputDirectory: $(Build.ArtifactStagingDirectory)/output
           # Distro-config RPM build-environment for the 4.0 branch.
           packageEnvironment: "4.0"


### PR DESCRIPTION
GitHub PRs, with approval via `/azp run`, trigger an ADO pipeline that requests Control Tower to upload sources + build scratch packages for changed components. To date, the scratch package building has been disabled in STAGING and PROD environments. This enables them for PROD now that the distro has been bootstrapped there.

_There are still ~70 packages known failing in PROD; maintainers can still bypass-ignore failures if there are changes made to them for the time being._

We leave STAGING configuration as-is.

### Validation

Validated with an earlier version of this PR that included a change to the `words` component (simple bump). Confirmed that `/azp run` queued off source uploads across all 3 envs *and* scratch package builds across DEV and PROD. All passed!