### PR TITLE
poetry: pin packaging==26.2 to fix %check test failure

### DIFF
--- a/SPECS/poetry/poetry.spec
+++ b/SPECS/poetry/poetry.spec
@@ -5,7 +5,7 @@ projects, ensuring you have the right stack everywhere.}
 Summary:        Python dependency management and packaging made easy
 Name:           %{pypi_name}
 Version:        1.8.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -87,8 +87,9 @@ pip3 install --ignore-installed \
             httpretty==1.1.4 \
             iniconfig==2.0.0 \
             installer==0.7.0 \
+            packaging==26.2 \
             pkginfo==1.12 \
-	        poetry==%{version} \
+            poetry==%{version} \
             poetry_plugin_export==1.8.0 \
             requests_toolbelt==1.0.0 \
             tomlkit==0.12.5 \
@@ -110,6 +111,11 @@ pip3 install --ignore-installed \
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Aug 11 2026 Kshitiz Godara <kgodara@microsoft.com> - 1.8.5-3
+- Pin packaging==26.2 in %%check. packaging 26.3 changed the platform tag
+  computed by env.supported_tags, breaking test_prepare_directory_with_extensions
+  (expected linux_x86_64, built wheel tagged manylinux_2_38_x86_64).
+
 * Wed Apr 29 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.8.5-2
 - Patch for CVE-2026-41140
 


### PR DESCRIPTION
test_prepare_directory_with_extensions asserts that the built wheel name matches env.supported_tags[0]. packaging 26.3 changed the platform tag computation, so the wheel was tagged manylinux_2_38_x86_64 while supported_tags[0] reported linux_x86_64, failing the assertion.

packaging was the only unpinned dependency in the %check pip install set, so it floated to a new PyPI release; the rest are already pinned to keep the tests stable. Bump release to 3.