### PR TITLE
fix(vm-iso-installer): add XFS tooling

### DIFF
--- a/base/images/vm-iso-installer/config.sh
+++ b/base/images/vm-iso-installer/config.sh
@@ -102,6 +102,7 @@ INSTALL_PKGS=(
     rootfiles
     shadow-utils
     util-linux
+    xfsprogs
     selinux-policy-targeted
     audit
     chrony

--- a/base/images/vm-iso-installer/vm-iso-installer.kiwi
+++ b/base/images/vm-iso-installer/vm-iso-installer.kiwi
@@ -116,6 +116,7 @@
         <package name="anaconda-core" />
         <package name="anaconda-tui" />
         <package name="anaconda-install-env-deps" />
+        <package name="xfsprogs" />
 
         <!-- Offline repo creation -->
         <package name="createrepo_c" />


### PR DESCRIPTION
## Summary

- install `xfsprogs` in the live installer image
- include `xfsprogs` in the generated kickstart and offline repository
- rely on the existing `--resolve --alldeps` download step for the runtime dependency closure

## Why

Custom kickstarts that select `--fstype=xfs` cannot format the target filesystem because the live installer does not include `mkfs.xfs`. The offline repository also needs `xfsprogs` so the installed system can retain the XFS user-space tools.

Closes #17914.

## Validation

- `bash -n base/images/vm-iso-installer/config.sh`
- `xmllint --noout base/images/vm-iso-installer/vm-iso-installer.kiwi`
- `git diff --check`
- pinned `azldev image list -q -O json`
- pinned `azldev config dump -q -f json`
- Azure Linux 4 ARM64: `dnf5 install -y xfsprogs` confirmed that `inih`, `libedit`, and `userspace-rcu` are resolved automatically

A complete ISO build was not run locally: the official `azldev` runner does not include KIWI, and the development host is macOS. The image pipeline is required for the full build validation.
