### PR TITLE
chore(azure-cli): move package to microsoft repo

### DIFF
--- a/base/comps/components-publish-channels.toml
+++ b/base/comps/components-publish-channels.toml
@@ -90,7 +90,6 @@ components = [
     "autofs",
     "automake",
     "avahi",
-    "azure-cli",
     "azure-vm-utils",
     "azurelinux-logos",
     "azurelinux-release",
@@ -3007,4 +3006,14 @@ packages = [
     "ghc-ShellCheck-devel", # srpm: ShellCheck
     "ghc-ShellCheck-doc", # srpm: ShellCheck
     "ghc-ShellCheck-prof", # srpm: ShellCheck
+]
+
+# This group includes packages intentionally included in the `microsoft` repo.
+[component-groups.microsoft-packages]
+description = "microsoft packages"
+default-component-config.publish.srpm-channel = "rpm-microsoft-srpm"
+default-component-config.publish.rpm-channel = "rpm-microsoft"
+default-component-config.publish.debuginfo-channel = "rpm-microsoft-debuginfo"
+components = [
+    "azure-cli",
 ]


### PR DESCRIPTION
## Summary

Moves the `azure-cli` component from the base repository to the Microsoft repository.

- Removes `azure-cli` from the base component group.
- Adds a `microsoft-packages` component group.
- Publishes the component through `rpm-microsoft`, `rpm-microsoft-srpm`, and `rpm-microsoft-debuginfo`.

[AB#22845](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22845)