### PR TITLE
feat(images): add 1p-vm-base-gen1 image

### DIFF
--- a/base/images/1p-vm-base-gen1/1p-vm-base-gen1.kiwi
+++ b/base/images/1p-vm-base-gen1/1p-vm-base-gen1.kiwi
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="https://raw.githubusercontent.com/OSInside/kiwi/refs/tags/v10.2.33/kiwi/schema/kiwi.rng" type="application/xml"?>
+<image schemaversion="8.3" name="azl4-1p-vm-base-gen1">
+    <description type="system">
+        <author>Azure Linux</author>
+        <contact>azurelinux@microsoft.com</contact>
+        <specification>Azure Linux 4.0 1P VM Base Gen1 (BIOS) Image</specification>
+    </description>
+
+    <preferences arch="x86_64">
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type
+            image="oem"
+            format="vhd-fixed"
+            formatoptions="force_size"
+            initrd_system="dracut"
+            filesystem="ext4"
+            fscreateoptions="-m 1"
+            kernelcmdline="console=ttyS0 rd.shell=0"
+            firmware="bios"
+            overlayroot="false"
+            eficsm="false"
+            bootpartition="false"
+            rootfs_label="azurelinux">
+            <bootloader name="grub2" bls="true" console="serial" timeout="1" />
+            <size unit="G">5</size>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
+    </preferences>
+
+    <!-- Build-time package source; koji overrides this for distro builds. -->
+    <repository type="rpm-md" alias="azurelinux-base">
+        <source path="https://packages.microsoft.com/azurelinux/4.0/beta/base/$basearch" />
+    </repository>
+
+    <packages type="image">
+        <!-- core-packages-image -->
+        <package name="ca-certificates" />
+        <package name="cronie-anacron" />
+        <package name="logrotate" />
+        <package name="shadow-utils" />
+        <package name="dracut" />
+
+        <!-- core-packages-base-image -->
+        <package name="azurelinux-rpm-config" />
+        <package name="bc" />
+        <package name="chrony" />
+        <package name="cpio" />
+        <package name="cracklib-dicts" />
+        <package name="cryptsetup" />
+        <package name="dbus" />
+        <package name="e2fsprogs" />
+        <package name="file" />
+        <package name="gdbm" />
+        <package name="glibc" />
+        <package name="glibc-langpack-en" /> <!-- provides en_US.UTF-8 locale -->
+        <package name="libtool" />
+        <package name="iproute" />
+        <package name="nftables" />
+        <package name="iputils" />
+        <package name="irqbalance" />
+        <package name="lvm2" />
+        <package name="lz4" />
+        <package name="net-tools" />
+        <package name="openssh-clients" />
+        <package name="pkg-config" />
+        <package name="procps-ng" />
+        <package name="selinux-policy-targeted" />
+        <package name="setup" />
+        <package name="sudo" />
+        <package name="systemd" />
+        <package name="systemd-networkd" />
+        <package name="systemd-resolved" />
+        <package name="systemd-udev" />
+        <package name="tar" />
+        <package name="tzdata" />
+        <package name="util-linux" />
+        <package name="which" />
+
+        <!-- core-packages-container -->
+        <package name="bash" />
+        <package name="bzip2" />
+        <package name="curl" />
+        <package name="elfutils-libelf" />
+        <package name="expat" />
+        <package name="filesystem" />
+        <package name="findutils" />
+        <package name="grep" />
+        <package name="gzip" />
+        <package name="azurelinux-release-cloud" />
+        <package name="ncurses-libs" />
+        <package name="openssl" />
+        <package name="readline" />
+        <package name="rpm" />
+        <package name="rpm-libs" />
+        <package name="sed" />
+        <package name="sqlite-libs" />
+        <package name="SymCrypt" />
+        <package name="SymCrypt-OpenSSL" />
+        <package name="tdnf" />
+        <package name="xz" />
+        <package name="zlib" />
+
+        <!-- marketplace-tools -->
+        <package name="dnf5" />
+        <package name="wget" />
+
+        <!-- azurevm -->
+        <package name="cloud-init" />
+        <package name="cloud-utils-growpart" />
+        <package name="dhcpcd" />
+        <package name="grubby" />
+        <package name="hyperv-daemons" />
+        <package name="openssh-server" />
+        <package name="python3" />
+        <package name="rsyslog" />
+        <package name="WALinuxAgent" />
+        <package name="wireless-regdb" />
+
+        <!-- Hyper-V via kernel-modules + hyperv-daemons) -->
+        <package name="kernel-modules" />
+
+        <!-- boot: kernel + bootloader -->
+        <package name="kernel" />
+        <package name="grub2" />
+        <package name="grub2-pc" />
+        <package name="grub2-pc-modules" />
+
+        <!-- runtime repos: points OS at PMC beta -->
+        <package name="azurelinux-repos" />
+
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="filesystem" />
+        <package name="azurelinux-release-identity-cloud" />
+        <package name="grub2-pc" />
+    </packages>
+</image>

--- a/base/images/images.toml
+++ b/base/images/images.toml
@@ -93,6 +93,26 @@ container = false
 systemd = true
 runtime-package-management = true
 
+# ---- 1p-vm-base-gen1 ---------------------------------------------------
+
+[images.1p-vm-base-gen1]
+description = "1P VM Base Gen1 Image (BIOS)"
+definition = { type = "kiwi", path = "1p-vm-base-gen1/1p-vm-base-gen1.kiwi" }
+tests.test-suites = [
+  { name = "static-image-checks" },
+  { name = "lisa-main" },
+  { name = "lisa-xfs" },
+  { name = "lisa-perf" },
+  { name = "lisa-smoke" },
+  { name = "lisa-kernel-ltp" },
+]
+
+[images.1p-vm-base-gen1.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
 # ---- container-base (core profile) -------------------------------------
 [images.container-base]
 description = "Container Base Image"


### PR DESCRIPTION
## Summary

- add the Azure Linux 4.0 1P VM Base Gen1 BIOS image
- use package-provided cloud-init, chrony/PTP, and Hyper-V configuration
- remove all KIWI file injections and their loose configuration files
- use systemd-networkd without netplan or post-install config.sh customization

## Testing

- built with `azldev image build 1p-vm-base-gen1 --arch x86_64`
- passed `azldev image test 1p-vm-base-gen1` (9 passed, 7 skipped)

[AB#18608](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/18608)