### PR TITLE
fix(azurelinux-release): configure CIS login banners

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -307,14 +307,11 @@ BUG_REPORT_URL="%{dist_bug_report_url}"
 EOF
 
 # Create the common /etc/issue
-echo "\S" > %{buildroot}%{_prefix}/lib/issue
-echo "Kernel \r on \m (\l)" >> %{buildroot}%{_prefix}/lib/issue
-echo >> %{buildroot}%{_prefix}/lib/issue
+echo "Authorized use only. All activity may be monitored and reported." > %{buildroot}%{_prefix}/lib/issue
 ln -s ../usr/lib/issue %{buildroot}%{_sysconfdir}/issue
 
 # Create /etc/issue.net
-echo "\S" > %{buildroot}%{_prefix}/lib/issue.net
-echo "Kernel \r on \m (\l)" >> %{buildroot}%{_prefix}/lib/issue.net
+echo "Authorized use only. All activity may be monitored and reported." > %{buildroot}%{_prefix}/lib/issue.net
 ln -s ../usr/lib/issue.net %{buildroot}%{_sysconfdir}/issue.net
 
 # Create /etc/issue.d
@@ -485,6 +482,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-23
+- Configure neutral local and remote login banners
+
 * Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-22
 - Persist CIS network sysctl defaults
 

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:7cb3a4f68594b2f5acd31b5f3a552a02f4a288fe936b97b660b207270e2f2603'
+input-fingerprint = 'sha256:8ae71c852990b62eb011c724348b26fb2793a9f5616d59816b112e09c8541a18'

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -310,14 +310,11 @@ BUG_REPORT_URL="%{dist_bug_report_url}"
 EOF
 
 # Create the common /etc/issue
-echo "\S" > %{buildroot}%{_prefix}/lib/issue
-echo "Kernel \r on \m (\l)" >> %{buildroot}%{_prefix}/lib/issue
-echo >> %{buildroot}%{_prefix}/lib/issue
+echo "Authorized use only. All activity may be monitored and reported." > %{buildroot}%{_prefix}/lib/issue
 ln -s ../usr/lib/issue %{buildroot}%{_sysconfdir}/issue
 
 # Create /etc/issue.net
-echo "\S" > %{buildroot}%{_prefix}/lib/issue.net
-echo "Kernel \r on \m (\l)" >> %{buildroot}%{_prefix}/lib/issue.net
+echo "Authorized use only. All activity may be monitored and reported." > %{buildroot}%{_prefix}/lib/issue.net
 ln -s ../usr/lib/issue.net %{buildroot}%{_sysconfdir}/issue.net
 
 # Create /etc/issue.d
@@ -488,6 +485,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-23
+- Configure neutral local and remote login banners
+
 * Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-22
 - Persist CIS network sysctl defaults
 


### PR DESCRIPTION
### Summary

Configure neutral, static login banners for Azure Linux 4:

- Set `/etc/issue` and `/etc/issue.net` to:
  `Authorized use only. All activity may be monitored and reported.`
- Remove dynamic platform and kernel information from the default banners.

### CIS rules

- **1.7.2 Ensure `/etc/issue` is configured** — Fixes [AB#22867](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22867)
- **1.7.3 Ensure `/etc/issue.net` is configured** — Fixes [AB#22868](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22868)

### Validation

- Installed the built RPMs on a fresh Azure Linux 4 Marketplace VM.
- CIS-CAT Level 1 Server assessment passed both listed rules.