### PR TITLE
[Medium] patch golang-1.26.5 for CVE-2026-46600.

### DIFF
--- a/SPECS/golang/CVE-2026-46600.patch
+++ b/SPECS/golang/CVE-2026-46600.patch
@@ -1,0 +1,86 @@
+From 82e7868a02167540748b74780b0bf825985256f7 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Tue, 2 Jun 2026 14:48:48 -0700
+Subject: [PATCH] dns/dnsmessage: avoid panic when parsing SVCB record with
+ truncated data
+
+Thanks to Mundur (https://github.com/M0nd0R) for reporting this issue.
+
+Fixes golang/go#79795
+Fixes CVE-2026-46600
+
+Change-Id: Ie32a9dae6789eb98c816bc7508feba686a6a6964
+Reviewed-on: https://go-review.googlesource.com/c/net/+/786345
+LUCI-TryBot-Result: golang-scoped@luci-project-accounts.iam.gserviceaccount.com <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Damien Neil <dneil@google.com>
+Reviewed-by: Nicholas Husin <husin@google.com>
+Reviewed-by: Nicholas Husin <nsh@golang.org>
+
+Upstream Patch Reference: https://github.com/golang/net/commit/82e7868a02167540748b74780b0bf825985256f7.patch
+
+---
+ .../golang.org/x/net/dns/dnsmessage/svcb.go   | 25 ++++++++---------
+ 1 file changed, 14 insertions(+), 11 deletions(-)
+
+diff --git a/src/vendor/golang.org/x/net/dns/dnsmessage/svcb.go b/src/vendor/golang.org/x/net/dns/dnsmessage/svcb.go
+index 4840516a7f..252401b3ce 100644
+--- a/src/vendor/golang.org/x/net/dns/dnsmessage/svcb.go
++++ b/src/vendor/golang.org/x/net/dns/dnsmessage/svcb.go
+@@ -205,7 +205,7 @@ func unpackSVCBResource(msg []byte, off int, length uint16) (SVCBResource, error
+ 	off = paramsOff
+ 	var previousKey uint16
+ 	for off < bodyEnd {
+-		var key, len uint16
++		var key, size uint16
+ 		if key, off, err = unpackUint16(msg, off); err != nil {
+ 			return SVCBResource{}, &nestedError{"Params key", err}
+ 		}
+@@ -214,14 +214,14 @@ func unpackSVCBResource(msg []byte, off int, length uint16) (SVCBResource, error
+ 			// consider the RR malformed if the SvcParamKeys are not in strictly increasing numeric order
+ 			return SVCBResource{}, &nestedError{"Params", errParamOutOfOrder}
+ 		}
+-		if len, off, err = unpackUint16(msg, off); err != nil {
++		if size, off, err = unpackUint16(msg, off); err != nil {
+ 			return SVCBResource{}, &nestedError{"Params value length", err}
+ 		}
+-		if off+int(len) > bodyEnd {
++		if off+int(size) > bodyEnd {
+ 			return SVCBResource{}, errResourceLen
+ 		}
+-		totalValueLen += len
+-		off += int(len)
++		totalValueLen += size
++		off += int(size)
+ 		n++
+ 	}
+ 	if off != bodyEnd {
+@@ -236,20 +236,23 @@ func unpackSVCBResource(msg []byte, off int, length uint16) (SVCBResource, error
+ 	off = paramsOff
+ 	for i := 0; i < n; i++ {
+ 		p := &r.Params[i]
+-		var key, len uint16
++		var key, size uint16
+ 		if key, off, err = unpackUint16(msg, off); err != nil {
+ 			return SVCBResource{}, &nestedError{"param key", err}
+ 		}
+ 		p.Key = SVCParamKey(key)
+-		if len, off, err = unpackUint16(msg, off); err != nil {
++		if size, off, err = unpackUint16(msg, off); err != nil {
+ 			return SVCBResource{}, &nestedError{"param length", err}
+ 		}
+-		if copy(valuesBuf, msg[off:off+int(len)]) != int(len) {
++		if len(msg[off:]) < int(size) {
+ 			return SVCBResource{}, &nestedError{"param value", errCalcLen}
+ 		}
+-		p.Value = valuesBuf[:len:len]
+-		valuesBuf = valuesBuf[len:]
+-		off += int(len)
++		if copy(valuesBuf, msg[off:][:int(size)]) != int(size) {
++			return SVCBResource{}, &nestedError{"param value", errCalcLen}
++		}
++		p.Value = valuesBuf[:size:size]
++		valuesBuf = valuesBuf[size:]
++		off += int(size)
+ 	}
+ 
+ 	return r, nil

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -15,7 +15,7 @@
 Summary:        Go
 Name:           golang
 Version:        1.26.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -36,6 +36,7 @@ Source4:        https://github.com/microsoft/go/releases/download/v1.22.12-2/go1
 Source5:        https://github.com/microsoft/go/releases/download/v1.24.13-1/go1.24.13-20260204.5.src.tar.gz
 
 Patch1:         CVE-2026-39821.patch
+Patch2:         CVE-2026-46600.patch
 
 Provides:       %{name} = %{version}
 Provides:       go = %{version}-%{release}
@@ -172,6 +173,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Fri Aug 14 2026 Akarsh Chaudhary <v-akarshc@microsoft.com>  - 1.26.5-3
+- Patch for CVE-2026-46600
+
 * Fri Jul 10 2026 bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com> - 1.26.5-2
 - Bump version to 1.26.5-2
 

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -173,7 +173,7 @@ fi
 %{_bindir}/*
 
 %changelog
-* Fri Aug 14 2026 Akarsh Chaudhary <v-akarshc@microsoft.com>  - 1.26.5-3
+* Fri Aug 14 2026 Akarsh Chaudhary <v-akarshc@microsoft.com> - 1.26.5-3
 - Patch for CVE-2026-46600
 
 * Fri Jul 10 2026 bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com> - 1.26.5-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
### Vulnerability Summary
This PR fixes **CVE-2026-46600**,Parsing an invalid SVCB or HTTPS RR can panic when the size of a parameter value overflows the message buffer. .

###### Backport adaptations for golang-1.26.5 <!-- REQUIRED -->

1. Removed the tests from patch as their is no check section in our spec. Even the file to which those tests are being added is not present in our sources.
2. Rest fix applies as it is as in upstream patch.
3. But tested the test present in upstream patch against the fixed rpms and unfixed rpms output of both pasted in the test methodology section.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/golang/golang.spec
- SPECS/golang/CVE-2026-46600.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-46600

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Screenshot of successful local build-
<img width="601" height="295" alt="image" src="https://github.com/user-attachments/assets/11598391-6b0c-49ce-8c8e-45e6b0b85fe2" />

patch is getting applied cleanly-
<img width="961" height="176" alt="image" src="https://github.com/user-attachments/assets/5b758d58-b4dc-41a4-9db5-be2c0d102125" />

Tried the test present in the upstream against the fixed and unfixed rpms patch ran test with -v option it is required to Go's own verbose flag — produces the === RUN / --- PASS lines. Cosmetic.
Before fix output-
<img width="1032" height="549" alt="image" src="https://github.com/user-attachments/assets/db39a9bc-83cc-4c9b-af2a-69e358dd938e" />

After fix-
<img width="996" height="135" alt="image" src="https://github.com/user-attachments/assets/843691cb-c428-4cb1-9b42-a4007e4f321e" />

- Pipeline build url:
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1182582&view=results