### PR TITLE
fix(azurelinux-release): persist CIS kernel sysctls

### DIFF
--- a/base/comps/azurelinux-release/70-azurelinux-hardening.conf
+++ b/base/comps/azurelinux-release/70-azurelinux-hardening.conf
@@ -2,6 +2,18 @@
 # Hide kernel addresses from unprivileged users
 kernel.kptr_restrict = 1
 
+# CIS Rule: Ensure kernel.dmesg_restrict is configured
+# restrict access to the kernel message buffer to root
+kernel.dmesg_restrict = 1
+
+# CIS Rule: Ensure kernel.yama.ptrace_scope is configured
+# restrict ptrace to child processes only (yama restricted mode)
+kernel.yama.ptrace_scope = 1
+
+# CIS Rule: Ensure kernel.randomize_va_space is configured
+# enable full address space layout randomization (ASLR)
+kernel.randomize_va_space = 2
+
 # Strict return path filtering
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        23%{?dist}
+Release:        24%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -482,6 +482,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Thu Aug 13 2026 Tobias Brick <tobiasb@microsoft.com> - 4.0-24
+- Persist CIS kernel sysctl defaults (dmesg_restrict, yama.ptrace_scope, randomize_va_space)
+
 * Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-23
 - Configure neutral local and remote login banners
 

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:8ae71c852990b62eb011c724348b26fb2793a9f5616d59816b112e09c8541a18'
+input-fingerprint = 'sha256:b3c0486c855a4d81ee902b70d2e1422f9f8961a9a8a619ce2abaa5daaf74203f'

--- a/specs/a/azurelinux-release/70-azurelinux-hardening.conf
+++ b/specs/a/azurelinux-release/70-azurelinux-hardening.conf
@@ -2,6 +2,18 @@
 # Hide kernel addresses from unprivileged users
 kernel.kptr_restrict = 1
 
+# CIS Rule: Ensure kernel.dmesg_restrict is configured
+# restrict access to the kernel message buffer to root
+kernel.dmesg_restrict = 1
+
+# CIS Rule: Ensure kernel.yama.ptrace_scope is configured
+# restrict ptrace to child processes only (yama restricted mode)
+kernel.yama.ptrace_scope = 1
+
+# CIS Rule: Ensure kernel.randomize_va_space is configured
+# enable full address space layout randomization (ASLR)
+kernel.randomize_va_space = 2
+
 # Strict return path filtering
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.all.rp_filter = 1

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        23%{?dist}
+Release:        24%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -485,6 +485,9 @@ install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
 
 
 %changelog
+* Thu Aug 13 2026 Tobias Brick <tobiasb@microsoft.com> - 4.0-24
+- Persist CIS kernel sysctl defaults (dmesg_restrict, yama.ptrace_scope, randomize_va_space)
+
 * Tue Aug 11 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-23
 - Configure neutral local and remote login banners
 


### PR DESCRIPTION
Explicitly persist three CIS Level 1 kernel sysctls in `70-azurelinux-hardening.conf` (shipped by `azurelinux-release-common`) so hardening scans see command-level evidence. The kernel already enforces these defaults; this just makes them explicit in a persisted sysctl.d file.

| CIS | sysctl |
|---|---|
| 1.5.5 | `kernel.dmesg_restrict = 1` |
| 1.5.7 | `kernel.yama.ptrace_scope = 1` |
| 1.5.8 | `kernel.randomize_va_space = 2` |

Bumps `azurelinux-release` to `4.0-23` so installed systems receive the updated payload.

**Validation:** installed the updated `azurelinux-release-common` on a fresh VM and confirmed `/usr/lib/sysctl.d/70-azurelinux-hardening.conf` carries the three lines and the runtime sysctl values are correct.

Resolves [AB#22862](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22862), [AB#22863](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22863), [AB#22864](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22864)