### PR TITLE
e2fsprogs: backport fix for e2fsck skipping checks with orphan_file 

### DIFF
--- a/SPECS/e2fsprogs/CVE-2024-e2fsck-orphan-file-skip-check.patch
+++ b/SPECS/e2fsprogs/CVE-2024-e2fsck-orphan-file-skip-check.patch
@@ -1,0 +1,38 @@
+From a8df015009e7cd71b411f21e7d6f0797a28cba5c Mon Sep 17 00:00:00 2001
+From: Luis Henriques (SUSE) <luis.henriques@linux.dev>
+Date: Tue, 11 Jun 2024 15:27:04 +0100
+Subject: [PATCH] e2fsck: don't skip checks if the orphan file is present in
+ the filesystem
+
+If the filesystem supports the orphan file feature and that file is present
+then don't skip the filesystem checks as that file may need to be
+cleaned up.
+
+Signed-off-by: Luis Henriques (SUSE) <luis.henriques@linux.dev>
+Link: https://lore.kernel.org/r/20240611142704.14307-2-luis.henriques@linux.dev
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+
+Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=2318710
+Addresses: https://bugzilla.suse.com/show_bug.cgi?id=1226043
+---
+ e2fsck/unix.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/e2fsck/unix.c b/e2fsck/unix.c
+index 7f0f77f..b3a1234 100644
+--- a/e2fsck/unix.c
++++ b/e2fsck/unix.c
+@@ -370,6 +370,10 @@ static void check_if_skip(e2fsck_t ctx)
+ 	if (ctx->options & E2F_OPT_JOURNAL_ONLY)
+ 		goto skip;
+ 
++	if (ext2fs_has_feature_orphan_file(fs->super) &&
++	    ext2fs_has_feature_orphan_present(fs->super))
++		return;
++
+ 	lastcheck = fs->super->s_lastcheck;
+ 	if (lastcheck > ctx->now)
+ 		lastcheck -= ctx->time_fudge;
+-- 
+2.39.2
+

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -1,13 +1,14 @@
 Summary:        Contains the utilities for the ext2 file system
 Name:           e2fsprogs
 Version:        1.47.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2 AND LGPLv2 AND BSD AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System Environment/Base
 URL:            http://e2fsprogs.sourceforge.net
 Source0:        https://prdownloads.sourceforge.net/e2fsprogs/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-e2fsck-orphan-file-skip-check.patch
 Requires:       %{name}-libs = %{version}-%{release}
 Conflicts:      toybox
 
@@ -148,6 +149,12 @@ done
 %defattr(-,root,root)
 
 %changelog
+* Wed Aug 06 2025 Ankita Pareek <ankitapareek@microsoft.com> - 1.47.0-3
+- Backport upstream fix for e2fsck skipping checks when orphan file is present
+- Resolves: emergency mode after unclean reboot on filesystems with orphan_file feature
+- Upstream commit: a8df015009e7cd71b411f21e7d6f0797a28cba5c
+- Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2318710
+
 * Mon Aug 19 2024 Andrew Phelps <anphel@microsoft.com> - 1.47.0-2
 - Remove known bad package test
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -188,9 +188,9 @@ rpm-lang-4.18.2-2.azl3.aarch64.rpm
 rpm-libs-4.18.2-2.azl3.aarch64.rpm
 cpio-2.14-2.azl3.aarch64.rpm
 cpio-lang-2.14-2.azl3.aarch64.rpm
-e2fsprogs-libs-1.47.0-2.azl3.aarch64.rpm
-e2fsprogs-1.47.0-2.azl3.aarch64.rpm
-e2fsprogs-devel-1.47.0-2.azl3.aarch64.rpm
+e2fsprogs-libs-1.47.0-3.azl3.aarch64.rpm
+e2fsprogs-1.47.0-3.azl3.aarch64.rpm
+e2fsprogs-devel-1.47.0-3.azl3.aarch64.rpm
 libsolv-0.7.28-5.azl3.aarch64.rpm
 libsolv-devel-0.7.28-5.azl3.aarch64.rpm
 libssh2-1.11.1-6.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -188,9 +188,9 @@ rpm-lang-4.18.2-2.azl3.x86_64.rpm
 rpm-libs-4.18.2-2.azl3.x86_64.rpm
 cpio-2.14-2.azl3.x86_64.rpm
 cpio-lang-2.14-2.azl3.x86_64.rpm
