### PR TITLE
Run fast-track cherry-pick pipeline on AZL3 managed pool instead of Ubuntu

### DIFF
--- a/.pipelines/cherrypick/CherryPick.yml
+++ b/.pipelines/cherrypick/CherryPick.yml
@@ -21,7 +21,7 @@ jobs:
     pool:
       type: linux
       isCustom: true
-      name: "$(DEV_AMD64_Ubuntu_Managed)"
+      name: "$(DEV_AMD64_Managed_AZL3)"
     timeoutInMinutes: 15
     displayName: 'Cherry-pick commit'
 


### PR DESCRIPTION
## Summary
Switch the `FastTrack-CherryPickToStaging` job from the **Ubuntu** DEV pool to the **AZL3 managed** DEV pool.

| | Before | After |
|---|---|---|
| Pool var | `$(DEV_AMD64_Ubuntu_Managed)` | `$(DEV_AMD64_Managed_AZL3)` |
| Pool | `mariner-core-x64-1es-ubuntu-22.04` | `mariner-core-amd64-1es-mariner3` |

## Why
The cherry-pick pipeline (`.pipelines/cherrypick/CherryPick.yml`) bootstraps its prerequisites in `spec-auto-patch-update/script/Tools-Common.sh`. On the **Ubuntu** pool that path runs plain `apt install python3-pip python3-rpm golang ...` against the **public** `azure.archive.ubuntu.com` mirror — a single point of failure with **no retry** and no internal mirror.

On **2026-08-19**, that mirror was briefly unreachable, so `python3-pip` never installed. Because pip was absent, the `pip install -r requirements.txt` step never ran, and the failure surfaced downstream as a misleading:

```
ModuleNotFoundError: No module named 'tenacity'
```

...even though `tenacity` is correctly declared in `requirements.txt`. Four cherry-pick runs failed in a 3-minute window (postgresql, erlang, kbd, gh upgrades) — all the same root cause. Worse, the "Install prerequisites" step reported **success** despite the fatal apt errors, masking the real cause.

## Why AZL3 fixes it
`Tools-Common.sh` **already fully supports Azure Linux** — every prerequisite has a `tdnf`/`pip --user` install path for `$ID == "azurelinux"` (packages, `azure-cli`, `msodbcsql18`/`mssql-tools18`, `cargo`, and the `requirements.txt` install). Moving to the AZL3 managed image sources OS packages from the Azure Linux repos instead of the public Ubuntu mirror, removing the fragile external dependency.

The AZL3 managed pool (`mariner-core-amd64-1es-mariner3`) carries a **UMI**, satisfying the `ManagedIdentityCredential` / `az login --identity` the cherry-pick and security-config steps rely on.

## Scope / risk
- **One-line pool swap.** No script changes — the Azure Linux code paths in `Tools-Common.sh` are pre-existing.
- This is a **non-production** automation pipeline (DEV pool, custom/non-governed, no OneBranch Official template), so blast radius is limited to fast-track cherry-pick staging.
- **Validation note:** the Azure Linux branch of `Tools-Common.sh` has not previously run in this pipeline. Please watch the first post-merge cherry-pick run for any AZL3 package-name / repo-availability gaps (e.g. `msodbcsql18`/`mssql-tools18` repo presence on the image).

## Follow-ups (not in this PR)
- Make the "Install prerequisites" step **fail-fast** on apt/tdnf errors instead of reporting success.
- The pipeline definition's YAML source branch is currently a personal dev branch (`aaruagrawal/autoCPtest`) — worth repointing to a stable branch.
