### PR TITLE
feat(openssl): force SymCrypt as FIPS provider in kernel FIPS mode

### DIFF
--- a/base/comps/openssl/0080-azl-force-symcrypt-in-kernel-fips-mode.patch
+++ b/base/comps/openssl/0080-azl-force-symcrypt-in-kernel-fips-mode.patch
@@ -1,0 +1,652 @@
+From df00358b070084d74f8a29a606f89245527f0def Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Fri, 7 Aug 2026 03:11:02 +0000
+Subject: [PATCH] feat(fips): activate and prefer SymCrypt, enforce it in
+ kernel FIPS mode
+
+Azure Linux ships SymCrypt-OpenSSL as its FIPS provider. Drive it from
+the providers configuration module:
+
+- In all cases, ensure symcryptprovider is active. If the ambient
+  configuration already activated it, provider_conf_activate()
+  short-circuits on the already-active name check and this is a no-op.
+  Otherwise load the provider from its fixed, package-owned drop-in
+  (OPENSSLDIR/openssl.d/symcrypt_prov.cnf) so activation never depends
+  on the ambient configuration carrying the SymCrypt section. This is
+  what makes a later, unrelated OSSL_LIB_CTX_load_config() safe.
+
+- Base enforcement on actual provider state, not on whether the drop-in
+  load succeeded: consult the activation registry (a side-effect-free
+  state query) so an already-active SymCrypt satisfies enforcement even
+  when the fixed file is absent.
+
+- In all cases, merge the optional "?provider=symcryptprovider" default
+  property so SymCrypt is preferred while leaving fetches for algorithms
+  it does not provide free to resolve elsewhere.
+
+- In kernel FIPS mode, fail out of the configuration function if SymCrypt
+  is not active (a soft failure that does not abort when configuration
+  errors are ignored), and activate the base provider.
+
+- In kernel FIPS mode, merge the optional "?fips=yes" default property to
+  prefer FIPS-certified operations. It is intentionally optional:
+  SymCrypt's contract is to provide a FIPS-certified provider, not to
+  forbid non-approved algorithms, so FIPS_mode() intentionally stays
+  disabled.
+
+Preserve Fedora's config-module failure delivery; do not force
+configuration diagnostics.
+
+Add coverage for the property merges, kernel-FIPS enforcement, the
+inactive-but-configured case, and the unrelated-later-load guarantee.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Copilot-Session: 5f315f8d-6603-4659-8d14-4476bc265450
+---
+ crypto/evp/evp_fetch.c                        |   4 +-
+ crypto/provider_conf.c                        |  89 +++++--
+ include/crypto/evp.h                          |   2 +
+ test/build.info                               |   5 +
+ test/prov_conf_symcrypt.cnf                   |  16 ++
+ test/prov_conf_symcrypt_active.cnf            |  14 ++
+ test/prov_conf_symcrypt_app.cnf               |   7 +
+ test/prov_conf_symcrypt_missing.cnf           |  12 +
+ test/prov_conf_symcrypt_test.c                | 237 ++++++++++++++++++
+ test/recipes/03-test_prov_conf_symcrypt.t     |  26 ++
+ test/recipes/03-test_prov_conf_symcrypt_off.t |  38 +++
+ .../03-test_prov_conf_symcrypt_realinit.t     |  21 ++
+ 12 files changed, 453 insertions(+), 18 deletions(-)
+ create mode 100644 test/prov_conf_symcrypt.cnf
+ create mode 100644 test/prov_conf_symcrypt_active.cnf
+ create mode 100644 test/prov_conf_symcrypt_app.cnf
+ create mode 100644 test/prov_conf_symcrypt_missing.cnf
+ create mode 100644 test/prov_conf_symcrypt_test.c
+ create mode 100644 test/recipes/03-test_prov_conf_symcrypt.t
+ create mode 100644 test/recipes/03-test_prov_conf_symcrypt_off.t
+ create mode 100644 test/recipes/03-test_prov_conf_symcrypt_realinit.t
+
+diff --git a/crypto/evp/evp_fetch.c b/crypto/evp/evp_fetch.c
+index fbebca1..e300e5f 100644
+--- a/crypto/evp/evp_fetch.c
++++ b/crypto/evp/evp_fetch.c
+@@ -527,8 +527,8 @@ int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq)
+     return evp_set_default_properties_int(libctx, propq, 1, 0);
+ }
+ 
+-static int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq,
+-                                        int loadconfig)
++int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq,
++                                 int loadconfig)
+ {
+     OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, loadconfig);
+     OSSL_PROPERTY_LIST *pl1, *pl2;
+diff --git a/crypto/provider_conf.c b/crypto/provider_conf.c
+index 1e5053c..b1915fc 100644
+--- a/crypto/provider_conf.c
++++ b/crypto/provider_conf.c
+@@ -11,12 +11,12 @@
+ #include <openssl/trace.h>
+ #include <openssl/err.h>
+ #include <openssl/evp.h>
+-#include <unistd.h>
+ #include <openssl/conf.h>
+ #include <openssl/safestack.h>
+ #include <openssl/provider.h>
+ #include "internal/provider.h"
+ #include "internal/cryptlib.h"
++#include "crypto/evp.h"
+ #include "provider_local.h"
+ #include "crypto/context.h"
+ 
+@@ -424,28 +424,85 @@ static int provider_conf_init(CONF_IMODULE *md, const CONF *cnf)
+             return 0;
+     }
+ 
+-    if (ossl_get_kernel_fips_flag() != 0) { /* XXX from provider_conf_load */
++    {
+         OSSL_LIB_CTX *libctx = NCONF_get0_libctx((CONF *)cnf);
+-#  define FIPS_LOCAL_CONF           OPENSSLDIR "/fips_local.cnf"
++        int in_kernel_fips = ossl_get_kernel_fips_flag() != 0;
++        int symcrypt_active = 0;
++        CONF *sc_conf;
++        PROVIDER_CONF_GLOBAL *pcgbl;
++#  define AZL_SYMCRYPT_PROVIDER_NAME    "symcryptprovider"
++#  define AZL_SYMCRYPT_PROVIDER_SECTION "symcrypt_prov_sect"
++#  define AZL_SYMCRYPT_PROVIDER_CONF    OPENSSLDIR "/openssl.d/symcrypt_prov.cnf"
+ 
+-        if (access(FIPS_LOCAL_CONF, R_OK) == 0) {
+-            CONF *fips_conf = NCONF_new_ex(libctx, NCONF_default());
+-            if (NCONF_load(fips_conf, FIPS_LOCAL_CONF, NULL) <= 0)
++        /*
++         * In all cases, ensure SymCrypt (Azure Linux's FIPS provider) is
++         * active. If the ambient configuration already activated it,
++         * provider_conf_activate() short-circuits on the already-active name
++         * check and this is a no-op. Otherwise load the provider from its
++         * fixed, package-owned drop-in so activation never depends on the
++         * ambient configuration carrying the SymCrypt section (this is what
++         * makes a later, unrelated OSSL_LIB_CTX_load_config() safe).
++         *
++         * Use provider_conf_load() (not provider_conf_activate() directly) so
++         * the drop-in section's module=/identity=/activate= directives are
++         * honored, exactly as the ambient provider loop and Fedora's original
++         * fips_local.cnf handling do.
++         */
++        sc_conf = NCONF_new_ex(libctx, NCONF_default());
++        if (sc_conf != NULL
++                && NCONF_load(sc_conf, AZL_SYMCRYPT_PROVIDER_CONF, NULL) > 0
++                && NCONF_get_section(sc_conf,
++                                     AZL_SYMCRYPT_PROVIDER_SECTION) != NULL)
++            provider_conf_load(libctx, AZL_SYMCRYPT_PROVIDER_NAME,
++                               AZL_SYMCRYPT_PROVIDER_SECTION, sc_conf);
++        NCONF_free(sc_conf);
++
++        /*
++         * Enforcement below must reflect actual provider state, not merely
++         * whether our drop-in load succeeded: the ambient configuration's own
++         * drop-in may have already activated SymCrypt (and the fixed file may
++         * be absent). Consult the activation registry directly -- this is a
++         * pure state query with no fetch or fallback-loading side effects.
++         */
++        pcgbl = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_CONF_INDEX);
++        if (pcgbl != NULL && CRYPTO_THREAD_read_lock(pcgbl->lock)) {
++            symcrypt_active =
++                prov_already_activated(AZL_SYMCRYPT_PROVIDER_NAME,
++                                       pcgbl->activated_providers);
++            CRYPTO_THREAD_unlock(pcgbl->lock);
++        }
++
++        /*
++         * In all cases, prefer SymCrypt for algorithm fetches. The "?" makes
++         * this an optional preference, not a hard filter, so algorithms
++         * SymCrypt does not provide still resolve elsewhere.
++         */
++        if (evp_default_properties_merge(libctx,
++                                         "?provider=" AZL_SYMCRYPT_PROVIDER_NAME,
++                                         0) != 1)
++            return 0;
++
++        if (in_kernel_fips) {
++            /*
++             * In kernel FIPS mode, SymCrypt must be present. This is a soft
++             * failure: it fails out of the configuration function, which does
++             * not abort when configuration errors are ignored.
++             */
++            if (!symcrypt_active)
+                 return 0;
+ 
+-            if (provider_conf_load(libctx, "fips", "fips_sect", fips_conf) != 1) {
+-                NCONF_free(fips_conf);
++            if (provider_conf_activate(libctx, "base", NULL, NULL, 0, NULL) != 1)
+                 return 0;
+-            }
+-            NCONF_free(fips_conf);
+-        } else {
+-            if (provider_conf_activate(libctx, "fips", NULL, NULL, 0, NULL) != 1)
++
++            /*
++             * In kernel FIPS mode, prefer FIPS-certified operations. Optional
++             * by design: SymCrypt's contract is to provide a FIPS-certified
++             * provider, not to forbid non-approved algorithms, so FIPS_mode()
++             * intentionally remains disabled.
++             */
++            if (evp_default_properties_merge(libctx, "?fips=yes", 0) != 1)
+                 return 0;
+         }
+-        if (provider_conf_activate(libctx, "base", NULL, NULL, 0, NULL) != 1)
+-            return 0;
+-        if (EVP_default_properties_enable_fips(libctx, 1) != 1)
+-            return 0;
+     }
+ 
+     return 1;
+diff --git a/include/crypto/evp.h b/include/crypto/evp.h
+index 3f1eed3..16ca594 100644
+--- a/include/crypto/evp.h
++++ b/include/crypto/evp.h
+@@ -933,6 +933,8 @@ int evp_method_store_remove_all_provided(const OSSL_PROVIDER *prov);
+ 
+ int evp_default_properties_enable_fips_int(OSSL_LIB_CTX *libctx, int enable,
+                                            int loadconfig);
++int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq,
++                                 int loadconfig);
+ int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
+                                    int loadconfig, int mirrored);
+ char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig);
+diff --git a/test/build.info b/test/build.info
+index 3dca611..d557b60 100644
+--- a/test/build.info
++++ b/test/build.info
+@@ -1113,6 +1113,11 @@ IF[{- !$disabled{tests} -}]
+   INCLUDE[context_internal_test]=.. ../include ../apps/include
+   DEPEND[context_internal_test]=../libcrypto.a libtestutil.a
+ 
++  PROGRAMS{noinst}=prov_conf_symcrypt_test
++  SOURCE[prov_conf_symcrypt_test]=prov_conf_symcrypt_test.c
++  INCLUDE[prov_conf_symcrypt_test]=.. ../include ../apps/include
++  DEPEND[prov_conf_symcrypt_test]=../libcrypto.a libtestutil.a
++
+   IF[{- !$disabled{zlib} || !$disabled{brotli} || !$disabled{zstd} -}]
+     PROGRAMS{noinst}=bio_comp_test
+     SOURCE[bio_comp_test]=bio_comp_test.c
+diff --git a/test/prov_conf_symcrypt.cnf b/test/prov_conf_symcrypt.cnf
+new file mode 100644
+index 0000000..88a2d7b
+--- /dev/null
++++ b/test/prov_conf_symcrypt.cnf
+@@ -0,0 +1,16 @@
++openssl_conf = openssl_init
++
++# Match the shipped default: provider-module failures may be ignored by the
++# real OPENSSL_init_crypto() path.
++config_diagnostics = 0
++
++[openssl_init]
++providers = provider_sect
++
++[provider_sect]
++symcryptprovider = symcrypt_prov_sect
++
++[symcrypt_prov_sect]
++module = p_test.so
++activate = 0
++greeting = SymCrypt test provider
+diff --git a/test/prov_conf_symcrypt_active.cnf b/test/prov_conf_symcrypt_active.cnf
+new file mode 100644
+index 0000000..3383dce
+--- /dev/null
++++ b/test/prov_conf_symcrypt_active.cnf
+@@ -0,0 +1,14 @@
++openssl_conf = openssl_init
++
++config_diagnostics = 0
++
++[openssl_init]
++providers = provider_sect
++
++[provider_sect]
++symcryptprovider = symcrypt_prov_sect
++
++[symcrypt_prov_sect]
++module = p_test.so
++activate = 1
++greeting = SymCrypt test provider
+diff --git a/test/prov_conf_symcrypt_app.cnf b/test/prov_conf_symcrypt_app.cnf
+new file mode 100644
+index 0000000..f96252a
+--- /dev/null
++++ b/test/prov_conf_symcrypt_app.cnf
+@@ -0,0 +1,7 @@
++openssl_conf = openssl_init
++
++[openssl_init]
++alg_section = evp_properties
++
++[evp_properties]
++default_properties = app.prop=1
+diff --git a/test/prov_conf_symcrypt_missing.cnf b/test/prov_conf_symcrypt_missing.cnf
+new file mode 100644
+index 0000000..9ca89d5
+--- /dev/null
++++ b/test/prov_conf_symcrypt_missing.cnf
+@@ -0,0 +1,12 @@
++openssl_conf = openssl_init
++
++config_diagnostics = 0
++
++[openssl_init]
++providers = provider_sect
++
++[provider_sect]
++null = null_sect
++
++[null_sect]
++activate = 1
+diff --git a/test/prov_conf_symcrypt_test.c b/test/prov_conf_symcrypt_test.c
+new file mode 100644
+index 0000000..ce97f5d
+--- /dev/null
++++ b/test/prov_conf_symcrypt_test.c
+@@ -0,0 +1,237 @@
++/*
++ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++ *
++ * Licensed under the Apache License 2.0 (the "License").  You may not use
++ * this file except in compliance with the License.  You can obtain a copy
++ * in the file LICENSE in the source distribution or at
++ * https://www.openssl.org/source/license.html
++ */
++
++#include <stdlib.h>
++#include <string.h>
++#include <openssl/conf.h>
++#include <openssl/err.h>
++#include <openssl/evp.h>
++#include <openssl/provider.h>
++#include "crypto/evp.h"
++#include "testutil.h"
++
++/*
++ * Azure Linux drives SymCrypt activation from crypto/provider_conf.c. These
++ * tests exercise the observable contract, parametrized by whether the process
++ * is in kernel FIPS mode (argv: expect_kernel_fips = 0 or 1, forced by the
++ * recipes via OPENSSL_FORCE_FIPS_MODE):
++ *
++ *   - In all cases, once SymCrypt is active the default properties gain the
++ *     optional "?provider=symcryptprovider" preference.
++ *   - In kernel FIPS mode only, they additionally gain "?fips=yes", and the
++ *     "base" provider is activated.
++ *   - In kernel FIPS mode, a config that does not (directly or via an earlier
++ *     load) leave SymCrypt active fails to load; outside FIPS it loads.
++ *   - A later, unrelated config load does not re-require SymCrypt's section:
++ *     once SymCrypt is active in the libctx, subsequent loads succeed even in
++ *     FIPS mode (the property that makes PKCS#11 &c. config loads safe).
++ *
++ * The fixed package drop-in (OPENSSLDIR/openssl.d/symcrypt_prov.cnf) is not
++ * present in the build tree, so the pure "force from the fixed file" backstop
++ * is covered at package/integration level, not here. Here SymCrypt is made
++ * active through an ambient config using the p_test.so stub provider, which is
++ * exactly the normal-system path.
++ */
++
++static char *symcrypt_active_cnf = NULL; /* activates symcryptprovider */
++static char *symcrypt_inactive_cnf = NULL; /* configures but activate=0 */
++static char *missing_cnf = NULL;         /* unrelated: no symcrypt at all */
++static char *app_cnf = NULL;             /* sets default_properties=app.prop=1 */
++static int expect_kernel_fips = 0;
++
++static int has_property_token(const char *properties, const char *token)
++{
++    const char *start = properties;
++    size_t token_len = strlen(token);
++
++    while (start != NULL) {
++        const char *end = strchr(start, ',');
++        size_t len = end == NULL ? strlen(start) : (size_t)(end - start);
++
++        if (len == token_len && strncmp(start, token, len) == 0)
++            return 1;
++        start = end == NULL ? NULL : end + 1;
++    }
++    return 0;
++}
++
++/*
++ * Verify the default properties: the app-configured token is preserved, the
++ * SymCrypt preference is always merged, and the FIPS preference is merged iff
++ * we are in kernel FIPS mode.
++ */
++static int check_properties(OSSL_LIB_CTX *ctx)
++{
++    char *propstr = evp_get_global_properties_str(ctx, 0);
++    int testresult = 0;
++
++    if (!TEST_ptr(propstr))
++        return 0;
++    TEST_info("default properties: %s", propstr);
++
++    if (!TEST_true(has_property_token(propstr, "app.prop=1")))
++        goto err;
++    if (!TEST_true(has_property_token(propstr, "?provider=symcryptprovider")))
++        goto err;
++    if (expect_kernel_fips) {
++        if (!TEST_true(has_property_token(propstr, "?fips=yes")))
++            goto err;
++    } else if (!TEST_false(has_property_token(propstr, "?fips=yes"))) {
++        goto err;
++    }
++
++    testresult = 1;
++ err:
++    OPENSSL_free(propstr);
++    return testresult;
++}
++
++/*
++ * An ambient config that activates SymCrypt: the provider is available, the
++ * SymCrypt (and, in FIPS, FIPS + base) preferences are applied.
++ */
++static int test_active_ambient(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, app_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, symcrypt_active_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_PROVIDER_available(ctx, "symcryptprovider")))
++        goto err;
++    if (expect_kernel_fips
++            && !TEST_true(OSSL_PROVIDER_available(ctx, "base")))
++        goto err;
++    if (!check_properties(ctx))
++        goto err;
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++/*
++ * The DR-002 guarantee: once SymCrypt is active in the libctx, a later,
++ * unrelated config load (here one that mentions no SymCrypt section at all)
++ * must still succeed -- even in kernel FIPS mode. The old design failed this
++ * because it re-required symcrypt_prov_sect in every loaded config.
++ */
++static int test_unrelated_load_is_safe(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, app_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, symcrypt_active_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_PROVIDER_available(ctx, "symcryptprovider")))
++        goto err;
++    /* The unrelated load must not be rejected for lacking SymCrypt's section. */
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, missing_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_PROVIDER_available(ctx, "symcryptprovider")))
++        goto err;
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++/*
++ * With no path to an active SymCrypt (no ambient activation and no fixed
++ * drop-in in the build tree), kernel FIPS mode fails the config load; outside
++ * FIPS it loads.
++ */
++static int test_enforced_without_symcrypt(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int loaded;
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++
++    loaded = OSSL_LIB_CTX_load_config(ctx, missing_cnf);
++    if (expect_kernel_fips) {
++        if (!TEST_false(loaded))
++            goto err;
++        ERR_clear_error();
++    } else if (!TEST_true(loaded)) {
++        goto err;
++    }
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++/*
++ * Configuring SymCrypt without activating it (activate=0) is not sufficient:
++ * enforcement keys off actual activation, so kernel FIPS mode still fails.
++ */
++static int test_inactive_ambient_not_sufficient(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int loaded;
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, app_cnf)))
++        goto err;
++
++    loaded = OSSL_LIB_CTX_load_config(ctx, symcrypt_inactive_cnf);
++    if (expect_kernel_fips) {
++        if (!TEST_false(loaded))
++            goto err;
++        ERR_clear_error();
++    } else if (!TEST_true(loaded)) {
++        goto err;
++    }
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++OPT_TEST_DECLARE_USAGE("active_cnf inactive_cnf missing_cnf app_cnf expect_kernel_fips\n")
++
++int setup_tests(void)
++{
++    if (!test_skip_common_options()) {
++        TEST_error("Error parsing test options\n");
++        return 0;
++    }
++
++    if (!TEST_ptr(symcrypt_active_cnf = test_get_argument(0))
++            || !TEST_ptr(symcrypt_inactive_cnf = test_get_argument(1))
++            || !TEST_ptr(missing_cnf = test_get_argument(2))
++            || !TEST_ptr(app_cnf = test_get_argument(3))
++            || !TEST_ptr(test_get_argument(4)))
++        return 0;
++
++    expect_kernel_fips = atoi(test_get_argument(4)) != 0;
++
++    ADD_TEST(test_active_ambient);
++    ADD_TEST(test_unrelated_load_is_safe);
++    ADD_TEST(test_enforced_without_symcrypt);
++    ADD_TEST(test_inactive_ambient_not_sufficient);
++    return 1;
++}
+diff --git a/test/recipes/03-test_prov_conf_symcrypt.t b/test/recipes/03-test_prov_conf_symcrypt.t
+new file mode 100644
+index 0000000..a090992
+--- /dev/null
++++ b/test/recipes/03-test_prov_conf_symcrypt.t
+@@ -0,0 +1,26 @@
++#! /usr/bin/env perl
++# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++#
++# Licensed under the Apache License 2.0 (the "License").  You may not use
++# this file except in compliance with the License.  You can obtain a copy
++# in the file LICENSE in the source distribution or at
++# https://www.openssl.org/source/license.html
++
++use strict;
++use warnings;
++use OpenSSL::Test qw/:DEFAULT bldtop_dir srctop_file/;
++
++setup("test_prov_conf_symcrypt");
++
++plan tests => 1;
++
++$ENV{OPENSSL_FORCE_FIPS_MODE} = 1;
++$ENV{OPENSSL_MODULES} = bldtop_dir("test");
++
++ok(run(test(["prov_conf_symcrypt_test",
++             srctop_file("test", "prov_conf_symcrypt_active.cnf"),
++             srctop_file("test", "prov_conf_symcrypt.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_missing.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_app.cnf"),
++             "1"])),
++   "kernel FIPS mode enforces SymCrypt, merges ?provider/?fips, and keeps unrelated loads safe");
+diff --git a/test/recipes/03-test_prov_conf_symcrypt_off.t b/test/recipes/03-test_prov_conf_symcrypt_off.t
+new file mode 100644
+index 0000000..bb54ea7
+--- /dev/null
++++ b/test/recipes/03-test_prov_conf_symcrypt_off.t
+@@ -0,0 +1,38 @@
++#! /usr/bin/env perl
++# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++#
++# Licensed under the Apache License 2.0 (the "License").  You may not use
++# this file except in compliance with the License.  You can obtain a copy
++# in the file LICENSE in the source distribution or at
++# https://www.openssl.org/source/license.html
++
++use strict;
++use warnings;
++use OpenSSL::Test qw/:DEFAULT bldtop_dir srctop_file/;
++
++setup("test_prov_conf_symcrypt_off");
++
++delete $ENV{OPENSSL_FORCE_FIPS_MODE};
++
++my $host_fips = 0;
++if (open(my $fh, '<', '/proc/sys/crypto/fips_enabled')) {
++    my $val = <$fh>;
++    close($fh);
++    $host_fips = 1 if defined $val && $val =~ /^\s*1/;
++}
++
++plan skip_all =>
++    "host kernel is in FIPS mode; cannot exercise the non-FIPS path"
++    if $host_fips;
++
++plan tests => 1;
++
++$ENV{OPENSSL_MODULES} = bldtop_dir("test");
++
++ok(run(test(["prov_conf_symcrypt_test",
++             srctop_file("test", "prov_conf_symcrypt_active.cnf"),
++             srctop_file("test", "prov_conf_symcrypt.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_missing.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_app.cnf"),
++             "0"])),
++   "non-FIPS mode prefers SymCrypt without forcing it or merging ?fips=yes");
+diff --git a/test/recipes/03-test_prov_conf_symcrypt_realinit.t b/test/recipes/03-test_prov_conf_symcrypt_realinit.t
+new file mode 100644
+index 0000000..2fae905
+--- /dev/null
++++ b/test/recipes/03-test_prov_conf_symcrypt_realinit.t
+@@ -0,0 +1,21 @@
++#! /usr/bin/env perl
++# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++#
++# Licensed under the Apache License 2.0 (the "License").  You may not use
++# this file except in compliance with the License.  You can obtain a copy
++# in the file LICENSE in the source distribution or at
++# https://www.openssl.org/source/license.html
++
++use strict;
++use warnings;
++use OpenSSL::Test qw/:DEFAULT srctop_file/;
++
++setup("test_prov_conf_symcrypt_realinit");
++
++plan tests => 1;
++
++$ENV{OPENSSL_FORCE_FIPS_MODE} = 1;
++$ENV{OPENSSL_CONF} = srctop_file("test", "prov_conf_symcrypt_missing.cnf");
++
++ok(run(app(["openssl", "list", "-providers"])),
++   "real init retains Fedora's ignored provider-module failure behavior");
+-- 
+2.52.0
+

