### PR TITLE
build(atlas): bump rebuild counter to pick up fixed annobin plugin

### DIFF
--- a/locks/atlas.lock
+++ b/locks/atlas.lock
@@ -2,5 +2,6 @@
 version = 1
 import-commit = '6f21b7ab02f2016124cbde752f11c15ac9dbbbd5'
 upstream-commit = '6f21b7ab02f2016124cbde752f11c15ac9dbbbd5'
-input-fingerprint = 'sha256:a840f8467064830d37772e9d983a4fbdf96fbbcf25ef914ba7f9b24c3fdffaee'
+manual-bump = 1
+input-fingerprint = 'sha256:61647f67842ef44e26b2b6c54c9399e47a3af42b44488bf6d57e9cad67e09e56'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/a/atlas/atlas.spec
+++ b/specs/a/atlas/atlas.spec
@@ -9,7 +9,7 @@ Version:        3.10.3
 %if "%{?enable_native_atlas}" != "0"
 %define dist .native
 %endif
-Release: 31%{?dist}
+Release: 32%{?dist}
 Summary:        Automatically Tuned Linear Algebra Software
 
 License:        BSD-3-Clause


### PR DESCRIPTION
atlas forces -fplugin=annobin, so it failed against the mis-built annobin-plugin-gcc that shipped annobin.so under the bootstrap gcc triple (x86_64-redhat-linux) instead of x86_64-azurelinux-linux. Bump the manual rebuild counter so atlas rebuilds against the corrected annobin (12.99-4).