### PR TITLE
feat(images): add marketplace Gen2 image definitions

### DIFF
--- a/base/images/images.toml
+++ b/base/images/images.toml
@@ -104,6 +104,46 @@ systemd = true
 runtime-package-management = true
 
 # ---- marketplace-gen2-cvm -----------------------------------------------
+# ---- marketplace-gen2-cvm -----------------------------------------------
+
+[images.marketplace-gen2-cvm]
+description = "Marketplace Gen2 Confidential VM Image"
+definition = { type = "kiwi", path = "marketplace-gen2-cvm/marketplace-gen2-cvm.kiwi", profile = "marketplace-gen2-cvm" }
+tests.test-suites = [
+  { name = "static-image-checks" },
+  { name = "lisa-main" },
+  { name = "lisa-xfs" },
+  { name = "lisa-perf" },
+  { name = "lisa-smoke" },
+  { name = "lisa-cvm" },
+  { name = "lisa-kernel-ltp" },
+]
+
+[images.marketplace-gen2-cvm.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
+[images.marketplace-gen2-cvm-dev]
+description = "Marketplace Gen2 Confidential VM Image (dev)"
+definition = { type = "kiwi", path = "marketplace-gen2-cvm/marketplace-gen2-cvm.kiwi", profile = "marketplace-gen2-cvm-dev" }
+tests.test-suites = [
+  { name = "static-image-checks" },
+  { name = "lisa-main" },
+  { name = "lisa-xfs" },
+  { name = "lisa-perf" },
+  { name = "lisa-smoke" },
+  { name = "lisa-cvm" },
+  { name = "lisa-kernel-ltp" },
+]
+
+[images.marketplace-gen2-cvm-dev.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
 # ---- minimal-os --------------------------------------------------------
 
 [images.minimal-os]

--- a/base/images/images.toml
+++ b/base/images/images.toml
@@ -104,7 +104,6 @@ systemd = true
 runtime-package-management = true
 
 # ---- marketplace-gen2-cvm -----------------------------------------------
-# ---- marketplace-gen2-cvm -----------------------------------------------
 
 [images.marketplace-gen2-cvm]
 description = "Marketplace Gen2 Confidential VM Image"
@@ -139,6 +138,46 @@ tests.test-suites = [
 ]
 
 [images.marketplace-gen2-cvm-dev.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
+# ---- marketplace-gen2-fips ----------------------------------------------
+
+[images.marketplace-gen2-fips]
+description = "Marketplace Gen2 FIPS Image"
+definition = { type = "kiwi", path = "marketplace-gen2-fips/marketplace-gen2-fips.kiwi", profile = "marketplace-gen2-fips" }
+tests.test-suites = [
+  { name = "static-image-checks" },
+  { name = "lisa-main" },
+  { name = "lisa-xfs" },
+  { name = "lisa-perf" },
+  { name = "lisa-smoke" },
+  { name = "lisa-kernel-ltp" },
+  { name = "lisa-fips" },
+]
+
+[images.marketplace-gen2-fips.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
+[images.marketplace-gen2-fips-dev]
+description = "Marketplace Gen2 FIPS Image (dev)"
+definition = { type = "kiwi", path = "marketplace-gen2-fips/marketplace-gen2-fips.kiwi", profile = "marketplace-gen2-fips-dev" }
+tests.test-suites = [
+  { name = "static-image-checks" },
+  { name = "lisa-main" },
+  { name = "lisa-xfs" },
+  { name = "lisa-perf" },
+  { name = "lisa-smoke" },
+  { name = "lisa-kernel-ltp" },
+  { name = "lisa-fips" },
+]
+
+[images.marketplace-gen2-fips-dev.capabilities]
 machine-bootable = true
 container = false
 systemd = true
@@ -299,6 +338,10 @@ description = "Lisa cvm tests"
 [test-suites.lisa-kernel-ltp]
 type = "lisa"
 description = "Lisa kernel LTP tests"
+
+[test-suites.lisa-fips]
+type = "lisa"
+description = "Lisa FIPS tests"
 
 # Single shared pytest suite for static (offline) image validation.
 [test-suites.static-image-checks]

--- a/base/images/images.toml
+++ b/base/images/images.toml
@@ -65,6 +65,45 @@ container = false
 systemd = true
 runtime-package-management = true
 
+# ---- marketplace-gen2 ---------------------------------------------------
+
+[images.marketplace-gen2]
+description = "Marketplace Gen2 Image"
+definition = { type = "kiwi", path = "marketplace-gen2/marketplace-gen2.kiwi", profile = "marketplace-gen2" }
+tests.test-suites = [
+  { name = "static-image-checks" },
+  { name = "lisa-main" },
+  { name = "lisa-xfs" },
+  { name = "lisa-perf" },
+  { name = "lisa-smoke" },
+  { name = "lisa-kernel-ltp" },
+]
+
+[images.marketplace-gen2.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
+[images.marketplace-gen2-dev]
+description = "Marketplace Gen2 Image (dev)"
+definition = { type = "kiwi", path = "marketplace-gen2/marketplace-gen2.kiwi", profile = "marketplace-gen2-dev" }
+tests.test-suites = [
+  { name = "static-image-checks" },
+  { name = "lisa-main" },
+  { name = "lisa-xfs" },
+  { name = "lisa-perf" },
+  { name = "lisa-smoke" },
+  { name = "lisa-kernel-ltp" },
+]
+
+[images.marketplace-gen2-dev.capabilities]
+machine-bootable = true
+container = false
+systemd = true
+runtime-package-management = true
+
+# ---- marketplace-gen2-cvm -----------------------------------------------
 # ---- minimal-os --------------------------------------------------------
 
 [images.minimal-os]

--- a/base/images/marketplace-gen2-cvm/marketplace-gen2-cvm.kiwi
+++ b/base/images/marketplace-gen2-cvm/marketplace-gen2-cvm.kiwi
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="https://raw.githubusercontent.com/OSInside/kiwi/refs/tags/v10.2.33/kiwi/schema/kiwi.rng" type="application/xml"?>
+<image schemaversion="8.3" name="azl4-marketplace-gen2-cvm">
+    <description type="system">
+        <author>Azure Linux</author>
+        <contact>azurelinux@microsoft.com</contact>
+        <specification>Azure Linux 4.0 Marketplace Gen2 Confidential VM (CVM) Image</specification>
+    </description>
+
+    <profiles>
+        <profile name="marketplace-gen2-cvm"     description="Ships azurelinux-repos (runtime → PMC)" import="false" />
+        <profile name="marketplace-gen2-cvm-dev" description="Ships azurelinux-repos-dev (runtime → azl4-dev)" import="false" />
+    </profiles>
+
+    <!-- CVM is AMD64-only per PRD -->
+    <preferences arch="x86_64">
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type
+            image="oem"
+            format="vhd-fixed"
+            formatoptions="force_size"
+            initrd_system="dracut"
+            filesystem="ext4"
+            fscreateoptions="-m 1"
+            kernelcmdline="console=ttyS0 earlyprintk=ttyS0 rd.shell=0"
+            firmware="uefi"
+            overlayroot="false"
+            eficsm="false"
+            bootpartition="false"
+            efipartsize="200"
+            rootfs_label="azurelinux">
+            <bootloader name="grub2" bls="true" console="serial" timeout="1" />
+            <size unit="G">5</size>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
+    </preferences>
+
+    <!-- Build-time package source; koji overrides this for distro builds. -->
+    <repository type="rpm-md" alias="azurelinux-base">
+        <source path="https://packages.microsoft.com/azurelinux/4.0/beta/base/$basearch" />
+    </repository>
+
+    <packages type="image">
+        <!-- CVM-specific: TPM2 tooling for attestation -->
+        <package name="tpm2-tools" />
+
+        <!-- core-packages-image -->
+        <package name="ca-certificates" />
+        <package name="cronie-anacron" />
+        <package name="dracut" />
+        <package name="logrotate" />
+        <package name="shadow-utils" />
+
+        <!-- core-packages-base-image -->
+        <package name="azurelinux-rpm-config" />
+        <package name="bc" />
+        <package name="chrony" />
+        <package name="cpio" />
+        <package name="cracklib-dicts" />
+        <package name="cryptsetup" />
+        <package name="dbus" />
+        <package name="e2fsprogs" />
+        <package name="file" />
+        <package name="gdbm" />
+        <package name="glibc" />
+        <package name="glibc-langpack-en" />
+        <package name="iproute" />
+        <package name="iptables" />
+        <package name="iputils" />
+        <package name="irqbalance" />
+        <package name="libtool" />
+        <package name="lvm2" />
+        <package name="lz4" />
+        <package name="net-tools" />
+        <package name="openssh-clients" />
+        <package name="pkg-config" />
+        <package name="procps-ng" />
+        <package name="setup" />
+        <package name="sudo" />
+        <package name="systemd" />
+        <package name="systemd-networkd" />
+        <package name="systemd-resolved" />
+        <package name="systemd-udev" />
+        <package name="tar" />
+        <package name="tzdata" />
+        <package name="util-linux" />
+        <package name="which" />
+
+        <!-- core-packages-container -->
+        <package name="bash" />
+        <package name="bzip2" />
+        <package name="curl" />
+        <package name="elfutils-libelf" />
+        <package name="expat" />
+        <package name="filesystem" />
+        <package name="findutils" />
+        <package name="grep" />
+        <package name="gzip" />
+        <package name="azurelinux-release-cloud" />
+        <package name="ncurses-libs" />
+        <package name="openssl" />
+        <package name="readline" />
+        <package name="rpm" />
+        <package name="rpm-libs" />
+        <package name="sed" />
+        <package name="sqlite-libs" />
+        <package name="SymCrypt" />
+        <package name="SymCrypt-OpenSSL" />
+        <package name="xz" />
+        <package name="zlib" />
+
+        <!-- marketplace-tools -->
+        <package name="debootstrap" />
+        <package name="dnf5" />
+        <package name="wget" />
+
+        <!-- Administration, diagnostics, and troubleshooting baseline -->
+        <package name="acl" />
+        <package name="at" />
+        <package name="atop" />
+        <package name="attr" />
+        <package name="audit" />
+        <package name="bash-completion" />
+        <package name="bind-utils" />
+        <package name="dnf-plugins-core" />
+        <package name="hostname" />
+        <package name="jemalloc" />
+        <package name="keyutils" />
+        <package name="libdnf" />
+        <package name="libuser" />
+        <package name="lsof" />
+        <package name="man-db" />
+        <package name="nano" />
+        <package name="ncurses" />
+        <package name="ncurses-term" />
+        <package name="newt" />
+        <package name="nftables" />
+        <package name="nss" />
+        <package name="nvme-cli" />
+        <package name="pciutils" />
+        <package name="rng-tools" />
+        <package name="rootfiles" />
+        <package name="rsync" />
+        <package name="strace" />
+        <package name="sysstat" />
+        <package name="tcpdump" />
+        <package name="time" />
+        <package name="tmux" />
+        <package name="tpm2-tss" />
+        <package name="traceroute" />
+        <package name="unzip" />
+        <package name="vim-minimal" />
+        <package name="zchunk" />
+
+        <!-- SELinux -->
+        <package name="selinux-policy-targeted" />
+
+        <!-- Azure VM provisioning and guest integration -->
+        <package name="cloud-init" />
+        <package name="cloud-utils-growpart" />
+        <package name="dhcpcd" />
+        <package name="grubby" />
+        <package name="hyperv-daemons" />
+        <package name="openssh-server" />
+        <package name="python3" />
+        <package name="rsyslog" />
+        <package name="WALinuxAgent" />
+        <package name="wireless-regdb" />
+
+        <!-- Azure VM integration -->
+        <package name="azure-vm-utils" />
+        <package name="kernel-modules" />
+
+        <!-- boot: kernel + UEFI bootloader (CVM uses GRUB2 until UKI is available) -->
+        <package name="kernel" />
+        <package name="grub2" />
+        <package name="grub2-efi-x64" />
+        <package name="grub2-efi-x64-modules" />
+        <package name="shim" />
+        <package name="efibootmgr" />
+
+    </packages>
+
+    <!-- Variant-scoped repos package -->
+    <packages type="image" profiles="marketplace-gen2-cvm-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="image" profiles="marketplace-gen2-cvm">
+        <package name="azurelinux-repos" />
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="filesystem" />
+        <package name="azurelinux-release-identity-cloud" />
+        <package name="grub2-efi-x64-modules" />
+        <package name="grub2-efi-x64" />
+        <package name="shim" />
+    </packages>
+
+    <packages type="bootstrap" profiles="marketplace-gen2-cvm-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="bootstrap" profiles="marketplace-gen2-cvm">
+        <package name="azurelinux-repos" />
+    </packages>
+</image>

--- a/base/images/marketplace-gen2-fips/marketplace-gen2-fips.kiwi
+++ b/base/images/marketplace-gen2-fips/marketplace-gen2-fips.kiwi
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="https://raw.githubusercontent.com/OSInside/kiwi/refs/tags/v10.2.33/kiwi/schema/kiwi.rng" type="application/xml"?>
+<image schemaversion="8.3" name="azl4-marketplace-gen2-fips">
+    <description type="system">
+        <author>Azure Linux</author>
+        <contact>azurelinux@microsoft.com</contact>
+        <specification>Azure Linux 4.0 Marketplace Gen2 (UEFI) FIPS Image</specification>
+    </description>
+
+    <profiles>
+        <profile name="marketplace-gen2-fips"     description="Ships azurelinux-repos (runtime → PMC)" import="false" />
+        <profile name="marketplace-gen2-fips-dev" description="Ships azurelinux-repos-dev (runtime → azl4-dev)" import="false" />
+    </profiles>
+
+    <preferences arch="x86_64">
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type
+            image="oem"
+            format="vhd-fixed"
+            formatoptions="force_size"
+            initrd_system="dracut"
+            filesystem="ext4"
+            fscreateoptions="-m 1"
+            kernelcmdline="console=ttyS0 fips=1 rd.shell=0"
+            firmware="uefi"
+            overlayroot="false"
+            eficsm="false"
+            bootpartition="false"
+            efipartsize="200"
+            rootfs_label="azurelinux">
+            <bootloader name="grub2" bls="true" console="serial" timeout="1" />
+            <size unit="G">5</size>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
+    </preferences>
+
+    <preferences arch="aarch64">
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type
+            image="oem"
+            format="vhd-fixed"
+            formatoptions="force_size"
+            initrd_system="dracut"
+            filesystem="ext4"
+            fscreateoptions="-m 1"
+            kernelcmdline="console=ttyAMA0 fips=1 rd.shell=0"
+            firmware="uefi"
+            overlayroot="false"
+            eficsm="false"
+            bootpartition="false"
+            efipartsize="200"
+            rootfs_label="azurelinux">
+            <bootloader name="grub2" bls="true" console="serial" timeout="1" />
+            <size unit="G">5</size>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
+    </preferences>
+
+    <!-- Build-time package source; koji overrides this for distro builds. -->
+    <repository type="rpm-md" alias="azurelinux-base">
+        <source path="https://packages.microsoft.com/azurelinux/4.0/beta/base/$basearch" />
+    </repository>
+
+    <packages type="image">
+        <!-- FIPS: dracut module for fips=1 kernel parameter -->
+        <package name="dracut-fips" />
+
+        <!-- core-packages-image -->
+        <package name="ca-certificates" />
+        <package name="cronie-anacron" />
+        <package name="dracut" />
+        <package name="logrotate" />
+        <package name="shadow-utils" />
+
+        <!-- core-packages-base-image -->
+        <package name="azurelinux-rpm-config" />
+        <package name="bc" />
+        <package name="chrony" />
+        <package name="cpio" />
+        <package name="cracklib-dicts" />
+        <package name="cryptsetup" />
+        <package name="dbus" />
+        <package name="e2fsprogs" />
+        <package name="file" />
+        <package name="gdbm" />
+        <package name="glibc" />
+        <package name="glibc-langpack-en" />
+        <package name="iproute" />
+        <package name="iptables" />
+        <package name="iputils" />
+        <package name="irqbalance" />
+        <package name="libtool" />
+        <package name="lvm2" />
+        <package name="lz4" />
+        <package name="net-tools" />
+        <package name="openssh-clients" />
+        <package name="pkg-config" />
+        <package name="procps-ng" />
+        <package name="setup" />
+        <package name="sudo" />
+        <package name="systemd" />
+        <package name="systemd-networkd" />
+        <package name="systemd-resolved" />
+        <package name="systemd-udev" />
+        <package name="tar" />
+        <package name="tzdata" />
+        <package name="util-linux" />
+        <package name="which" />
+
+        <!-- core-packages-container -->
+        <package name="bash" />
+        <package name="bzip2" />
+        <package name="curl" />
+        <package name="elfutils-libelf" />
+        <package name="expat" />
+        <package name="filesystem" />
+        <package name="findutils" />
+        <package name="grep" />
+        <package name="gzip" />
+        <package name="azurelinux-release-cloud" />
+        <package name="ncurses-libs" />
+        <package name="openssl" />
+        <package name="readline" />
+        <package name="rpm" />
+        <package name="rpm-libs" />
+        <package name="sed" />
+        <package name="sqlite-libs" />
+        <package name="SymCrypt" />
+        <package name="SymCrypt-OpenSSL" />
+        <package name="xz" />
+        <package name="zlib" />
+
+        <!-- marketplace-tools -->
+        <package name="debootstrap" />
+        <package name="dnf5" />
+        <package name="wget" />
+
+        <!-- Administration, diagnostics, and troubleshooting baseline -->
+        <package name="acl" />
+        <package name="at" />
+        <package name="atop" />
+        <package name="attr" />
+        <package name="audit" />
+        <package name="bash-completion" />
+        <package name="bind-utils" />
+        <package name="dnf-plugins-core" />
+        <package name="hostname" />
+        <package name="jemalloc" />
+        <package name="keyutils" />
+        <package name="libdnf" />
+        <package name="libuser" />
+        <package name="lsof" />
+        <package name="man-db" />
+        <package name="nano" />
+        <package name="ncurses" />
+        <package name="ncurses-term" />
+        <package name="newt" />
+        <package name="nftables" />
+        <package name="nss" />
+        <package name="nvme-cli" />
+        <package name="pciutils" />
+        <package name="rng-tools" />
+        <package name="rootfiles" />
+        <package name="rsync" />
+        <package name="strace" />
+        <package name="sysstat" />
+        <package name="tcpdump" />
+        <package name="time" />
+        <package name="tmux" />
+        <package name="tpm2-tss" />
+        <package name="traceroute" />
+        <package name="unzip" />
+        <package name="vim-minimal" />
+        <package name="zchunk" />
+
+        <!-- SELinux -->
+        <package name="selinux-policy-targeted" />
+
+        <!-- Azure VM provisioning and guest integration -->
+        <package name="cloud-init" />
+        <package name="cloud-utils-growpart" />
+        <package name="dhcpcd" />
+        <package name="grubby" />
+        <package name="hyperv-daemons" />
+        <package name="openssh-server" />
+        <package name="python3" />
+        <package name="rsyslog" />
+        <package name="WALinuxAgent" />
+        <package name="wireless-regdb" />
+
+        <!-- Azure VM integration -->
+        <package name="azure-vm-utils" />
+        <package name="kernel-modules" />
+
+        <!-- boot: kernel + UEFI bootloader -->
+        <package name="kernel" />
+        <package name="grub2" />
+        <package name="grub2-efi-x64" arch="x86_64" />
+        <package name="grub2-efi-x64-modules" arch="x86_64" />
+        <package name="grub2-efi-aa64" arch="aarch64" />
+        <package name="grub2-efi-aa64-modules" arch="aarch64" />
+        <package name="shim" arch="x86_64" />
+        <package name="shim" arch="aarch64" />
+        <package name="efibootmgr" />
+
+    </packages>
+
+    <!-- Variant-scoped repos package -->
+    <packages type="image" profiles="marketplace-gen2-fips-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="image" profiles="marketplace-gen2-fips">
+        <package name="azurelinux-repos" />
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="filesystem" />
+        <package name="azurelinux-release-identity-cloud" />
+        <package name="grub2-efi-x64-modules" arch="x86_64" />
+        <package name="grub2-efi-x64" arch="x86_64" />
+        <package name="grub2-efi-aa64-modules" arch="aarch64" />
+        <package name="grub2-efi-aa64" arch="aarch64" />
+        <package name="shim" arch="x86_64" />
+        <package name="shim" arch="aarch64" />
+    </packages>
+
+    <packages type="bootstrap" profiles="marketplace-gen2-fips-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="bootstrap" profiles="marketplace-gen2-fips">
+        <package name="azurelinux-repos" />
+    </packages>
+</image>

--- a/base/images/marketplace-gen2/marketplace-gen2.kiwi
+++ b/base/images/marketplace-gen2/marketplace-gen2.kiwi
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="https://raw.githubusercontent.com/OSInside/kiwi/refs/tags/v10.2.33/kiwi/schema/kiwi.rng" type="application/xml"?>
+<image schemaversion="8.3" name="azl4-marketplace-gen2">
+    <description type="system">
+        <author>Azure Linux</author>
+        <contact>azurelinux@microsoft.com</contact>
+        <specification>Azure Linux 4.0 Marketplace Gen2 (UEFI) Image</specification>
+    </description>
+
+    <profiles>
+        <profile name="marketplace-gen2"     description="Ships azurelinux-repos (runtime → PMC)" import="false" />
+        <profile name="marketplace-gen2-dev" description="Ships azurelinux-repos-dev (runtime → azl4-dev)" import="false" />
+    </profiles>
+
+    <preferences arch="x86_64">
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type
+            image="oem"
+            format="vhd-fixed"
+            formatoptions="force_size"
+            initrd_system="dracut"
+            filesystem="ext4"
+            fscreateoptions="-m 1"
+            kernelcmdline="console=ttyS0 earlyprintk=ttyS0 rd.shell=0"
+            firmware="uefi"
+            overlayroot="false"
+            eficsm="false"
+            bootpartition="false"
+            efipartsize="200"
+            rootfs_label="azurelinux">
+            <bootloader name="grub2" bls="true" console="serial" timeout="1" />
+            <size unit="G">5</size>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
+    </preferences>
+
+    <preferences arch="aarch64">
+        <version>0.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <release-version>4.0</release-version>
+        <type
+            image="oem"
+            format="vhd-fixed"
+            formatoptions="force_size"
+            initrd_system="dracut"
+            filesystem="ext4"
+            fscreateoptions="-m 1"
+            kernelcmdline="console=ttyAMA0 earlyprintk=ttyAMA0 rd.shell=0"
+            firmware="uefi"
+            overlayroot="false"
+            eficsm="false"
+            bootpartition="false"
+            efipartsize="200"
+            rootfs_label="azurelinux">
+            <bootloader name="grub2" bls="true" console="serial" timeout="1" />
+            <size unit="G">5</size>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
+    </preferences>
+
+    <!-- Build-time package source; koji overrides this for distro builds. -->
+    <repository type="rpm-md" alias="azurelinux-base">
+        <source path="https://packages.microsoft.com/azurelinux/4.0/beta/base/$basearch" />
+    </repository>
+
+    <packages type="image">
+        <!-- core-packages-image -->
+        <package name="ca-certificates" />
+        <package name="cronie-anacron" />
+        <package name="dracut" />
+        <package name="logrotate" />
+        <package name="shadow-utils" />
+
+        <!-- core-packages-base-image -->
+        <package name="azurelinux-rpm-config" />
+        <package name="bc" />
+        <package name="chrony" />
+        <package name="cpio" />
+        <package name="cracklib-dicts" />
+        <package name="cryptsetup" />
+        <package name="dbus" />
+        <package name="e2fsprogs" />
+        <package name="file" />
+        <package name="gdbm" />
+        <package name="glibc" />
+        <package name="glibc-langpack-en" />
+        <package name="iproute" />
+        <package name="iptables" />
+        <package name="iputils" />
+        <package name="irqbalance" />
+        <package name="libtool" />
+        <package name="lvm2" />
+        <package name="lz4" />
+        <package name="net-tools" />
+        <package name="openssh-clients" />
+        <package name="pkg-config" />
+        <package name="procps-ng" />
+        <package name="setup" />
+        <package name="sudo" />
+        <package name="systemd" />
+        <package name="systemd-networkd" />
+        <package name="systemd-resolved" />
+        <package name="systemd-udev" />
+        <package name="tar" />
+        <package name="tzdata" />
+        <package name="util-linux" />
+        <package name="which" />
+
+        <!-- core-packages-container -->
+        <package name="bash" />
+        <package name="bzip2" />
+        <package name="curl" />
+        <package name="elfutils-libelf" />
+        <package name="expat" />
+        <package name="filesystem" />
+        <package name="findutils" />
+        <package name="grep" />
+        <package name="gzip" />
+        <package name="azurelinux-release-cloud" />
+        <package name="ncurses-libs" />
+        <package name="openssl" />
+        <package name="readline" />
+        <package name="rpm" />
+        <package name="rpm-libs" />
+        <package name="sed" />
+        <package name="sqlite-libs" />
+        <package name="SymCrypt" />
+        <package name="SymCrypt-OpenSSL" />
+        <package name="xz" />
+        <package name="zlib" />
+
+        <!-- marketplace-tools -->
+        <package name="debootstrap" />
+        <package name="dnf5" />
+        <package name="wget" />
+
+        <!-- Administration, diagnostics, and troubleshooting baseline -->
+        <package name="acl" />
+        <package name="at" />
+        <package name="atop" />
+        <package name="attr" />
+        <package name="audit" />
+        <package name="bash-completion" />
+        <package name="bind-utils" />
+        <package name="dnf-plugins-core" />
+        <package name="hostname" />
+        <package name="jemalloc" />
+        <package name="keyutils" />
+        <package name="libdnf" />
+        <package name="libuser" />
+        <package name="lsof" />
+        <package name="man-db" />
+        <package name="nano" />
+        <package name="ncurses" />
+        <package name="ncurses-term" />
+        <package name="newt" />
+        <package name="nftables" />
+        <package name="nss" />
+        <package name="nvme-cli" />
+        <package name="pciutils" />
+        <package name="rng-tools" />
+        <package name="rootfiles" />
+        <package name="rsync" />
+        <package name="strace" />
+        <package name="sysstat" />
+        <package name="tcpdump" />
+        <package name="time" />
+        <package name="tmux" />
+        <package name="tpm2-tss" />
+        <package name="traceroute" />
+        <package name="unzip" />
+        <package name="vim-minimal" />
+        <package name="zchunk" />
+
+        <!-- SELinux -->
+        <package name="selinux-policy-targeted" />
+
+        <!-- Azure VM provisioning and guest integration -->
+        <package name="cloud-init" />
+        <package name="cloud-utils-growpart" />
+        <package name="dhcpcd" />
+        <package name="grubby" />
+        <package name="hyperv-daemons" />
+        <package name="openssh-server" />
+        <package name="python3" />
+        <package name="rsyslog" />
+        <package name="WALinuxAgent" />
+        <package name="wireless-regdb" />
+
+        <!-- Azure VM integration -->
+        <package name="azure-vm-utils" />
+        <package name="kernel-modules" />
+
+        <!-- boot: kernel + UEFI bootloader -->
+        <package name="kernel" />
+        <package name="grub2" />
+        <package name="grub2-efi-x64" arch="x86_64" />
+        <package name="grub2-efi-x64-modules" arch="x86_64" />
+        <package name="grub2-efi-aa64" arch="aarch64" />
+        <package name="grub2-efi-aa64-modules" arch="aarch64" />
+        <package name="shim" arch="x86_64" />
+        <package name="shim" arch="aarch64" />
+        <package name="efibootmgr" />
+
+    </packages>
+
+    <!-- Variant-scoped repos package -->
+    <packages type="image" profiles="marketplace-gen2-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="image" profiles="marketplace-gen2">
+        <package name="azurelinux-repos" />
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="filesystem" />
+        <package name="azurelinux-release-identity-cloud" />
+        <package name="grub2-efi-x64-modules" arch="x86_64" />
+        <package name="grub2-efi-x64" arch="x86_64" />
+        <package name="grub2-efi-aa64-modules" arch="aarch64" />
+        <package name="grub2-efi-aa64" arch="aarch64" />
+        <package name="shim" arch="x86_64" />
+        <package name="shim" arch="aarch64" />
+    </packages>
+
+    <packages type="bootstrap" profiles="marketplace-gen2-dev">
+        <package name="azurelinux-repos-dev" />
+    </packages>
+    <packages type="bootstrap" profiles="marketplace-gen2">
+        <package name="azurelinux-repos" />
+    </packages>
+</image>


### PR DESCRIPTION
Adds three Azure Marketplace Gen2 VM image definitions for Azure Linux 4.0:

- **marketplace-gen2** — Standard Gen2 image (AMD64 + ARM64)
- **marketplace-gen2-cvm** — Confidential VM image (AMD64)
- **marketplace-gen2-fips** — Gen2 image with FIPS cryptographic configuration (AMD64 + ARM64)

Each image provides an administration, diagnostics, and troubleshooting baseline suitable for general-purpose cloud workloads on Azure. Includes provisioning via cloud-init, WALinuxAgent integration, SELinux targeted policy, and a comprehensive set of system utilities.

Test suites: static-image-checks, lisa-main, lisa-xfs, lisa-perf, lisa-smoke, lisa-kernel-ltp (plus lisa-cvm for CVM, lisa-fips for FIPS).

Validated marketplace-gen2 and marketplace-gen2-fips on Azure VMs (aarch64):
- Boot, networking, SSHD confirmed working
- FIPS mode active on fips image (`/proc/sys/crypto/fips_enabled = 1`)
- 502 packages installed
- Key utilities verified: strace, tcpdump, lsof, traceroute, atop, tmux, debootstrap, dnf5
- `rd.shell=0` confirmed in kernel cmdline
- CVM image not testable on aarch64 host (x86_64-only)