### PR TITLE
[High] Patch telegraf for CVE-2026-54332, CVE-2026-65819

### DIFF
--- a/SPECS/telegraf/CVE-2026-54332.patch
+++ b/SPECS/telegraf/CVE-2026-54332.patch
@@ -1,0 +1,82 @@
+From 5e4feb69db81746203277f85d3bda9d5c85a58d5 Mon Sep 17 00:00:00 2001
+From: tonghuaroot <tonghuaroot@gmail.com>
+Date: Fri, 5 Jun 2026 04:44:08 +0800
+Subject: [PATCH] Merge commit from fork
+
+The sFlow ExtendedGatewayFlow (record type 1003) decoder allocated slices
+with make([]uint32, n) where n is a raw 32-bit wire field with no upper
+bound, and the allocation ran before the loop that consumes the bytes. A
+single ~104-byte UDP datagram could therefore request up to 16 GiB and
+OOM-kill any service parsing sFlow with gopacket (unauthenticated remote
+DoS, CWE-770).
+
+Both decodeExtendedGatewayFlowRecord (communitiesLength) and decodePath
+(ad.Count) now reject any count that exceeds the bytes actually remaining
+in the datagram (each element is 4 bytes on the wire, so the bound is
+len(remaining)/4) and return a decode error instead of pre-allocating.
+decodePath now returns that error and its caller propagates it.
+
+Adds a regression test that feeds an oversized communities count and
+asserts a decode error rather than an unbounded allocation, plus a
+negative control that a correctly sized record still decodes.
+
+Signed-off-by: Azure Linux Security Servicing Account <azurelinux-security@microsoft.com>
+Upstream-reference: https://github.com/gopacket/gopacket/commit/76119086f5936aacd7088bdf97d565501bb6c4cc.patch
+---
+ .../gopacket/gopacket/layers/sflow.go         | 22 +++++++++++++++++--
+ 1 file changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/github.com/gopacket/gopacket/layers/sflow.go b/vendor/github.com/gopacket/gopacket/layers/sflow.go
+index 70fd787a..e2f7cabf 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/sflow.go
++++ b/vendor/github.com/gopacket/gopacket/layers/sflow.go
+@@ -1270,15 +1270,23 @@ func (asd SFlowASDestination) String() string {
+ 	}
+ }
+ 
+-func (ad *SFlowASDestination) decodePath(data *[]byte) {
++func (ad *SFlowASDestination) decodePath(data *[]byte) error {
+ 	*data, ad.Type = (*data)[4:], SFlowASPathType(binary.BigEndian.Uint32((*data)[:4]))
+ 	*data, ad.Count = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
++	// ad.Count is an attacker-controlled 32-bit field and each member that
++	// follows is 4 bytes on the wire. Reject any count that cannot be backed
++	// by the bytes actually remaining, otherwise make([]uint32, ad.Count) lets
++	// a tiny datagram drive an arbitrarily large allocation (CWE-770).
++	if ad.Count > uint32(len(*data)/4) {
++		return fmt.Errorf("SFlow AS path member count %d exceeds remaining buffer", ad.Count)
++	}
+ 	ad.Members = make([]uint32, ad.Count)
+ 	for i := uint32(0); i < ad.Count; i++ {
+ 		var member uint32
+ 		*data, member = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
+ 		ad.Members[i] = member
+ 	}
++	return nil
+ }
+ 
+ func decodeExtendedGatewayFlowRecord(data *[]byte) (SFlowExtendedGatewayFlowRecord, error) {
+@@ -1299,10 +1307,20 @@ func decodeExtendedGatewayFlowRecord(data *[]byte) (SFlowExtendedGatewayFlowReco
+ 	*data, eg.ASPathCount = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
+ 	for i := uint32(0); i < eg.ASPathCount; i++ {
+ 		asPath := SFlowASDestination{}
+-		asPath.decodePath(data)
++		if err := asPath.decodePath(data); err != nil {
++			return eg, err
++		}
+ 		eg.ASPath = append(eg.ASPath, asPath)
+ 	}
+ 	*data, communitiesLength = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
++	// communitiesLength is an attacker-controlled 32-bit field and each
++	// community that follows is 4 bytes on the wire. Reject any count that
++	// cannot be backed by the bytes actually remaining, otherwise
++	// make([]uint32, communitiesLength) lets a tiny datagram drive an
++	// arbitrarily large allocation (CWE-770).
++	if communitiesLength > uint32(len(*data)/4) {
++		return eg, fmt.Errorf("SFlow community count %d exceeds remaining buffer", communitiesLength)
++	}
+ 	eg.Communities = make([]uint32, communitiesLength)
+ 	for j := uint32(0); j < communitiesLength; j++ {
+ 		*data, community = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
+-- 
+2.45.4
+

--- a/SPECS/telegraf/CVE-2026-65819.patch
+++ b/SPECS/telegraf/CVE-2026-65819.patch
@@ -1,0 +1,356 @@
+From 210f25fb9b3ca1af2eb649936f78ad6991b6c9c5 Mon Sep 17 00:00:00 2001
+From: Ali <10158936+mosajjal@users.noreply.github.com>
+Date: Fri, 3 Jul 2026 20:49:03 +1200
+Subject: [PATCH] Merge commit from fork
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Multiple layer decoders read or sliced packet data using an
+attacker-controlled length, count, or offset before validating it
+against the buffer size. A single malformed packet triggered a runtime
+panic (out-of-bounds slice/index or unsigned-integer underflow). Via
+DecodingLayerParser or a direct DecodeFromBytes call the panic is not
+recovered, crashing the caller — an unauthenticated remote DoS. Same
+class as the earlier GRE (#154) and IPv4 option (#159) fixes.
+
+Fixed decoders: TLS handshake/ClientHello, DHCPv4, sFlow datagram,
+IPSec AH, VRRPv2, Diameter, GTPv1-U, ERSPAN II, LCM, RadioTap, and
+Dot11 InformationElement. Each attacker-controlled length is now
+validated against len(data) (in int arithmetic that cannot underflow)
+before use, returning df.SetTruncated() and an error instead of
+panicking. The TLS ClientHello parser is rewritten to bounds-check
+every field while preserving its existing read-to-capacity behavior so
+SNI extraction on real captures is unchanged.
+
+Adds TestDecodeOOBRegression covering all twelve crafted inputs.
+
+Ref: GHSA-8mcr-459q-5mx2
+
+
+Claude-Session: https://claude.ai/code/session_01AEgqcfwb9wTW91oZQv9K7X
+
+Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
+
+Upstream Patch Reference: https://github.com/gopacket/gopacket/commit/210f25fb9b3ca1af2eb649936f78ad6991b6c9c5.patch
+---
+ .../gopacket/layers/decode_oob_test.go        | 70 +++++++++++++++++++
+ .../gopacket/gopacket/layers/dhcpv4.go        |  5 ++
+ .../gopacket/gopacket/layers/erspan2.go       |  5 ++
+ .../gopacket/gopacket/layers/gtp.go           |  3 +
+ .../gopacket/gopacket/layers/ipsec.go         |  5 ++
+ .../gopacket/gopacket/layers/lcm.go           |  7 ++
+ .../gopacket/gopacket/layers/radiotap.go      |  4 ++
+ .../gopacket/gopacket/layers/sflow.go         |  9 +++
+ .../gopacket/gopacket/layers/tls_handshake.go | 61 +++++++++++++---
+ .../gopacket/gopacket/layers/vrrp.go          |  4 ++
+ 10 files changed, 165 insertions(+), 8 deletions(-)
+ create mode 100644 vendor/github.com/gopacket/gopacket/layers/decode_oob_test.go
+
+diff --git a/vendor/github.com/gopacket/gopacket/layers/decode_oob_test.go b/vendor/github.com/gopacket/gopacket/layers/decode_oob_test.go
+new file mode 100644
+index 00000000..7a31a6ae
+--- /dev/null
++++ b/vendor/github.com/gopacket/gopacket/layers/decode_oob_test.go
+@@ -0,0 +1,70 @@
++// Copyright 2026 The GoPacket Authors. All rights reserved.
++//
++// Use of this source code is governed by a BSD-style license
++// that can be found in the LICENSE file in the root of the source
++// tree.
++
++package layers
++
++import (
++	"testing"
++
++	"github.com/gopacket/gopacket"
++)
++
++// TestDecodeOOBRegression verifies that crafted, truncated packets which
++// previously triggered out-of-bounds panics (GHSA-8mcr-459q-5mx2) are now
++// rejected with an error instead of crashing. Each decoder is driven through
++// the direct DecodeFromBytes path, which does not recover panics (unlike
++// gopacket.NewPacket with default options), mirroring how DecodingLayerParser
++// invokes decoders.
++func TestDecodeOOBRegression(t *testing.T) {
++	dhcp := make([]byte, 240)
++	dhcp[2] = 0xFF // HardwareLen: 28+0xFF wraps in uint8
++	dhcp[236], dhcp[237], dhcp[238], dhcp[239] = 0x63, 0x82, 0x53, 0x63
++
++	cases := []struct {
++		name   string
++		layer  func() gopacket.DecodingLayer
++		decode func([]byte) error
++		data   []byte
++	}{
++		{"TLS/empty-handshake", func() gopacket.DecodingLayer { return &TLS{} }, nil, []byte{0x16, 0x03, 0x01, 0x00, 0x00}},
++		{"TLS/short-clienthello", func() gopacket.DecodingLayer { return &TLS{} }, nil, []byte{0x16, 0x03, 0x01, 0x00, 0x01, 0x01}},
++		{"DHCPv4/hwlen-overflow", func() gopacket.DecodingLayer { return &DHCPv4{} }, nil, dhcp},
++		{"SFlow/short-header", func() gopacket.DecodingLayer { return &SFlowDatagram{} }, nil, []byte{0x00, 0x00, 0x00}},
++		{"IPSecAH/short-actuallen", nil, decodeLayer(LayerTypeIPSecAH), make([]byte, 12)},
++		{"VRRPv2/count-overrun", func() gopacket.DecodingLayer { return &VRRPv2{} }, nil, []byte{0x21, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00}},
++		{"GTPv1U/ext-header-overrun", func() gopacket.DecodingLayer { return &GTPv1U{} }, nil, []byte{0x04, 0xFF, 0x00, 0x04, 0, 0, 0, 0, 0, 0, 0, 0x01}},
++		{"ERSPANII/short", func() gopacket.DecodingLayer { return &ERSPANII{} }, nil, make([]byte, 6)},
++		{"LCM/short-fragmented", func() gopacket.DecodingLayer { return &LCM{} }, nil, []byte{0x4c, 0x43, 0x30, 0x33, 0x00, 0x00, 0x00, 0x00}},
++		{"RadioTap/present-ext-overrun", func() gopacket.DecodingLayer { return &RadioTap{} }, nil, []byte{0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x80}},
++	}
++
++	for _, c := range cases {
++		t.Run(c.name, func(t *testing.T) {
++			defer func() {
++				if r := recover(); r != nil {
++					t.Fatalf("decoder panicked on crafted input: %v", r)
++				}
++			}()
++			// A returned error is expected and fine; the point is that it must
++			// not panic.
++			if c.decode != nil {
++				_ = c.decode(c.data)
++				return
++			}
++			_ = c.layer().DecodeFromBytes(c.data, gopacket.NilDecodeFeedback)
++		})
++	}
++}
++
++func decodeLayer(layerType gopacket.LayerType) func([]byte) error {
++	return func(data []byte) error {
++		packet := gopacket.NewPacket(data, layerType, gopacket.DecodeOptions{SkipDecodeRecovery: true})
++		if errLayer := packet.ErrorLayer(); errLayer != nil {
++			return errLayer.Error()
++		}
++		return nil
++	}
++}
+diff --git a/vendor/github.com/gopacket/gopacket/layers/dhcpv4.go b/vendor/github.com/gopacket/gopacket/layers/dhcpv4.go
+index 1f1e623e..cd44a607 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/dhcpv4.go
++++ b/vendor/github.com/gopacket/gopacket/layers/dhcpv4.go
+@@ -132,6 +132,11 @@ func (d *DHCPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error
+ 	d.Operation = DHCPOp(data[0])
+ 	d.HardwareType = LinkType(data[1])
+ 	d.HardwareLen = data[2]
++	if d.HardwareLen > 16 {
++		// The BOOTP chaddr field is fixed at 16 bytes (data[28:44]); a larger
++		// hardware length would read past it (and 28+HardwareLen wraps in uint8).
++		return fmt.Errorf("DHCPv4 hardware address length %d exceeds 16", d.HardwareLen)
++	}
+ 	d.RelayHops = data[3]
+ 	d.Xid = binary.BigEndian.Uint32(data[4:8])
+ 	d.Secs = binary.BigEndian.Uint16(data[8:10])
+diff --git a/vendor/github.com/gopacket/gopacket/layers/erspan2.go b/vendor/github.com/gopacket/gopacket/layers/erspan2.go
+index dae2b30c..57029346 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/erspan2.go
++++ b/vendor/github.com/gopacket/gopacket/layers/erspan2.go
+@@ -8,6 +8,7 @@ package layers
+ 
+ import (
+ 	"encoding/binary"
++	"errors"
+ 
+ 	"github.com/gopacket/gopacket"
+ )
+@@ -34,6 +35,10 @@ func (erspan2 *ERSPANII) LayerType() gopacket.LayerType { return LayerTypeERSPAN
+ // DecodeFromBytes decodes the given bytes into this layer.
+ func (erspan2 *ERSPANII) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+ 	erspan2Length := 8
++	if len(data) < erspan2Length {
++		df.SetTruncated()
++		return errors.New("ERSPAN II header too short")
++	}
+ 	erspan2.Version = data[0] & 0xF0 >> 4
+ 	erspan2.VLANIdentifier = binary.BigEndian.Uint16(data[:2]) & 0x0FFF
+ 	erspan2.CoS = data[2] & 0xE0 >> 5
+diff --git a/vendor/github.com/gopacket/gopacket/layers/gtp.go b/vendor/github.com/gopacket/gopacket/layers/gtp.go
+index 82b80bed..a11c7c81 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/gtp.go
++++ b/vendor/github.com/gopacket/gopacket/layers/gtp.go
+@@ -80,6 +80,9 @@ func (g *GTPv1U) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error
+ 		if g.ExtensionHeaderFlag {
+ 			extensionFlag := true
+ 			for extensionFlag {
++				if int(cIndex) >= dLen {
++					return fmt.Errorf("GTP packet too small: %d bytes", dLen)
++				}
+ 				extensionType := uint8(data[cIndex-1])
+ 				extensionLength := uint(data[cIndex])
+ 				if extensionLength == 0 {
+diff --git a/vendor/github.com/gopacket/gopacket/layers/ipsec.go b/vendor/github.com/gopacket/gopacket/layers/ipsec.go
+index 7f789acd..ac56ffba 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/ipsec.go
++++ b/vendor/github.com/gopacket/gopacket/layers/ipsec.go
+@@ -43,6 +43,11 @@ func decodeIPSecAH(data []byte, p gopacket.PacketBuilder) error {
+ 		Seq:      binary.BigEndian.Uint32(data[8:12]),
+ 	}
+ 	i.ActualLength = (int(i.HeaderLength) + 2) * 4
++	if i.ActualLength < 12 {
++		// Authentication data starts at byte 12; a shorter header would make
++		// the data[12:ActualLength] slice below have out-of-order bounds.
++		return errors.New("AH packet ActualLength < 12")
++	}
+ 	if len(data) < i.ActualLength {
+ 		p.SetTruncated()
+ 		return errors.New("Truncated AH packet < ActualLength")
+diff --git a/vendor/github.com/gopacket/gopacket/layers/lcm.go b/vendor/github.com/gopacket/gopacket/layers/lcm.go
+index 04db3bc3..64c50b47 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/lcm.go
++++ b/vendor/github.com/gopacket/gopacket/layers/lcm.go
+@@ -136,6 +136,13 @@ func (lcm *LCM) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+ 	if lcm.Magic == LCMFragmentedHeaderMagic {
+ 		lcm.Fragmented = true
+ 
++		// The fragmented header adds size(4) + fragOffset(4) + fragNumber(2) +
++		// totalFragments(2) = 12 bytes on top of the 8 already consumed.
++		if len(data) < offset+12 {
++			df.SetTruncated()
++			return errors.New("LCM fragmented header truncated")
++		}
++
+ 		lcm.PayloadSize = binary.BigEndian.Uint32(data[offset : offset+4])
+ 		offset += 4
+ 
+diff --git a/vendor/github.com/gopacket/gopacket/layers/radiotap.go b/vendor/github.com/gopacket/gopacket/layers/radiotap.go
+index 89641e4a..0424b97f 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/radiotap.go
++++ b/vendor/github.com/gopacket/gopacket/layers/radiotap.go
+@@ -745,6 +745,10 @@ func (m *RadioTap) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) erro
+ 		// and expects all fields are packed in the first it_present.
+ 		// Extended bitmap will be just ignored.
+ 		offset += 4
++		if int(offset)+4 > len(data) {
++			df.SetTruncated()
++			return errors.New("RadioTap present bitmap extends beyond data")
++		}
+ 	}
+ 	offset += 4 // skip the bitmap
+ 
+diff --git a/vendor/github.com/gopacket/gopacket/layers/sflow.go b/vendor/github.com/gopacket/gopacket/layers/sflow.go
+index e2f7cabf..19d67ad0 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/sflow.go
++++ b/vendor/github.com/gopacket/gopacket/layers/sflow.go
+@@ -302,8 +302,17 @@ func (s SFlowIPType) Length() int {
+ func (s *SFlowDatagram) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+ 	var agentAddressType SFlowIPType
+ 
++	if len(data) < 8 {
++		df.SetTruncated()
++		return errors.New("SFlow datagram too short")
++	}
+ 	data, s.DatagramVersion = data[4:], binary.BigEndian.Uint32(data[:4])
+ 	data, agentAddressType = data[4:], SFlowIPType(binary.BigEndian.Uint32(data[:4]))
++	// agent address + subAgentID + sequence + uptime + sampleCount = agentAddr + 16.
++	if len(data) < agentAddressType.Length()+16 {
++		df.SetTruncated()
++		return errors.New("SFlow datagram too short for agent address and header")
++	}
+ 	data, s.AgentAddress = data[agentAddressType.Length():], data[:agentAddressType.Length()]
+ 	data, s.SubAgentID = data[4:], binary.BigEndian.Uint32(data[:4])
+ 	data, s.SequenceNumber = data[4:], binary.BigEndian.Uint32(data[:4])
+diff --git a/vendor/github.com/gopacket/gopacket/layers/tls_handshake.go b/vendor/github.com/gopacket/gopacket/layers/tls_handshake.go
+index dba0c4c7..dcc1f7f6 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/tls_handshake.go
++++ b/vendor/github.com/gopacket/gopacket/layers/tls_handshake.go
+@@ -69,6 +69,18 @@ type TLSHandshakeRecord struct {
+ }
+ 
+ func (t *TLSHandshakeRecordClientHello) decodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
++	// The record framing hands us a slice whose length is the TLS record body
++	// but whose capacity may span the rest of the packet buffer. The original
++	// parser read up to that capacity; re-slice to it so the bounds checks
++	// below reflect the bytes actually available and can never read past the
++	// underlying buffer (which is what caused the panics this guards against).
++	data = data[:cap(data)]
++
++	// Fixed prefix: type(1) + length(3) + version(2) + random(32) + sessionIDLen(1).
++	if len(data) < 39 {
++		df.SetTruncated()
++		return errors.New("TLS ClientHello too short")
++	}
+ 	t.HandshakeType = data[0]
+ 	d := make([]byte, 4)
+ 	for k, v := range data[1:4] {
+@@ -78,13 +90,42 @@ func (t *TLSHandshakeRecordClientHello) decodeFromBytes(data []byte, df gopacket
+ 	t.ProtocolVersion = TLSVersion(binary.BigEndian.Uint16(data[4:6]))
+ 	t.Random = data[6:38]
+ 	t.SessionIDLength = data[38]
+-	t.SessionID = data[39 : 39+t.SessionIDLength]
+-	t.CipherSuitsLength = binary.BigEndian.Uint16(data[39+t.SessionIDLength : 39+t.SessionIDLength+2])
+-	t.CipherSuits = data[39+t.SessionIDLength+2 : (39 + uint16(t.SessionIDLength) + 2 + t.CipherSuitsLength)]
+-	t.CompressionMethodsLength = data[(39 + uint16(t.SessionIDLength) + 2 + t.CipherSuitsLength)]
+-	t.CompressionMethods = data[(39+uint16(t.SessionIDLength)+2+t.CipherSuitsLength)+1 : (39+uint16(t.SessionIDLength)+2+t.CipherSuitsLength)+1+uint16(t.CompressionMethodsLength)]
+-	t.ExtensionsLength = binary.BigEndian.Uint16(data[(39+uint16(t.SessionIDLength)+2+t.CipherSuitsLength)+1+uint16(t.CompressionMethodsLength) : (39+uint16(t.SessionIDLength)+2+t.CipherSuitsLength)+1+uint16(t.CompressionMethodsLength)+2])
+-	t.Extensions = data[((39 + uint16(t.SessionIDLength) + 2 + t.CipherSuitsLength) + 1 + uint16(t.CompressionMethodsLength) + 2) : ((39+uint16(t.SessionIDLength)+2+t.CipherSuitsLength)+1+uint16(t.CompressionMethodsLength)+2)+t.ExtensionsLength]
++
++	// All subsequent offsets are computed in int to avoid uint16 overflow,
++	// and each variable-length field is bounds-checked before it is read.
++	pos := 39 + int(t.SessionIDLength)
++	if len(data) < pos+2 {
++		df.SetTruncated()
++		return errors.New("TLS ClientHello truncated in session ID")
++	}
++	t.SessionID = data[39:pos]
++	t.CipherSuitsLength = binary.BigEndian.Uint16(data[pos : pos+2])
++	pos += 2
++
++	if len(data) < pos+int(t.CipherSuitsLength)+1 {
++		df.SetTruncated()
++		return errors.New("TLS ClientHello truncated in cipher suites")
++	}
++	t.CipherSuits = data[pos : pos+int(t.CipherSuitsLength)]
++	pos += int(t.CipherSuitsLength)
++	t.CompressionMethodsLength = data[pos]
++	pos++
++
++	if len(data) < pos+int(t.CompressionMethodsLength)+2 {
++		df.SetTruncated()
++		return errors.New("TLS ClientHello truncated in compression methods")
++	}
++	t.CompressionMethods = data[pos : pos+int(t.CompressionMethodsLength)]
++	pos += int(t.CompressionMethodsLength)
++	t.ExtensionsLength = binary.BigEndian.Uint16(data[pos : pos+2])
++	pos += 2
++	if len(data) < pos+int(t.ExtensionsLength) {
++		df.SetTruncated()
++		return errors.New("TLS ClientHello truncated in extensions")
++	}
++	data = data[pos : pos+int(t.ExtensionsLength)]
++	t.Extensions = data
++
+ 	return nil
+ }
+ func (t *TLSHandshakeRecordClientKeyChange) decodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+@@ -133,10 +174,14 @@ func (t *TLSHandshakeRecord) decodeFromBytes(h TLSRecordHeader, data []byte, df
+ 		fmt.Printf("encrypted message\n")
+ 		return nil
+ 	}
++	if len(data) < 1 {
++		df.SetTruncated()
++		return errors.New("TLS handshake record too short")
++	}
+ 	handshakeType := data[0]
+ 	switch handshakeType {
+ 	case TLSHandshakeClientHello:
+-		t.ClientHello.decodeFromBytes(data, df)
++		return t.ClientHello.decodeFromBytes(data, df)
+ 	case TLSHandshakeClientKeyExchange:
+ 		t.ClientKeyChange.decodeFromBytes(data, df)
+ 	default:
+diff --git a/vendor/github.com/gopacket/gopacket/layers/vrrp.go b/vendor/github.com/gopacket/gopacket/layers/vrrp.go
+index b512e6f8..e3bb9ce0 100644
+--- a/vendor/github.com/gopacket/gopacket/layers/vrrp.go
++++ b/vendor/github.com/gopacket/gopacket/layers/vrrp.go
+@@ -116,6 +116,10 @@ func (v *VRRPv2) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error
+ 	// populate the IPAddress field. The number of addresses is specified in the v.CountIPAddr field
+ 	// offset references the starting byte containing the list of ip addresses
+ 	offset := 8
++	if len(data) < offset+4*int(v.CountIPAddr) {
++		df.SetTruncated()
++		return errors.New("VRRPv2 packet too short for the advertised IP address count")
++	}
+ 	for i := uint8(0); i < v.CountIPAddr; i++ {
+ 		v.IPAddress = append(v.IPAddress, data[offset:offset+4])
+ 		offset += 4
+-- 
+2.45.4
+

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.31.0
-Release:        29%{?dist}
+Release:        30%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -70,6 +70,7 @@ Patch54:        CVE-2025-29923.patch
 Patch55:        CVE-2025-46327.patch
 Patch56:        CVE-2026-54908.patch
 Patch57:        CVE-2026-54332.patch
+Patch58:        CVE-2026-65819.patch
 
 BuildRequires:  golang
 BuildRequires:  systemd-devel
@@ -134,6 +135,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Thu Aug 13 2026 Sushil Sati <v-sushilsati@microsoft.com> - 1.31.0-30
+- Patch for CVE-2026-65819
+
 * Sat Aug 08 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.31.0-29
 - Patch for CVE-2026-54332
 

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.31.0
-Release:        28%{?dist}
+Release:        29%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -69,6 +69,7 @@ Patch53:        CVE-2026-56852.patch
 Patch54:        CVE-2025-29923.patch
 Patch55:        CVE-2025-46327.patch
 Patch56:        CVE-2026-54908.patch
+Patch57:        CVE-2026-54332.patch
 
 BuildRequires:  golang
 BuildRequires:  systemd-devel
@@ -133,6 +134,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Sat Aug 08 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.31.0-29
+- Patch for CVE-2026-54332
+
 * Fri Aug 07 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.31.0-28
 - Patch for CVE-2026-54908
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->
 
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge
 
---
**Summary**
Patch telegraf for CVE-2026-65819

Upstream patch has been backported manually.
Patch matches with the upstream patch.
Upstream Patch Reference https://github.com/gopacket/gopacket/commit/210f25fb9b3ca1af2eb649936f78ad6991b6c9c5.patch

**Change Log**
-modified: SPECS/telegraf/telegraf.spec
-new: /SPECS/telegraf/CVE-2026-65819.patch

Does this affect the toolchain?
No

Links to CVEs
https://nvd.nist.gov/vuln/detail/CVE-2026-65819

**Note:**  cherry pick the following 3.0-dev merged pr
3. Patch telegraf for CVE-2026-54332 [MEDIUM] (#18363)


**Patch Analysis:**

1.Telegraf 1.31.0 vendors gopacket v1.2.0, which is affected by CVE-2026-65819 because the advisory’s affected range is <= 1.7.0.
2.Compared with upstream, these two source files are not included in the Azure Linux backport:
          vendor/github.com/gopacket/gopacket/layers/diameter.go
          vendor/github.com/gopacket/gopacket/layers/dot11.go
          The corresponding regression cases are also omitted:
         
     files are not included because:
           diameter.go does not exist in current Azure telegraf version.
           dot11.go affected ID == 255 operation does not exist in this version.

3. New test file decode_oob_test.go adds a regression test for CVE-2026-65819. %check is disabled in the current RPM build, but  Keeping the upstream 
4. removes the inapplicable Diameter and Dot11 cases because those vulnerable paths do not exist in vendored gopacket v1.2.0.
5. In gopacket v1.2.0, IPSecAH does not implement gopacket.DecodingLayer. therefore adds an optional function field and Added Backport Helper.



**Test Methodology**
Local build and buddy build was successful.
buddy build
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1181860&view=results

<img width="926" height="354" alt="image" src="https://github.com/user-attachments/assets/19081e66-c799-447a-8de1-e2894425715a" />

The patches have been successfully applied
<img width="940" height="121" alt="image" src="https://github.com/user-attachments/assets/92b0754d-a584-4384-b2d1-8cbce0f93962" />

All modified file contributed compiled code to the Telegraf RPM binary.
<img width="940" height="157" alt="image" src="https://github.com/user-attachments/assets/51afe9c4-7286-40b3-b5b7-0d0b64de8901" />
RUN the added Go  Test “TestDecodeOOBRegression” and result is ok
<img width="940" height="296" alt="image" src="https://github.com/user-attachments/assets/5b5557fa-5c10-402f-8ea0-a16118e7a14f" />


