### PR TITLE
tookit: switch from parted to sfdisk

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -137,7 +137,7 @@ A sample PartitionSettings entry, designating an EFI and a root partitions:
 
 A PartitionSetting may set a `MountIdentifier` to control how a partition is identified in the `fstab` file. The supported options are `uuid`, `partuuid`, and `partlabel`. If the `MountIdentifier` is omitted `partuuid` will be selected by default.
 
-`partlabel` may not be used with `mbr` disks, and requires the `Name` key in the corresponding `Partition` be populated. An example with the rootfs mounted via `PARTLABEL=my_rootfs`, but the boot mount using the default `PARTUUID=<PARTUUID>`:
+`partlabel` requires the `Name` key in the corresponding `Partition` be populated. An example with the rootfs mounted via `PARTLABEL=my_rootfs`, but the boot mount using the default `PARTUUID=<PARTUUID>`:
 
 ``` json
 "Partitions": [

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -116,7 +116,7 @@ func (d *Disk) IsValid() error {
 		}
 
 		// Verify MaxSize value.
-		lastPartition := d.Partitions[len(d.Partitions)-1]
+		lastPartition := &d.Partitions[len(d.Partitions)-1]
 		lastPartitionEnd, lastPartitionHasEnd := lastPartition.GetEnd()
 
 		switch {
@@ -143,6 +143,14 @@ func (d *Disk) IsValid() error {
 			if requiredSize > *d.MaxSize {
 				return fmt.Errorf("disk's partitions need %s but maxSize is only %s:\nGPT footer size is %s",
 					requiredSize.HumanReadable(), d.MaxSize.HumanReadable(), gptFooterSize.HumanReadable())
+			}
+
+			if !lastPartitionHasEnd {
+				// Explicitly set the size of the last partition.
+				// This allows us to control the alignment of the GPT footer instead of relying on the behavior of the
+				// partitioning tool (e.g. sfdisk).
+				lastPartitionEnd := *d.MaxSize - gptFooterSize
+				lastPartition.End = &lastPartitionEnd
 			}
 		}
 	}

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -151,6 +151,7 @@ func (d *Disk) IsValid() error {
 				// partitioning tool (e.g. sfdisk).
 				lastPartitionEnd := *d.MaxSize - gptFooterSize
 				lastPartition.End = &lastPartitionEnd
+				lastPartition.filled = true
 			}
 		}
 	}

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -17,11 +17,17 @@ type Partition struct {
 	// Note: When not provided, value is filled in by Disk.IsValid().
 	Start *DiskSize `yaml:"start"`
 	// End is the offset where the partition ends (exclusive).
+	// Note: When not provided, value may be filled in by Disk.IsValid().
 	End *DiskSize `yaml:"end"`
 	// Size is the size of the partition.
 	Size PartitionSize `yaml:"size"`
 	// Type specifies the type of partition the partition is.
 	Type PartitionType `yaml:"type"`
+
+	// filled records that Disk.IsValid() has already populated the values above.
+	// It allows IsValid() to be called more than once on the same object, which this repo does (see
+	// UnmarshalYaml() and validateConfig()).
+	filled bool
 }
 
 func (p *Partition) IsValid() error {
@@ -30,7 +36,9 @@ func (p *Partition) IsValid() error {
 		return err
 	}
 
-	if p.End != nil && p.Size.Type != PartitionSizeTypeUnset {
+	// Skip this check once Disk.IsValid() has filled in End, since doing so legitimately produces a partition
+	// that has both an End and a Size.
+	if !p.filled && p.End != nil && p.Size.Type != PartitionSizeTypeUnset {
 		return fmt.Errorf("cannot specify both end and size on partition (%s)", p.Id)
 	}
 

--- a/toolkit/tools/imagegen/configuration/configuration_test.go
+++ b/toolkit/tools/imagegen/configuration/configuration_test.go
@@ -232,26 +232,20 @@ func TestShouldFailMissingPartition(t *testing.T) {
 	assert.Equal(t, "failed to parse [Config]:\ninvalid [Config]:\n[SystemConfig] (SmallerDisk) mounts a [Partition] (NOT_AN_ID) which has no corresponding partition on a [Disk]", err.Error())
 }
 
-func TestShouldFailMissmatchedGPTMountsWithNonMBRDisk(t *testing.T) {
+func TestShouldFailMbrDisk(t *testing.T) {
 	var checkedConfig Config
 	testConfig := expectedConfiguration
 
 	testConfig.Disks = append([]Disk{}, expectedConfiguration.Disks...)
 	testConfig.Disks[0].PartitionTableType = PartitionTableTypeMbr
-	testConfig.Disks[0].Partitions = append([]Partition{}, expectedConfiguration.Disks[0].Partitions...)
-	testConfig.Disks[0].Partitions[0].Name = "LABEL_NAME"
-
-	testConfig.SystemConfigs = append([]SystemConfig{}, expectedConfiguration.SystemConfigs...)
-	testConfig.SystemConfigs[0].PartitionSettings = append([]PartitionSetting{}, expectedConfiguration.SystemConfigs[0].PartitionSettings...)
-	testConfig.SystemConfigs[0].PartitionSettings[0].MountIdentifier = MountIdentifierPartLabel
 
 	err := testConfig.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "invalid [Config]:\n[SystemConfig] (SmallerDisk) mounts a [Partition] (MyBoot) via PARTLABEL, but that partition is on an MBR disk which does not support PARTLABEL", err.Error())
+	assert.Equal(t, "invalid [Disks]:\ninvalid [PartitionTableType]: MBR partition tables are no longer supported, use (gpt) instead", err.Error())
 
 	err = remarshalJSON(testConfig, &checkedConfig)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [Config]:\ninvalid [Config]:\n[SystemConfig] (SmallerDisk) mounts a [Partition] (MyBoot) via PARTLABEL, but that partition is on an MBR disk which does not support PARTLABEL", err.Error())
+	assert.Equal(t, "failed to parse [Config]:\nfailed to parse [Disk]: failed to parse [PartitionTableType]: MBR partition tables are no longer supported, use (gpt) instead", err.Error())
 }
 
 func TestShouldFailPartLabelWithNoName(t *testing.T) {
@@ -334,7 +328,7 @@ var expectedConfiguration Config = Config{
 			},
 		},
 		{
-			PartitionTableType: "mbr",
+			PartitionTableType: "gpt",
 			MaxSize:            uint64(4096),
 			TargetDisk: TargetDisk{
 				Type:  "path",

--- a/toolkit/tools/imagegen/configuration/partitiontabletype.go
+++ b/toolkit/tools/imagegen/configuration/partitiontabletype.go
@@ -37,13 +37,18 @@ func (p PartitionTableType) String() string {
 func (p *PartitionTableType) GetValidPartitionTableTypes() (types []PartitionTableType) {
 	return []PartitionTableType{
 		PartitionTableTypeGpt,
-		PartitionTableTypeMbr,
 		PartitionTableTypeNone,
 	}
 }
 
 // IsValid returns an error if the PartitionTableType is not valid
 func (p *PartitionTableType) IsValid() (err error) {
+	if *p == PartitionTableTypeMbr {
+		// Fail here rather than part way through the build, once the disk has already been created and
+		// partially partitioned.
+		return fmt.Errorf("MBR partition tables are no longer supported, use (%s) instead", PartitionTableTypeGpt)
+	}
+
 	for _, valid := range p.GetValidPartitionTableTypes() {
 		if *p == valid {
 			return

--- a/toolkit/tools/imagegen/configuration/partitiontabletype.go
+++ b/toolkit/tools/imagegen/configuration/partitiontabletype.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// PartitionTableType is either gpt, mbr, or none
+// PartitionTableType is either gpt or none. MBR is no longer supported.
 type PartitionTableType string
 
 const (
@@ -21,12 +21,6 @@ const (
 	// PartitionTableTypeNone selects no partition type
 	PartitionTableTypeNone PartitionTableType = ""
 )
-
-var partitionTableTypeToPartedArgument = map[PartitionTableType]string{
-	PartitionTableTypeGpt:  "gpt",
-	PartitionTableTypeMbr:  "msdos",
-	PartitionTableTypeNone: "",
-}
 
 func (p PartitionTableType) String() string {
 	return string(p)
@@ -55,16 +49,6 @@ func (p *PartitionTableType) IsValid() (err error) {
 		}
 	}
 	return fmt.Errorf("invalid value for PartitionTableType (%s)", p)
-}
-
-// ConvertToPartedArgument returns the parted argument corresponding to the
-// partition table type
-func (p *PartitionTableType) ConvertToPartedArgument() (partedArgument string, err error) {
-	if err = p.IsValid(); err != nil {
-		return
-	}
-	partedArgument = partitionTableTypeToPartedArgument[*p]
-	return
 }
 
 // UnmarshalJSON Unmarshals a PartitionTableType entry

--- a/toolkit/tools/imagegen/configuration/partitiontabletype_test.go
+++ b/toolkit/tools/imagegen/configuration/partitiontabletype_test.go
@@ -14,7 +14,6 @@ import (
 var (
 	validPartitionTableTypes = []PartitionTableType{
 		PartitionTableType("gpt"),
-		PartitionTableType("mbr"),
 		PartitionTableType(""),
 	}
 	invalidPartitionTableType                 = PartitionTableType("not_a_partition_type")
@@ -22,7 +21,6 @@ var (
 	invalidPartitionTableTypeJSON             = `1234`
 	validPartitionTableTypesToPartedArguments = map[PartitionTableType]string{
 		PartitionTableType("gpt"): "gpt",
-		PartitionTableType("mbr"): "msdos",
 		PartitionTableType(""):    "",
 	}
 )
@@ -96,4 +94,17 @@ func TestShouldFailConvertToPartedArgument_PartitionTableType(t *testing.T) {
 	_, err := invalidPartitionTableType.ConvertToPartedArgument()
 	assert.Error(t, err)
 	assert.Equal(t, "invalid value for PartitionTableType (not_a_partition_type)", err.Error())
+}
+
+func TestShouldFailParsingMbrPartitionTableType_PartitionTableType(t *testing.T) {
+	var checkedPartitionType PartitionTableType
+
+	mbr := PartitionTableTypeMbr
+	err := mbr.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "MBR partition tables are no longer supported, use (gpt) instead", err.Error())
+
+	err = remarshalJSON(mbr, &checkedPartitionType)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [PartitionTableType]: MBR partition tables are no longer supported, use (gpt) instead", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/partitiontabletype_test.go
+++ b/toolkit/tools/imagegen/configuration/partitiontabletype_test.go
@@ -16,13 +16,9 @@ var (
 		PartitionTableType("gpt"),
 		PartitionTableType(""),
 	}
-	invalidPartitionTableType                 = PartitionTableType("not_a_partition_type")
-	validPartitionTableTypeJSON               = `"gpt"`
-	invalidPartitionTableTypeJSON             = `1234`
-	validPartitionTableTypesToPartedArguments = map[PartitionTableType]string{
-		PartitionTableType("gpt"): "gpt",
-		PartitionTableType(""):    "",
-	}
+	invalidPartitionTableType     = PartitionTableType("not_a_partition_type")
+	validPartitionTableTypeJSON   = `"gpt"`
+	invalidPartitionTableTypeJSON = `1234`
 )
 
 func TestShouldSucceedValidPartitionsMatch_PartitionTableType(t *testing.T) {
@@ -77,23 +73,6 @@ func TestShouldFailParsingInvalidJSON_PartitionTableType(t *testing.T) {
 	err := marshalJSONString(invalidPartitionTableTypeJSON, &checkedPartitionType)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [PartitionTableType]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypePartitionTableType", err.Error())
-}
-
-func TestShouldSucceedConvertToPartedArgument_PartitionTableType(t *testing.T) {
-	var ptt PartitionTableType
-	assert.Equal(t, len(validPartitionTableTypes), len(ptt.GetValidPartitionTableTypes()))
-
-	for _, partitionType := range validPartitionTableTypes {
-		partedArgument, err := partitionType.ConvertToPartedArgument()
-		assert.NoError(t, err)
-		assert.Equal(t, partedArgument, validPartitionTableTypesToPartedArguments[partitionType])
-	}
-}
-
-func TestShouldFailConvertToPartedArgument_PartitionTableType(t *testing.T) {
-	_, err := invalidPartitionTableType.ConvertToPartedArgument()
-	assert.Error(t, err)
-	assert.Equal(t, "invalid value for PartitionTableType (not_a_partition_type)", err.Error())
 }
 
 func TestShouldFailParsingMbrPartitionTableType_PartitionTableType(t *testing.T) {

--- a/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
+++ b/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
@@ -53,7 +53,7 @@
             ]
         },
         {
-            "PartitionTableType": "mbr",
+            "PartitionTableType": "gpt",
             "MaxSize": 4096,
             "TargetDisk": {
                 "Type": "path",

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -127,15 +127,6 @@ const (
 const (
 	// mappingFilePath is used for device mapping paths
 	mappingFilePath = "/dev/mapper/"
-
-	// maxPrimaryPartitionsForMBR is the maximum number of primary partitions
-	// allowed in the case of MBR partition
-	maxPrimaryPartitionsForMBR = 4
-
-	// name of all possible partition types
-	primaryPartitionType  = "primary"
-	extendedPartitionType = "extended"
-	logicalPartitionType  = "logical"
 )
 
 // Unit to byte conversion values
@@ -568,25 +559,11 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 		return
 	}
 
-	usingExtendedPartition := (len(disk.Partitions) > maxPrimaryPartitionsForMBR) && (partitionTableType == configuration.PartitionTableTypeMbr)
-
 	// Partitions assumed to be defined in sorted order
 	for idx, partition := range disk.Partitions {
-		partType, partitionNumber := obtainPartitionDetail(idx, usingExtendedPartition)
-		// Insert an extended partition
-		if partType == extendedPartitionType {
-			err = createExtendedPartition(diskDevPath, partitionTableType, disk.Partitions, partIDToFsTypeMap,
-				partDevPathMap)
-			if err != nil {
-				return
-			}
+		partitionNumber := idx + 1
 
-			// Update partType and partitionNumber
-			partType = logicalPartitionType
-			partitionNumber = partitionNumber + 1
-		}
-
-		partDevPath, err := createSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition, partType)
+		partDevPath, err := createSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition)
 		if err != nil {
 			err = fmt.Errorf("failed to create single partition:\n%w", err)
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
@@ -649,7 +626,7 @@ func createPartitionTable(diskDevPath string, partitionTableType configuration.P
 
 // createSinglePartition creates a single partition based on the partition config
 func createSinglePartition(diskDevPath string, partitionNumber int, partitionTableType configuration.PartitionTableType,
-	partition configuration.Partition, partType string,
+	partition configuration.Partition,
 ) (partDevPath string, err error) {
 	const (
 		timeoutInSeconds = "5"
@@ -666,16 +643,10 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 
 	start := partition.Start * MiB / logicalSectorSize
 
-	end := partition.End*MiB/logicalSectorSize - 1
-	if partition.End == 0 {
-		end = 0
-	}
-
-	if partType == logicalPartitionType {
-		start = start + 1
-		if end != 0 {
-			end = end + 1
-		}
+	// Note: an End of 0 means "no explicit end", not "ends at sector 0".
+	end := uint64(0)
+	if partition.End != 0 {
+		end = partition.End*MiB/logicalSectorSize - 1
 	}
 
 	// Check whether the start sector is 4K-aligned
@@ -756,24 +727,30 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 
 // Adds escaping of string values for sfdisk scripts.
 //
-// Note: Support string escaping was only added in util-linux v2.32.1 (commits: 75ef5a1, 810b313)
+// Note: Support for string escaping was only added in util-linux v2.32.1 (commits: 75ef5a1, 810b313)
 //
-// util-linux versions:
-// - Ubuntu 20.04: v2.34.0
+// util-linux versions of the supported build hosts:
+// - Ubuntu 22.04: v2.37.2
 // - Azure Linux 2.0: v2.37.4
 //
-// So, it should be fine to assume that it is supported.
+// Both are well above the v2.36 already required by the "--lock" option used above, so it is fine to assume that
+// escaping is supported.
 func escapeSfdiskString(value string) string {
 	builder := strings.Builder{}
 	builder.WriteString("\"")
 
 	for _, c := range value {
-		switch c {
-		case '"':
+		switch {
+		case c == '"':
 			builder.WriteString("\\x22")
 
-		case '\\':
+		case c == '\\':
 			builder.WriteString("\\x5c")
+
+		case c < 0x20 || c == 0x7f:
+			// sfdisk scripts are line based, so a control character (a newline in particular) would let a
+			// partition name terminate the current directive and inject another one.
+			builder.WriteString(fmt.Sprintf("\\x%02x", c))
 
 		default:
 			builder.WriteRune(c)
@@ -784,7 +761,7 @@ func escapeSfdiskString(value string) string {
 	return builder.String()
 }
 
-// InitializeSinglePartition initializes a single partition based on the given partition configuration
+// waitForPartitionCreation waits for the device node of a newly created partition to appear.
 func waitForPartitionCreation(diskDevPath string, partitionNumber int) (partDevPath string, err error) {
 	const (
 		retryDuration    = time.Second
@@ -1028,26 +1005,6 @@ func ReadDiskPartitionTable(diskDevPath string) (*PartitionTable, error) {
 	return output.PartitionTable, nil
 }
 
-func createExtendedPartition(diskDevPath string, partitionTableType configuration.PartitionTableType,
-	partitions []configuration.Partition, partIDToFsTypeMap, partDevPathMap map[string]string,
-) (err error) {
-	// Create a new partition object for extended partition
-	extendedPartition := configuration.Partition{}
-	extendedPartition.ID = extendedPartitionType
-	extendedPartition.Start = partitions[maxPrimaryPartitionsForMBR-1].Start
-	extendedPartition.End = partitions[len(partitions)-1].End
-
-	partDevPath, err := createSinglePartition(diskDevPath, maxPrimaryPartitionsForMBR, partitionTableType,
-		extendedPartition, extendedPartitionType)
-	if err != nil {
-		err = fmt.Errorf("failed to create extended partition:\n%w", err)
-		return
-	}
-	partIDToFsTypeMap[extendedPartition.ID] = ""
-	partDevPathMap[extendedPartition.ID] = partDevPath
-	return
-}
-
 func getPartUUID(device string) (uuid string, err error) {
 	stdout, _, err := shell.Execute("blkid", device, "-s", "UUID", "-o", "value")
 	if err != nil {
@@ -1124,33 +1081,6 @@ func alignSectorAddress(sectorAddr, logicalSectorSize, physicalSectorSize uint64
 		alignedSector = sectorAddr
 	} else {
 		alignedSector = (sectorAddr/physicalSectorSize + 1) * physicalSectorSize
-	}
-
-	return
-}
-
-func obtainPartitionDetail(partitionIndex int, hasExtendedPartition bool) (partType string, partitionNumber int) {
-	const (
-		indexOffsetForNormalPartitionNumber  = 1
-		indexOffsetForLogicalPartitionNumber = 2
-	)
-
-	// partitionIndex is the index of the partition in the partition array, which starts at 0.
-	// partitionNumber, however, starts at 1 (E.g. /dev/sda1), and thus partitionNumber = partitionIndex + 1.
-	// In the case of logical partitions, since an extra extended partition has to be created first in order to
-	// to create logical partitions, so the partition number will further increase by 1, which equals partitionIndex + 2.
-
-	if hasExtendedPartition && partitionIndex >= (maxPrimaryPartitionsForMBR-1) {
-		if partitionIndex == (maxPrimaryPartitionsForMBR - 1) {
-			partType = extendedPartitionType
-			partitionNumber = partitionIndex + indexOffsetForNormalPartitionNumber
-		} else {
-			partType = logicalPartitionType
-			partitionNumber = partitionIndex + indexOffsetForLogicalPartitionNumber
-		}
-	} else {
-		partType = primaryPartitionType
-		partitionNumber = partitionIndex + indexOffsetForNormalPartitionNumber
 	}
 
 	return

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -6,7 +6,9 @@
 package diskutils
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,7 +22,9 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/retry"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -84,6 +88,35 @@ type loopbackListOutput struct {
 type loopbackDevice struct {
 	Name        string `json:"name"`
 	BackingFile string `json:"back-file"`
+}
+
+type PartitionTablePartition struct {
+	// Populated from "sfdisk --json":
+	Path         string `json:"node"`  // Example: /dev/loop1p1
+	Start        int64  `json:"start"` // Example: 2048
+	Size         int64  `json:"size"`  // Example: 16384
+	PartTypeUuid string `json:"type"`  // Example: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+	PartUuid     string `json:"uuid"`  // Example: 2789D1BC-3909-4B06-AD2D-DA531DABF7C8
+	PartLabel    string `json:"name"`  // Example: rootfs
+
+	// Populated from "blkid --probe":
+	FileSystemType string // Example: vfat
+	FileSystemUuid string // Example: 4BD9-3A78
+}
+
+type PartitionTable struct {
+	Label      string                    `json:"label"`      // Example: gpt
+	Id         string                    `json:"id"`         // Example: 1DFD88CF-6214-4574-97A2-C605D411CFBE
+	Device     string                    `json:"device"`     // Example: /dev/loop1
+	Unit       string                    `json:"unit"`       // Example: sectors
+	FirstLba   int64                     `json:"firstlba"`   // Example: 2048
+	LastLba    int64                     `json:"lastlba"`    // Example: 8388574
+	SectorSize int                       `json:"sectorsize"` // Example: 512
+	Partitions []PartitionTablePartition `json:"partitions"`
+}
+
+type partitionTableOutput struct {
+	PartitionTable *PartitionTable `json:"partitiontable"`
 }
 
 const (
@@ -423,9 +456,99 @@ func WaitForLoopbackToDetach(devicePath string, diskPath string) error {
 	return fmt.Errorf("timed out waiting for loopback device (%s) for disk (%s) to close", devicePath, diskPath)
 }
 
-// WaitForDevicesToSettle waits for all udev events to be processed on the system.
+func WaitForDiskDevice(diskDevPath string) error {
+	err := waitForDevicesToSettle()
+	if err != nil {
+		return err
+	}
+
+	// 'udevadm settle' is sometimes not enough.
+	// So, double check that the partitions have been populated.
+	// Ideally, we would use 'udevadm wait' instead of 'udevadm settle'. But it is too new and so isn't universally
+	// available yet.
+	err = waitForDiskToPopulate(diskDevPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func waitForDiskToPopulate(diskDevPath string) error {
+	partitionTable, err := ReadDiskPartitionTable(diskDevPath)
+	if err != nil {
+		return err
+	}
+
+	if partitionTable == nil {
+		// Disk is empty.
+		return nil
+	}
+
+	_, err = retry.RunWithExpBackoff(context.Background(), func() error {
+		kernelPartitions, err := GetDiskPartitions(diskDevPath)
+		if err != nil {
+			return err
+		}
+
+		errs := []error(nil)
+		for _, partition := range partitionTable.Partitions {
+			info, found := sliceutils.FindValueFunc(kernelPartitions, func(info PartitionInfo) bool {
+				return info.Path == partition.Path
+			})
+			if !found {
+				err := fmt.Errorf("failed to find partition device node (%s)", partition.Path)
+				errs = append(errs, err)
+				continue
+			}
+
+			if !strings.EqualFold(partition.PartTypeUuid, info.PartitionTypeUuid) {
+				err := fmt.Errorf("partition's (%s) type UUID is wrong: expected (%s), actual (%s)",
+					partition.Path, partition.PartTypeUuid, info.PartitionTypeUuid)
+				errs = append(errs, err)
+			}
+
+			if !strings.EqualFold(partition.PartUuid, info.PartUuid) {
+				err := fmt.Errorf("partition's (%s) UUID is wrong: expected (%s), actual (%s)",
+					partition.Path, partition.PartUuid, info.PartUuid)
+				errs = append(errs, err)
+			}
+
+			if partition.PartLabel != info.PartLabel {
+				err := fmt.Errorf("partition's (%s) label is wrong: expected (%s), actual (%s)",
+					partition.Path, partition.PartLabel, info.PartLabel)
+				errs = append(errs, err)
+			}
+
+			if partition.FileSystemType != info.FileSystemType {
+				err := fmt.Errorf("partition's (%s) filesystem type is wrong: expected (%s), actual (%s)",
+					partition.Path, partition.FileSystemType, info.FileSystemType)
+				errs = append(errs, err)
+			}
+
+			if !strings.EqualFold(partition.FileSystemUuid, info.Uuid) {
+				err := fmt.Errorf("partition's (%s) filesystem UUID is wrong: expected (%s), actual (%s)",
+					partition.Path, partition.FileSystemUuid, info.Uuid)
+				errs = append(errs, err)
+			}
+		}
+
+		if len(errs) > 0 {
+			return errors.Join(errs...)
+		}
+
+		return nil
+	}, 10, 120*time.Millisecond, 2.0)
+	if err != nil {
+		return fmt.Errorf("timed out waiting for disk (%s) info to be populated:\n%w", diskDevPath, err)
+	}
+
+	return nil
+}
+
+// waitForDevicesToSettle waits for all udev events to be processed on the system.
 // This can be used to wait for partitions to be discovered after mounting a disk.
-func WaitForDevicesToSettle() error {
+func waitForDevicesToSettle() error {
 	logger.Log.Debugf("Waiting for devices to settle")
 	_, _, err := shell.Execute("udevadm", "settle")
 	if err != nil {
@@ -513,6 +636,13 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 
 		partIDToFsTypeMap[partition.ID] = partFsType
 	}
+
+	// Wait for the disk's metadata to populate.
+	err = RefreshPartitions(diskDevPath)
+	if err != nil {
+		return
+	}
+
 	return
 }
 
@@ -897,13 +1027,8 @@ func SystemBlockDevices() (systemDevices []SystemBlockDevice, err error) {
 	return
 }
 
+// GetDiskPartitions gets the kernel's view of a disk's partitions.
 func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
-	// Just in case the disk was only recently connected, wait for the OS to finish processing it.
-	err := WaitForDevicesToSettle()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
-	}
-
 	// Read the disk's partitions.
 	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE", "--json", "--list")
 	if err != nil {
@@ -919,6 +1044,66 @@ func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	}
 
 	return output.Devices, err
+}
+
+// ReadPartitionTable reads the partition table directly from the disk.
+func ReadDiskPartitionTable(diskDevPath string) (*PartitionTable, error) {
+	// Read the partition table directly from disk.
+	stdout, stderr, err := shell.Execute("flock", "--timeout", "5", "--shared", diskDevPath,
+		"sfdisk", "--lock=no", "--dump", "--json", diskDevPath)
+	if err != nil {
+		if strings.Contains(stderr, "does not contain a recognized partition table") {
+			// Empty partition table.
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to read partition table (%s):\n%s\n%w", diskDevPath, stderr, err)
+	}
+
+	var output partitionTableOutput
+	if stdout == "" {
+		return output.PartitionTable, nil
+	}
+
+	err = json.Unmarshal([]byte(stdout), &output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse disk (%s) partition table JSON:\n%w", diskDevPath, err)
+	}
+
+	if output.PartitionTable == nil {
+		// Disk is empty.
+		return nil, nil
+	}
+
+	partitionTable := output.PartitionTable
+
+	if partitionTable.Unit != "sectors" {
+		return nil, fmt.Errorf("sfdisk returned unexpected unit size '%s': expecting 'sectors'", partitionTable.Unit)
+	}
+
+	for i := range partitionTable.Partitions {
+		partition := &partitionTable.Partitions[i]
+
+		// Read the filesystem type directly from disk.
+		stdout, _, err := shell.Execute("flock", "--timeout", "5", "--shared", diskDevPath,
+			"blkid", "--probe", "-s", "TYPE", "-o", "value", partition.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get filesystem type of partition (%s)\n%w", partition.Path, err)
+		}
+
+		partition.FileSystemType = strings.TrimSpace(stdout)
+
+		// Read the filesystem UUID directly from disk.
+		stdout, _, err = shell.Execute("flock", "--timeout", "5", "--shared", diskDevPath,
+			"blkid", "--probe", "-s", "UUID", "-o", "value", partition.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get filesystem UUID of partition (%s)\n%w", partition.Path, err)
+		}
+
+		partition.FileSystemUuid = strings.TrimSpace(stdout)
+	}
+
+	return output.PartitionTable, nil
 }
 
 func createExtendedPartition(diskDevPath string, partitionTableType configuration.PartitionTableType,
@@ -1048,4 +1233,47 @@ func obtainPartitionDetail(partitionIndex int, hasExtendedPartition bool) (partT
 	}
 
 	return
+}
+
+func RefreshPartitions(diskDevPath string) error {
+	err := requestKernelRereadPartitionTable(diskDevPath)
+	if err != nil {
+		return fmt.Errorf("failed to request partition table reread (%s):\n%w", diskDevPath, err)
+	}
+
+	err = WaitForDiskDevice(diskDevPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Requests that the kernel reread the partition table for the given disk device.
+func requestKernelRereadPartitionTable(diskDevPath string) error {
+	diskFile, err := os.OpenFile(diskDevPath, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer diskFile.Close()
+
+	waitTime := 125 * time.Millisecond
+	retries := 10
+	for i := 0; ; i = 1 {
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, diskFile.Fd(), unix.BLKRRPART, 0)
+		switch {
+		case errno == unix.EBUSY && i < retries:
+			// Something else is using the disk at the moment.
+			// So, retry in a little bit.
+			time.Sleep(waitTime)
+			waitTime *= 2
+			continue
+
+		case errno != 0:
+			return errno
+
+		default:
+			return nil
+		}
+	}
 }

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -628,10 +628,14 @@ func createPartitionTable(diskDevPath string, partitionTableType configuration.P
 	}
 
 	// Create new partition table.
-	// This will also wipe the existing partition.
+	// This replaces any existing partition table.
 	sfdiskScript := "label: gpt"
 
-	err := shell.NewExecBuilder("flock", "--timeout", "5", diskDevPath, "sfdisk", "--lock=no", diskDevPath).
+	// sfdisk only wipes pre-existing filesystem/RAID signatures when it is run interactively, so ask for it
+	// explicitly. Otherwise, stale signatures from a previous install survive in the newly partitioned space and
+	// confuse blkid/lsblk/udev. (This replaces the `sfdisk --delete` call that used to run before `parted mklabel`.)
+	err := shell.NewExecBuilder("flock", "--timeout", "5", diskDevPath, "sfdisk", "--lock=no", "--wipe=always",
+		"--wipe-partitions=always", diskDevPath).
 		Stdin(sfdiskScript).
 		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
 		ErrorStderrLines(1).
@@ -726,7 +730,7 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 	logger.Log.Debugf("sfdisk script:\n%s", sfdiskScript)
 
 	err = shell.NewExecBuilder("flock", "--timeout", timeoutInSeconds, diskDevPath, "sfdisk", "--lock=no",
-		"--append", diskDevPath).
+		"--wipe-partitions=always", "--append", diskDevPath).
 		Stdin(sfdiskScript).
 		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
 		ErrorStderrLines(1).

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -722,7 +722,14 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 			typeId = partition.TypeUUID
 
 		case partition.Type != "":
-			typeId = configuration.PartitionTypeNameToUUID[partition.Type]
+			// Partition.IsValid() rejects unknown type names, but it is only run on configs that come from JSON.
+			// Check here as well so that a caller that builds a config programmatically can't end up writing an
+			// sfdisk script with an empty "type=" field.
+			uuid, found := configuration.PartitionTypeNameToUUID[partition.Type]
+			if !found {
+				return "", fmt.Errorf("unrecognized partition (%d) type (%s)", partitionNumber, partition.Type)
+			}
+			typeId = uuid
 		}
 	}
 

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -121,7 +121,7 @@ const (
 
 	EfiSystemPartitionTypeUuid    = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
 	BiosBootPartitionTypeUuid     = "21686148-6449-6e6f-744e-656564454649"
-	GenericLinuxPartitionTypeUuid = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+	GenericLinuxPartitionTypeUuid = "0fc63daf-8483-4772-8e79-3d69d8477de4"
 )
 
 const (

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -40,11 +40,6 @@ var (
 		// ^metadata_csum_seed disables filesystem to store the metadata checksum seed in the superblock, hence disables changing uuid of mounted filesystem
 		"ext4": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize,^metadata_csum_seed"},
 	}
-
-	partedVersionRegex = regexp.MustCompile(`^parted \(GNU parted\) (\d+)\.(\d+)`)
-
-	// The default partition name used when the version of `parted` is too old (<3.5).
-	LegacyDefaultParitionName = "primary"
 )
 
 type blockDevicesOutput struct {
@@ -79,6 +74,7 @@ type PartitionInfo struct {
 	Mountpoint        string `json:"mountpoint"` // Example: /mnt/os/boot
 	PartLabel         string `json:"partlabel"`  // Example: boot
 	Type              string `json:"type"`       // Example: part
+	SizeInBytes       uint64 `json:"size"`       // Example: 4096
 }
 
 type loopbackListOutput struct {
@@ -123,8 +119,9 @@ const (
 	// AutoEndSize is used as the disk's "End" value to indicate it should be picked automatically
 	AutoEndSize = 0
 
-	EfiSystemPartitionTypeUuid = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
-	BiosBootPartitionTypeUuid  = "21686148-6449-6e6f-744e-656564454649"
+	EfiSystemPartitionTypeUuid    = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+	BiosBootPartitionTypeUuid     = "21686148-6449-6e6f-744e-656564454649"
+	GenericLinuxPartitionTypeUuid = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
 )
 
 const (
@@ -142,7 +139,6 @@ const (
 )
 
 // Unit to byte conversion values
-// See https://www.gnu.org/software/parted/manual/parted.html#unit
 const (
 	B  = 1
 	KB = 1000
@@ -559,40 +555,20 @@ func waitForDevicesToSettle() error {
 
 // CreatePartitions creates partitions on the specified disk according to the disk config
 func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryption configuration.RootEncryption,
-	diskKnownToBeEmpty bool,
 ) (partDevPathMap map[string]string, partIDToFsTypeMap map[string]string, encryptedRoot EncryptedRootDevice, err error) {
-	const timeoutInSeconds = "5"
 	partDevPathMap = make(map[string]string)
 	partIDToFsTypeMap = make(map[string]string)
 
-	// Clear any old partition table info to prevent errors during partition creation
-	if !diskKnownToBeEmpty {
-		_, stderr, err := shell.Execute("sfdisk", "--delete", diskDevPath)
-		if err != nil {
-			logger.Log.Warnf("Failed to clear partition table. Expected if the disk is blank: %v", stderr)
-		}
-	}
-
-	// Create new partition table
 	partitionTableType := disk.PartitionTableType
-	logger.Log.Debugf("Converting partition table type (%v) to parted argument", partitionTableType)
-	partedArgument, err := partitionTableType.ConvertToPartedArgument()
+
+	// Create new partition table.
+	// This will also wipe the existing partition.
+	err = createPartitionTable(diskDevPath, partitionTableType)
 	if err != nil {
-		err = fmt.Errorf("failed to convert partition table type (%v) to parted argument:\n%w", partitionTableType, err)
-		return
-	}
-	_, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "parted", diskDevPath, "--script", "mklabel", partedArgument)
-	if err != nil {
-		err = fmt.Errorf("failed to set partition table type using parted:\n%v\n%w", stderr, err)
 		return
 	}
 
 	usingExtendedPartition := (len(disk.Partitions) > maxPrimaryPartitionsForMBR) && (partitionTableType == configuration.PartitionTableTypeMbr)
-
-	partedSupportsEmptyStringArgs, err := PartedSupportsEmptyString()
-	if err != nil {
-		return
-	}
 
 	// Partitions assumed to be defined in sorted order
 	for idx, partition := range disk.Partitions {
@@ -600,7 +576,7 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 		// Insert an extended partition
 		if partType == extendedPartitionType {
 			err = createExtendedPartition(diskDevPath, partitionTableType, disk.Partitions, partIDToFsTypeMap,
-				partDevPathMap, partedSupportsEmptyStringArgs)
+				partDevPathMap)
 			if err != nil {
 				return
 			}
@@ -610,14 +586,13 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 			partitionNumber = partitionNumber + 1
 		}
 
-		partDevPath, err := createSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition, partType,
-			partedSupportsEmptyStringArgs)
+		partDevPath, err := createSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition, partType)
 		if err != nil {
 			err = fmt.Errorf("failed to create single partition:\n%w", err)
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
 		}
 
-		partFsType, err := FormatSinglePartition(partDevPath, partition)
+		partFsType, err := FormatSinglePartition(diskDevPath, partDevPath, partition)
 		if err != nil {
 			err = fmt.Errorf("failed to format partition:\n%w", err)
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
@@ -646,13 +621,33 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 	return
 }
 
+func createPartitionTable(diskDevPath string, partitionTableType configuration.PartitionTableType) error {
+	if partitionTableType != configuration.PartitionTableTypeGpt {
+		// When switching from "parted" to "sfdisk", MBR support was omitted.
+		return fmt.Errorf("only support for GPT disks is implemented")
+	}
+
+	// Create new partition table.
+	// This will also wipe the existing partition.
+	sfdiskScript := "label: gpt"
+
+	err := shell.NewExecBuilder("flock", "--timeout", "5", diskDevPath, "sfdisk", "--lock=no", diskDevPath).
+		Stdin(sfdiskScript).
+		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
+		ErrorStderrLines(1).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("failed to create partition table (%s) using sfdisk:\n%w", diskDevPath, err)
+	}
+
+	return nil
+}
+
 // createSinglePartition creates a single partition based on the partition config
 func createSinglePartition(diskDevPath string, partitionNumber int, partitionTableType configuration.PartitionTableType,
-	partition configuration.Partition, partType string, partedSupportsEmptyStringArgs bool,
+	partition configuration.Partition, partType string,
 ) (partDevPath string, err error) {
 	const (
-		fillToEndOption  = "100%"
-		sFmt             = "%ds"
 		timeoutInSeconds = "5"
 	)
 
@@ -661,7 +656,12 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		return
 	}
 
+	if partition.End != 0 && partition.Start >= partition.End {
+		return "", fmt.Errorf("invalid partition: start (%d) >= end (%d)", partition.Start, partition.End)
+	}
+
 	start := partition.Start * MiB / logicalSectorSize
+
 	end := partition.End*MiB/logicalSectorSize - 1
 	if partition.End == 0 {
 		end = 0
@@ -677,127 +677,104 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 	// Check whether the start sector is 4K-aligned
 	start = alignSectorAddress(start, logicalSectorSize, physicalSectorSize)
 
+	sizeArg := ""
+	if end > 0 {
+		size := end - start + 1
+		sizeArg = fmt.Sprintf(", size=%d", size)
+	}
+
 	logger.Log.Debugf("Input partition start: %d, aligned start sector: %d", partition.Start, start)
 	logger.Log.Debugf("Input partition end: %d, end sector: %d", partition.End, end)
 
-	mkpartArgs := []string{"--timeout", timeoutInSeconds, diskDevPath, "parted", diskDevPath, "--script", "mkpart"}
-
+	name := ""
+	typeId := ""
 	switch partitionTableType {
 	case configuration.PartitionTableTypeMbr:
-		// Part type.
-		mkpartArgs = append(mkpartArgs, partType)
+		// When switching from using "parted" to using "sfdisk", MBR support was omitted.
+		return "", fmt.Errorf("MBR support is not implemented")
 
 	case configuration.PartitionTableTypeGpt:
-		// Partition label.
-		if partition.Name == "" {
-			if partedSupportsEmptyStringArgs {
-				// For parted, you have to specify "" to represent an empty string.
-				mkpartArgs = append(mkpartArgs, `""`)
-			} else {
-				// This version of parted has no way to specify an empty partition name. :-(
-				// So, use the legacy label of "primary" (which was used in Azure Linux 2.0) instead.
-				logger.Log.Warnf("parted version <3.5 does not support empty partition names: using partition name '%s' instead",
-					LegacyDefaultParitionName)
-				mkpartArgs = append(mkpartArgs, LegacyDefaultParitionName)
+		name = escapeSfdiskString(partition.Name)
+		typeId = GenericLinuxPartitionTypeUuid
+
+		for _, flag := range partition.Flags {
+			switch flag {
+			case configuration.PartitionFlagESP, configuration.PartitionFlagBoot:
+				typeId = EfiSystemPartitionTypeUuid
+
+			case configuration.PartitionFlagGrub, configuration.PartitionFlagBiosGrub, configuration.PartitionFlagBiosGrubLegacy:
+				typeId = BiosBootPartitionTypeUuid
+
+			case configuration.PartitionFlagDeviceMapperRoot:
+				//Ignore, only used for internal tooling
+
+			default:
+				return partDevPath, fmt.Errorf("unknown partition (%d) flag (%v)", partitionNumber, flag)
 			}
-		} else {
-			mkpartArgs = append(mkpartArgs, partition.Name)
+		}
+
+		switch {
+		case partition.TypeUUID != "":
+			typeId = partition.TypeUUID
+
+		case partition.Type != "":
+			typeId = configuration.PartitionTypeNameToUUID[partition.Type]
 		}
 	}
 
-	fsType := partition.FsType
-	if fsType == "vfat" {
-		// 'parted mkpart' requires value of either 'fat16' or 'fat32'.
-		fsType = "fat32"
-	}
+	sfdiskScript := fmt.Sprintf("unit: sectors\nstart=%d, type=%s, name=%s%s", start, typeId, name, sizeArg)
+	logger.Log.Debugf("sfdisk script:\n%s", sfdiskScript)
 
-	if fsType != "" {
-		mkpartArgs = append(mkpartArgs, fsType)
-	}
-
-	mkpartArgs = append(mkpartArgs, fmt.Sprintf(sFmt, start))
-
-	if end == 0 {
-		mkpartArgs = append(mkpartArgs, fillToEndOption)
-	} else {
-		mkpartArgs = append(mkpartArgs, fmt.Sprintf(sFmt, end))
-	}
-
-	_, stderr, err := shell.Execute("flock", mkpartArgs...)
+	err = shell.NewExecBuilder("flock", "--timeout", timeoutInSeconds, diskDevPath, "sfdisk", "--lock=no",
+		"--append", diskDevPath).
+		Stdin(sfdiskScript).
+		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
+		ErrorStderrLines(1).
+		Execute()
 	if err != nil {
-		err = fmt.Errorf("failed to create partition using parted:\n%v\n%w", stderr, err)
+		return "", fmt.Errorf("failed to create partition using sfdisk:\n%w", err)
+	}
+
+	partDevPath, err = waitForPartitionCreation(diskDevPath, partitionNumber)
+	if err != nil {
 		return "", err
 	}
 
-	// Update kernel partition table information
-	//
-	// There can be a timing issue where partition creation finishes but the
-	// devtmpfs files are not populated in time for partition initialization.
-	// So to deal with this, we call partprobe here to query and flush the
-	// partition table information, which should enforce that the devtmpfs
-	// files are created when partprobe returns control.
-	//
-	// Added flock because "partprobe -s" apparently doesn't always block.
-	// flock is part of the util-linux package and helps to synchronize access
-	// with other cooperating processes. The important part is it will block
-	// if the fd is busy, and then execute the command. Adding a timeout
-	// to prevent us from possibly waiting forever.
-	stdout, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "partprobe", "-s", diskDevPath)
-	if err != nil {
-		err = fmt.Errorf("failed to execute partprobe:\n%v\n%w", stderr, err)
-		return "", err
-	}
-	logger.Log.Debugf("Partprobe -s returned: %s", stdout)
-	return InitializeSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition)
+	return partDevPath, nil
 }
 
-// Returns true if the version of 'parted' supports the 'type' session command.
-// Since v3.6
-func PartedSupportsTypeCommand() (bool, error) {
-	major, minor, err := getPartedVersion()
-	if err != nil {
-		return false, err
+// Adds escaping of string values for sfdisk scripts.
+//
+// Note: Support string escaping was only added in util-linux v2.32.1 (commits: 75ef5a1, 810b313)
+//
+// util-linux versions:
+// - Ubuntu 20.04: v2.34.0
+// - Azure Linux 2.0: v2.37.4
+//
+// So, it should be fine to assume that it is supported.
+func escapeSfdiskString(value string) string {
+	builder := strings.Builder{}
+	builder.WriteString("\"")
+
+	for _, c := range value {
+		switch c {
+		case '"':
+			builder.WriteString("\\x22")
+
+		case '\\':
+			builder.WriteString("\\x5c")
+
+		default:
+			builder.WriteRune(c)
+		}
 	}
 
-	supports := major >= 4 || (major == 3 && minor >= 6)
-	return supports, nil
-}
-
-// Returns if the version of 'parted' supports empty (quoted) string parameters.
-// Specifically, parted v3.5+.
-func PartedSupportsEmptyString() (bool, error) {
-	major, minor, err := getPartedVersion()
-	if err != nil {
-		return false, err
-	}
-
-	supports := major >= 4 || (major == 3 && minor >= 5)
-	return supports, nil
-}
-
-func getPartedVersion() (int, int, error) {
-	stdout, _, err := shell.Execute("parted", "--version")
-	if err != nil {
-		err = fmt.Errorf("failed to get 'parted' version:\n%w", err)
-		return 0, 0, err
-	}
-
-	matches := partedVersionRegex.FindStringSubmatch(stdout)
-	if matches == nil {
-		err = fmt.Errorf("failed to parse 'parted' version:\n%w", err)
-		return 0, 0, err
-	}
-
-	major, _ := strconv.Atoi(matches[1])
-	minor, _ := strconv.Atoi(matches[2])
-
-	return major, minor, nil
+	builder.WriteString("\"")
+	return builder.String()
 }
 
 // InitializeSinglePartition initializes a single partition based on the given partition configuration
-func InitializeSinglePartition(diskDevPath string, partitionNumber int,
-	partitionTableType configuration.PartitionTableType, partition configuration.Partition,
-) (partDevPath string, err error) {
+func waitForPartitionCreation(diskDevPath string, partitionNumber int) (partDevPath string, err error) {
 	const (
 		retryDuration    = time.Second
 		timeoutInSeconds = "5"
@@ -836,56 +813,12 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int,
 			logger.Log.Debugf("Could not find partition path (%s). Checking other naming convention", testPartDevPath)
 		}
 		logger.Log.Warnf("Could not find any valid partition paths. Will retry up to %d times", totalAttempts)
-		err = fmt.Errorf("could not find partition to initialize in /dev")
+		err = fmt.Errorf("could not find partition (%d) in /dev", partitionNumber)
 		return err
 	}, totalAttempts, retryDuration)
-
 	if err != nil {
 		return
 	}
-
-	logger.Log.Debugf("Initializing partition device path: %v", partDevPath)
-
-	// Set partition friendly name and partition type UUID (only for gpt)
-	if partitionTableType == configuration.PartitionTableTypeGpt {
-		setGptPartitionType(partition, timeoutInSeconds, diskDevPath, partitionNumberStr)
-	}
-
-	// Set partition flags if necessary
-	for _, flag := range partition.Flags {
-		args := []string{diskDevPath, "--script", "set", partitionNumberStr}
-		var flagToSet string
-		switch flag {
-		case configuration.PartitionFlagESP:
-			flagToSet = "esp"
-		case configuration.PartitionFlagGrub, configuration.PartitionFlagBiosGrub, configuration.PartitionFlagBiosGrubLegacy:
-			flagToSet = "bios_grub"
-		case configuration.PartitionFlagBoot:
-			flagToSet = "boot"
-		case configuration.PartitionFlagDeviceMapperRoot:
-			//Ignore, only used for internal tooling
-		default:
-			return partDevPath, fmt.Errorf("partition %v - Unknown partition flag: %v", partitionNumber, flag)
-		}
-		if flagToSet != "" {
-			args = append(args, flagToSet, "on")
-			// Golang does not allow mixing of variadic and regular arguments. So add all of the flock args to
-			// the overall arg slice and pass that to execute
-			args = append([]string{"--timeout", timeoutInSeconds, diskDevPath, "parted"}, args...)
-			_, stderr, err := shell.Execute("flock", args...)
-			if err != nil {
-				logger.Log.Warnf("Failed to set flag (%s) using parted: %v", flagToSet, stderr)
-			}
-		}
-	}
-
-	// Make sure all partition information is actually updated.
-	stdout, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "partprobe", "-s", diskDevPath)
-	if err != nil {
-		err = fmt.Errorf("failed to execute partprobe after partition initialization:\n%v\n%w", stderr, err)
-		return "", err
-	}
-	logger.Log.Debugf("Partprobe -s returned: %s", stdout)
 
 	return
 }
@@ -894,31 +827,8 @@ func isDigit(c byte) bool {
 	return c >= '0' && c <= '9'
 }
 
-func setGptPartitionType(partition configuration.Partition, timeoutInSeconds, diskDevPath, partitionNumberStr string) (err error) {
-	if supports, _ := PartedSupportsTypeCommand(); !supports {
-		logger.Log.Warn("parted version <3.6 does not support the 'type' session command - skipping this operation")
-		return
-	}
-
-	if partition.TypeUUID != "" || partition.Type != "" {
-		var typeUUID string
-		if partition.TypeUUID != "" {
-			typeUUID = partition.TypeUUID
-		} else {
-			typeUUID = configuration.PartitionTypeNameToUUID[partition.Type]
-		}
-		_, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "parted", diskDevPath, "--script", "type", partitionNumberStr, typeUUID)
-		if err != nil {
-			logger.Log.Warnf("failed to set partition type using parted: %v", stderr)
-			err = nil
-			// Not-fatal
-		}
-	}
-	return
-}
-
 // FormatSinglePartition formats the given partition to the type specified in the partition configuration
-func FormatSinglePartition(partDevPath string, partition configuration.Partition,
+func FormatSinglePartition(diskDevPath string, partDevPath string, partition configuration.Partition,
 ) (fsType string, err error) {
 	const (
 		totalAttempts = 5
@@ -928,7 +838,7 @@ func FormatSinglePartition(partDevPath string, partition configuration.Partition
 	fsType = partition.FsType
 
 	// Note: It is possible for the format partition command to fail with error "The file does not exist and no size was specified".
-	// This is due to a possible race condition in Linux/parted where the partition may not actually be ready after being newly created.
+	// This is due to a possible race condition in Linux where the partition may not actually be ready after being newly created.
 	// To handle such cases, we can retry the command.
 	switch fsType {
 	case "fat32", "fat16", "vfat", "ext2", "ext3", "ext4", "xfs":
@@ -938,12 +848,12 @@ func FormatSinglePartition(partDevPath string, partition configuration.Partition
 			fsType = "vfat"
 		}
 
-		mkfsArgs := []string{"-t", fsType}
+		mkfsArgs := []string{"--timeout", "5", diskDevPath, "mkfs", "-t", fsType}
 		mkfsArgs = append(mkfsArgs, mkfsOptions...)
 		mkfsArgs = append(mkfsArgs, partDevPath)
 
 		err = retry.Run(func() error {
-			_, stderr, err := shell.Execute("mkfs", mkfsArgs...)
+			_, stderr, err := shell.Execute("flock", mkfsArgs...)
 			if err != nil {
 				logger.Log.Warnf("Failed to format partition using mkfs: %v", stderr)
 				return err
@@ -1030,7 +940,8 @@ func SystemBlockDevices() (systemDevices []SystemBlockDevice, err error) {
 // GetDiskPartitions gets the kernel's view of a disk's partitions.
 func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	// Read the disk's partitions.
-	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE", "--json", "--list")
+	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output",
+		"NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE,SIZE", "--bytes", "--json", "--list")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}
@@ -1108,7 +1019,6 @@ func ReadDiskPartitionTable(diskDevPath string) (*PartitionTable, error) {
 
 func createExtendedPartition(diskDevPath string, partitionTableType configuration.PartitionTableType,
 	partitions []configuration.Partition, partIDToFsTypeMap, partDevPathMap map[string]string,
-	partedSupportsEmptyStringArgs bool,
 ) (err error) {
 	// Create a new partition object for extended partition
 	extendedPartition := configuration.Partition{}
@@ -1117,7 +1027,7 @@ func createExtendedPartition(diskDevPath string, partitionTableType configuratio
 	extendedPartition.End = partitions[len(partitions)-1].End
 
 	partDevPath, err := createSinglePartition(diskDevPath, maxPrimaryPartitionsForMBR, partitionTableType,
-		extendedPartition, extendedPartitionType, partedSupportsEmptyStringArgs)
+		extendedPartition, extendedPartitionType)
 	if err != nil {
 		err = fmt.Errorf("failed to create extended partition:\n%w", err)
 		return

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -373,7 +373,7 @@ func setupDisk(outputDir, diskName string, liveInstallFlag bool, diskConfig conf
 		if liveInstallFlag {
 			diskDevPath = diskConfig.TargetDisk.Value
 			partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = setupRealDisk(diskDevPath, diskConfig,
-				rootEncryption, false /*diskKnownToBeEmpty*/)
+				rootEncryption)
 		} else {
 			err = fmt.Errorf("target Disk Type is set but --live-install option is not set. Please check your config or enable the --live-install option")
 			return
@@ -409,8 +409,7 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 		return
 	}
 
-	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = setupRealDisk(diskDevPath, diskConfig, rootEncryption,
-		true /*diskKnownToBeEmpty*/)
+	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = setupRealDisk(diskDevPath, diskConfig, rootEncryption)
 	if err != nil {
 		err = fmt.Errorf("failed to setup loopback disk partitions (%s):\n%w", rawDisk, err)
 		return
@@ -419,11 +418,11 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 	return
 }
 
-func setupRealDisk(diskDevPath string, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption, diskKnownToBeEmpty bool,
+func setupRealDisk(diskDevPath string, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption,
 ) (partIDToDevPathMap, partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, err error) {
 	// Set up partitions
 	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = diskutils.CreatePartitions(diskDevPath, diskConfig,
-		rootEncryption, diskKnownToBeEmpty)
+		rootEncryption)
 	if err != nil {
 		err = fmt.Errorf("failed to create partitions on disk (%s):\n%w", diskDevPath, err)
 		return

--- a/toolkit/tools/internal/safeloopback/safeloopback.go
+++ b/toolkit/tools/internal/safeloopback/safeloopback.go
@@ -51,7 +51,7 @@ func (l *Loopback) newLoopbackHelper() error {
 	l.diskIdMin = min
 
 	// Ensure all the partitions have finished populating.
-	err = diskutils.WaitForDevicesToSettle()
+	err = diskutils.WaitForDiskDevice(devicePath)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/internal/safemount/safemount_test.go
+++ b/toolkit/tools/internal/safemount/safemount_test.go
@@ -67,7 +67,7 @@ func TestResourceBusy(t *testing.T) {
 
 	// Set up partitions.
 	_, _, _, err = diskutils.CreatePartitions(loopback.DevicePath(), diskConfig,
-		configuration.RootEncryption{}, true /*diskKnownToBeEmpty*/)
+		configuration.RootEncryption{})
 	if !assert.NoError(t, err, "failed to create partitions on disk", loopback.DevicePath()) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
@@ -84,17 +85,12 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 	}
 	defer imageConnection.Close()
 
-	defaultPartitionName := diskutils.LegacyDefaultParitionName
-	if partedSupportsEmptyString, _ := diskutils.PartedSupportsEmptyString(); partedSupportsEmptyString {
-		defaultPartitionName = ""
-	}
-
 	partitions, err := getDiskPartitionsMap(imageConnection.Loopback().DevicePath())
 	if assert.NoError(t, err, "read partition table") {
-		assert.Equal(t, defaultPartitionName, partitions[1].PartLabel)
-		assert.Equal(t, defaultPartitionName, partitions[2].PartLabel)
+		assert.Equal(t, "", partitions[1].PartLabel)
+		assert.Equal(t, "", partitions[2].PartLabel)
 		assert.Equal(t, "rootfs", partitions[3].PartLabel)
-		assert.Equal(t, defaultPartitionName, partitions[4].PartLabel)
+		assert.Equal(t, "", partitions[4].PartLabel)
 	}
 
 	// Check for key files/directories on the partitions.
@@ -110,6 +106,24 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 		partitions[mountPoints[1].PartitionNum],
 		partitions[mountPoints[0].PartitionNum],
 		imageVersion)
+
+	// Check the partition types.
+	assert.Equal(t, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b", partitions[1].PartitionTypeUuid) // esp
+	assert.Equal(t, "bc13c2ff-59e6-4262-a352-b275fd6f7172", partitions[2].PartitionTypeUuid) // xbootldr
+	assert.Equal(t, "4d21b016-b534-45c2-a9fb-5c16e091fd2d", partitions[4].PartitionTypeUuid) // var
+
+	switch runtime.GOARCH {
+	case "amd64":
+		assert.Equal(t, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", partitions[3].PartitionTypeUuid) // root (x64)
+	case "arm64":
+		assert.Equal(t, "b921b045-1df0-41c3-af44-4c6f280d3fae", partitions[3].PartitionTypeUuid) // root (arm64)
+	}
+
+	// Check the partition sizes.
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
+	assert.Equal(t, uint64(99*diskutils.MiB), partitions[2].SizeInBytes)
+	assert.Equal(t, uint64(1940*diskutils.MiB), partitions[3].SizeInBytes)
+	assert.Equal(t, uint64(2047*diskutils.MiB), partitions[4].SizeInBytes)
 }
 
 func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
@@ -170,6 +184,16 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 		partitions[mountPoints[0].PartitionNum],
 		partitions[mountPoints[0].PartitionNum],
 		baseImageVersionDefault)
+
+	// Check the partition types.
+	assert.Equal(t, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b", partitions[1].PartitionTypeUuid) // esp
+	assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
+	assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[3].PartitionTypeUuid) // linux generic
+
+	// Check the partition sizes.
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
+	assert.Equal(t, uint64(2*diskutils.GiB), partitions[2].SizeInBytes)
+	assert.Equal(t, uint64(2*diskutils.GiB), partitions[3].SizeInBytes)
 }
 
 func TestCustomizeImagePartitionsEfiToLegacy(t *testing.T) {
@@ -226,6 +250,14 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 		partitions[coreLegacyMountPoints[0].PartitionNum],
 		partitions[coreLegacyMountPoints[0].PartitionNum],
 		imageVersion)
+
+	// Check the partition types.
+	assert.Equal(t, "21686148-6449-6e6f-744e-656564454649", partitions[1].PartitionTypeUuid) // BIOS boot
+	assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
+
+	// Check the partition sizes.
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
+	assert.Equal(t, uint64(4086*diskutils.MiB), partitions[2].SizeInBytes)
 }
 
 func TestCustomizeImageKernelCommandLine(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
@@ -108,16 +107,13 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 		imageVersion)
 
 	// Check the partition types.
-	assert.Equal(t, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b", partitions[1].PartitionTypeUuid) // esp
-	assert.Equal(t, "bc13c2ff-59e6-4262-a352-b275fd6f7172", partitions[2].PartitionTypeUuid) // xbootldr
-	assert.Equal(t, "4d21b016-b534-45c2-a9fb-5c16e091fd2d", partitions[4].PartitionTypeUuid) // var
-
-	switch runtime.GOARCH {
-	case "amd64":
-		assert.Equal(t, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", partitions[3].PartitionTypeUuid) // root (x64)
-	case "arm64":
-		assert.Equal(t, "b921b045-1df0-41c3-af44-4c6f280d3fae", partitions[3].PartitionTypeUuid) // root (arm64)
-	}
+	// Only the ESP partition has an explicit type in partitions-config.yaml. The imagecustomizer API does not
+	// support the Discoverable Partitions Specification types, so every other partition gets the generic Linux
+	// filesystem data type.
+	assert.Equal(t, diskutils.EfiSystemPartitionTypeUuid, partitions[1].PartitionTypeUuid)    // esp
+	assert.Equal(t, diskutils.GenericLinuxPartitionTypeUuid, partitions[2].PartitionTypeUuid) // boot
+	assert.Equal(t, diskutils.GenericLinuxPartitionTypeUuid, partitions[3].PartitionTypeUuid) // rootfs
+	assert.Equal(t, diskutils.GenericLinuxPartitionTypeUuid, partitions[4].PartitionTypeUuid) // var
 
 	// Check the partition sizes.
 	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
@@ -186,9 +182,9 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 		baseImageVersionDefault)
 
 	// Check the partition types.
-	assert.Equal(t, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b", partitions[1].PartitionTypeUuid) // esp
-	assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
-	assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[3].PartitionTypeUuid) // linux generic
+	assert.Equal(t, diskutils.EfiSystemPartitionTypeUuid, partitions[1].PartitionTypeUuid)    // esp
+	assert.Equal(t, diskutils.GenericLinuxPartitionTypeUuid, partitions[2].PartitionTypeUuid) // linux generic
+	assert.Equal(t, diskutils.GenericLinuxPartitionTypeUuid, partitions[3].PartitionTypeUuid) // linux generic
 
 	// Check the partition sizes.
 	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
@@ -252,8 +248,8 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 		imageVersion)
 
 	// Check the partition types.
-	assert.Equal(t, "21686148-6449-6e6f-744e-656564454649", partitions[1].PartitionTypeUuid) // BIOS boot
-	assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
+	assert.Equal(t, diskutils.BiosBootPartitionTypeUuid, partitions[1].PartitionTypeUuid)     // BIOS boot
+	assert.Equal(t, diskutils.GenericLinuxPartitionTypeUuid, partitions[2].PartitionTypeUuid) // linux generic
 
 	// Check the partition sizes.
 	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
@@ -65,6 +65,12 @@ func resetPartitionsUuids(buildImageFile string, buildDir string) error {
 		newPartUuids[i] = newPartUuid
 	}
 
+	// Wait for the partition table updates to be processed.
+	err = diskutils.WaitForDiskDevice(loopback.DevicePath())
+	if err != nil {
+		return err
+	}
+
 	// Fix /etc/fstab file.
 	err = fixPartitionUuidsInFstabFile(partitions, newUuids, newPartUuids, buildDir)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -183,12 +183,6 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}
 
-	// Refresh partition entries under /dev.
-	err = refreshPartitions(imageConnection.Loopback().DevicePath())
-	if err != nil {
-		return nil, "", err
-	}
-
 	// Read the disk partitions.
 	diskPartitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -177,8 +177,7 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 
 	// Set up partitions.
 	partIDToDevPathMap, partIDToFsTypeMap, _, err := diskutils.CreatePartitions(
-		imageConnection.Loopback().DevicePath(), imagerDiskConfig, configuration.RootEncryption{},
-		true /*diskKnownToBeEmpty*/)
+		imageConnection.Loopback().DevicePath(), imagerDiskConfig, configuration.RootEncryption{})
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -18,7 +18,6 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 )
 
@@ -460,14 +459,4 @@ func getPartitionNum(partitionLoopDevice string) (int, error) {
 	}
 
 	return num, nil
-}
-
-func refreshPartitions(diskDevPath string) error {
-	err := shell.ExecuteLiveWithErr(1 /*stderrLines*/, "flock", "--timeout", "5", diskDevPath,
-		"partprobe", "-s", diskDevPath)
-	if err != nil {
-		return fmt.Errorf("partprobe failed:\n%w", err)
-	}
-
-	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -107,10 +107,11 @@ func shrinkFilesystems(imageLoopDevice string, verity []imagecustomizerapi.Verit
 			return fmt.Errorf("failed to resizepart %s with parted (and flock):\n%v", partitionLoopDevice, stderr)
 		}
 
-		// Re-read the partition table
-		err = refreshPartitions(imageLoopDevice)
+		// Changes to the partition table causes all of the disk's parition /dev nodes to be deleted and then
+		// recreated. So, wait for that to finish.
+		err = diskutils.WaitForDiskDevice(imageLoopDevice)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to wait for disk (%s) to update:\n%w", imageLoopDevice, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
- * Switch from `parted` to `sfdisk`.*

Switch from using `parted` for creating partitions to using `sfdisk`
instead. The `sfdisk` API is slightly nicer to use. For example, we
only need a single call to `sfdisk` to provision a partition, instead
of multiple calls to `parted`. Also, `sfdisk` acquired some (GPT)
features a lot earlier than `parted`. So, using `sfdisk` allows us to
avoid disabling features for older versions of `parted`. In addition,
this avoids an annoying patch[1] in Ubuntu which calls `udevadm settle`
in `parted` which can cause our code to deadlock in Ubuntu 24.04.

[1] https://git.launchpad.net/ubuntu/+source/parted/tree/debian/patches/udevadm-settle.patch

Ported from microsoft/azure-linux-image-tools#164.

Note: unlike upstream, `parted` is kept in the tool dependency list and
the prerequisite docs because `shrinkfilesystems.go` in this repo still
invokes `parted resizepart`.

- *Ensure partition metadata is populated in kernel.*

The `udevadm settle` command is commonly used to wait for udev to read
a disk and populate the disk's metadata in the kernel. While this works
most of the time, it is well known `udevadm settle` isn't quite enough
to guarantee that the metadata population has finished. In theory,
`udevadm wait` is new command that does provide that guarantee. But that
command isn't widely available yet.

This change works around this problem by adding a wait loop that checks
the kernel's cached disk's metadata and compares it to the expected
values read directly from disk.

This change also replaces the usage of `partprobe` with a call to the
`BLKRRPART` (block device read partition) IOCTL syscall. This was done
because `partprobe` manually handles the partition node updates.
Whereas, calling `BLKRRPART` allows the kernel to handle the update,
which is more efficient and reliable.

Ported from microsoft/azure-linux-image-tools#140.

