### PR TITLE
feat(gcc): add libbacktrace-static subpackage

### DIFF
--- a/base/comps/gcc/overlays/0002-libbacktrace-static.overlay.toml
+++ b/base/comps/gcc/overlays/0002-libbacktrace-static.overlay.toml
@@ -1,0 +1,67 @@
+# Azure Linux exposes GCC's internal libbacktrace as a standalone
+# `libbacktrace-static` subpackage. There is no upstream package to
+# import. Downstream consumers need the static library + header
+# at build time, so we install them here.
+
+[metadata]
+category = "azl-platform-adaptation"
+upstream-status = "inapplicable"
+
+# Bump the manual gcc release so the new subpackage and its dependents rebuild.
+[[overlays]]
+description = "Bump gcc release for the added libbacktrace-static subpackage"
+type = "spec-search-replace"
+regex = '^%global gcc_release 7$'
+replacement = "%global gcc_release 8"
+
+# Declare the new subpackage right after the C++ package/description block.
+[[overlays]]
+description = "Declare the libbacktrace-static subpackage"
+type = "spec-append-lines"
+section = "%description"
+package = "c++"
+lines = [
+    "%package -n libbacktrace-static",
+    "Summary: Static library for GCC's libbacktrace",
+    "",
+    "%description -n libbacktrace-static",
+    "This package contains GCC's static libbacktrace library and its header.",
+    "",
+]
+
+# Install the internal libbacktrace static archive and its header.
+[[overlays]]
+description = "Install libbacktrace static library and header into the buildroot"
+type = "spec-append-lines"
+section = "%install"
+lines = [
+    "# Azure Linux: expose GCC's internal libbacktrace as a static library + header.",
+    "_azl_bt=%{_builddir}/gcc-%{version}-%{DATE}/obj-%{gcc_target_platform}/libbacktrace/.libs/libbacktrace.a",
+    "install -m 0644 -D \"$_azl_bt\" %{buildroot}%{_libdir}/libbacktrace.a",
+    "install -m 0644 -D %{_builddir}/gcc-%{version}-%{DATE}/libbacktrace/backtrace.h %{buildroot}%{_includedir}/backtrace.h",
+    "",
+]
+
+# List the installed libbacktrace-static files.
+[[overlays]]
+description = "Package the libbacktrace-static files"
+type = "spec-append-lines"
+section = "%files"
+package = "c++"
+lines = [
+    "%files -n libbacktrace-static",
+    "%{_includedir}/backtrace.h",
+    "%{_libdir}/libbacktrace.a",
+    "",
+]
+
+[[overlays]]
+description = "Add changelog entry for the libbacktrace-static subpackage"
+type = "spec-prepend-lines"
+section = "%changelog"
+lines = [
+    "* Fri Aug 14 2026 Nan Liu <liunan@microsoft.com> - 15.2.1-8",
+    "- Add libbacktrace-static subpackage exposing GCC's internal libbacktrace",
+    "  static library and header for downstream consumers.",
+    "",
+]

--- a/locks/gcc.lock
+++ b/locks/gcc.lock
@@ -2,5 +2,5 @@
 version = 1
 import-commit = 'fef47e540ee170873511546e35fc912cceed23f1'
 upstream-commit = 'fef47e540ee170873511546e35fc912cceed23f1'
-input-fingerprint = 'sha256:9cba33f3d0d76e1ebc779c654cb919773192af830efc66a9bc45454c89b42071'
+input-fingerprint = 'sha256:f7bfc24cb117570fda996fc1a6963305202fc45b15c114a7984cca4be7957394'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/gcc/gcc.spec
+++ b/specs/g/gcc/gcc.spec
@@ -7,7 +7,7 @@
 %global gcc_major 15
 # Note, gcc_release must be integer, if you want to add suffixes to
 # %%{release}, append them after %%{gcc_release} on Release: line.
-%global gcc_release 7
+%global gcc_release 8
 %global nvptx_tools_gitrev a0c1fff6534a4df9fb17937c3c4a4b1071212029
 %global newlib_cygwin_gitrev d35cc82b5ec15bb8a5fe0fe11e183d1887992e99
 %global _unpackaged_files_terminate_build 0