--- a/base/comps/openssl/openssl.comp.toml
+++ b/base/comps/openssl/openssl.comp.toml
@@ -7,19 +7,12 @@ spec = { type = "upstream", upstream-commit = "0990e54a2f6b6b8e4f3e238175382505f
 
 # Azure Linux does not ship fips.so. Extend the existing RHEL fips.so-deletion
 # path to cover Azure Linux so the module and its config are excluded from the
-# package.
+# package. This also enables the Requires: openssl-fips-provider guard, which
+# the SymCrypt overlay (overlays/0001-force-symcrypt-fips.overlay.toml)
+# rewrites to Requires: SymCrypt-OpenSSL.
 [[components.openssl.overlays]]
 type = "spec-search-replace"
 regex = '%if \( %\{defined rhel\} && \(! %\{defined centos\}\) && \(! %\{defined eln\}\) \)'
 replacement = '%if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || %{defined azurelinux}'
 description = "Remove fips.so from openssl on Azure Linux (not supported for public preview)"
-
-# The above replacement also hits the Requires: openssl-fips-provider guard.
-# Suppress that dependency on Azure Linux — openssl-fips-provider is not
-# shipped for public preview.
-[[components.openssl.overlays]]
-type = "spec-remove-tag"
-tag = "Requires"
-value = "openssl-fips-provider"
-package = "libs"
-description = "Don't require openssl-fips-provider on Azure Linux"
+metadata = { category = "azl-pruning", upstream-status = "inapplicable" }

--- a/base/comps/openssl/overlays/0001-force-symcrypt-fips.overlay.toml
+++ b/base/comps/openssl/overlays/0001-force-symcrypt-fips.overlay.toml
@@ -1,0 +1,39 @@
+# Force SymCrypt as Azure Linux's OpenSSL FIPS provider in kernel FIPS mode.
+# These overlays share one provenance: patch 0080 hard-codes SymCrypt as the
+# FIPS provider, which makes SymCrypt-OpenSSL a hard runtime dependency and
+# renders Fedora's fips_local.cnf symlink obsolete.
+[metadata]
+category = "azl-security-compliance"
+upstream-status = "inapplicable"
+
+# The fips.so-removal overlay (in openssl.comp.toml) also enables Fedora's
+# FIPS-provider dependency. Azure Linux uses SymCrypt-OpenSSL instead of
+# openssl-fips-provider. The version floor guarantees a build that ships the
+# OpenSSL 3 provider and its symcrypt_prov.cnf drop-in: the provider was
+# introduced in 1.4.0, and 1.11.0 is the release verified against OpenSSL 3.5.
+# Without the floor, an engine-only release would satisfy RPM while leaving the
+# hard-coded [symcrypt_prov_sect] section absent at runtime.
+[[overlays]]
+type = "spec-search-replace"
+regex = '^Requires: openssl-fips-provider$'
+replacement = 'Requires: SymCrypt-OpenSSL >= 1.11.0'
+description = "Replace Fedora's FIPS-provider dependency with SymCrypt"
+
+[[overlays]]
+type = "patch-add"
+source = "../0080-azl-force-symcrypt-in-kernel-fips-mode.patch"
+description = "Force SymCrypt with ?fips=yes when the kernel is in FIPS mode"
+
+# Fedora's force-FIPS patch reads fips_local.cnf to configure fips.so. Azure
+# Linux hard-codes SymCrypt instead, so the symlink is unused.
+[[overlays]]
+type = "spec-search-replace"
+regex = '^ln -s /etc/crypto-policies/back-ends/openssl_fips\.config \$RPM_BUILD_ROOT%\{_sysconfdir\}/pki/tls/fips_local\.cnf$'
+replacement = ''
+description = "Remove obsolete fips_local.cnf symlink creation"
+
+[[overlays]]
+type = "spec-search-replace"
+regex = '^%config %\{_sysconfdir\}/pki/tls/fips_local\.cnf$'
+replacement = ''
+description = "Remove obsolete fips_local.cnf from %files"

--- a/locks/openssl.lock
+++ b/locks/openssl.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = '8e2fde9ae8b83393b6d58c62492106751e52a696'
 upstream-commit = '0990e54a2f6b6b8e4f3e238175382505fff8be51'
-input-fingerprint = 'sha256:c3005ddb1be362e7d6627f19ba5a93f57b88525a0acd2ae2f560d208a0a00588'
+input-fingerprint = 'sha256:0e55a92abd4e376a25868756acac2e62bd9da1dfba0800c8eb41fa8adb412179'
 resolution-input-hash = 'sha256:888b19e73f615d9932deea30309a22436c3d0f059c9f14437204e2e1887dc692'

--- a/specs/o/openssl/0080-azl-force-symcrypt-in-kernel-fips-mode.patch
+++ b/specs/o/openssl/0080-azl-force-symcrypt-in-kernel-fips-mode.patch
@@ -1,0 +1,652 @@
+From df00358b070084d74f8a29a606f89245527f0def Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Fri, 7 Aug 2026 03:11:02 +0000
+Subject: [PATCH] feat(fips): activate and prefer SymCrypt, enforce it in
+ kernel FIPS mode
+
+Azure Linux ships SymCrypt-OpenSSL as its FIPS provider. Drive it from
+the providers configuration module:
+
+- In all cases, ensure symcryptprovider is active. If the ambient
+  configuration already activated it, provider_conf_activate()
+  short-circuits on the already-active name check and this is a no-op.
+  Otherwise load the provider from its fixed, package-owned drop-in
+  (OPENSSLDIR/openssl.d/symcrypt_prov.cnf) so activation never depends
+  on the ambient configuration carrying the SymCrypt section. This is
+  what makes a later, unrelated OSSL_LIB_CTX_load_config() safe.
+
+- Base enforcement on actual provider state, not on whether the drop-in
+  load succeeded: consult the activation registry (a side-effect-free
+  state query) so an already-active SymCrypt satisfies enforcement even
+  when the fixed file is absent.
+
+- In all cases, merge the optional "?provider=symcryptprovider" default
+  property so SymCrypt is preferred while leaving fetches for algorithms
+  it does not provide free to resolve elsewhere.
+
+- In kernel FIPS mode, fail out of the configuration function if SymCrypt
+  is not active (a soft failure that does not abort when configuration
+  errors are ignored), and activate the base provider.
+
+- In kernel FIPS mode, merge the optional "?fips=yes" default property to
+  prefer FIPS-certified operations. It is intentionally optional:
+  SymCrypt's contract is to provide a FIPS-certified provider, not to
+  forbid non-approved algorithms, so FIPS_mode() intentionally stays
+  disabled.
+
+Preserve Fedora's config-module failure delivery; do not force
+configuration diagnostics.
+
+Add coverage for the property merges, kernel-FIPS enforcement, the
+inactive-but-configured case, and the unrelated-later-load guarantee.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Copilot-Session: 5f315f8d-6603-4659-8d14-4476bc265450
+---
+ crypto/evp/evp_fetch.c                        |   4 +-
+ crypto/provider_conf.c                        |  89 +++++--
+ include/crypto/evp.h                          |   2 +
+ test/build.info                               |   5 +
+ test/prov_conf_symcrypt.cnf                   |  16 ++
+ test/prov_conf_symcrypt_active.cnf            |  14 ++
+ test/prov_conf_symcrypt_app.cnf               |   7 +
+ test/prov_conf_symcrypt_missing.cnf           |  12 +
+ test/prov_conf_symcrypt_test.c                | 237 ++++++++++++++++++
+ test/recipes/03-test_prov_conf_symcrypt.t     |  26 ++
+ test/recipes/03-test_prov_conf_symcrypt_off.t |  38 +++
+ .../03-test_prov_conf_symcrypt_realinit.t     |  21 ++
+ 12 files changed, 453 insertions(+), 18 deletions(-)
+ create mode 100644 test/prov_conf_symcrypt.cnf
+ create mode 100644 test/prov_conf_symcrypt_active.cnf
+ create mode 100644 test/prov_conf_symcrypt_app.cnf
+ create mode 100644 test/prov_conf_symcrypt_missing.cnf
+ create mode 100644 test/prov_conf_symcrypt_test.c
+ create mode 100644 test/recipes/03-test_prov_conf_symcrypt.t
+ create mode 100644 test/recipes/03-test_prov_conf_symcrypt_off.t
+ create mode 100644 test/recipes/03-test_prov_conf_symcrypt_realinit.t
+
+diff --git a/crypto/evp/evp_fetch.c b/crypto/evp/evp_fetch.c
+index fbebca1..e300e5f 100644
+--- a/crypto/evp/evp_fetch.c
++++ b/crypto/evp/evp_fetch.c
+@@ -527,8 +527,8 @@ int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq)
+     return evp_set_default_properties_int(libctx, propq, 1, 0);
+ }
+ 
+-static int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq,
+-                                        int loadconfig)
++int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq,
++                                 int loadconfig)
+ {
+     OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, loadconfig);
+     OSSL_PROPERTY_LIST *pl1, *pl2;
+diff --git a/crypto/provider_conf.c b/crypto/provider_conf.c
+index 1e5053c..b1915fc 100644
+--- a/crypto/provider_conf.c
++++ b/crypto/provider_conf.c
+@@ -11,12 +11,12 @@
+ #include <openssl/trace.h>
+ #include <openssl/err.h>
+ #include <openssl/evp.h>
+-#include <unistd.h>
+ #include <openssl/conf.h>
+ #include <openssl/safestack.h>
+ #include <openssl/provider.h>
+ #include "internal/provider.h"
+ #include "internal/cryptlib.h"
++#include "crypto/evp.h"
+ #include "provider_local.h"
+ #include "crypto/context.h"
+ 
+@@ -424,28 +424,85 @@ static int provider_conf_init(CONF_IMODULE *md, const CONF *cnf)
+             return 0;
+     }
+ 
+-    if (ossl_get_kernel_fips_flag() != 0) { /* XXX from provider_conf_load */
++    {
+         OSSL_LIB_CTX *libctx = NCONF_get0_libctx((CONF *)cnf);
+-#  define FIPS_LOCAL_CONF           OPENSSLDIR "/fips_local.cnf"
++        int in_kernel_fips = ossl_get_kernel_fips_flag() != 0;
++        int symcrypt_active = 0;
++        CONF *sc_conf;
++        PROVIDER_CONF_GLOBAL *pcgbl;
++#  define AZL_SYMCRYPT_PROVIDER_NAME    "symcryptprovider"
++#  define AZL_SYMCRYPT_PROVIDER_SECTION "symcrypt_prov_sect"
++#  define AZL_SYMCRYPT_PROVIDER_CONF    OPENSSLDIR "/openssl.d/symcrypt_prov.cnf"
+ 
+-        if (access(FIPS_LOCAL_CONF, R_OK) == 0) {
+-            CONF *fips_conf = NCONF_new_ex(libctx, NCONF_default());
+-            if (NCONF_load(fips_conf, FIPS_LOCAL_CONF, NULL) <= 0)
++        /*
++         * In all cases, ensure SymCrypt (Azure Linux's FIPS provider) is
++         * active. If the ambient configuration already activated it,
++         * provider_conf_activate() short-circuits on the already-active name
++         * check and this is a no-op. Otherwise load the provider from its
++         * fixed, package-owned drop-in so activation never depends on the
++         * ambient configuration carrying the SymCrypt section (this is what
++         * makes a later, unrelated OSSL_LIB_CTX_load_config() safe).
++         *
++         * Use provider_conf_load() (not provider_conf_activate() directly) so
++         * the drop-in section's module=/identity=/activate= directives are
++         * honored, exactly as the ambient provider loop and Fedora's original
++         * fips_local.cnf handling do.
++         */
++        sc_conf = NCONF_new_ex(libctx, NCONF_default());
++        if (sc_conf != NULL
++                && NCONF_load(sc_conf, AZL_SYMCRYPT_PROVIDER_CONF, NULL) > 0
++                && NCONF_get_section(sc_conf,
++                                     AZL_SYMCRYPT_PROVIDER_SECTION) != NULL)
++            provider_conf_load(libctx, AZL_SYMCRYPT_PROVIDER_NAME,
++                               AZL_SYMCRYPT_PROVIDER_SECTION, sc_conf);
++        NCONF_free(sc_conf);
++
++        /*
++         * Enforcement below must reflect actual provider state, not merely
++         * whether our drop-in load succeeded: the ambient configuration's own
++         * drop-in may have already activated SymCrypt (and the fixed file may
++         * be absent). Consult the activation registry directly -- this is a
++         * pure state query with no fetch or fallback-loading side effects.
++         */
++        pcgbl = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_CONF_INDEX);
++        if (pcgbl != NULL && CRYPTO_THREAD_read_lock(pcgbl->lock)) {
++            symcrypt_active =
++                prov_already_activated(AZL_SYMCRYPT_PROVIDER_NAME,
++                                       pcgbl->activated_providers);
++            CRYPTO_THREAD_unlock(pcgbl->lock);
++        }
++
++        /*
++         * In all cases, prefer SymCrypt for algorithm fetches. The "?" makes
++         * this an optional preference, not a hard filter, so algorithms
++         * SymCrypt does not provide still resolve elsewhere.
++         */
++        if (evp_default_properties_merge(libctx,
++                                         "?provider=" AZL_SYMCRYPT_PROVIDER_NAME,
++                                         0) != 1)
++            return 0;
++
++        if (in_kernel_fips) {
++            /*
++             * In kernel FIPS mode, SymCrypt must be present. This is a soft
++             * failure: it fails out of the configuration function, which does
++             * not abort when configuration errors are ignored.
++             */
++            if (!symcrypt_active)
+                 return 0;
+ 
+-            if (provider_conf_load(libctx, "fips", "fips_sect", fips_conf) != 1) {
+-                NCONF_free(fips_conf);
++            if (provider_conf_activate(libctx, "base", NULL, NULL, 0, NULL) != 1)
+                 return 0;
+-            }
+-            NCONF_free(fips_conf);
+-        } else {
+-            if (provider_conf_activate(libctx, "fips", NULL, NULL, 0, NULL) != 1)
++
++            /*
++             * In kernel FIPS mode, prefer FIPS-certified operations. Optional
++             * by design: SymCrypt's contract is to provide a FIPS-certified
++             * provider, not to forbid non-approved algorithms, so FIPS_mode()
++             * intentionally remains disabled.
++             */
++            if (evp_default_properties_merge(libctx, "?fips=yes", 0) != 1)
+                 return 0;
+         }
+-        if (provider_conf_activate(libctx, "base", NULL, NULL, 0, NULL) != 1)
+-            return 0;
+-        if (EVP_default_properties_enable_fips(libctx, 1) != 1)
+-            return 0;
+     }
+ 
+     return 1;
+diff --git a/include/crypto/evp.h b/include/crypto/evp.h
+index 3f1eed3..16ca594 100644
+--- a/include/crypto/evp.h
++++ b/include/crypto/evp.h
+@@ -933,6 +933,8 @@ int evp_method_store_remove_all_provided(const OSSL_PROVIDER *prov);
+ 
+ int evp_default_properties_enable_fips_int(OSSL_LIB_CTX *libctx, int enable,
+                                            int loadconfig);
++int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq,
++                                 int loadconfig);
+ int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
+                                    int loadconfig, int mirrored);
+ char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig);
+diff --git a/test/build.info b/test/build.info
+index 3dca611..d557b60 100644
+--- a/test/build.info
++++ b/test/build.info
+@@ -1113,6 +1113,11 @@ IF[{- !$disabled{tests} -}]
+   INCLUDE[context_internal_test]=.. ../include ../apps/include
+   DEPEND[context_internal_test]=../libcrypto.a libtestutil.a
+ 
++  PROGRAMS{noinst}=prov_conf_symcrypt_test
++  SOURCE[prov_conf_symcrypt_test]=prov_conf_symcrypt_test.c
++  INCLUDE[prov_conf_symcrypt_test]=.. ../include ../apps/include
++  DEPEND[prov_conf_symcrypt_test]=../libcrypto.a libtestutil.a
++
+   IF[{- !$disabled{zlib} || !$disabled{brotli} || !$disabled{zstd} -}]
+     PROGRAMS{noinst}=bio_comp_test
+     SOURCE[bio_comp_test]=bio_comp_test.c
+diff --git a/test/prov_conf_symcrypt.cnf b/test/prov_conf_symcrypt.cnf
+new file mode 100644
+index 0000000..88a2d7b
+--- /dev/null
++++ b/test/prov_conf_symcrypt.cnf
+@@ -0,0 +1,16 @@
++openssl_conf = openssl_init
++
++# Match the shipped default: provider-module failures may be ignored by the
++# real OPENSSL_init_crypto() path.
++config_diagnostics = 0
++
++[openssl_init]
++providers = provider_sect
++
++[provider_sect]
++symcryptprovider = symcrypt_prov_sect
++
++[symcrypt_prov_sect]
++module = p_test.so
++activate = 0
++greeting = SymCrypt test provider
+diff --git a/test/prov_conf_symcrypt_active.cnf b/test/prov_conf_symcrypt_active.cnf
+new file mode 100644
+index 0000000..3383dce
+--- /dev/null
++++ b/test/prov_conf_symcrypt_active.cnf
+@@ -0,0 +1,14 @@
++openssl_conf = openssl_init
++
++config_diagnostics = 0
++
++[openssl_init]
++providers = provider_sect
++
++[provider_sect]
++symcryptprovider = symcrypt_prov_sect
++
++[symcrypt_prov_sect]
++module = p_test.so
++activate = 1
++greeting = SymCrypt test provider
+diff --git a/test/prov_conf_symcrypt_app.cnf b/test/prov_conf_symcrypt_app.cnf
+new file mode 100644
+index 0000000..f96252a
+--- /dev/null
++++ b/test/prov_conf_symcrypt_app.cnf
+@@ -0,0 +1,7 @@
++openssl_conf = openssl_init
++
++[openssl_init]
++alg_section = evp_properties
++
++[evp_properties]
++default_properties = app.prop=1
+diff --git a/test/prov_conf_symcrypt_missing.cnf b/test/prov_conf_symcrypt_missing.cnf
+new file mode 100644
+index 0000000..9ca89d5
+--- /dev/null
++++ b/test/prov_conf_symcrypt_missing.cnf
+@@ -0,0 +1,12 @@
++openssl_conf = openssl_init
++
++config_diagnostics = 0
++
++[openssl_init]
++providers = provider_sect
++
++[provider_sect]
++null = null_sect
++
++[null_sect]
++activate = 1
+diff --git a/test/prov_conf_symcrypt_test.c b/test/prov_conf_symcrypt_test.c
+new file mode 100644
+index 0000000..ce97f5d
+--- /dev/null
++++ b/test/prov_conf_symcrypt_test.c
+@@ -0,0 +1,237 @@
++/*
++ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++ *
++ * Licensed under the Apache License 2.0 (the "License").  You may not use
++ * this file except in compliance with the License.  You can obtain a copy
++ * in the file LICENSE in the source distribution or at
++ * https://www.openssl.org/source/license.html
++ */
++
++#include <stdlib.h>
++#include <string.h>
++#include <openssl/conf.h>
++#include <openssl/err.h>
++#include <openssl/evp.h>
++#include <openssl/provider.h>
++#include "crypto/evp.h"
++#include "testutil.h"
++
++/*
++ * Azure Linux drives SymCrypt activation from crypto/provider_conf.c. These
++ * tests exercise the observable contract, parametrized by whether the process
++ * is in kernel FIPS mode (argv: expect_kernel_fips = 0 or 1, forced by the
++ * recipes via OPENSSL_FORCE_FIPS_MODE):
++ *
++ *   - In all cases, once SymCrypt is active the default properties gain the
++ *     optional "?provider=symcryptprovider" preference.
++ *   - In kernel FIPS mode only, they additionally gain "?fips=yes", and the
++ *     "base" provider is activated.
++ *   - In kernel FIPS mode, a config that does not (directly or via an earlier
++ *     load) leave SymCrypt active fails to load; outside FIPS it loads.
++ *   - A later, unrelated config load does not re-require SymCrypt's section:
++ *     once SymCrypt is active in the libctx, subsequent loads succeed even in
++ *     FIPS mode (the property that makes PKCS#11 &c. config loads safe).
++ *
++ * The fixed package drop-in (OPENSSLDIR/openssl.d/symcrypt_prov.cnf) is not
++ * present in the build tree, so the pure "force from the fixed file" backstop
++ * is covered at package/integration level, not here. Here SymCrypt is made
++ * active through an ambient config using the p_test.so stub provider, which is
++ * exactly the normal-system path.
++ */
++
++static char *symcrypt_active_cnf = NULL; /* activates symcryptprovider */
++static char *symcrypt_inactive_cnf = NULL; /* configures but activate=0 */
++static char *missing_cnf = NULL;         /* unrelated: no symcrypt at all */
++static char *app_cnf = NULL;             /* sets default_properties=app.prop=1 */
++static int expect_kernel_fips = 0;
++
++static int has_property_token(const char *properties, const char *token)
++{
++    const char *start = properties;
++    size_t token_len = strlen(token);
++
++    while (start != NULL) {
++        const char *end = strchr(start, ',');
++        size_t len = end == NULL ? strlen(start) : (size_t)(end - start);
++
++        if (len == token_len && strncmp(start, token, len) == 0)
++            return 1;
++        start = end == NULL ? NULL : end + 1;
++    }
++    return 0;
++}
++
++/*
++ * Verify the default properties: the app-configured token is preserved, the
++ * SymCrypt preference is always merged, and the FIPS preference is merged iff
++ * we are in kernel FIPS mode.
++ */
++static int check_properties(OSSL_LIB_CTX *ctx)
++{
++    char *propstr = evp_get_global_properties_str(ctx, 0);
++    int testresult = 0;
++
++    if (!TEST_ptr(propstr))
++        return 0;
++    TEST_info("default properties: %s", propstr);
++
++    if (!TEST_true(has_property_token(propstr, "app.prop=1")))
++        goto err;
++    if (!TEST_true(has_property_token(propstr, "?provider=symcryptprovider")))
++        goto err;
++    if (expect_kernel_fips) {
++        if (!TEST_true(has_property_token(propstr, "?fips=yes")))
++            goto err;
++    } else if (!TEST_false(has_property_token(propstr, "?fips=yes"))) {
++        goto err;
++    }
++
++    testresult = 1;
++ err:
++    OPENSSL_free(propstr);
++    return testresult;
++}
++
++/*
++ * An ambient config that activates SymCrypt: the provider is available, the
++ * SymCrypt (and, in FIPS, FIPS + base) preferences are applied.
++ */
++static int test_active_ambient(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, app_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, symcrypt_active_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_PROVIDER_available(ctx, "symcryptprovider")))
++        goto err;
++    if (expect_kernel_fips
++            && !TEST_true(OSSL_PROVIDER_available(ctx, "base")))
++        goto err;
++    if (!check_properties(ctx))
++        goto err;
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++/*
++ * The DR-002 guarantee: once SymCrypt is active in the libctx, a later,
++ * unrelated config load (here one that mentions no SymCrypt section at all)
++ * must still succeed -- even in kernel FIPS mode. The old design failed this
++ * because it re-required symcrypt_prov_sect in every loaded config.
++ */
++static int test_unrelated_load_is_safe(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, app_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, symcrypt_active_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_PROVIDER_available(ctx, "symcryptprovider")))
++        goto err;
++    /* The unrelated load must not be rejected for lacking SymCrypt's section. */
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, missing_cnf)))
++        goto err;
++    if (!TEST_true(OSSL_PROVIDER_available(ctx, "symcryptprovider")))
++        goto err;
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++/*
++ * With no path to an active SymCrypt (no ambient activation and no fixed
++ * drop-in in the build tree), kernel FIPS mode fails the config load; outside
++ * FIPS it loads.
++ */
++static int test_enforced_without_symcrypt(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int loaded;
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++
++    loaded = OSSL_LIB_CTX_load_config(ctx, missing_cnf);
++    if (expect_kernel_fips) {
++        if (!TEST_false(loaded))
++            goto err;
++        ERR_clear_error();
++    } else if (!TEST_true(loaded)) {
++        goto err;
++    }
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++/*
++ * Configuring SymCrypt without activating it (activate=0) is not sufficient:
++ * enforcement keys off actual activation, so kernel FIPS mode still fails.
++ */
++static int test_inactive_ambient_not_sufficient(void)
++{
++    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
++    int loaded;
++    int testresult = 0;
++
++    if (!TEST_ptr(ctx))
++        return 0;
++    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, app_cnf)))
++        goto err;
++
++    loaded = OSSL_LIB_CTX_load_config(ctx, symcrypt_inactive_cnf);
++    if (expect_kernel_fips) {
++        if (!TEST_false(loaded))
++            goto err;
++        ERR_clear_error();
++    } else if (!TEST_true(loaded)) {
++        goto err;
++    }
++
++    testresult = 1;
++ err:
++    OSSL_LIB_CTX_free(ctx);
++    return testresult;
++}
++
++OPT_TEST_DECLARE_USAGE("active_cnf inactive_cnf missing_cnf app_cnf expect_kernel_fips\n")
++
++int setup_tests(void)
++{
++    if (!test_skip_common_options()) {
++        TEST_error("Error parsing test options\n");
++        return 0;
++    }
++
++    if (!TEST_ptr(symcrypt_active_cnf = test_get_argument(0))
++            || !TEST_ptr(symcrypt_inactive_cnf = test_get_argument(1))
++            || !TEST_ptr(missing_cnf = test_get_argument(2))
++            || !TEST_ptr(app_cnf = test_get_argument(3))
++            || !TEST_ptr(test_get_argument(4)))
++        return 0;
++
++    expect_kernel_fips = atoi(test_get_argument(4)) != 0;
++
++    ADD_TEST(test_active_ambient);
++    ADD_TEST(test_unrelated_load_is_safe);
++    ADD_TEST(test_enforced_without_symcrypt);
++    ADD_TEST(test_inactive_ambient_not_sufficient);
++    return 1;
++}
+diff --git a/test/recipes/03-test_prov_conf_symcrypt.t b/test/recipes/03-test_prov_conf_symcrypt.t
+new file mode 100644
+index 0000000..a090992
+--- /dev/null
++++ b/test/recipes/03-test_prov_conf_symcrypt.t
+@@ -0,0 +1,26 @@
++#! /usr/bin/env perl
++# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++#
++# Licensed under the Apache License 2.0 (the "License").  You may not use
++# this file except in compliance with the License.  You can obtain a copy
++# in the file LICENSE in the source distribution or at
++# https://www.openssl.org/source/license.html
++
++use strict;
++use warnings;
++use OpenSSL::Test qw/:DEFAULT bldtop_dir srctop_file/;
++
++setup("test_prov_conf_symcrypt");
++
++plan tests => 1;
++
++$ENV{OPENSSL_FORCE_FIPS_MODE} = 1;
++$ENV{OPENSSL_MODULES} = bldtop_dir("test");
++
++ok(run(test(["prov_conf_symcrypt_test",
++             srctop_file("test", "prov_conf_symcrypt_active.cnf"),
++             srctop_file("test", "prov_conf_symcrypt.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_missing.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_app.cnf"),
++             "1"])),
++   "kernel FIPS mode enforces SymCrypt, merges ?provider/?fips, and keeps unrelated loads safe");
+diff --git a/test/recipes/03-test_prov_conf_symcrypt_off.t b/test/recipes/03-test_prov_conf_symcrypt_off.t
+new file mode 100644
+index 0000000..bb54ea7
+--- /dev/null
++++ b/test/recipes/03-test_prov_conf_symcrypt_off.t
+@@ -0,0 +1,38 @@
++#! /usr/bin/env perl
++# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++#
++# Licensed under the Apache License 2.0 (the "License").  You may not use
++# this file except in compliance with the License.  You can obtain a copy
++# in the file LICENSE in the source distribution or at
++# https://www.openssl.org/source/license.html
++
++use strict;
++use warnings;
++use OpenSSL::Test qw/:DEFAULT bldtop_dir srctop_file/;
++
++setup("test_prov_conf_symcrypt_off");
++
++delete $ENV{OPENSSL_FORCE_FIPS_MODE};
++
++my $host_fips = 0;
++if (open(my $fh, '<', '/proc/sys/crypto/fips_enabled')) {
++    my $val = <$fh>;
++    close($fh);
++    $host_fips = 1 if defined $val && $val =~ /^\s*1/;
++}
++
++plan skip_all =>
++    "host kernel is in FIPS mode; cannot exercise the non-FIPS path"
++    if $host_fips;
++
++plan tests => 1;
++
++$ENV{OPENSSL_MODULES} = bldtop_dir("test");
++
++ok(run(test(["prov_conf_symcrypt_test",
++             srctop_file("test", "prov_conf_symcrypt_active.cnf"),
++             srctop_file("test", "prov_conf_symcrypt.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_missing.cnf"),
++             srctop_file("test", "prov_conf_symcrypt_app.cnf"),
++             "0"])),
++   "non-FIPS mode prefers SymCrypt without forcing it or merging ?fips=yes");
+diff --git a/test/recipes/03-test_prov_conf_symcrypt_realinit.t b/test/recipes/03-test_prov_conf_symcrypt_realinit.t
+new file mode 100644
+index 0000000..2fae905
+--- /dev/null
++++ b/test/recipes/03-test_prov_conf_symcrypt_realinit.t
+@@ -0,0 +1,21 @@
++#! /usr/bin/env perl
++# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
++#
++# Licensed under the Apache License 2.0 (the "License").  You may not use
++# this file except in compliance with the License.  You can obtain a copy
++# in the file LICENSE in the source distribution or at
++# https://www.openssl.org/source/license.html
++
++use strict;
++use warnings;
++use OpenSSL::Test qw/:DEFAULT srctop_file/;
++
++setup("test_prov_conf_symcrypt_realinit");
++
++plan tests => 1;
++
++$ENV{OPENSSL_FORCE_FIPS_MODE} = 1;
++$ENV{OPENSSL_CONF} = srctop_file("test", "prov_conf_symcrypt_missing.cnf");
++
++ok(run(app(["openssl", "list", "-providers"])),
++   "real init retains Fedora's ignored provider-module failure behavior");
+-- 
+2.52.0
+