-e2fsprogs-libs-1.47.0-2.azl3.x86_64.rpm
-e2fsprogs-1.47.0-2.azl3.x86_64.rpm
-e2fsprogs-devel-1.47.0-2.azl3.x86_64.rpm
+e2fsprogs-libs-1.47.0-3.azl3.x86_64.rpm
+e2fsprogs-1.47.0-3.azl3.x86_64.rpm
+e2fsprogs-devel-1.47.0-3.azl3.x86_64.rpm
 libsolv-0.7.28-5.azl3.x86_64.rpm
 libsolv-devel-0.7.28-5.azl3.x86_64.rpm
 libssh2-1.11.1-6.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -80,11 +80,11 @@ docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 dwz-0.14-2.azl3.aarch64.rpm
 dwz-debuginfo-0.14-2.azl3.aarch64.rpm
-e2fsprogs-1.47.0-2.azl3.aarch64.rpm
-e2fsprogs-debuginfo-1.47.0-2.azl3.aarch64.rpm
-e2fsprogs-devel-1.47.0-2.azl3.aarch64.rpm
-e2fsprogs-lang-1.47.0-2.azl3.aarch64.rpm
-e2fsprogs-libs-1.47.0-2.azl3.aarch64.rpm
+e2fsprogs-1.47.0-3.azl3.aarch64.rpm
+e2fsprogs-debuginfo-1.47.0-3.azl3.aarch64.rpm
+e2fsprogs-devel-1.47.0-3.azl3.aarch64.rpm
+e2fsprogs-lang-1.47.0-3.azl3.aarch64.rpm
+e2fsprogs-libs-1.47.0-3.azl3.aarch64.rpm
 elfutils-0.189-6.azl3.aarch64.rpm
 elfutils-debuginfo-0.189-6.azl3.aarch64.rpm
 elfutils-default-yama-scope-0.189-6.azl3.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -85,11 +85,11 @@ docbook-dtd-xml-4.5-11.azl3.noarch.rpm
 docbook-style-xsl-1.79.1-14.azl3.noarch.rpm
 dwz-0.14-2.azl3.x86_64.rpm
 dwz-debuginfo-0.14-2.azl3.x86_64.rpm
-e2fsprogs-1.47.0-2.azl3.x86_64.rpm
-e2fsprogs-debuginfo-1.47.0-2.azl3.x86_64.rpm
-e2fsprogs-devel-1.47.0-2.azl3.x86_64.rpm
-e2fsprogs-lang-1.47.0-2.azl3.x86_64.rpm
-e2fsprogs-libs-1.47.0-2.azl3.x86_64.rpm
+e2fsprogs-1.47.0-3.azl3.x86_64.rpm
+e2fsprogs-debuginfo-1.47.0-3.azl3.x86_64.rpm
+e2fsprogs-devel-1.47.0-3.azl3.x86_64.rpm
+e2fsprogs-lang-1.47.0-3.azl3.x86_64.rpm
+e2fsprogs-libs-1.47.0-3.azl3.x86_64.rpm
 elfutils-0.189-6.azl3.x86_64.rpm
 elfutils-debuginfo-0.189-6.azl3.x86_64.rpm
 elfutils-default-yama-scope-0.189-6.azl3.noarch.rpm


### PR DESCRIPTION
###### Merge Checklist

- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted
- [x] LICENSE-MAP files are up-to-date
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary

Backport upstream fix for e2fsck incorrectly skipping filesystem checks when the `orphan_file` feature is enabled and orphan inodes are present. After an unclean reboot, this causes the kernel to reject mounting with "bad orphan inode" errors, dropping the system into emergency mode.

The fix is a minimal 4-line backport of upstream commit [a8df015](https://github.com/tytso/e2fsprogs/commit/a8df015009e7cd71b411f21e7d6f0797a28cba5c) which adds a check in `check_if_skip()` to force e2fsck to run when both `orphan_file` and `orphan_present` superblock features are set.

This same fix was validated by Fedora (e2fsprogs-1.47.1-6) and SUSE, and confirmed working by multiple independent testers.

###### Change Log

- Backport upstream commit a8df015 to e2fsprogs 1.47.0 (patch: `CVE-2024-e2fsck-orphan-file-skip-check.patch`)
- Bump release from 2 to 3
- Update toolchain and pkggen manifests for aarch64 and x86_64

###### Does this affect the toolchain?

**YES**

###### Associated issues
- Emergency mode after unclean reboot on ext4 filesystems with orphan_file feature

###### Links to CVEs

- https://bugzilla.redhat.com/show_bug.cgi?id=2318710
- https://bugzilla.suse.com/show_bug.cgi?id=1226043
- Upstream fix: https://github.com/tytso/e2fsprogs/commit/a8df015009e7cd71b411f21e7d6f0797a28cba5c
- Release notes: https://github.com/tytso/e2fsprogs/blob/master/doc/RelNotes/v1.47.2.txt#L38

###### Test Methodology
- Same patch confirmed working by Fedora and SUSE in production
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1193888&view=results
- Successful Full Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1195500&view=results
- Shared test rpms with partner team and they confirmed that the fix is working
