### PR TITLE
Resolved `ptest` failures in `ocaml-fmt` package

### DIFF
--- a/SPECS/ocaml-fmt/ocaml-fmt-0.9.0-dont-run-perf-bug-benchmark.patch
+++ b/SPECS/ocaml-fmt/ocaml-fmt-0.9.0-dont-run-perf-bug-benchmark.patch
@@ -1,0 +1,21 @@
+pkg/pkg.ml: build but do not run the styled_perf_bug benchmark
+
+test/styled_perf_bug.ml is an infinite-loop (`while true do ... done`)
+micro-benchmark that prints formatting throughput forever ("Formatted N
+messages/second"). It is a manual reproducer for a styling performance bug,
+not a pass/fail test. Registered with a plain `Pkg.test`, it is executed by
+`ocaml pkg/pkg.ml test` (the %check step) and never returns, so the package
+build hangs until the CI 4h timeout.
+
+Mark it `~run:false` (topkg's build-only mode) so the executable is still
+compiled -- keeping build coverage -- but is not run. test/test still runs.
+
+--- a/pkg/pkg.ml
++++ b/pkg/pkg.ml
+@@ -16,5 +16,5 @@
+        Pkg.mllib ~api:[] "src/fmt_top.mllib";
+        Pkg.lib "src/fmt_tty_top_init.ml";
+        Pkg.test "test/test";
+-       Pkg.test "test/styled_perf_bug";
++       Pkg.test ~run:false "test/styled_perf_bug";
+      ]

--- a/SPECS/ocaml-fmt/ocaml-fmt.spec
+++ b/SPECS/ocaml-fmt/ocaml-fmt.spec
@@ -7,12 +7,15 @@
 Summary:        OCaml Format pretty-printer combinators
 Name:           ocaml-%{srcname}
 Version:        0.9.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://erratique.ch/software/fmt
 Source0:        https://github.com/dbuenzli/fmt/archive/v%{version}/%{srcname}-%{version}.tar.gz
+# test/styled_perf_bug is an infinite-loop throughput benchmark (not a pass/fail
+# test); mark it build-only so `pkg.ml test` (%check) doesn't hang until timeout.
+Patch0:         ocaml-fmt-0.9.0-dont-run-perf-bug-benchmark.patch
 
 BuildRequires:  ocaml >= 4.05.0
 BuildRequires:  ocaml-cmdliner-devel >= 0.9.8
@@ -101,6 +104,11 @@ ocaml pkg/pkg.ml test
 %{_libdir}/ocaml/%{srcname}/%{srcname}*.mli
 
 %changelog
+* Mon Jul 20 2026 Sumit Jena <v-sumitjena@microsoft.com> - 0.9.0-2
+- Mark test/styled_perf_bug as build-only (~run:false) in pkg/pkg.ml (Patch0);
+  it is an infinite-loop throughput benchmark that hung `pkg.ml test` in %%check
+  until the build timed out. test/test still runs.
+
 * Tue Jun 04 2024 Andrew Phelps <anphel@microsoft.com> - 0.9.0-1
 - Upgrade to version 0.9.0
 


### PR DESCRIPTION
###### Merge Checklist

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary

What does the PR accomplish, why was it needed?

This PR is to fix the existing ptest failures for the `ocaml-fmt` package.

`test/styled_perf_bug` is a throughput benchmark rather than a pass/fail test: it loops indefinitely to measure formatting performance. Because `pkg/pkg.ml` registered it as a runnable test, the `pkg.ml test` invocation in `%check` never returned and the package build hung until it timed out.

`Patch0` marks that target as build-only (`~run:false`), so it is still compiled (keeping build coverage) but no longer executed during `%check`. The real `test/test` suite continues to run and is still enforced.

###### Change Log

- SPECS/ocaml-fmt/ocaml-fmt.spec
- SPECS/ocaml-fmt/ocaml-fmt-0.9.0-dont-run-perf-bug-benchmark.patch

###### Does this affect the toolchain?

**NO**

###### Associated issues

- #xxxx

###### Links to CVEs

- None

###### Test Methodology

- Local Build
