### PR TITLE
fix(annobin): bump rebuild counter to re-place gcc plugin at correct triple

### DIFF
--- a/locks/annobin.lock
+++ b/locks/annobin.lock
@@ -2,6 +2,6 @@
 version = 1
 import-commit = '8bc321d24a8e1f4307d19a062bf857e5b88bd1b2'
 upstream-commit = '8bc321d24a8e1f4307d19a062bf857e5b88bd1b2'
-manual-bump = 1
-input-fingerprint = 'sha256:cac6d612c6e2e079f7846e6dd74563dff72ecb942f2d068baa4074f5e90babb3'
+manual-bump = 2
+input-fingerprint = 'sha256:eb1aef723898d18adf8eaf2c1d4344bdf21dd638bc788b9e05fc31369d989bfa'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/a/annobin/annobin.spec
+++ b/specs/a/annobin/annobin.spec
@@ -5,7 +5,7 @@
 Name:    annobin
 Summary: Annotate and examine compiled binary files
 Version: 12.99
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: GPL-3.0-or-later AND LGPL-2.0-or-later AND (GPL-2.0-or-later WITH GCC-exception-2.0) AND (LGPL-2.0-or-later WITH GCC-exception-2.0) AND GFDL-1.3-or-later
 URL: https://sourceware.org/annobin/
 # Maintainer: nickc@redhat.com


### PR DESCRIPTION
The published annobin-plugin-gcc was built against the bootstrap gcc (gcc-15.2.1-7.azl4~bootstrap, triple x86_64-redhat-linux), so annobin.spec's %(gcc --print-file-name=plugin) resolved to the redhat-triple plugin dir and shipped annobin.so under /usr/lib/gcc/x86_64-redhat-linux/15/plugin/. Azure Linux's final gcc uses x86_64-azurelinux-linux and searches the matching dir, so -fplugin=annobin could not find the plugin and every consumer that forces it (e.g. atlas) failed to build. Bump the manual-rebuild counter so a rebuild against the final (non-bootstrap) gcc supersedes the mis-built NVR with the plugin at the correct target-triple path.