### PR TITLE
[High] Patch prometheus-adapter for CVE-2026-33186

### DIFF
--- a/SPECS/prometheus-adapter/CVE-2026-33186.patch
+++ b/SPECS/prometheus-adapter/CVE-2026-33186.patch
@@ -1,0 +1,141 @@
+From 72186f163e75a065c39e6f7df9b6dea07fbdeff5 Mon Sep 17 00:00:00 2001
+From: Easwar Swaminathan <easwars@google.com>
+Date: Tue, 17 Mar 2026 16:06:00 -0700
+Subject: [PATCH] grpc: enforce strict path checking for incoming requests on
+ the server (#8981)
+
+RELEASE NOTES:
+* server: fix an authorization bypass where malformed :path headers
+(missing the leading slash) could bypass path-based restricted "deny"
+rules in interceptors like `grpc/authz`. Any request with a
+non-canonical path is now immediately rejected with an `Unimplemented`
+error.
+
+Upstream Patch reference: https://github.com/grpc/grpc-go/commit/72186f163e75a065c39e6f7df9b6dea07fbdeff5.patch
+---
+ .../grpc/internal/envconfig/envconfig.go      | 15 +++++
+ vendor/google.golang.org/grpc/server.go       | 57 +++++++++++++------
+ 2 files changed, 56 insertions(+), 16 deletions(-)
+
+diff --git a/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go b/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
+index 685a3cb..70ebf0d 100644
+--- a/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
++++ b/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
+@@ -43,6 +43,21 @@ var (
+ 	// ALTSMaxConcurrentHandshakes is the maximum number of concurrent ALTS
+ 	// handshakes that can be performed.
+ 	ALTSMaxConcurrentHandshakes = uint64FromEnv("GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES", 100, 1, 100)
++	// DisableStrictPathChecking indicates whether strict path checking is
++	// disabled. This feature can be disabled by setting the environment
++	// variable GRPC_GO_EXPERIMENTAL_DISABLE_STRICT_PATH_CHECKING to "true".
++	//
++	// When strict path checking is enabled, gRPC will reject requests with
++	// paths that do not conform to the gRPC over HTTP/2 specification found at
++	// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
++	//
++	// When disabled, gRPC will allow paths that do not contain a leading slash.
++	// Enabling strict path checking is recommended for security reasons, as it
++	// prevents potential path traversal vulnerabilities.
++	//
++	// A future release will remove this environment variable, enabling strict
++	// path checking behavior unconditionally.
++	DisableStrictPathChecking = boolFromEnv("GRPC_GO_EXPERIMENTAL_DISABLE_STRICT_PATH_CHECKING", false)
+ )
+ 
+ func boolFromEnv(envVar string, def bool) bool {
+diff --git a/vendor/google.golang.org/grpc/server.go b/vendor/google.golang.org/grpc/server.go
+index 682fa18..d9f6ac0 100644
+--- a/vendor/google.golang.org/grpc/server.go
++++ b/vendor/google.golang.org/grpc/server.go
+@@ -43,6 +43,7 @@ import (
+ 	"google.golang.org/grpc/internal"
+ 	"google.golang.org/grpc/internal/binarylog"
+ 	"google.golang.org/grpc/internal/channelz"
++	"google.golang.org/grpc/internal/envconfig"
+ 	"google.golang.org/grpc/internal/grpcsync"
+ 	"google.golang.org/grpc/internal/grpcutil"
+ 	"google.golang.org/grpc/internal/transport"
+@@ -146,6 +147,8 @@ type Server struct {
+ 
+ 	serverWorkerChannel      chan func()
+ 	serverWorkerChannelClose func()
++
++	strictPathCheckingLogEmitted atomic.Bool
+ }
+ 
+ type serverOptions struct {
+@@ -1716,6 +1719,24 @@ func (s *Server) processStreamingRPC(ctx context.Context, t transport.ServerTran
+ 	return t.WriteStatus(ss.s, statusOK)
+ }
+ 
++func (s *Server) handleMalformedMethodName(t transport.ServerTransport, stream *transport.Stream, ti *traceInfo) {
++	if ti != nil {
++		ti.tr.LazyLog(&fmtStringer{"Malformed method name %q", []any{stream.Method()}}, true)
++		ti.tr.SetError()
++	}
++	errDesc := fmt.Sprintf("malformed method name: %q", stream.Method())
++	if err := t.WriteStatus(stream, status.New(codes.Unimplemented, errDesc)); err != nil {
++		if ti != nil {
++			ti.tr.LazyLog(&fmtStringer{"%v", []any{err}}, true)
++			ti.tr.SetError()
++		}
++		channelz.Warningf(logger, s.channelzID, "grpc: Server.handleStream failed to write status: %v", err)
++	}
++	if ti != nil {
++		ti.tr.Finish()
++	}
++}
++
+ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Stream) {
+ 	ctx := stream.Context()
+ 	ctx = contextWithServer(ctx, s)
+@@ -1736,26 +1757,30 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
+ 	}
+ 
+ 	sm := stream.Method()
+-	if sm != "" && sm[0] == '/' {
++	if sm == "" {
++		s.handleMalformedMethodName(t, stream, ti)
++		return
++	}
++	if sm[0] != '/' {
++		// TODO(easwars): Add a link to the CVE in the below log messages once
++		// published.
++		if envconfig.DisableStrictPathChecking {
++			if old := s.strictPathCheckingLogEmitted.Swap(true); !old {
++				channelz.Warningf(logger, s.channelzID, "grpc: Server.handleStream received malformed method name %q. Allowing it because the environment variable GRPC_GO_EXPERIMENTAL_DISABLE_STRICT_PATH_CHECKING is set to true, but this option will be removed in a future release.", sm)
++			}
++		} else {
++			if old := s.strictPathCheckingLogEmitted.Swap(true); !old {
++				channelz.Warningf(logger, s.channelzID, "grpc: Server.handleStream rejected malformed method name %q. To temporarily allow such requests, set the environment variable GRPC_GO_EXPERIMENTAL_DISABLE_STRICT_PATH_CHECKING to true. Note that this is not recommended as it may allow requests to bypass security policies.", sm)
++			}
++			s.handleMalformedMethodName(t, stream, ti)
++			return
++		}
++	} else {
+ 		sm = sm[1:]
+ 	}
+ 	pos := strings.LastIndex(sm, "/")
+ 	if pos == -1 {
+-		if ti != nil {
+-			ti.tr.LazyLog(&fmtStringer{"Malformed method name %q", []any{sm}}, true)
+-			ti.tr.SetError()
+-		}
+-		errDesc := fmt.Sprintf("malformed method name: %q", stream.Method())
+-		if err := t.WriteStatus(stream, status.New(codes.Unimplemented, errDesc)); err != nil {
+-			if ti != nil {
+-				ti.tr.LazyLog(&fmtStringer{"%v", []any{err}}, true)
+-				ti.tr.SetError()
+-			}
+-			channelz.Warningf(logger, s.channelzID, "grpc: Server.handleStream failed to write status: %v", err)
+-		}
+-		if ti != nil {
+-			ti.tr.Finish()
+-		}
++		s.handleMalformedMethodName(t, stream, ti)
+ 		return
+ 	}
+ 	service := sm[:pos]
+-- 
+2.34.1
+

--- a/SPECS/prometheus-adapter/prometheus-adapter.spec
+++ b/SPECS/prometheus-adapter/prometheus-adapter.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes Custom, Resource, and External Metric APIs implemented to work with Prometheus.
 Name:           prometheus-adapter
 Version:        0.12.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -18,6 +18,7 @@ Patch7:         CVE-2026-25680.patch
 Patch8:         CVE-2026-25681.patch
 Patch9:         CVE-2026-42502.patch
 Patch10:        CVE-2026-56852.patch
+Patch11:        CVE-2026-33186.patch
 BuildRequires:  golang < 1.25
 
 %description
@@ -52,6 +53,9 @@ make test
 %doc README.md RELEASE.md
 
 %changelog
+* Tue Aug 11 2026 Akhila Guruju <v-guakhila@microsoft.com> - 0.12.0-8
+- Patch CVE-2026-33186
+
 * Mon Jul 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 0.12.0-7
 - Patch for CVE-2026-56852
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->
 
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge
 
---
 
###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
 Patch prometheus-adapter for CVE-2026-33186
 
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
 - new file:   SPECS/prometheus-adapter/CVE-2026-33186.patch
 - modified:   SPECS/prometheus-adapter/prometheus-adapter.spec
 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**
 
###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx
 
###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-33186
 
###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
<img width="478" height="190" alt="image" src="https://github.com/user-attachments/assets/3b5f2360-34f1-486a-b77b-912659095263" />
