### PR TITLE
fix(azurelinux-release): harden cloud ssh defaults

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        25%{?dist}
+Release:        26%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -60,6 +60,7 @@ Source26:       azurelinux-sudoers.conf
 Source27:       azurelinux-sudo.conf
 Source28:       azurelinux-sudo.logrotate
 Source29:       azurelinux-sugroup.conf
+Source30:       azurelinux-sshd-cis.conf
 
 BuildArch:      noarch
 
@@ -346,6 +347,8 @@ install -Dm0644 %{SOURCE17} -t %{buildroot}%{_prefix}/lib/sysctl.d/
 install -Dm0644 %{SOURCE20} -t %{buildroot}%{_sysconfdir}/chrony.d/
 install -Dm0644 %{SOURCE21} -t %{buildroot}%{_prefix}/lib/systemd/networkd.conf.d/
 install -Dm0600 %{SOURCE23} -t %{buildroot}%{_sysconfdir}/ssh/sshd_config.d/
+install -Dm0600 %{SOURCE30} %{buildroot}%{_sysconfdir}/ssh/sshd_config.d/30-azurelinux-cis.conf
+
 install -Dm0644 %{SOURCE25} -t %{buildroot}%{_sysconfdir}/cloud/cloud.cfg.d/
 %endif
 
@@ -466,6 +469,8 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 %if %{with cloud}
 %files cloud
+%attr(0600,root,root) %config(noreplace) %{_sysconfdir}/ssh/sshd_config.d/30-azurelinux-cis.conf
+
 %files identity-cloud
 %{_prefix}/lib/os-release.cloud
 %attr(0644,root,root) %{_swidtagdir}/com.microsoft.AzureLinux-variant.swidtag.cloud
@@ -496,6 +501,9 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 
 %changelog
+* Mon Aug 17 2026 Tobias Brick <tobiasb@microsoft.com> - 4.0-26
+- Configure CIS SSH server defaults for Azure Linux cloud images
+
 * Thu Aug 13 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-25
 - Configure CIS privileged-command defaults
 

--- a/base/comps/azurelinux-release/azurelinux-sshd-cis.conf
+++ b/base/comps/azurelinux-release/azurelinux-sshd-cis.conf
@@ -1,0 +1,7 @@
+# Restrict SSH access and authentication defaults for Azure Linux cloud images.
+DenyUsers root
+Banner /etc/issue.net
+LoginGraceTime 60
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+MaxAuthTries 4
+MaxStartups 10:30:60

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,3 +1,3 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
-input-fingerprint = 'sha256:846c596d72152f2f76e02d283d0eec84425ebc1a94b3e45261b60e8bdb98e91f'
+input-fingerprint = 'sha256:89cea1fa5d68dfd9a7f0c37174688e00f912c42e9002fa482b04c02187930bf9'

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        25%{?dist}
+Release:        26%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -63,6 +63,7 @@ Source26:       azurelinux-sudoers.conf
 Source27:       azurelinux-sudo.conf
 Source28:       azurelinux-sudo.logrotate
 Source29:       azurelinux-sugroup.conf
+Source30:       azurelinux-sshd-cis.conf
 
 BuildArch:      noarch
 
@@ -349,6 +350,8 @@ install -Dm0644 %{SOURCE17} -t %{buildroot}%{_prefix}/lib/sysctl.d/
 install -Dm0644 %{SOURCE20} -t %{buildroot}%{_sysconfdir}/chrony.d/
 install -Dm0644 %{SOURCE21} -t %{buildroot}%{_prefix}/lib/systemd/networkd.conf.d/
 install -Dm0600 %{SOURCE23} -t %{buildroot}%{_sysconfdir}/ssh/sshd_config.d/
+install -Dm0600 %{SOURCE30} %{buildroot}%{_sysconfdir}/ssh/sshd_config.d/30-azurelinux-cis.conf
+
 install -Dm0644 %{SOURCE25} -t %{buildroot}%{_sysconfdir}/cloud/cloud.cfg.d/
 %endif
 
@@ -469,6 +472,8 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 %if %{with cloud}
 %files cloud
+%attr(0600,root,root) %config(noreplace) %{_sysconfdir}/ssh/sshd_config.d/30-azurelinux-cis.conf
+
 %files identity-cloud
 %{_prefix}/lib/os-release.cloud
 %attr(0644,root,root) %{_swidtagdir}/com.microsoft.AzureLinux-variant.swidtag.cloud
@@ -499,6 +504,9 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 
 %changelog
+* Mon Aug 17 2026 Tobias Brick <tobiasb@microsoft.com> - 4.0-26
+- Configure CIS SSH server defaults for Azure Linux cloud images
+
 * Thu Aug 13 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-25
 - Configure CIS privileged-command defaults
 

--- a/specs/a/azurelinux-release/azurelinux-sshd-cis.conf
+++ b/specs/a/azurelinux-release/azurelinux-sshd-cis.conf
@@ -1,0 +1,7 @@
+# Restrict SSH access and authentication defaults for Azure Linux cloud images.
+DenyUsers root
+Banner /etc/issue.net
+LoginGraceTime 60
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+MaxAuthTries 4
+MaxStartups 10:30:60


### PR DESCRIPTION
## Summary
Add an SSH server policy drop-in owned by `azurelinux-release-cloud`, per this table:
| CIS rule | Description | Task |
|---|---|---|
| 5.1.4 | Ensure sshd access is configured | [AB#22907](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22907) |
| 5.1.5 | Ensure sshd Banner is configured | [AB#22908](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22908) |
| 5.1.13 | Ensure sshd LoginGraceTime is configured | [AB#22909](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22909) |
| 5.1.15 | Ensure sshd MACs are configured | [AB#22910](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22910) |
| 5.1.16 | Ensure sshd MaxAuthTries is configured | [AB#22911](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22911) |
| 5.1.17 | Ensure sshd MaxStartups is configured | [AB#22912](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22912) |

## Testing
- built `azurelinux-release` successfully with `azldev comp build -p azurelinux-release`
- verified the installed file is owned by `azurelinux-release-cloud` and `sshd -t` accepts the configuration
- verified all six effective settings with `sshd -T` in a mock chroot
- installed the updated package on an Azure VM and reran the CIS Azure Linux 4 Level 1 Server benchmark; all six targeted controls passed