--- a/specs/o/openssl/openssl.spec
+++ b/specs/o/openssl/openssl.spec
@@ -37,7 +37,7 @@ print(string.sub(hash, 0, 16))
 Summary: Utilities from the general purpose cryptography library with TLS implementation
 Name: openssl
 Version: 3.5.4
-Release: 7%{?dist}
+Release: 8%{?dist}
 Epoch: 1
 Source0: openssl-%{version}.tar.gz
 Source1: fips-hmacify.sh
@@ -147,6 +147,7 @@ Requires: coreutils
 Requires: %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
 Obsoletes: oqsprovider < 0.9.0
 
+Patch80: 0080-azl-force-symcrypt-in-kernel-fips-mode.patch
 %description
 The OpenSSL toolkit provides support for secure communications between
 machines. OpenSSL includes a certificate management tool and shared
@@ -159,6 +160,7 @@ Requires: ca-certificates >= 2008-5
 Requires: crypto-policies >= 20180730
 Recommends: pkcs11-provider%{?_isa}
 %if ( %{defined rhel} && (! %{defined centos}) && (! %{defined eln}) ) || %{defined azurelinux}
+Requires: SymCrypt-OpenSSL >= 1.11.0
 %endif
 
 %description libs
@@ -435,7 +437,7 @@ cat $RPM_BUILD_ROOT/%{_prefix}/include/openssl/configuration.h >> \
 install -m644 %{SOURCE9} \
 	$RPM_BUILD_ROOT/%{_prefix}/include/openssl/configuration.h
 %endif
