### PR TITLE
feat(kernel): build base variants and restore selftests

### DIFF
--- a/base/comps/kernel/kernel.azl.macros
+++ b/base/comps/kernel/kernel.azl.macros
@@ -1,7 +1,0 @@
-# Transitional macros for the local-spec migration.
-# Removed once these defines move directly into kernel.spec.
-%_without_debug 1
-%_without_selftests 1
-%azl_pkgrelease 13
-%kextraversion 1
-%nvidia_open_version 595.58.03

--- a/base/comps/kernel/kernel.comp.toml
+++ b/base/comps/kernel/kernel.comp.toml
@@ -7,7 +7,7 @@ spec = { type = "local", path = "kernel.spec" }
 
 # The spec uses %{specrelease} (kextraversion.azl_pkgrelease.dist) which the
 # auto-calculator cannot parse. Release is managed manually: bump azl_pkgrelease
-# in kernel.azl.macros when rebuilding without a version change. The
+# in kernel.spec when rebuilding without a version change. The
 # %changelog is hand-curated inline in the spec.
 release = { calculation = "manual" }
 

--- a/base/comps/kernel/kernel.spec
+++ b/base/comps/kernel/kernel.spec
@@ -1,5 +1,18 @@
-# All Azure Linux specs with overlays include this macro file, irrespective of whether new macros have been added.
-%{load:%{_sourcedir}/kernel.azl.macros}
+# Azure Linux local kernel spec.
+#
+# This is a maintained local spec (migrated from the previous azldev TOML
+# overlay approach). Edit this file directly. Azure Linux customizations are
+# marked with "AZL:" comments throughout.
+
+# Azure Linux kernel build defines. These were previously injected via the
+# azldev-generated kernel.azl.macros file; they now live directly in the spec.
+# When rebuilding without a version change, bump azl_pkgrelease (manual release).
+%define azl_pkgrelease 14
+# 4th version component from the AZL kernel source (6.18.31.1). Flows into
+# Release:, uname -r, and the /lib/modules/ path.
+%define kextraversion 1
+# NVIDIA open GPU kernel module version (built as a kmod subpackage).
+%define nvidia_open_version 595.58.03
 
 # All Global changes to build and install go here.
 # Per the below section about __spec_install_pre, any rpm
@@ -691,6 +704,25 @@ Summary: The Linux kernel
 %define with_debug 0
 %endif
 
+# ============================================================================
+# AZL: Build only the base (up) kernel for x86_64 and aarch64.
+#
+# Azure Linux ships a single general-purpose kernel. All other variants
+# (debug, realtime/rt-64k, arm64-16k/64k, automotive, zfcpdump) are
+# disabled here. This gate runs after all upstream arch/variant resolution so
+# it wins; the disabled variant code is trimmed away incrementally. EFI UKI and
+# kernel selftests (kernel-selftests-internal) are intentionally left enabled.
+# ============================================================================
+%define with_debug 0
+%define with_debug_meta 0
+%define with_realtime 0
+%define with_realtime_arm64_64k 0
+%define with_arm64_16k 0
+%define with_arm64_64k 0
+%define with_automotive 0
+%define with_automotive_build 0
+%define with_zfcpdump 0
+
 # short-hand for "are we building base/non-debug variants of ...?"
 %if %{with_up} && %{with_base}
 %define with_up_base 1
@@ -1167,7 +1199,6 @@ Source3002: Patchlist.changelog
 Source4000: README.rst
 Source4001: rpminspect.yaml
 Source4002: gating.yaml
-Source9999: kernel.azl.macros
 Source5000: 6.18-x86_64-azl.config
 Source5001: 6.18-aarch64-azl.config
 Source5002: azurelinux-ca-20230216.pem
@@ -4575,6 +4606,9 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Fri Aug 07 2026 Rachel Menge <rachelmenge@microsoft.com> - 6.18.31-1.14
+- feat(kernel): build base variants, keep UKI, and restore selftests
+
 * Thu Aug 06 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.18.31-1.13
 - feat(kernel): enable ACPI APEI GHES (Generic Hardware Error Source) on x86_64
 - fix(kernel-config): enable EDAC_GHES for GHES memory error handling