@@ -401,6 +401,12 @@ Autoreq: true
 This package adds C++ support to the GNU Compiler Collection.
 It includes support for most of the current C++ specification,
 including templates and exception handling.
+
+%package -n libbacktrace-static
+Summary: Static library for GCC's libbacktrace
+
+%description -n libbacktrace-static
+This package contains GCC's static libbacktrace library and its header.
 
 %package -n libstdc++
 Summary: GNU Standard C++ Library
@@ -2473,6 +2479,11 @@ ln -sf gcc-annobin.so.0.0.0 $FULLPATH/plugin/gcc-annobin.so.0
 ln -sf gcc-annobin.so.0.0.0 $FULLPATH/plugin/gcc-annobin.so
 %endif
 
+# Azure Linux: expose GCC's internal libbacktrace as a static library + header.
+_azl_bt=%{_builddir}/gcc-%{version}-%{DATE}/obj-%{gcc_target_platform}/libbacktrace/.libs/libbacktrace.a
+install -m 0644 -D "$_azl_bt" %{buildroot}%{_libdir}/libbacktrace.a
+install -m 0644 -D %{_builddir}/gcc-%{version}-%{DATE}/libbacktrace/backtrace.h %{buildroot}%{_includedir}/backtrace.h
+
 %check
 cd obj-%{gcc_target_platform}
 
@@ -3031,6 +3042,10 @@ end
 %{_prefix}/lib/gcc/%{gcc_target_platform}/%{gcc_major}/libsupc++.a
 %endif
 %doc rpm.doc/changelogs/gcc/cp/ChangeLog*
+
+%files -n libbacktrace-static
+%{_includedir}/backtrace.h
+%{_libdir}/libbacktrace.a
 
 %files -n libstdc++
 %{_prefix}/%{_lib}/libstdc++.so.6*
@@ -3814,6 +3829,10 @@ end
 %endif
 
 %changelog
+* Fri Aug 14 2026 Nan Liu <liunan@microsoft.com> - 15.2.1-8
+- Add libbacktrace-static subpackage exposing GCC's internal libbacktrace
+  static library and header for downstream consumers.
+
 * Fri Jan 23 2026 Jakub Jelinek <jakub@redhat.com> 15.2.1-7
 - update from releases/gcc-15 branch
   - PRs c++/122070, c++/122550, c++/123597, libstdc++/123147,


### PR DESCRIPTION
## Summary

Upstream GCC builds libbacktrace **for internal use only** and deliberately does not install the static archive or header. This PR adds a new `libbacktrace-static` subpackage to `gcc`, exposing GCC's internal libbacktrace static library (`libbacktrace.a`) and its public header(`backtrace.h`).

## Changes

- New overlay file `base/comps/gcc/overlays/0002-libbacktrace-static.overlay.toml`
  (single file-level `[metadata]`, `category = azl-platform-adaptation`):
  - Bump the manual `gcc_release` (7 → 8) so the new subpackage and its
    dependents rebuild.
  - Declare `%package -n libbacktrace-static` + `%description`.
  - `%install`: locate the built `libbacktrace.a` in the obj tree and install it
    plus `backtrace.h` into the buildroot.
  - `%files -n libbacktrace-static`.
  - `%changelog` entry.
- Regenerated `specs/g/gcc/gcc.spec` and refreshed `locks/gcc.lock`.

The resulting `libbacktrace-static` RPM ships exactly:

```
/usr/include/backtrace.h
/usr/lib64/libbacktrace.a
```

with no runtime dependencies.

## Validation

All steps performed against the Azure Linux 4.0 stage2 mock environment
(`x86_64`).

1. **Render** the spec and confirm the overlays applied:

   ```sh
   azldev comp render -p gcc
   # Verified: %global gcc_release 8, %package -n libbacktrace-static,
   # %install find+install of libbacktrace.a/backtrace.h, %files block,
   # and the %changelog entry are all present in specs/g/gcc/gcc.spec.
   ```

