### PR TITLE
chore(pipelines): Add CodeQL pipeline definition for 4.0 branch

### DIFF
--- a/.pipelines/CodeQL/CodeQL.yml
+++ b/.pipelines/CodeQL/CodeQL.yml
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: CodeQL CBL-Mariner repository
+
+trigger: none
+
+resources:
+  repositories:
+    - repository: CBL-Mariner-Pipelines
+      type: git
+      name: mariner/CBL-Mariner-Pipelines
+      ref: 'refs/heads/master'
+
+stages:
+  - stage: CodeQlAnalysis
+    jobs:
+    - template: SDL/CodeQL-CBL-Mariner.yml@CBL-Mariner-Pipelines


### PR DESCRIPTION
Adds `.pipelines/CodeQL/CodeQL.yml` to the 4.0 branch (identical to the file already present on 2.0 and 3.0). This is required to repurpose the ADO CodeQL analysis pipeline (def 2477) from the EOL 2.0 branch to 4.0. The YAML uses `trigger: none` and delegates to the shared `SDL/CodeQL-CBL-Mariner.yml` template in CBL-Mariner-Pipelines; the scheduled trigger and target branch are configured in the ADO pipeline definition.