### PR TITLE
rasdaemon: backport upstream fix for SMCA bank type decoding

### DIFF
--- a/SPECS/rasdaemon/0001-rasdaemon-Fix-SMCA-bank-type-decoding.patch
+++ b/SPECS/rasdaemon/0001-rasdaemon-Fix-SMCA-bank-type-decoding.patch
@@ -1,0 +1,44 @@
+From a95fe9d5ba2ce313b7f6fc932f8e010a9662a0d2 Mon Sep 17 00:00:00 2001
+From: Avadhut Naik <avadhut.naik@amd.com>
+Date: Wed, 5 Aug 2026 11:24:59 -0400
+Subject: [PATCH] rasdaemon: Fix SMCA bank type decoding
+
+Bits 47:44 of the MCA_IPID register are either reserved or, on some
+modern AMD systems viz. Genoa, denote the InstanceIdHi value. The bits
+therefore, should not be associated with SMCA bank type decoding.
+
+Mask out bits 47:44 before matching the register against the cached
+(HWID, MCATYPE) tuples so that bank type decoding is not erroneous.
+
+This is a backport of upstream rasdaemon commit b6a64416 adapted to the
+0.8.0 (HWID, MCATYPE) tuple encoding, which does not repack the tuple
+table nor contain the fixup_hwid() helper introduced in later releases.
+---
+ mce-amd-smca.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/mce-amd-smca.c b/mce-amd-smca.c
+index 27ca8aa..53e1367 100644
+--- a/mce-amd-smca.c
++++ b/mce-amd-smca.c
+@@ -564,7 +564,16 @@ static void decode_smca_error(struct mce_event *e)
+ 	const char *ip_name;
+ 	unsigned short xec = (e->status >> 16) & 0x3f;
+ 	const struct smca_hwid *s_hwid;
+-	uint32_t mcatype_hwid = EXTRACT(e->ipid, 32, 63);
++	/*
++	 * Bits 47:44 of the MCA_IPID register do not play a part in SMCA bank
++	 * type decoding. They are either reserved or, on some modern AMD systems
++	 * (e.g. Genoa), denote the InstanceIdHi value. They are not guaranteed to
++	 * be zero, so mask them out before comparing against the (HWID, MCATYPE)
++	 * tuples cached in smca_hwid_mcatypes[]; otherwise bank type decoding can
++	 * be erroneous. Backport of upstream commit b6a64416 ("rasdaemon: Fix
++	 * SMCA bank type decoding") adapted to the 0.8.0 tuple encoding.
++	 */
++	uint32_t mcatype_hwid = EXTRACT(e->ipid, 32, 63) & ~0x0000f000U;
+ 	uint8_t mcatype_instancehi = EXTRACT(e->ipid, 44, 47);
+ 	unsigned int csrow = -1, channel = -1;
+ 	unsigned int i;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/rasdaemon/rasdaemon.spec
+++ b/SPECS/rasdaemon/rasdaemon.spec
@@ -2,11 +2,14 @@ Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Name:			rasdaemon
 Version:		0.8.0
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:		Utility to receive RAS error tracings
 License:		GPLv2
 URL:			http://git.infradead.org/users/mchehab/rasdaemon.git
 Source0:		http://www.infradead.org/~mchehab/rasdaemon/%{name}-%{version}.tar.bz2
+# Backport of upstream commit b6a64416 ("rasdaemon: Fix SMCA bank type
+# decoding") adapted to the 0.8.0 (HWID, MCATYPE) tuple encoding.
+Patch0:			0001-rasdaemon-Fix-SMCA-bank-type-decoding.patch
 
 ExcludeArch:		s390 s390x
 BuildRequires:		make
@@ -40,7 +43,7 @@ EDAC drivers and DIMM labels are loaded at system startup, as well as
 an utility for reporting current error counts from the EDAC sysfs files.
 
 %prep
-%setup -q
+%autosetup -p1
 autoreconf -vfi
 
 %build
@@ -75,6 +78,10 @@ rm INSTALL %{buildroot}/usr/include/*.h
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 
 %changelog
+* Wed Aug 05 2026 Andreas Zaugg <azaugg@linkedin.com> - 0.8.0-2
+- Backport upstream fix for SMCA bank type decoding (commit b6a64416) to
+  ignore MCA_IPID bits 47:44 (InstanceIdHi) on modern AMD systems.
+
 * Wed May 22 2024 Chris Co <chrco@microsoft.com> - 0.8.0-1
 - Update to version 0.8.0. From Fedora 40. License verified.
 


### PR DESCRIPTION
Backport upstream rasdaemon commit b6a64416 ("rasdaemon: Fix SMCA bank type decoding") as a patch instead of bumping the package version. The patch masks out MCA_IPID bits 47:44, which are either reserved or, on some modern AMD systems viz. Genoa, denote the InstanceIdHi value and therefore should not be associated with SMCA bank type decoding.

The upstream commit is adapted to the 0.8.0 (HWID, MCATYPE) tuple encoding, which neither repacks the tuple table nor contains the fixup_hwid() helper introduced in later releases. Release is bumped to 2.

Built package
```
processed_graph.dot
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/azurelinux/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Successfully created solvable subgraph
INFO[0000][scheduler] Building 26 nodes with 16 workers
INFO[0000][scheduler] Building: rasdaemon-0.8.0-2.azl3.src.rpm
INFO[0031][scheduler] Built: rasdaemon-0.8.0-2.azl3.src.rpm -> [/home/azaugg/azurelinux/out/RPMS/x86_64/rasdaemon-0.8.0-2.azl3.x86_64.rpm /home/azaugg/azurelinux/out/RPMS/x86_64/rasdaemon-debuginfo-0.8.0-2.azl3.x86_64.rpm]
INFO[0031][scheduler] 0 currently active build(s): [].
INFO[0031][scheduler] All packages built
INFO[0032][scheduler] ---------------------------
INFO[0032][scheduler] --------- Summary ---------
INFO[0032][scheduler] ---------------------------
```