2. **Build** the component:

   ```sh
   azldev comp build -p gcc
   # -> base/out/rpms/rpm-base/libbacktrace-static-15.2.1-8.azl4.x86_64.rpm
   ```

3. **Inspect** the produced RPM:

   ```sh
   RPM=base/out/rpms/rpm-base/libbacktrace-static-15.2.1-8.azl4.x86_64.rpm
   rpm -qlp "$RPM"        # /usr/include/backtrace.h, /usr/lib64/libbacktrace.a
   rpm -qp --provides "$RPM"   # libbacktrace-static = 15.2.1-8.azl4
   rpm -qp --requires "$RPM"   # only rpmlib(...) deps
   ```

4. **Install with `tdnf` in the 4.0 chroot** and verify the files land:

   ```sh
   # copy the built RPM into the persistent mock chroot
   mock -r distro/mock/azl4/stage2/azurelinux-4.0-x86_64.cfg \
        --configdir distro/mock/azl4/stage2 \
        --copyin "$RPM" /tmp/

   # install tdnf into the chroot, then tdnf-install the built package
   azldev adv mock shell --enable-network --add-package tdnf <<'EOF'
   tdnf install -y /tmp/libbacktrace-static-15.2.1-8.azl4.x86_64.rpm
   rpm -q libbacktrace-static
   ls -l /usr/lib64/libbacktrace.a /usr/include/backtrace.h
   EOF
   ```

   Result:

   ```
   Installing:
    libbacktrace-static  x86_64  15.2.1-8.azl4  @commandline  701.6 KiB
   ...
   Complete!

   libbacktrace-static-15.2.1-8.azl4.x86_64
   -rw-r--r-- 1 root root   9141 /usr/include/backtrace.h
   -rw-r--r-- 1 root root 709314 /usr/lib64/libbacktrace.a
   ```


6. **Compile + link + run smoke test** (proves the archive is usable and
   correct-arch, not just installable — a wrong-arch or corrupt `.a` fails at the
   `-lbacktrace` link or at runtime):

   ```sh
   RPM=base/out/rpms/rpm-base/libbacktrace-static-15.2.1-8.azl4.x86_64.rpm
   azldev adv mock shell --enable-network --add-package gcc --add-package "$RPM" <<'SMOKE'
   cat > /tmp/bt_smoke.c <<'SRC'
   #include <stdio.h>
   #include <stdint.h>
   #include <backtrace.h>
   static void err_cb(void *d, const char *m, int e) {
       fprintf(stderr, "libbacktrace error: %s (%d)\n", m, e);
   }
   static int full_cb(void *d, uintptr_t pc, const char *f, int l, const char *fn) {
       printf("  0x%lx %s:%d %s\n", (unsigned long)pc, f ? f : "?", l, fn ? fn : "?");
       return 0;
   }
   int main(void) {
       struct backtrace_state *s = backtrace_create_state(NULL, 0, err_cb, NULL);
       if (!s) { fprintf(stderr, "backtrace_create_state failed\n"); return 1; }
       backtrace_full(s, 0, full_cb, err_cb, NULL);
       printf("libbacktrace link+run OK\n");
       return 0;
   }
   SRC
   gcc -O2 -Wall -Werror /tmp/bt_smoke.c -o /tmp/bt_smoke -lbacktrace
   readelf -d /tmp/bt_smoke | grep -i backtrace || echo "good: statically linked, no libbacktrace shared dep"
   /tmp/bt_smoke
   SMOKE
   ```

   Result:

   ```
   -rw-r--r-- 1 root root 709314 /usr/lib64/libbacktrace.a
   (no shared lib; static only)
   # gcc -O2 -Wall -Werror ... -lbacktrace   -> compiled clean
   good: statically linked, no libbacktrace shared dep
     0x40057f ...
     0x7ec2948b95b4 ...
   libbacktrace link+run OK   (exit 0)
   ```

   Confirms: the header compiles, `-lbacktrace` links the static archive directly
   into the binary (no `DT_NEEDED` for libbacktrace), and the resulting program
   runs and exercises the libbacktrace API successfully.
