### PR TITLE
[High] patch python-cryptography for CVE-2026-69249.

### DIFF
--- a/SPECS/python-cryptography/CVE-2026-69249.patch
+++ b/SPECS/python-cryptography/CVE-2026-69249.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add a signature validation budget during path construction
 
 Backported to cryptography 42.0.5.
 
-Upstream Patch Reference: https://github.com/pyca/cryptography/commit/4a12cf49675a184e47f912b00b04f3a629283582
+Upstream Patch Reference: https://github.com/pyca/cryptography/commit/4a12cf49675a184e47f912b00b04f3a629283582.patch
 
 ---
  src/rust/cryptography-x509-verification/src/lib.rs        | 79 ++++++++++++++++++--

--- a/SPECS/python-cryptography/CVE-2026-69249.patch
+++ b/SPECS/python-cryptography/CVE-2026-69249.patch
@@ -1,0 +1,186 @@
+From 4a12cf49675a184e47f912b00b04f3a629283582 Mon Sep 17 00:00:00 2001
+From: William Woodruff <william@yossarian.net>
+Date: Sat, 6 Jun 2026 23:30:03 -0400
+Subject: [PATCH] Add a signature validation budget during path construction
+ (#14960)
+
+Backported to cryptography 42.0.5.
+
+Upstream Patch Reference: https://github.com/pyca/cryptography/commit/4a12cf49675a184e47f912b00b04f3a629283582
+
+---
+ src/rust/cryptography-x509-verification/src/lib.rs        | 79 ++++++++++++++++++--
+ src/rust/cryptography-x509-verification/src/policy/mod.rs |  7 ++
+ 2 files changed, 77 insertions(+), 9 deletions(-)
+
+--- a/src/rust/cryptography-x509-verification/src/lib.rs
++++ b/src/rust/cryptography-x509-verification/src/lib.rs
+@@ -13,11 +13,16 @@
+ 
+ use std::vec;
+ 
+-use cryptography_x509::extensions::{DuplicateExtensionsError, Extensions};
++use cryptography_x509::extensions::{
++    AuthorityKeyIdentifier, DuplicateExtensionsError, Extensions,
++};
+ use cryptography_x509::{
+     extensions::{NameConstraints, SubjectAlternativeName},
+     name::GeneralName,
+-    oid::{NAME_CONSTRAINTS_OID, SUBJECT_ALTERNATIVE_NAME_OID},
++    oid::{
++        AUTHORITY_KEY_IDENTIFIER_OID, NAME_CONSTRAINTS_OID, SUBJECT_ALTERNATIVE_NAME_OID,
++        SUBJECT_KEY_IDENTIFIER_OID,
++    },
+ };
+ 
+ use crate::certificate::cert_is_self_issued;
+@@ -38,15 +43,23 @@
+ 
+ struct Budget {
+     name_constraint_checks: usize,
++    signature_checks: usize,
+ }
+ 
+ impl Budget {
+-    // Same limit as other validators
++    // The maximum number of name constraint checks performed when attempting
++    // path construction. This is the same limit as other validators.
+     const DEFAULT_NAME_CONSTRAINT_CHECK_LIMIT: usize = 1 << 20;
++
++    // The maximum number of signature verifications performed when attempting
++    // path construction. This is similar to other validators:
++    // both Go and rustls-webpki pick 100.
++    const DEFAULT_SIGNATURE_CHECK_LIMIT: usize = 1 << 7;
+ 
+     fn new() -> Budget {
+         Budget {
+             name_constraint_checks: Self::DEFAULT_NAME_CONSTRAINT_CHECK_LIMIT,
++            signature_checks: Self::DEFAULT_SIGNATURE_CHECK_LIMIT,
+         }
+     }
+ 
+@@ -59,6 +67,16 @@
+                 ))?;
+         Ok(())
+     }
++
++    fn signature_check(&mut self) -> Result<(), ValidationError> {
++        self.signature_checks =
++            self.signature_checks
++                .checked_sub(1)
++                .ok_or(ValidationError::FatalError(
++                    "Exceeded maximum signature check limit",
++                ))?;
++        Ok(())
++    }
+ }
+ 
+ impl From<asn1::ParseError> for ValidationError {
+@@ -260,15 +283,54 @@
++    /// Identify and return potential issuers for `cert`, considering
++    /// candidates from both the trusted store and untrusted intermediate set.
++    /// Trusted candidates are returned before untrusted intermediate
++    /// candidates, and both groups are opportunistically ordered by
++    /// "likeliness" in terms of AKI/SKI match.
+     fn potential_issuers(
+         &'a self,
+         cert: &'a VerificationCertificate<'chain, B>,
+-    ) -> impl Iterator<Item = &'a VerificationCertificate<'chain, B>> + '_ {
+-        // TODO: Optimizations:
+-        // * Search by AKI and other identifiers?
+-        self.store
++        cert_extensions: &Extensions<'chain>,
++    ) -> Vec<&'a VerificationCertificate<'chain, B>> {
++        let mut candidates: Vec<&'a VerificationCertificate<'chain, B>> = self
++            .store
+             .get_by_subject(&cert.certificate().tbs_cert.issuer)
+             .iter()
+             .chain(self.intermediates.iter().filter(|&candidate| {
+                 candidate.certificate().subject() == cert.certificate().issuer()
+             }))
++            .collect();
++
++        let want_kid: Option<&[u8]> = cert_extensions
++            .get_extension(&AUTHORITY_KEY_IDENTIFIER_OID)
++            .and_then(|ext| ext.value::<AuthorityKeyIdentifier<'_>>().ok())
++            .and_then(|aki| aki.key_identifier);
++
++        // This mirrors Go's `findPotentialParents`: we have a global
++        // signature budget, so we want to bucket candidates by likeliness
++        // to avoid wasting budget on (potentially adversarial) name collisions.
++        //
++        // Observe that we use a stable sort to preserve trusted candidates
++        // before untrusted candidates in each likeliness bucket. In other
++        // words, we always try a likely trusted candidate over an equally
++        // likely untrusted one.
++        //
++        // See: <https://github.com/golang/go/blob/d00c67f297e/src/crypto/x509/cert_pool.go#L136>
++        candidates.sort_by_key(|candidate| {
++            let have_kid: Option<&[u8]> =
++                candidate.certificate().extensions().ok().and_then(|exts| {
++                    exts.get_extension(&SUBJECT_KEY_IDENTIFIER_OID)
++                        .and_then(|ext| ext.value::<&[u8]>().ok())
++                });
++
++            match (want_kid, have_kid) {
++                // cert AKID matches candidate SKID, highest likelihood.
++                (Some(want), Some(have)) if want == have => 0,
++                // cert AKID and candidate SKID don't match, lowest likelihood.
++                (Some(_), Some(_)) => 2,
++                // cert AKID and/or candidate SKID is not present, medium likelihood.
++                _ => 1u8,
++            }
++        });
++        candidates
+     }
+ 
+     fn build_chain_inner(
+@@ -301,7 +340,7 @@
+         // Otherwise, we collect a list of potential issuers for this cert,
+         // and continue with the first that verifies.
+         let mut last_err: Option<ValidationError> = None;
+-        for issuing_cert_candidate in self.potential_issuers(working_cert) {
++        for issuing_cert_candidate in self.potential_issuers(working_cert, working_cert_extensions) {
+             // A candidate issuer is said to verify if it both
+             // signs for the working certificate and conforms to the
+             // policy.
+@@ -311,6 +350,7 @@
+                 working_cert.certificate(),
+                 current_depth,
+                 &issuer_extensions,
++                budget,
+             ) {
+                 Ok(_) => {
+                     match self.build_chain_inner(
+--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
++++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
+@@ -25,7 +25,7 @@
+ use crate::ops::CryptoOps;
+ use crate::policy::extension::{ca, common, ee, Criticality, ExtensionPolicy, ExtensionValidator};
+ use crate::types::{DNSName, DNSPattern, IPAddress};
+-use crate::{ValidationError, VerificationCertificate};
++use crate::{Budget, ValidationError, VerificationCertificate};
+ 
+ // SubjectPublicKeyInfo AlgorithmIdentifier constants, as defined in CA/B 7.1.3.1.
+ 
+@@ -463,6 +463,7 @@
+         child: &Certificate<'_>,
+         current_depth: u8,
+         issuer_extensions: &Extensions<'_>,
++        budget: &mut Budget,
+     ) -> Result<(), ValidationError> {
+         // The issuer needs to be a valid CA at the current depth.
+         self.permits_ca(issuer.certificate(), current_depth, issuer_extensions)?;
+@@ -499,6 +500,10 @@
+         let pk = issuer
+             .public_key(&self.ops)
+             .map_err(|_| ValidationError::Other("issuer has malformed public key".to_string()))?;
++        // Charge the (potentially expensive) signature verification against the
++        // budget before performing it, bounding the total work an attacker can
++        // force during chain building.
++        budget.signature_check()?;
+         if self.ops.verify_signed_by(child, pk).is_err() {
+             return Err(ValidationError::Other(
+                 "signature does not match".to_string(),
+-- 
+2.45.4

--- a/SPECS/python-cryptography/python-cryptography.spec
+++ b/SPECS/python-cryptography/python-cryptography.spec
@@ -2,7 +2,7 @@
 Summary:        Python cryptography library
 Name:           python-cryptography
 Version:        42.0.5
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -17,6 +17,7 @@ Source1:        cryptography-%{version}-vendor.tar.gz
 Patch0:         0001-remove-openssl-cipher-Cipher-chacha20_poly1305.patch
 Patch1:         0002-remove-poly1305-tests.patch
 Patch2:         CVE-2026-26007.patch
+Patch3:         CVE-2026-69249.patch
 
 %description
 Cryptography is a Python library which exposes cryptographic recipes and primitives.
@@ -112,6 +113,9 @@ PYTHONPATH=%{buildroot}%{python3_sitearch} \
 %license LICENSE
 
 %changelog
+* Fri Aug 07 2026 Akarsh Chaudhary <v-akarshc@microsoft.com> - 42.0.5-5
+- Patch for CVE-2026-69249
+
 * Fri Feb 13 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 42.0.5-4
 - Patch for CVE-2026-26007
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
### Vulnerability Summary
This PR fixes **CVE-2026-69249**, Duplicate self-signed intermediates can cause exponential path-building.

###### Backport adaptations for cryptography 42.0.5 <!-- REQUIRED -->

1.Validation error API adaptation for cryptography 42.0.5
-------------------------------------------------------
This adaptation is necessary because cryptography 42.0.5 uses the older error
model:

* ValidationError is an enum with a FatalError variant.
* It does not use the newer generic ValidationResult<'chain, T, B> type.
* Errors are constructed directly rather than through
  ValidationError::new(ValidationErrorKind::...).

2.Omission of the newer-API regression test.- Upstream patch had test too which was omitted as it was using newer apis not feasible to our version.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/python-cryptography/python-cryptography.spec
- SPECS/python-cryptography/CVE-2026-69249.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-69249

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Screenshot of successful local build-
<img width="1048" height="673" alt="image" src="https://github.com/user-attachments/assets/206e6359-466a-46d9-8171-de2f1eab866c" />

patch is getting applied cleanly-
<img width="1868" height="474" alt="image" src="https://github.com/user-attachments/assets/8d76579f-5683-4a84-a2ed-096c2914867d" />

Done the advisory Poc to check vulnerability is fixed or not poc reference link-https://github.com/pyca/cryptography/security/advisories/GHSA-jwv3-5hgf-82ww
Before fix output-
<img width="604" height="306" alt="image" src="https://github.com/user-attachments/assets/0aaadb72-9ccb-46db-afba-f1567ccaa9c5" />
After fix-
<img width="599" height="345" alt="image" src="https://github.com/user-attachments/assets/335fbe5e-ff17-448d-ab5d-25acbc6fe6f7" />

- Pipeline build url:
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1179507&view=results