### PR TITLE
[Medium] Patch `erlang` for CVE-2026-53422, CVE-2026-54887, CVE-2026-55950, CVE-2026-59250

### DIFF
--- a/SPECS/erlang/CVE-2026-53422.patch
+++ b/SPECS/erlang/CVE-2026-53422.patch
@@ -1,0 +1,458 @@
+From 86622cfaacf57a02c7645d1999f946846b504c94 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20W=C4=85sowski?= <michal@erlang.org>
+Date: Thu, 25 Jun 2026 13:53:00 +0200
+Subject: [PATCH] Fix realpath path existence oracle
+
+Upstream Patch Reference: https://github.com/erlang/otp/commit/86622cfaacf57a02c7645d1999f946846b504c94.patch
+---
+ lib/ssh/src/ssh_sftpd.erl        |  27 +--
+ lib/ssh/test/ssh_sftpd_SUITE.erl | 297 +++++++++++++++++++++++--------
+ lib/ssh/test/ssh_test_lib.hrl    |  13 ++
+ 3 files changed, 256 insertions(+), 81 deletions(-)
+
+diff --git a/lib/ssh/src/ssh_sftpd.erl b/lib/ssh/src/ssh_sftpd.erl
+index 8de37bd..adee01f 100644
+--- a/lib/ssh/src/ssh_sftpd.erl
++++ b/lib/ssh/src/ssh_sftpd.erl
+@@ -277,19 +277,24 @@ handle_op(?SSH_FXP_INIT, Version, B, State) when is_binary(B) ->
+     ssh_xfer:xf_send_reply(XF1, ?SSH_FXP_VERSION, <<?UINT32(Vsn)>>),
+     State#state{xf = XF1};
+ handle_op(?SSH_FXP_REALPATH, ReqId,
+-	  <<?UINT32(RLen), RPath:RLen/binary>>,
+-	  State0) ->
++          <<?UINT32(RLen), RPath:RLen/binary>>,
++          State0) ->
+     RelPath = relate_file_name(RPath, State0, _Canonicalize=false),
+-    {Res, State} = resolve_symlinks(RelPath, State0),
++    {Res, #state{root = Root} = State} = resolve_symlinks(RelPath, State0),
+     case Res of
+-	{ok, AbsPath} ->
+-	    NewAbsPath = chroot_filename(AbsPath, State),
+-	    XF = State#state.xf,
+-	    Attr = #ssh_xfer_attr{type=directory},
+-	    ssh_xfer:xf_send_name(XF, ReqId, NewAbsPath, Attr),
+-	    State;
+-	{error, _} = Error ->
+-	    send_status(Error, ReqId, State)
++        {ok, AbsPath} ->
++            case Root =:= "" orelse is_within_root(Root, AbsPath) of
++                true ->
++                    NewAbsPath = chroot_filename(AbsPath, State),
++                    XF = State#state.xf,
++                    Attr = #ssh_xfer_attr{type=directory},
++                    ssh_xfer:xf_send_name(XF, ReqId, NewAbsPath, Attr),
++                    State;
++                false ->
++                    send_status({error, enoent}, ReqId, State)
++            end;
++        {error, _} = Error ->
++            send_status(Error, ReqId, State)
+     end;
+ handle_op(?SSH_FXP_OPENDIR, ReqId,
+ 	 <<?UINT32(RLen), RPath:RLen/binary>>,
+diff --git a/lib/ssh/test/ssh_sftpd_SUITE.erl b/lib/ssh/test/ssh_sftpd_SUITE.erl
+index 55c0401..a847215 100644
+--- a/lib/ssh/test/ssh_sftpd_SUITE.erl
++++ b/lib/ssh/test/ssh_sftpd_SUITE.erl
+@@ -44,6 +44,8 @@
+          read_file/1,
+          max_path/1,
+          real_path/1,
++         real_path_root/1,
++         real_path_links_root/1,
+          relative_path/1,
+          relpath/1,
+          remove_file/1,
+@@ -65,6 +67,14 @@
+ -include("ssh.hrl").
+ -include("ssh_test_lib.hrl").
+ 
++-record(link_test, {name,
++                    link1,
++                    link2,
++                    expected
++                   }).
++
++-record(link, {location, target}).
++
+ -define(USER, "Alladin").
+ -define(PASSWD, "Sesame").
+ %% -define(XFER_PACKET_SIZE, 32768).
+@@ -73,7 +83,7 @@
+ -define(REG_ATTERS, <<0,0,0,0,1>>).
+ -define(UNIX_EPOCH,  62167219200).
+ -define(MAX_HANDLES, 10).
+--define(MAX_PATH, 200).
++-define(MAX_PATH, 220).
+ -define(is_set(F, Bits), ((F) band (Bits)) == (F)).
+ 
+ %%--------------------------------------------------------------------
+@@ -94,6 +104,8 @@ all() ->
+      mk_rm_dir, 
+      remove_file,
+      real_path, 
++     real_path_root,
++     real_path_links_root,
+      retrieve_attributes, 
+      set_attributes, 
+      links,
+@@ -141,96 +153,41 @@ end_per_group(_GroupName, Config) ->
+ 
+ %%--------------------------------------------------------------------
+ 
+-init_per_testcase(TestCase, Config) ->
+-    {OsFamily, _} = os:type(),
++init_per_testcase(TestCase, Config0) ->
+     ssh:start(),
+-    prep(Config),
+-    PrivDir = proplists:get_value(priv_dir, Config),
++    prep(Config0),
++    PrivDir = proplists:get_value(priv_dir, Config0),
+     ClientUserDir = filename:join(PrivDir, nopubkey),
+-    SystemDir = filename:join(proplists:get_value(priv_dir, Config), system),
++    SystemDir = filename:join(proplists:get_value(priv_dir, Config0), system),
+ 
+     Options = [{system_dir, SystemDir},
+-	       {user_dir, PrivDir},
+-	       {user_passwords,[{?USER, ?PASSWD}]},
+-	       {pwdfun, fun(_,_) -> true end}],
+-    Result = case TestCase of
+-		      ver6_basic ->
+-			  SubSystems = [ssh_sftpd:subsystem_spec([{sftpd_vsn, 6}])],
+-			  ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+-                      access_outside_root ->
+-                          %% Build RootDir/access_outside_root/a/b and set Root and CWD
+-                          BaseDir = filename:join(PrivDir, access_outside_root),
+-                          RootDir = filename:join(BaseDir, a),
+-                          CWD     = filename:join(RootDir, b),
+-                          %% Make the directory chain:
+-                          ok = filelib:ensure_path(CWD),
+-                          SubSystems = [ssh_sftpd:subsystem_spec([{root, RootDir},
+-                                                                  {cwd, CWD}])],
+-                          ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+-                      access_attributes_outside_root when OsFamily =:= win32 ->
+-                          {skip, "Not implemented on windows"};
+-                      access_attributes_outside_root ->
+-                          Rand = integer_to_list(rand:uniform(1000000)),
+-                          RootDir = filename:join("/tmp", Rand),
+-                          ok = file:make_dir(RootDir),
+-                          SubSystems = [ssh_sftpd:subsystem_spec([{root, RootDir}])],
+-                          ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+-		      root_with_cwd ->
+-			  RootDir = filename:join(PrivDir, root_with_cwd),
+-			  CWD     = filename:join(RootDir, home),
+-			  SubSystems = [ssh_sftpd:subsystem_spec([{root, RootDir}, {cwd, CWD}])],
+-			  ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+-		      relative_path ->
+-			  SubSystems = [ssh_sftpd:subsystem_spec([{cwd, PrivDir}])],
+-			  ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+-		      open_file_dir_v5 ->
+-			  SubSystems = [ssh_sftpd:subsystem_spec([{cwd, PrivDir}])],
+-			  ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+-		      open_file_dir_v6 ->
+-			  SubSystems = [ssh_sftpd:subsystem_spec([{cwd, PrivDir},
+-								  {sftpd_vsn, 6}])],
+-			  ssh:daemon(0, [{subsystems, SubSystems}|Options]);
+-		      _ ->
+-			  SubSystems = [ssh_sftpd:subsystem_spec(
+-                                          [{max_handles, ?MAX_HANDLES},
+-					  {max_path, ?MAX_PATH}])],
+-			  ssh:daemon(0, [{subsystems, SubSystems}|Options])
+-		  end,
+-    
+-    case Result of
+-        {ok, Sftpd} ->
++               {user_dir, PrivDir},
++               {user_passwords,[{?USER, ?PASSWD}]},
++               {pwdfun, fun(_,_) -> true end}],
++    case prep_sftpd(TestCase, Config0) of
++        {{"sftp", _} = Spec, Config} ->
++            {ok, Sftpd} = ssh:daemon(0, [{subsystems, [Spec]} | Options]),
+             Port = ssh_test_lib:daemon_port(Sftpd),
+-
+             Cm = ssh_test_lib:connect(Port,
+                                       [{user_dir, ClientUserDir},
+                                        {user, ?USER}, {password, ?PASSWD},
+                                        {user_interaction, false},
+                                        {silently_accept_hosts, true}]),
+             {ok, Channel} =
+-                ssh_connection:session_channel(Cm, ?XFER_WINDOW_SIZE,
+-                                               ?XFER_PACKET_SIZE, ?SSH_TIMEOUT),
+-
++                ssh_connection:session_channel(Cm, ?XFER_WINDOW_SIZE, ?XFER_PACKET_SIZE, ?SSH_TIMEOUT),
+             success = ssh_connection:subsystem(Cm, Channel, "sftp", ?SSH_TIMEOUT),
+-
+             ProtocolVer = case atom_to_list(TestCase) of
+                               "ver3_" ++ _ ->
+                                   3;
+                               _ ->
+                                   ?SSH_SFTP_PROTOCOL_VERSION
+                           end,
+-
+-            Data = <<?UINT32(ProtocolVer)>> ,
+-
++            Data = <<?UINT32(ProtocolVer)>>,
+             Size = 1 + size(Data),
+-
+-            ssh_connection:send(Cm, Channel, << ?UINT32(Size),
+-                                                ?SSH_FXP_INIT, Data/binary >>),
+-
++            ssh_connection:send(Cm, Channel, <<?UINT32(Size), ?SSH_FXP_INIT, Data/binary >>),
+             {ok, <<?SSH_FXP_VERSION, ?UINT32(Version), _Ext/binary>>, _}
+                 = reply(Cm, Channel),
+-
+-            ct:log("Client: ~p Server ~p~n", [ProtocolVer, Version]),
+-
++            ?CT_LOG("Client: ~p Server ~p~n", [ProtocolVer, Version]),
+             [{sftp, {Cm, Channel}}, {sftpd, Sftpd }| Config];
+         Other ->
+             Other
+@@ -245,6 +202,11 @@ end_per_testcase(access_attributes_outside_root, Config) ->
+     {_, {_, SftpdOpts}} = lists:keyfind("sftp", 1, Subsystems),
+     RootDir = proplists:get_value(root, SftpdOpts),
+     file:del_dir_r(RootDir);
++end_per_testcase(real_path_links_root, Config) ->
++    %% Workaround for buggy filelib:fold_files/5-6, we have to remove symlinks after test
++    LinkTests = proplists:get_value(link_tests, Config),
++    [delete_link_test(LinkTest, Config) || LinkTest <- LinkTests],
++    ssh_cleanup(Config);
+ end_per_testcase(_TestCase, Config) ->
+     ssh_cleanup(Config).
+ 
+@@ -527,6 +489,29 @@ real_path(Config) when is_list(Config) ->
+ 	    true = RealPath == AbsPrivDir
+     end.
+ 
++%%--------------------------------------------------------------------
++real_path_root(Config) when is_list(Config) ->
++    {Cm, Channel} = proplists:get_value(sftp, Config),
++    Tests =
++        [{filename:join("/", below_root),        "/below_root"},
++         {filename:join("/", "."),               "/"},
++         {filename:join(["/", "..", above_root]),no_such_file},
++         {"below_root",                         "/below_root"},
++         {".",                                   "/"},
++         {filename:join("..", above_root),       no_such_file}],
++    [verify_realpath(Cm, Channel, ReqId, Path, Expected) ||
++        {ReqId, {Path, Expected}} <- lists:enumerate(0, Tests)],
++    ok.
++
++%%--------------------------------------------------------------------
++real_path_links_root(Config) ->
++    {Cm, Channel} = proplists:get_value(sftp, Config),
++    LinkTests = proplists:get_value(link_tests, Config),
++    [prep_link_test(LinkTest, Config) || LinkTest <- LinkTests],
++    [verify_realpath(Cm, Channel, ReqId, filename:join("/", Name), Expected) ||
++        {ReqId, #link_test{name = Name, expected = Expected}} <-
++            lists:enumerate(0, LinkTests)].
++
+ %%--------------------------------------------------------------------
+ links(Config) when is_list(Config) ->
+     case os:type() of
+@@ -923,6 +908,151 @@ prep(Config) ->
+     ok = file:write_file_info(TestFile,
+ 			      FileInfo#file_info{mode = Mode}).
+ 
++prep_sftpd(ver6_basic, Config) ->
++    {ssh_sftpd:subsystem_spec([{sftpd_vsn, 6}]), Config};
++prep_sftpd(access_outside_root, Config) ->
++    PrivDir = proplists:get_value(priv_dir, Config),
++    %% Build RootDir/access_outside_root/a/b and set Root and CWD
++    BaseDir = filename:join(PrivDir, access_outside_root),
++    RootDir = filename:join(BaseDir, a),
++    CWD     = filename:join(RootDir, b),
++    %% Make the directory chain:
++    ok = filelib:ensure_dir(filename:join(CWD, tmp)),
++    {ssh_sftpd:subsystem_spec([{root, RootDir}, {cwd, CWD}]), Config};
++prep_sftpd(access_attributes_outside_root, Config) ->
++    case os:type() of
++        {win32, _} ->
++            {skip, "Not implemented on windows"};
++        _ ->
++            Rand = integer_to_list(rand:uniform(1000000)),
++            RootDir = filename:join("/tmp", Rand),
++            ok = file:make_dir(RootDir),
++            {ssh_sftpd:subsystem_spec([{root, RootDir}]), Config}
++    end;
++prep_sftpd(root_with_cwd, Config) ->
++    PrivDir = proplists:get_value(priv_dir, Config),
++    RootDir = filename:join(PrivDir, root_with_cwd),
++    CWD     = filename:join(RootDir, home),
++    {ssh_sftpd:subsystem_spec([{root, RootDir}, {cwd, CWD}]), Config};
++prep_sftpd(TestCase, Config) when TestCase =:= relative_path;
++                                  TestCase =:= open_file_dir_v5;
++                                  TestCase =:= links ->
++    PrivDir = proplists:get_value(priv_dir, Config),
++    {ssh_sftpd:subsystem_spec([{cwd, PrivDir}]), Config};
++prep_sftpd(open_file_dir_v6, Config) ->
++    PrivDir = proplists:get_value(priv_dir, Config),
++    {ssh_sftpd:subsystem_spec([{cwd, PrivDir}, {sftpd_vsn, 6}]), Config};
++prep_sftpd(links_root, Config) ->
++    PrivDir = proplists:get_value(priv_dir, Config),
++    RootDir = filename:join(PrivDir, links_root),
++    ok = file:make_dir(RootDir),
++    {ssh_sftpd:subsystem_spec([{root, RootDir}, {cwd, RootDir}]), Config};
++prep_sftpd(real_path_root, Config0) ->
++    case os:type() of
++        {win32, _} ->
++            {skip, "Not a relevant test on windows"};
++        _ ->
++            PrivDir = proplists:get_value(priv_dir, Config0),
++            RootDir = filename:join(PrivDir, real_path_root),
++            ok = file:make_dir(RootDir),
++            BelowRootFile = filename:join(RootDir, below_root),
++            ok = file:write_file(BelowRootFile, <<>>),
++            AboveRootFile = filename:join(PrivDir, above_root),
++            ok = file:write_file(AboveRootFile, <<>>),
++            Config = [{root, RootDir}, {below_root, BelowRootFile}, {above_root, AboveRootFile} | Config0],
++            {ssh_sftpd:subsystem_spec([{root, RootDir}, {cwd, PrivDir}]), Config}
++    end;
++prep_sftpd(real_path_links_root = TestCase, Config0) ->
++    case os:type() of
++        {win32, _} ->
++            {skip, "Not a relevant test on windows"};
++        _ ->
++            PrivDir = proplists:get_value(priv_dir, Config0),
++            RootDir = filename:join(PrivDir, TestCase),
++
++            ok = file:make_dir(RootDir),
++            TargetAboveRoot = filename:join(PrivDir, target),
++            ok = file:write_file(TargetAboveRoot, <<>>),
++            TargetBelowRoot = filename:join(RootDir, target),
++            ok = file:write_file(TargetBelowRoot, <<>>),
++
++            LinkTests =
++                [#link_test{name = abs_to_parent_of_root,
++                            link1 = #link{target = [RootDir, ".."]},
++                            expected = no_such_file},
++                 #link_test{name = rel_to_parent_of_root,
++                            link1 = #link{target = [".."]},
++                            expected = no_such_file},
++                 #link_test{name = abs_return_to_below_root,
++                            link1 = #link{target = [TargetBelowRoot],
++                                          location = [PrivDir, abs_return_to_below_root]},
++                            link2 = #link{target = [PrivDir, abs_return_to_below_root]},
++                            expected = <<"/target">>},
++                 #link_test{name = rel_return_to_below_root,
++                            link1 = #link{target = [".", TestCase, target],
++                                          location = [PrivDir, rel_return_to_below_root]},
++                            link2 = #link{target = ["..", rel_return_to_below_root]},
++                            expected = <<"/target">>},
++                 #link_test{name = abs_return_to_above_root,
++                            link1 = #link{target = [TargetAboveRoot],
++                                          location = [PrivDir, abs_return_to_above_root]},
++                            link2 = #link{target = [PrivDir, abs_return_to_above_root]},
++                            expected = no_such_file},
++                 #link_test{name = rel_return_to_above_root,
++                            link1 = #link{target = [".", target],
++                                          location = [PrivDir, rel_return_to_above_root]},
++                            link2 = #link{target = ["..", rel_return_to_above_root]},
++                            expected = no_such_file},
++                 #link_test{name = abs_escape_above_root,
++                            link1 = #link{target = [RootDir, "..", target],
++                                          location = [PrivDir, abs_escape_above_root]},
++                            link2 = #link{target = [PrivDir, abs_escape_above_root]},
++                            expected = no_such_file},
++                 #link_test{name = rel_escape_above_root,
++                            link1 = #link{target = [".", TestCase, "..", target],
++                                          location = [PrivDir, rel_escape_above_root]},
++                            link2 = #link{target = ["..", rel_escape_above_root]},
++                            expected = no_such_file},
++                 #link_test{name = abs_escape_above_root_and_back,
++                            link1 = #link{target = [RootDir, "..", TestCase, target],
++                                          location = [PrivDir, abs_escape_above_root_and_back]},
++                            link2 = #link{target = [PrivDir, abs_escape_above_root_and_back]},
++                            expected = <<"/target">>},
++                 #link_test{name = rel_escape_above_root_and_back,
++                            link1 = #link{target = [".", TestCase, "..", TestCase, target],
++                                          location = [PrivDir, rel_escape_above_root_and_back]},
++                            link2 = #link{target = ["..", rel_escape_above_root_and_back]},
++                            expected = <<"/target">>}],
++            Config = [{root, RootDir}, {link_tests, LinkTests} | Config0],
++            {ssh_sftpd:subsystem_spec([{root, RootDir}, {cwd, PrivDir}]), Config}
++    end;
++prep_sftpd(_TestCase, Config) ->
++    {ssh_sftpd:subsystem_spec([{max_handles, ?MAX_HANDLES}, {max_path, ?MAX_PATH}]), Config}.
++
++prep_link_test(#link_test{name = Name, link1 = Link1, link2 = Link2}, Config) ->
++    ok = prep_link(Link1, Name, Config),
++    ok = prep_link(Link2, Name, Config).
++
++prep_link(undefined, _Name, _Config) ->
++    ok;
++prep_link(#link{location = undefined, target = Target}, Name, Config) ->
++    RootDir = proplists:get_value(root, Config),
++    ok = file:make_symlink(filename:join(Target), filename:join(RootDir, Name));
++prep_link(#link{location = Location, target = Target}, _Name, _Config) ->
++    ok = file:make_symlink(filename:join(Target), filename:join(Location)).
++
++delete_link_test(#link_test{name = Name, link1 = Link1, link2 = Link2}, Config) ->
++    delete_link(Link1, Name, Config),
++    delete_link(Link2, Name, Config).
++
++delete_link(undefined, _Name, _Config) ->
++    ok;
++delete_link(#link{location = undefined}, Name, Config) ->
++    RootDir = proplists:get_value(root, Config),
++    file:delete(filename:join(RootDir, Name));
++delete_link(#link{location = Location}, _Name, _Config) ->
++    file:delete(filename:join(Location)).
++
+ reply(Cm, Channel) ->
+     reply(Cm, Channel,<<>>).
+ 
+@@ -1198,3 +1328,30 @@ req_id() ->
+         end,
+     put(req_id, ReqId + 1),
+     ReqId.
++
++
++verify_realpath(Cm, Channel, ReqId, Path, no_such_file) ->
++    case real_path(Path, Cm, Channel, ReqId) of
++        {ok, <<?SSH_FXP_STATUS, ?UINT32(ReqId), ?UINT32(?SSH_FX_NO_SUCH_FILE), _/binary>>, _} ->
++            ok;
++        {ok, <<?SSH_FXP_NAME, ?UINT32(ReqId), ?UINT32(_), ?UINT32(Len),
++               ActualPath:Len/binary, _/binary>>, _} ->
++            ?CT_FAIL("Escape from root detected!~nPath: ~p~nExpected: SSH_FX_NO_SUCH_FILE~nActual: ~p~n",
++                     [Path, ActualPath]);
++        Other ->
++            ?CT_FAIL("Unexpected response for path: ~p~nExpected: SSH_FX_NO_SUCH_FILE~nActual: ~p~n",
++                     [Path, Other])
++    end;
++verify_realpath(Cm, Channel, ReqId, Path, Expected) ->
++    ExpBin = iolist_to_binary(Expected),
++    case real_path(Path, Cm, Channel, ReqId) of
++        {ok, <<?SSH_FXP_NAME, ?UINT32(ReqId), ?UINT32(_), ?UINT32(Len),
++               ExpBin:Len/binary, _/binary>>, _} ->
++            ok;
++        {ok, <<?SSH_FXP_STATUS, ?UINT32(ReqId), ?UINT32(Status), _/binary>>, _} ->
++            ?CT_FAIL("Unexpected status for path: ~p~nExpected: ~p~nActual: ~p~n",
++                     [Path, Expected, Status]);
++        Other ->
++            ?CT_FAIL("Unexpected response for path: ~p~nExpected: ~p~nActual: ~p~n",
++                     [Path, Expected, Other])
++    end.
+diff --git a/lib/ssh/test/ssh_test_lib.hrl b/lib/ssh/test/ssh_test_lib.hrl
+index ade4174..4954e2a 100644
+--- a/lib/ssh/test/ssh_test_lib.hrl
++++ b/lib/ssh/test/ssh_test_lib.hrl
+@@ -67,3 +67,16 @@
+                 ct:log("~p:~p Show file~n~s =~n~s~n",
+                        [?MODULE,?LINE,File__, Contents__])
+         end)(File)).
++
++-define(SSH_TEST_LIB_FORMAT, "(~s ~p:~p in ~p) ").
++-define(SSH_TEST_LIB_ARGS,
++        [erlang:pid_to_list(self()), ?MODULE, ?LINE, ?FUNCTION_NAME]).
++-define(CT_LOG(F),
++        (ct:log(?SSH_TEST_LIB_FORMAT ++ F, ?SSH_TEST_LIB_ARGS, [esc_chars]))).
++-define(CT_LOG(F, Args),
++        (ct:log(
++           ?SSH_TEST_LIB_FORMAT ++ F,
++           ?SSH_TEST_LIB_ARGS ++ Args,
++           [esc_chars]))).
++-define(CT_FAIL(F, Args),
++        (ct:fail(?SSH_TEST_LIB_FORMAT ++ F, ?SSH_TEST_LIB_ARGS ++ Args))).
+-- 
+2.45.4
+

--- a/SPECS/erlang/CVE-2026-54887.patch
+++ b/SPECS/erlang/CVE-2026-54887.patch
@@ -1,0 +1,26 @@
+From 888e3bcd72d5406016b9e0de741026bc2a6f114d Mon Sep 17 00:00:00 2001
+From: Ingela Anderton Andin <ingela@erlang.org>
+Date: Mon, 15 Jun 2026 14:08:08 +0200
+Subject: [PATCH] ssl: Avoid cookie forgery during setup up window
+
+Upstream Patch Reference: https://github.com/erlang/otp/commit/888e3bcd72d5406016b9e0de741026bc2a6f114d.patch
+---
+ lib/ssl/src/dtls_connection.erl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/ssl/src/dtls_connection.erl b/lib/ssl/src/dtls_connection.erl
+index aa93b54..798826e 100644
+--- a/lib/ssl/src/dtls_connection.erl
++++ b/lib/ssl/src/dtls_connection.erl
+@@ -243,7 +243,7 @@ initial_hello({call, From}, {start, Timeout},
+     dtls_gen_connection:next_event(hello, no_record, State, [{{timeout, handshake}, Timeout, close} | Actions]);
+ initial_hello({call, _} = Type, Event, #state{static_env = #static_env{role = server},
+                                               protocol_specific = PS0} = State) ->
+-    PS = PS0#{current_cookie_secret => dtls_v1:cookie_secret(), previous_cookie_secret => <<>>},
++    PS = PS0#{current_cookie_secret => dtls_v1:cookie_secret(), previous_cookie_secret => dtls_v1:cookie_secret()},
+     Result = ssl_gen_statem:?FUNCTION_NAME(Type, Event, State#state{protocol_specific = PS}),
+     erlang:send_after(dtls_v1:cookie_timeout(), self(), new_cookie_secret),
+     Result;
+-- 
+2.45.4
+

--- a/SPECS/erlang/CVE-2026-55950.patch
+++ b/SPECS/erlang/CVE-2026-55950.patch
@@ -1,0 +1,37 @@
+From e44d2bf01c4473ef2ea7f09e3523cf96de6e4a04 Mon Sep 17 00:00:00 2001
+From: Ingela Anderton Andin <ingela@erlang.org>
+Date: Thu, 25 Jun 2026 14:11:06 +0200
+Subject: [PATCH] ssl: Fix DTLS race condition
+
+Could be used to DoS attack DTLS servers.
+
+Upstream Patch Reference: https://github.com/erlang/otp/commit/e44d2bf01c4473ef2ea7f09e3523cf96de6e4a04.patch
+---
+ lib/ssl/src/dtls_packet_demux.erl | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/ssl/src/dtls_packet_demux.erl b/lib/ssl/src/dtls_packet_demux.erl
+index 3e9ce07..7043f2e 100644
+--- a/lib/ssl/src/dtls_packet_demux.erl
++++ b/lib/ssl/src/dtls_packet_demux.erl
+@@ -160,7 +160,7 @@ handle_call({new_connection, Old, _Pid}, _,
+             case kv_lookup(Old, MsgQs0) of
+                 {value, OldQueue} ->
+                     MsgQs1 = kv_delete(Old, MsgQs0),
+-                    MsgQs = kv_insert({old,Old}, OldQueue, MsgQs1),
++                    MsgQs = kv_enter({old,Old}, OldQueue, MsgQs1),
+                     {reply, true, State#state{dtls_msq_queues = MsgQs}};
+                 none ->
+                     %% Already set as old
+@@ -363,6 +363,8 @@ kv_lookup(Key, Store) ->
+     gb_trees:lookup(Key, Store).
+ kv_insert(Key, Value, Store) ->
+     gb_trees:insert(Key, Value, Store).
++kv_enter(Key, Value, Store) ->
++    gb_trees:enter(Key, Value, Store).
+ kv_get(Key, Store) ->
+     gb_trees:get(Key, Store).
+ kv_delete(Key, Store) ->
+-- 
+2.45.4
+

--- a/SPECS/erlang/CVE-2026-59250.patch
+++ b/SPECS/erlang/CVE-2026-59250.patch
@@ -1,0 +1,62 @@
+From 8704c8f550a11ed5f825e3c011ecb03565b79c4f Mon Sep 17 00:00:00 2001
+From: Jakub Witczak <kuba@erlang.org>
+Date: Tue, 30 Jun 2026 19:37:37 +0200
+Subject: [PATCH] megaco: fix sprintf buffer overflow in flex scanner
+
+Replace all sprintf(dataP->error_msg, ...) calls with
+snprintf(dataP->error_msg, sizeof(dataP->error_msg), ...) in
+mfs_load_property_groups and mfs_alloc_failed.
+
+A property name longer than 452 bytes in a Local/Remote descriptor
+causes sprintf to write past the fixed 512-byte error_msg buffer,
+corrupting adjacent struct fields (text_buf, term_spec pointers).
+On FORTIFY_SOURCE-enabled systems this results in SIGABRT; without
+FORTIFY the corrupted pointers are later passed to FREE(), giving
+an arbitrary-free primitive.
+
+The overflow is reachable pre-auth via a single crafted H.248
+message when the flex scanner is enabled ({scanner, flex}).
+
+Upstream Patch Reference: https://github.com/erlang/otp/commit/8704c8f550a11ed5f825e3c011ecb03565b79c4f.patch
+---
+ lib/megaco/src/flex/megaco_flex_scanner_drv.flex.src | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/lib/megaco/src/flex/megaco_flex_scanner_drv.flex.src b/lib/megaco/src/flex/megaco_flex_scanner_drv.flex.src
+index 50cf5f7..f0895ce 100644
+--- a/lib/megaco/src/flex/megaco_flex_scanner_drv.flex.src
++++ b/lib/megaco/src/flex/megaco_flex_scanner_drv.flex.src
+@@ -821,7 +821,7 @@ static void mfs_alloc_failed(MfsErlDrvData* dataP, char* msg, int sz)
+ 
+     int msg_len = strlen(msg);
+     if ((10 + 10 + msg_len) < sizeof(dataP->error_msg)) {
+-      if (0 >= sprintf(dataP->error_msg, "%s of %d bytes", msg, sz)) {
++      if (0 >= snprintf(dataP->error_msg, sizeof(dataP->error_msg), "%s of %d bytes", msg, sz)) {
+ 	mfs_fatal_error(dataP, msg);
+       }
+     } else {
+@@ -1156,8 +1156,8 @@ static void mfs_load_property_groups(MfsErlDrvData* dataP)
+              *          }).
+              */ 
+     
+-            if (0 >= sprintf(dataP->error_msg, "%s %s %s", 
+-                             PG_ERR_PRE, PG_ERR1, name)) {
++            if (0 >= snprintf(dataP->error_msg, sizeof(dataP->error_msg),
++                              "%s %s %s", PG_ERR_PRE, PG_ERR1, name)) {
+               mfs_fatal_error(dataP, PG_ERR1);
+             }
+             dataP->error = TRUE;
+@@ -1237,8 +1237,8 @@ static void mfs_load_property_groups(MfsErlDrvData* dataP)
+               "property parm name not found when "
+               "nameStart = %d\n", nameStart) );
+ 
+-        if (0 >= sprintf(dataP->error_msg, "%s %s (name start at %d)", 
+-                         PG_ERR_PRE, PG_ERR2, nameStart)) {
++        if (0 >= snprintf(dataP->error_msg, sizeof(dataP->error_msg),
++                          "%s %s (name start at %d)", PG_ERR_PRE, PG_ERR2, nameStart)) {
+           mfs_fatal_error(dataP, PG_ERR2);
+         }
+ 
+-- 
+2.45.4
+

--- a/SPECS/erlang/erlang.spec
+++ b/SPECS/erlang/erlang.spec
@@ -2,7 +2,7 @@
 Summary:        erlang
 Name:           erlang
 Version:        26.2.5.21
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -21,6 +21,13 @@ Patch8:         CVE-2026-55953.patch
 Patch9:         CVE-2026-58227.patch
 Patch10:        CVE-2026-59251.patch
 Patch11:        CVE-2026-54886.patch
+Patch12:        CVE-2026-53422.patch
+Patch13:        CVE-2026-54887.patch
+Patch14:        CVE-2026-55950.patch
+Patch15:        CVE-2026-59250.patch
+BuildRequires:  ncurses-devel
+BuildRequires:  openssl-devel
+BuildRequires:  unixODBC-devel
 BuildRequires:  unzip
 
 %if 0%{?with_check}
@@ -62,6 +69,9 @@ export ERL_TOP=`pwd`
 %{_libdir}/erlang/*
 
 %changelog
+
+* Tue Aug 11 2026 Aditya Singh <v-aditysing@microsoft.com> - 26.2.5.21-5
+- Patch for CVE-2026-53422, CVE-2026-54887, CVE-2026-55950, CVE-2026-59250
 
 * Sat Aug 01 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 26.2.5.21-4
 - Patch for CVE-2026-54886


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Patch `erlang` for CVE-2026-53422, CVE-2026-54887, CVE-2026-55950, CVE-2026-59250

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/erlang/CVE-2026-53422.patch
- new file:   SPECS/erlang/CVE-2026-54887.patch
- new file:   SPECS/erlang/CVE-2026-55950.patch
- new file:   SPECS/erlang/CVE-2026-59250.patch
- modified:   SPECS/erlang/erlang.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-53422
- https://nvd.nist.gov/vuln/detail/CVE-2026-54887
- https://nvd.nist.gov/vuln/detail/CVE-2026-55950
- https://nvd.nist.gov/vuln/detail/CVE-2026-59250

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.
- Patches apply cleanly.
  <img width="1178" height="370" alt="image" src="https://github.com/user-attachments/assets/d86363b3-7ad4-4362-9cdc-57e95b872fbd" />

- License check script shows no warning.
- Installation and Uninstallation on docker image was successful.