### PR TITLE
gawk: drop sudo/shadow-utils BuildRequires to fix toolchain graph cycle

### DIFF
--- a/SPECS/gawk/gawk.spec
+++ b/SPECS/gawk/gawk.spec
@@ -1,7 +1,7 @@
 Summary:        Contains programs for manipulating text files
 Name:           gawk
 Version:        5.2.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -14,10 +14,6 @@ Patch2:         CVE-2026-40553.patch
 Requires:       gmp
 Requires:       mpfr
 Requires:       readline >= 7.0
-%if 0%{?with_check}
-BuildRequires:  shadow-utils
-BuildRequires:  sudo
-%endif
 Provides:       /bin/awk
 Provides:       /bin/gawk
 Provides:       awk
@@ -51,12 +47,7 @@ sed -i 's/ pty1 / /' test/Makefile
 # Generate locale for `en_US.iso88591` which is required for ptest
 # Ideally it should have been present. Investigate if its a `chroot` only issue
 %{_sbindir}/locale-gen.sh
-
-# gawk's check_pma_security() refuses persistent memory when geteuid() == 0, so the
-# pma test only runs if the suite is not run as root.
-useradd testuser -m
-chown -R testuser:testuser .
-sudo -u testuser make %{?_smp_mflags} check
+make %{?_smp_mflags} check
 
 %post   -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
@@ -75,6 +66,12 @@ sudo -u testuser make %{?_smp_mflags} check
 %{_sysconfdir}/profile.d/gawk.sh
 
 %changelog
+* Wed Aug 19 2026 Jon Slobodzian <joslobo@microsoft.com> - 5.2.2-3
+- Revert the `%check` section to its 5.2.2-1 form: run the test suite directly and
+  drop the sudo and shadow-utils BuildRequires. gawk is a toolchain bootstrap
+  package; those build-time deps created an unresolvable cycle in the package
+  dependency graph (grapher panic), breaking all check-enabled source builds.
+
 * Wed Jul 15 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 5.2.2-2
 - Patch for CVE-2026-40553, CVE-2026-40468, CVE-2026-40467
 - Run the test suite as an unprivileged user so the pma test is exercised.

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -61,7 +61,7 @@ m4-1.4.19-2.azl3.aarch64.rpm
 grep-3.11-2.azl3.aarch64.rpm
 grep-lang-3.11-2.azl3.aarch64.rpm
 diffutils-3.10-1.azl3.aarch64.rpm
-gawk-5.2.2-2.azl3.aarch64.rpm
+gawk-5.2.2-3.azl3.aarch64.rpm
 findutils-4.9.0-1.azl3.aarch64.rpm
 findutils-lang-4.9.0-1.azl3.aarch64.rpm
 gettext-0.22-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -61,7 +61,7 @@ m4-1.4.19-2.azl3.x86_64.rpm
 grep-3.11-2.azl3.x86_64.rpm
 grep-lang-3.11-2.azl3.x86_64.rpm
 diffutils-3.10-1.azl3.x86_64.rpm
-gawk-5.2.2-2.azl3.x86_64.rpm
+gawk-5.2.2-3.azl3.x86_64.rpm
 findutils-4.9.0-1.azl3.x86_64.rpm
 findutils-lang-4.9.0-1.azl3.x86_64.rpm
 gettext-0.22-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -110,8 +110,8 @@ findutils-lang-4.9.0-1.azl3.aarch64.rpm
 flex-2.6.4-7.azl3.aarch64.rpm
 flex-debuginfo-2.6.4-7.azl3.aarch64.rpm
 flex-devel-2.6.4-7.azl3.aarch64.rpm
-gawk-5.2.2-2.azl3.aarch64.rpm
-gawk-debuginfo-5.2.2-2.azl3.aarch64.rpm
+gawk-5.2.2-3.azl3.aarch64.rpm
+gawk-debuginfo-5.2.2-3.azl3.aarch64.rpm
 gcc-13.2.0-7.azl3.aarch64.rpm
 gcc-c++-13.2.0-7.azl3.aarch64.rpm
 gcc-debuginfo-13.2.0-7.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -115,8 +115,8 @@ findutils-lang-4.9.0-1.azl3.x86_64.rpm
 flex-2.6.4-7.azl3.x86_64.rpm
 flex-debuginfo-2.6.4-7.azl3.x86_64.rpm
 flex-devel-2.6.4-7.azl3.x86_64.rpm
-gawk-5.2.2-2.azl3.x86_64.rpm
-gawk-debuginfo-5.2.2-2.azl3.x86_64.rpm
+gawk-5.2.2-3.azl3.x86_64.rpm
+gawk-debuginfo-5.2.2-3.azl3.x86_64.rpm
 gcc-13.2.0-7.azl3.x86_64.rpm
 gcc-aarch64-linux-gnu-13.2.0-7.azl3.x86_64.rpm
 gcc-c++-13.2.0-7.azl3.x86_64.rpm


### PR DESCRIPTION
## Summary
Reverts the `%check` section of `SPECS/gawk/gawk.spec` to its **5.2.2-1** form and drops the `sudo` + `shadow-utils` `BuildRequires` added in 5.2.2-2 (#18426). **CVE patches (CVE-2026-40467/40468/40553) are unchanged.** Release `2 → 3`.

## Why
gawk is a **toolchain/bootstrap package** and previously had *no* `BuildRequires`. 5.2.2-2 added, under `%if 0%{?with_check}`, `BuildRequires: shadow-utils` + `sudo` so the pma test could run as a non-root user. Under `with_check=1` this expands gawk's build closure into `sudo`/`shadow-utils` → glibc(`/sbin/ldconfig`) → gawk, forming an **unresolvable dependency-graph cycle** the grapher cannot break with prebuilt/PMC RPMs. It **panics during full-graph generation** (`graph.dot`), before any package is selected:
`
PANI[grapher] unfixable circular dependency ... gawk-5.2.2-2 ... /sbin/ldconfig
make: *** [pkggen.mk:150: .../graph.dot] Error 2
`
Because the panic is in whole-repo graph construction, it breaks **every check-enabled source build regardless of the package being built** — e.g. **~100% of buddy builds since 08-17** (any target: flannel, golang, packer, expat, kubevirt, gh…).

Not affected: PMC consumers of the binary RPM, Fast-Track PROD (built/published gawk fine with checks off at graph time), and the DEV RPM cascade.

## Fix
Restore the `-1` `%check` (run the suite directly) and remove the two `BuildRequires`. Trade-off: the pma persistent-memory test is skipped when the suite runs as root (`check_pma_security()` refuses persistent memory for euid 0) — same coverage as `-1` and every prior release.

## Follow-up
- Auto-cherry-pick to `3.0-dev` (also carries the poisoned spec).
- Cleaner future option that keeps pma coverage: run the test via `runuser` (util-linux, already in base) instead of `useradd`+`sudo`, avoiding the toolchain build-dep.