### PR TITLE
build(libtool): rebuild to ensure it captures the Azure Linux triple

### DIFF
--- a/locks/libtool.lock
+++ b/locks/libtool.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = 'ad7f75a9881731ecc9ceda8c83bf56813c4df49a'
 upstream-commit = 'ad7f75a9881731ecc9ceda8c83bf56813c4df49a'
-input-fingerprint = 'sha256:61496421675a049f17648ddf480a85264de3484e243de3c9359e5c78fa6eb8de'
+manual-bump = 1
+input-fingerprint = 'sha256:62cac4fa730e9e76869499d42f435f5cf32677d855ba5543852c82d2b3675d16'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/l/libtool/libtool.spec
+++ b/specs/l/libtool/libtool.spec
@@ -11,7 +11,7 @@
 Summary: The GNU Portable Library Tool
 Name:    libtool
 Version: 2.5.4
-Release: 9%{?dist}
+Release: 10%{?dist}
 
 # To help future rebase, the following licenses were seen in the following files/folders:
 # '*' is anything that was not explicitly listed earlier in the folder


### PR DESCRIPTION
`libtool` in our prod environment is still the one that was built using a bootstrapped buildroot and doesn't have the right compiler triple in its generated outputs (e.g, /bin/libtool).

This is a pure bump of the package to rebuild it.

Resolves: [AB#23143](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/23143)