### PR TITLE
ocaml-fmt: bound the styled_perf_bug benchmark loop

### DIFF
--- a/SPECS/ocaml-fmt/ocaml-fmt-bound-benchmark.patch
+++ b/SPECS/ocaml-fmt/ocaml-fmt-bound-benchmark.patch
@@ -1,0 +1,31 @@
+From d2e69485450bfc4aa943d349a5838aab066deaa7 Mon Sep 17 00:00:00 2001
+From: Kshitiz Godara <kgodara@microsoft.com>
+Date: Tue, 11 Aug 2026 00:00:00 +0000
+Subject: [PATCH] test: bound the styled_perf_bug benchmark loop
+
+styled_perf_bug reproduces the ephemeron-based performance regression
+fixed in v0.9.0 by printing formatting throughput indefinitely, which is
+useful when watching it by hand but hangs any automated test run.
+
+Run a fixed number of rounds instead, so the benchmark still exercises the
+Fmt.styled/Fmt.str code path that regressed and then terminates.
+---
+ test/styled_perf_bug.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/styled_perf_bug.ml b/test/styled_perf_bug.ml
+index d8e69a1..fe652e1 100644
+--- a/test/styled_perf_bug.ml
++++ b/test/styled_perf_bug.ml
+@@ -1,7 +1,7 @@
+ let n = 10000
+ 
+ let () =
+-  while true do
++  for _round = 1 to 5 do
+     let t0 = Unix.gettimeofday () in
+     for _i = 1 to n do
+       ignore @@ Fmt.str "Hello %a" Fmt.string "world"
+-- 
+2.53.0
+

--- a/SPECS/ocaml-fmt/ocaml-fmt.spec
+++ b/SPECS/ocaml-fmt/ocaml-fmt.spec
@@ -7,12 +7,15 @@
 Summary:        OCaml Format pretty-printer combinators
 Name:           ocaml-%{srcname}
 Version:        0.9.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://erratique.ch/software/fmt
 Source0:        https://github.com/dbuenzli/fmt/archive/v%{version}/%{srcname}-%{version}.tar.gz
+# test/styled_perf_bug is a hand-watched benchmark that loops forever; bound it
+# so it still exercises the regressed code path without hanging %%check.
+Patch0:         ocaml-fmt-bound-benchmark.patch
 
 BuildRequires:  ocaml >= 4.05.0
 BuildRequires:  ocaml-cmdliner-devel >= 0.9.8
@@ -101,6 +104,11 @@ ocaml pkg/pkg.ml test
 %{_libdir}/ocaml/%{srcname}/%{srcname}*.mli
 
 %changelog
+* Tue Aug 11 2026 Kshitiz Godara <kgodara@microsoft.com> - 0.9.0-2
+- Bound the test/styled_perf_bug benchmark loop. It ran "while true", so %%check
+  never finished and hit the build timeout; it now runs a fixed number of rounds
+  and still exercises the Fmt.styled/Fmt.str path it was written to check.
+
 * Tue Jun 04 2024 Andrew Phelps <anphel@microsoft.com> - 0.9.0-1
 - Upgrade to version 0.9.0
 


### PR DESCRIPTION
test/styled_perf_bug is the reproduction program from upstream issue #52 ("Fmt.styled gets slower over time"), committed verbatim as a regression artifact. It prints formatting throughput in a "while true" loop because the bug showed up as a decaying trend that a human had to watch, so it never terminates and %check ran until the configured build timeout.

Patch it to run a fixed number of rounds. The benchmark still exercises the Fmt.styled/Fmt.str path that regressed, and the throughput numbers stay in the build log, but the test suite now finishes in seconds. No throughput assertion is added since that would be machine dependent. Bump release to 2.