### PR TITLE
fix(mcp): sanitize azure devops server name

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -63,7 +63,7 @@
       ],
       "type": "stdio"
     },
-    "microsoft/azure-devops-mcp": {
+    "microsoft-azure-devops-mcp": {
       "args": [
         "-y",
         "@azure-devops/mcp@latest",


### PR DESCRIPTION
Copilot CLI rejects MCP server identifiers containing a slash. Replace the slash with a hyphen while leaving the Azure DevOps npm package and its arguments unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>