### PR TITLE
fix(azurelinux-release): persist CIS network sysctls

### DIFF
--- a/base/comps/azurelinux-release/70-azurelinux-hardening.conf
+++ b/base/comps/azurelinux-release/70-azurelinux-hardening.conf
@@ -7,9 +7,41 @@ net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.*.rp_filter = 1
 
+# Disable packet forwarding by default
+net.ipv4.conf.all.forwarding = 0
+net.ipv4.conf.default.forwarding = 0
+net.ipv6.conf.all.forwarding = 0
+net.ipv6.conf.default.forwarding = 0
+
+# Harden IPv4 ICMP handling
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+
 # Don't send or accept icmp redirects
 net.*.conf.*.accept_redirects = 0
 net.ipv4.conf.*.send_redirects = 0
 
+# CIS benchmark content validates all and default keys individually; it does
+# not recognize wildcard assignments as persistent configuration.
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+net.ipv6.conf.default.accept_redirects = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+
+# Disable source-routed packets
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv6.conf.all.accept_source_route = 0
+net.ipv6.conf.default.accept_source_route = 0
+
+# Protect against SYN flood attacks
+net.ipv4.tcp_syncookies = 1
+
 # Let everyone know if you see any Martians
 net.ipv4.conf.*.log_martians = 1
+
+# CIS benchmark content validates all and default keys individually; it does
+# not recognize wildcard assignments as persistent configuration.
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        21%{?dist}
+Release:        22%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -485,6 +485,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-22
+- Persist CIS network sysctl defaults
+
 * Thu Jul 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-21
 - Set canonical product, documentation, support, and issue-reporting URLs
 - Remove the inactive default debuginfod server configuration

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:d1cc028f962349cd61ec32c56584dbb890aebb6120c0ff641cecdfd4117b31e2'
+input-fingerprint = 'sha256:7cb3a4f68594b2f5acd31b5f3a552a02f4a288fe936b97b660b207270e2f2603'

--- a/specs/a/azurelinux-release/70-azurelinux-hardening.conf
+++ b/specs/a/azurelinux-release/70-azurelinux-hardening.conf
@@ -7,9 +7,41 @@ net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.*.rp_filter = 1
 
+# Disable packet forwarding by default
+net.ipv4.conf.all.forwarding = 0
+net.ipv4.conf.default.forwarding = 0
+net.ipv6.conf.all.forwarding = 0
+net.ipv6.conf.default.forwarding = 0
+
+# Harden IPv4 ICMP handling
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+
 # Don't send or accept icmp redirects
 net.*.conf.*.accept_redirects = 0
 net.ipv4.conf.*.send_redirects = 0
 
+# CIS benchmark content validates all and default keys individually; it does
+# not recognize wildcard assignments as persistent configuration.
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+net.ipv6.conf.default.accept_redirects = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+
+# Disable source-routed packets
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv6.conf.all.accept_source_route = 0
+net.ipv6.conf.default.accept_source_route = 0
+
+# Protect against SYN flood attacks
+net.ipv4.tcp_syncookies = 1
+
 # Let everyone know if you see any Martians
 net.ipv4.conf.*.log_martians = 1
+
+# CIS benchmark content validates all and default keys individually; it does
+# not recognize wildcard assignments as persistent configuration.
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        21%{?dist}
+Release:        22%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -488,6 +488,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-22
+- Persist CIS network sysctl defaults
+
 * Thu Jul 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-21
 - Set canonical product, documentation, support, and issue-reporting URLs
 - Remove the inactive default debuginfod server configuration


### PR DESCRIPTION
### Summary

Persist the existing CIS-compliant network kernel defaults in
`/usr/lib/sysctl.d/70-azurelinux-hardening.conf`.

The benchmark evaluates each `all` and `default` key independently and does
not treat wildcard declarations as persistent configuration.

### CIS controls addressed

- Ensure net.ipv4.conf.all.forwarding is configured (fixes [AB#22881](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22881))
- Ensure net.ipv4.conf.default.forwarding is configured (fixes [AB#22882](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22882))
- Ensure net.ipv4.conf.all.send_redirects is configured (fixes [AB#22883](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22883))
- Ensure net.ipv4.conf.default.send_redirects is configured (fixes [AB#22884](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22884))
- Ensure net.ipv4.icmp_ignore_bogus_error_responses is configured (fixes [AB#22885](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22885))
- Ensure net.ipv4.icmp_echo_ignore_broadcasts is configured (fixes [AB#22886](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22886))
- Ensure net.ipv4.conf.all.accept_redirects is configured (fixes [AB#22887](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22887))
- Ensure net.ipv4.conf.default.accept_redirects is configured (fixes [AB#22888](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22888))
- Ensure net.ipv4.conf.all.accept_source_route is configured (fixes [AB#22891](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22891))
- Ensure net.ipv4.conf.all.log_martians is configured (fixes [AB#22892](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22892))
- Ensure net.ipv4.conf.default.log_martians is configured (fixes [AB#22893](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22893))
- Ensure net.ipv4.tcp_syncookies is configured (fixes [AB#22894](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22894))
- Ensure net.ipv6.conf.all.forwarding is configured (fixes [AB#22895](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22895))
- Ensure net.ipv6.conf.default.forwarding is configured (fixes [AB#22896](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22896))
- Ensure net.ipv6.conf.all.accept_redirects is configured (fixes [AB#22897](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22897))
- Ensure net.ipv6.conf.default.accept_redirects is configured (fixes [AB#22898](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22898))
- Ensure net.ipv6.conf.all.accept_source_route is configured (fixes [AB#22899](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22899))
- Ensure net.ipv6.conf.default.accept_source_route is configured (fixes [AB#22900](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22900))

### Validation

- Built `azurelinux-release-common` and verified the RPM payload in mock.
- Reinstalled the built RPM on a fresh Azure Linux 4 Marketplace VM and ran CIS-CAT.
- Assessment improved from **62.77% (145 pass / 86 fail)** to **70.56% (163 pass / 68 fail)**.
- All 18 controls above changed from fail to pass; no unrelated rule results changed.