--- a/locks/kernel.lock
+++ b/locks/kernel.lock
@@ -1,4 +1,4 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:d394de39efd61cb094626e61ae7bb15b66e1b2375b95bab5e892585f0c755a7c'
+input-fingerprint = 'sha256:27c920b119cd391713299612ac7c764c3dfb8125013b4aef9bf52cdc2ad70169'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/k/kernel/kernel.azl.macros
+++ b/specs/k/kernel/kernel.azl.macros
@@ -1,7 +1,0 @@
-# Transitional macros for the local-spec migration.
-# Removed once these defines move directly into kernel.spec.
-%_without_debug 1
-%_without_selftests 1
-%azl_pkgrelease 13
-%kextraversion 1
-%nvidia_open_version 595.58.03

--- a/specs/k/kernel/kernel.spec
+++ b/specs/k/kernel/kernel.spec
@@ -1,8 +1,21 @@
 # This spec file has been modified by azldev to include build configuration overlays.
 # Do not edit manually; changes may be overwritten.
 
-# All Azure Linux specs with overlays include this macro file, irrespective of whether new macros have been added.
-%{load:%{_sourcedir}/kernel.azl.macros}
+# Azure Linux local kernel spec.
+#
+# This is a maintained local spec (migrated from the previous azldev TOML
+# overlay approach). Edit this file directly. Azure Linux customizations are
+# marked with "AZL:" comments throughout.
+
+# Azure Linux kernel build defines. These were previously injected via the
+# azldev-generated kernel.azl.macros file; they now live directly in the spec.
+# When rebuilding without a version change, bump azl_pkgrelease (manual release).
+%define azl_pkgrelease 14
+# 4th version component from the AZL kernel source (6.18.31.1). Flows into
+# Release:, uname -r, and the /lib/modules/ path.
+%define kextraversion 1
+# NVIDIA open GPU kernel module version (built as a kmod subpackage).
+%define nvidia_open_version 595.58.03
 
 # All Global changes to build and install go here.
 # Per the below section about __spec_install_pre, any rpm
@@ -694,6 +707,25 @@ Summary: The Linux kernel
 %define with_debug 0
 %endif
 
+# ============================================================================
+# AZL: Build only the base (up) kernel for x86_64 and aarch64.
+#
+# Azure Linux ships a single general-purpose kernel. All other variants
+# (debug, realtime/rt-64k, arm64-16k/64k, automotive, zfcpdump) are
+# disabled here. This gate runs after all upstream arch/variant resolution so
+# it wins; the disabled variant code is trimmed away incrementally. EFI UKI and
+# kernel selftests (kernel-selftests-internal) are intentionally left enabled.
+# ============================================================================
+%define with_debug 0
+%define with_debug_meta 0
+%define with_realtime 0
+%define with_realtime_arm64_64k 0
+%define with_arm64_16k 0
+%define with_arm64_64k 0
+%define with_automotive 0
+%define with_automotive_build 0
+%define with_zfcpdump 0
+
 # short-hand for "are we building base/non-debug variants of ...?"
 %if %{with_up} && %{with_base}
 %define with_up_base 1
@@ -1170,7 +1202,6 @@ Source3002: Patchlist.changelog
 Source4000: README.rst
 Source4001: rpminspect.yaml
 Source4002: gating.yaml
-Source9999: kernel.azl.macros
 Source5000: 6.18-x86_64-azl.config
 Source5001: 6.18-aarch64-azl.config
 Source5002: azurelinux-ca-20230216.pem
@@ -4578,6 +4609,9 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Fri Aug 07 2026 Rachel Menge <rachelmenge@microsoft.com> - 6.18.31-1.14
+- feat(kernel): build base variants, keep UKI, and restore selftests
+
 * Thu Aug 06 2026 Andreas Zaugg <azaugg@linkedin.com> - 6.18.31-1.13
 - feat(kernel): enable ACPI APEI GHES (Generic Hardware Error Source) on x86_64
 - fix(kernel-config): enable EDAC_GHES for GHES memory error handling


### PR DESCRIPTION
## Summary

Build only the Azure Linux base kernel variants while keeping EFI UKI enabled and restoring `kernel-selftests-internal`.

This moves the Azure Linux kernel build defines out of the transitional generated `kernel.azl.macros` file and into the maintained local kernel spec. The generated macro file is removed from both the component source and rendered spec output.

This is intended as a transitional commit before trimming additional unused variant logic from the local spec.

## Changes

- Move Azure Linux kernel build defines into `kernel.spec`
- Remove generated `kernel.azl.macros` from source and rendered output
- Disable non-base variants:
  - debug
  - realtime / rt-64k
  - arm64 16k / 64k
  - automotive
  - zfcpdump
- Keep EFI UKI enabled
- Keep `kernel-selftests-internal` enabled
- Bump manual kernel release to `6.18.31-1.14`
- Refresh rendered kernel output and `locks/kernel.lock`
