### PR TITLE
Resolved `ptest` failures in `meson` package

### DIFF
--- a/SPECS/meson/meson.spec
+++ b/SPECS/meson/meson.spec
@@ -1,7 +1,7 @@
 Summary:        Extremely fast and user friendly build system
 Name:           meson
 Version:        1.3.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -20,6 +20,10 @@ BuildRequires:  cmake
 BuildRequires:  gtest
 BuildRequires:  gmock
 BuildRequires:  git
+# Let meson's unit test suite run in parallel via pytest (-n auto) instead of
+# falling back to slow sequential unittest execution.
+BuildRequires:  python3-pytest
+BuildRequires:  python3-pytest-xdist
 %endif
 
 Requires:       ninja-build
@@ -67,6 +71,12 @@ python3 ./run_tests.py
 %{_datadir}/polkit-1/actions/com.mesonbuild.install.policy
 
 %changelog
+* Wed Jul 22 2026 Sumit Jena <v-sumitjena@microsoft.com> - 1.3.1-2
+- Add python3-pytest and python3-pytest-xdist build dependencies so meson's
+  unit test suite runs in parallel via pytest (-n auto) instead of the slow
+  sequential unittest fallback, substantially reducing %check runtime and
+  avoiding pipeline test timeouts.
+
 * Thu Feb 29 2024 Betty Lakes <bettylakes@microsoft.com> - 1.3.1-1
 - Update version to 1.3.1
 - Remove flaky and unsupported tests

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -262,7 +262,7 @@ m4-1.4.19-2.azl3.aarch64.rpm
 m4-debuginfo-1.4.19-2.azl3.aarch64.rpm
 make-4.4.1-2.azl3.aarch64.rpm
 make-debuginfo-4.4.1-2.azl3.aarch64.rpm
-meson-1.3.1-1.azl3.noarch.rpm
+meson-1.3.1-2.azl3.noarch.rpm
 mpfr-4.2.1-1.azl3.aarch64.rpm
 mpfr-debuginfo-4.2.1-1.azl3.aarch64.rpm
 mpfr-devel-4.2.1-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -270,7 +270,7 @@ m4-1.4.19-2.azl3.x86_64.rpm
 m4-debuginfo-1.4.19-2.azl3.x86_64.rpm
 make-4.4.1-2.azl3.x86_64.rpm
 make-debuginfo-4.4.1-2.azl3.x86_64.rpm
-meson-1.3.1-1.azl3.noarch.rpm
+meson-1.3.1-2.azl3.noarch.rpm
 mpfr-4.2.1-1.azl3.x86_64.rpm
 mpfr-debuginfo-4.2.1-1.azl3.x86_64.rpm
 mpfr-devel-4.2.1-1.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary

What does the PR accomplish, why was it needed?

This PR is to fix the existing ptest failures for the `meson` package.

Meson's `%check` intermittently exceeds the build/test time budget. The test log shows the cause:

```
pytest not found, using unittest instead
Ran 507 tests in 10851.272s
```

`run_unittests.py` runs the unit suite through `pytest -n auto` (distributed across all cores via `pytest-xdist`) when both modules are importable, and otherwise falls back to a strictly sequential `unittest` run. Because neither `pytest` nor `pytest-xdist` was a build dependency, meson always took the slow path: the unit phase alone took roughly three hours, pushing the whole `%check` to about 3.5 hours. The project-test phase was unaffected because it already parallelises itself (16 workers, ~21 minutes).

Adding `python3-pytest` and `python3-pytest-xdist` as test-only build dependencies restores the intended parallel path. No tests are skipped or disabled: the same set of tests still runs, just concurrently.

###### Change Log

- SPECS/meson/meson.spec

###### Does this affect the toolchain?

**NO**

###### Associated issues

- #xxxx

###### Links to CVEs

- None

###### Test Methodology

- Local Build. With `pytest` and `pytest-xdist` available, the `AllPlatformTests` and `LinuxlikeTests` classes complete in 109s versus 530s sequentially (~5x faster), reporting `212 passed, 36 skipped, 0 failed` — identical coverage.