-ln -s /etc/crypto-policies/back-ends/openssl_fips.config $RPM_BUILD_ROOT%{_sysconfdir}/pki/tls/fips_local.cnf
+
 
 %files
 %{!?_licensedir:%global license %%doc}
@@ -458,7 +460,7 @@ ln -s /etc/crypto-policies/back-ends/openssl_fips.config $RPM_BUILD_ROOT%{_sysco
 %dir %{_sysconfdir}/pki/tls/openssl.d
 %config(noreplace) %{_sysconfdir}/pki/tls/openssl.cnf
 %config(noreplace) %{_sysconfdir}/pki/tls/ct_log_list.cnf
-%config %{_sysconfdir}/pki/tls/fips_local.cnf
+
 %attr(0755,root,root) %{_libdir}/libcrypto.so.%{version}
 %{_libdir}/libcrypto.so.%{soversion}
 %attr(0755,root,root) %{_libdir}/libssl.so.%{version}


### PR DESCRIPTION
Replaces Fedora's fips.so/fips_local.cnf activation with Azure Linux's SymCrypt provider.

The openssl config-time provider module now enforces the following in `crypto/provider_conf.c`:

**All cases (FIPS or not):**
- Ensure `symcryptprovider` is activated — best-effort load of the fixed drop-in at `<openssldir>/openssl.d/symcrypt_prov.cnf` (via `provider_conf_load`, so the drop-in's `module=`/`identity=` are honored), then read the authoritative active state from the activation registry.
- Merge best-effort `?provider=symcryptprovider` into the default property query, so SymCrypt is preferred when present, without disturbing application-configured properties.

**Kernel FIPS mode only:**
- If `symcryptprovider` is not active, fail configuration (soft-fail).
- Otherwise activate `base` and merge best-effort `?fips=yes`.

The property merges (`?provider`, `?fips=yes`) are additive and optional by design: SymCrypt provides certified crypto but does not forbid non-approved algorithms, and it under-advertises some approved operations, so a mandatory `fips=yes` would break real usage. Application-set default properties are preserved.

[AB#23016](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/23016)

- Patch80 hard-codes `symcryptprovider`/`symcrypt_prov_sect`, matching the drop-in shipped by SymCrypt-OpenSSL.
- `openssl-libs` now requires `SymCrypt-OpenSSL` instead of `openssl-fips-provider`.
- Drops the obsolete `fips_local.cnf` symlink and `%files` entry.

Validation:
- Builds locally and on build server.
- Bundled unit tests (`test_prov_conf_symcrypt` + `_off`) cover the active/inactive/missing/unrelated-load cases in both FIPS and non-FIPS mode.
- Verified the fixed-path backstop live: an ambient config with no SymCrypt entry plus a fixed drop-in still activates `symcryptprovider`; removing the drop-in makes it disappear.
- Created a new VM with a local dnf repo with the updated `openssl` rpms. Updated `openssl`, put the machine into kernel FIPS mode and rebooted. I was able to `ssh` into the machine, do general `openssl` operations and `dnf --refresh` install something (which is a real-world usage of `openssl`).
