### PR TITLE
Upgrade `libkcapi` package to version 1.5.1 to fix CVE-2026-71225[Medium], CVE-2026-71226[High], CVE-2026-71227[Medium]

### DIFF
--- a/SPECS/libkcapi/libkcapi.signatures.json
+++ b/SPECS/libkcapi/libkcapi.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libkcapi-1.5.0.tar.xz": "15b550c14165a266fa233b485d029d54508da593dfa6d1731ec5d5a285c716e9"
+  "libkcapi-1.5.1.tar.xz": "bd2e4c5731380922a8a6a45cc6dce0477bab000c917086f802d983d65441599a"
  }
 }

--- a/SPECS/libkcapi/libkcapi.spec
+++ b/SPECS/libkcapi/libkcapi.spec
@@ -3,7 +3,7 @@
 # Shared object version of libkcapi.
 %global vmajor            1
 %global vminor            5
-%global vpatch            0
+%global vpatch            1
 # This package needs at least Linux Kernel v4.10.0.
 %global min_kernel_ver    4.10.0
 # Do we need to tweak sysctl.d? In newer versions of the Linux
@@ -65,12 +65,12 @@ ln -s libkcapi.so.%{version}.hmac                            \\\
 Summary:        User space interface to the Linux Kernel Crypto API
 Name:           libkcapi
 Version:        %{vmajor}.%{vminor}.%{vpatch}
-Release:        2%{?dist}
+Release:        1%{?dist}
 License:        BSD OR GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://www.chronox.de/%{name}.html
-Source0:        https://www.chronox.de/%{name}/releases/%{version}/%{name}-1.5.0.tar.xz
+Source0:        https://www.chronox.de/%{name}/releases/%{version}/%{name}-%{version}.tar.xz
 BuildRequires:  bash
 BuildRequires:  clang
 BuildRequires:  coreutils
@@ -275,6 +275,10 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libexecdir}/%{name}/*
 
 %changelog
+* Mon Aug 10 2026 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 1.5.1-1
+- Upgrade to version 1.5.1.
+- Fixes CVE-2026-71225, CVE-2026-71226, CVE-2026-71227.
+
 * Tue May 28 2024 Cameron Baird <cameronbaird@microsoft.com> - 1.5.0-2
 - Install hard links from apps_hmaccalc to kcapi-hasher to
     resolve incompatibility with dracut.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -10191,8 +10191,8 @@
         "type": "other",
         "other": {
           "name": "libkcapi",
-          "version": "1.5.0",
-          "downloadUrl": "https://www.chronox.de/libkcapi/releases/1.5.0/libkcapi-1.5.0.tar.xz"
+          "version": "1.5.1",
+          "downloadUrl": "https://www.chronox.de/libkcapi/releases/1.5.1/libkcapi-1.5.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- CVE-2026-71225 [Medium],
Upgrading to a version 1.5.1 fixed this CVE, since the affected range for this CVE is before 1.5.1

- CVE-2026-71226 [High],
Upgrading to a version 1.5.1 fixed this CVE, since the affected range for this CVE is before 1.5.1

- CVE-2026-71227 [Medium],
Upgrading to a version 1.5.1 fixed this CVE, since the affected range for this CVE is before 1.5.1


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
./SPECS/libkcapi/libkcapi.spec
./SPECS/libkcapi/libkcapi.signatures.json
./cgmanifest.json

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->

- Pipeline build id: xxxx
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1179842&view=results
