### PR TITLE
Add ADO definitions for P0 PR checks

### DIFF
--- a/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
+++ b/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
@@ -6,11 +6,6 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
-pr:
-  branches:
-    include:
-      - fasttrack/3.0
-
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
+++ b/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
@@ -6,6 +6,11 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
+pr:
+  branches:
+    include:
+      - fasttrack/3.0
+
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
+++ b/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
@@ -50,6 +50,14 @@ extends:
               - checkout: self
                 fetchDepth: 1
 
+              - bash: |
+                  set -euo pipefail
+
+                  echo "Installing Python 3.12 or later."
+                  sudo tdnf install -y python3 python3-pip
+                  python3 -c 'import sys; assert sys.version_info >= (3, 12), sys.version'
+                displayName: "Install Python 3.12 or later"
+
               - task: PipAuthenticate@1
                 displayName: "Authenticate internal pip feed"
                 inputs:
@@ -59,11 +67,14 @@ extends:
               - bash: |
                   set -euo pipefail
 
-                  python3 --version | grep -E '^Python 3\.12(\.|$)'
+                  echo "Creating the virtual environment and installing dependencies."
                   python3 -m venv "$(Agent.TempDirectory)/check-entangled-specs-venv"
                   source "$(Agent.TempDirectory)/check-entangled-specs-venv/bin/activate"
                   python -m pip install --quiet -r toolkit/scripts/requirements.txt
 
+                  echo "Running the entangled-spec checker unit tests."
                   PYTHONPATH=toolkit/scripts python toolkit/scripts/tests/test_check_entangled_specs.py
+
+                  echo "Checking repository spec entanglements."
                   python toolkit/scripts/check_entangled_specs.py .
                 displayName: "Check entangled specs"

--- a/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
+++ b/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Keep this definition in lock-step with .github/workflows/check-entangled-specs.yml.
+
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 

--- a/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
+++ b/.pipelines/prchecks/ado/CheckEntangledSpecs.yml
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Triggers are configured on the ADO pipeline definition.
+trigger: none
+
+parameters:
+  - name: debug
+    type: boolean
+    default: false
+    displayName: "Run in debug mode"
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+variables:
+  - group: "Agent pools (DEV)"
+  - name: system.debug
+    value: "${{ parameters.debug }}"
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      use1esentry: false # Required by the current hosted-pool configuration.
+      LinuxHostVersion:
+        Network: R1
+    globalSdl:
+      credscan:
+        suppressionsFile: .config/CredScanSuppressions.json
+    stages:
+      - stage: CheckEntangledSpecs
+        displayName: "Spec Entanglement Mismatch Check"
+        jobs:
+          - job: CheckEntangledSpecs
+            displayName: "Spec Entanglement Mismatch Check"
+            pool:
+              type: linux
+              isCustom: true
+              name: "$(DEV_AMD64_Managed_NoUMI_AZL3)"
+            variables:
+              ob_outputDirectory: "$(Pipeline.Workspace)/not_used/CheckEntangledSpecs"
+            steps:
+              - checkout: self
+                fetchDepth: 1
+
+              - task: PipAuthenticate@1
+                displayName: "Authenticate internal pip feed"
+                inputs:
+                  onlyAddExtraIndex: false
+                  artifactFeeds: "MarinerFeed"
+
+              - bash: |
+                  set -euo pipefail
+
+                  python3 --version | grep -E '^Python 3\.12(\.|$)'
+                  python3 -m venv "$(Agent.TempDirectory)/check-entangled-specs-venv"
+                  source "$(Agent.TempDirectory)/check-entangled-specs-venv/bin/activate"
+                  python -m pip install --quiet -r toolkit/scripts/requirements.txt
+
+                  PYTHONPATH=toolkit/scripts python toolkit/scripts/tests/test_check_entangled_specs.py
+                  python toolkit/scripts/check_entangled_specs.py .
+                displayName: "Check entangled specs"

--- a/.pipelines/prchecks/ado/CheckManifests.yml
+++ b/.pipelines/prchecks/ado/CheckManifests.yml
@@ -6,11 +6,6 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
-pr:
-  branches:
-    include:
-      - fasttrack/3.0
-
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckManifests.yml
+++ b/.pipelines/prchecks/ado/CheckManifests.yml
@@ -6,6 +6,11 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
+pr:
+  branches:
+    include:
+      - fasttrack/3.0
+
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckManifests.yml
+++ b/.pipelines/prchecks/ado/CheckManifests.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Keep this definition in lock-step with .github/workflows/check-manifests.yml.
+
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 

--- a/.pipelines/prchecks/ado/CheckManifests.yml
+++ b/.pipelines/prchecks/ado/CheckManifests.yml
@@ -1,0 +1,80 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Triggers are configured on the ADO pipeline definition.
+trigger: none
+
+parameters:
+  - name: debug
+    type: boolean
+    default: false
+    displayName: "Run in debug mode"
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+variables:
+  - group: "Agent pools (DEV)"
+  - name: system.debug
+    value: "${{ parameters.debug }}"
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      use1esentry: false # Required by the current hosted-pool configuration.
+      LinuxHostVersion:
+        Network: R1
+    globalSdl:
+      credscan:
+        suppressionsFile: .config/CredScanSuppressions.json
+    stages:
+      - stage: CheckManifests
+        displayName: "Check Manifests"
+        jobs:
+          - job: CheckManifests
+            displayName: "Check Manifests"
+            pool:
+              type: linux
+              isCustom: true
+              name: "$(DEV_AMD64_Managed_NoUMI_AZL3)"
+            variables:
+              ob_outputDirectory: "$(Pipeline.Workspace)/not_used/CheckManifests"
+            steps:
+              - checkout: self
+                fetchDepth: 1
+
+              - bash: |
+                  set -euo pipefail
+
+                  if [[ -n "$(rpm --eval '%bcond test 1')" ]]; then
+                    echo '%bcond() %[ (%{2}) ? "%{expand:%%bcond_without %{1}}" : "%{expand:%%bcond_with %{1}}" ]' > ~/.rpmmacros
+                  fi
+                displayName: "Define missing RPM macros"
+
+              - bash: |
+                  set -euo pipefail
+
+                  echo "Ensure toolchain and pkggen manifests match the versions in the spec files."
+                  echo "Run './scripts/toolchain/check_manifests.sh -a x86_64' from toolkit/ to validate locally."
+
+                  pushd toolkit
+                  ./scripts/toolchain/check_manifests.sh -a x86_64
+                  popd
+                displayName: "Check x86_64 manifests"
+
+              - bash: |
+                  set -euo pipefail
+
+                  echo "Ensure toolchain and pkggen manifests match the versions in the spec files."
+                  echo "Run './scripts/toolchain/check_manifests.sh -a aarch64' from toolkit/ to validate locally."
+
+                  pushd toolkit
+                  ./scripts/toolchain/check_manifests.sh -a aarch64
+                  popd
+                condition: always()
+                displayName: "Check aarch64 manifests"

--- a/.pipelines/prchecks/ado/CheckSpecFiles.yml
+++ b/.pipelines/prchecks/ado/CheckSpecFiles.yml
@@ -6,11 +6,6 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
-pr:
-  branches:
-    include:
-      - fasttrack/3.0
-
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckSpecFiles.yml
+++ b/.pipelines/prchecks/ado/CheckSpecFiles.yml
@@ -6,6 +6,11 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
+pr:
+  branches:
+    include:
+      - fasttrack/3.0
+
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckSpecFiles.yml
+++ b/.pipelines/prchecks/ado/CheckSpecFiles.yml
@@ -1,0 +1,94 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Triggers are configured on the ADO pipeline definition.
+trigger: none
+
+parameters:
+  - name: debug
+    type: boolean
+    default: false
+    displayName: "Run in debug mode"
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+variables:
+  - group: "Agent pools (DEV)"
+  - name: system.debug
+    value: "${{ parameters.debug }}"
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      use1esentry: false # Required by the current hosted-pool configuration.
+      LinuxHostVersion:
+        Network: R1
+    globalSdl:
+      credscan:
+        suppressionsFile: .config/CredScanSuppressions.json
+    stages:
+      - stage: CheckSpecFiles
+        displayName: "Spec files check"
+        jobs:
+          - job: CheckSpecFiles
+            displayName: "Spec files check"
+            pool:
+              type: linux
+              isCustom: true
+              name: "$(DEV_AMD64_Managed_NoUMI_AZL3)"
+            variables:
+              ob_outputDirectory: "$(Pipeline.Workspace)/not_used/CheckSpecFiles"
+            steps:
+              - checkout: self
+                fetchDepth: 0
+                persistCredentials: true
+
+              - task: PipAuthenticate@1
+                displayName: "Authenticate internal pip feed"
+                inputs:
+                  onlyAddExtraIndex: false
+                  artifactFeeds: "MarinerFeed"
+
+              - bash: |
+                  set -euo pipefail
+
+                  if [[ -z "${SYSTEM_PULLREQUEST_TARGETBRANCH:-}" ]]; then
+                    echo "System.PullRequest.TargetBranch is required."
+                    exit 1
+                  fi
+
+                  target_branch="${SYSTEM_PULLREQUEST_TARGETBRANCH#refs/heads/}"
+                  git fetch origin "refs/heads/${target_branch}:refs/remotes/origin/${target_branch}"
+                  base_sha="$(git merge-base HEAD "refs/remotes/origin/${target_branch}")"
+
+                  mapfile -t changed_specs < <(
+                    git diff --diff-filter=d --name-only "${base_sha}" HEAD |
+                      grep -E '^SPECS[^/]*/.+\.spec$' || true
+                  )
+
+                  if (( ${#changed_specs[@]} == 0 )); then
+                    echo "No changed spec files to validate."
+                    exit 0
+                  fi
+
+                  printf 'Spec files to validate:\n'
+                  printf '  %s\n' "${changed_specs[@]}"
+
+                  toolchain_spec_list="$(make --no-print-directory -sC toolkit printvar-toolchain_spec_list)"
+
+                  python3 --version | grep -E '^Python 3\.12(\.|$)'
+                  python3 -m venv "$(Agent.TempDirectory)/check-spec-files-venv"
+                  source "$(Agent.TempDirectory)/check-spec-files-venv/bin/activate"
+                  python -m pip install --quiet -r toolkit/scripts/requirements.txt
+                  python toolkit/scripts/check_spec_guidelines.py \
+                    --toolchain_specs "${toolchain_spec_list}" \
+                    --specs "${changed_specs[@]}"
+                displayName: "Check changed spec files"
+                env:
+                  SYSTEM_PULLREQUEST_TARGETBRANCH: "$(System.PullRequest.TargetBranch)"

--- a/.pipelines/prchecks/ado/CheckSpecFiles.yml
+++ b/.pipelines/prchecks/ado/CheckSpecFiles.yml
@@ -51,6 +51,14 @@ extends:
                 fetchDepth: 0
                 persistCredentials: true
 
+              - bash: |
+                  set -euo pipefail
+
+                  echo "Installing Python 3.12 or later."
+                  sudo tdnf install -y python3 python3-pip
+                  python3 -c 'import sys; assert sys.version_info >= (3, 12), sys.version'
+                displayName: "Install Python 3.12 or later"
+
               - task: PipAuthenticate@1
                 displayName: "Authenticate internal pip feed"
                 inputs:
@@ -84,10 +92,12 @@ extends:
 
                   toolchain_spec_list="$(make --no-print-directory -sC toolkit printvar-toolchain_spec_list)"
 
-                  python3 --version | grep -E '^Python 3\.12(\.|$)'
+                  echo "Creating the virtual environment and installing dependencies."
                   python3 -m venv "$(Agent.TempDirectory)/check-spec-files-venv"
                   source "$(Agent.TempDirectory)/check-spec-files-venv/bin/activate"
                   python -m pip install --quiet -r toolkit/scripts/requirements.txt
+
+                  echo "Checking changed spec files."
                   python toolkit/scripts/check_spec_guidelines.py \
                     --toolchain_specs "${toolchain_spec_list}" \
                     --specs "${changed_specs[@]}"

--- a/.pipelines/prchecks/ado/CheckSpecFiles.yml
+++ b/.pipelines/prchecks/ado/CheckSpecFiles.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Keep this definition in lock-step with .github/workflows/check-spec.yml.
+
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 

--- a/.pipelines/prchecks/ado/CheckStaticGlibc.yml
+++ b/.pipelines/prchecks/ado/CheckStaticGlibc.yml
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Triggers are configured on the ADO pipeline definition.
+trigger: none
+
+parameters:
+  - name: debug
+    type: boolean
+    default: false
+    displayName: "Run in debug mode"
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+variables:
+  - group: "Agent pools (DEV)"
+  - name: system.debug
+    value: "${{ parameters.debug }}"
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      use1esentry: false # Required by the current hosted-pool configuration.
+      LinuxHostVersion:
+        Network: R1
+    globalSdl:
+      credscan:
+        suppressionsFile: .config/CredScanSuppressions.json
+    stages:
+      - stage: CheckStaticGlibc
+        displayName: "Static glibc version check"
+        jobs:
+          - job: CheckStaticGlibc
+            displayName: "Static glibc version check"
+            pool:
+              type: linux
+              isCustom: true
+              name: "$(DEV_AMD64_Managed_NoUMI_AZL3)"
+            variables:
+              ob_outputDirectory: "$(Pipeline.Workspace)/not_used/CheckStaticGlibc"
+            steps:
+              - checkout: self
+                fetchDepth: 1
+
+              - task: PipAuthenticate@1
+                displayName: "Authenticate internal pip feed"
+                inputs:
+                  onlyAddExtraIndex: false
+                  artifactFeeds: "MarinerFeed"
+
+              - bash: |
+                  set -euo pipefail
+
+                  python3 --version | grep -E '^Python 3\.12(\.|$)'
+                  python3 -m venv "$(Agent.TempDirectory)/check-static-glibc-venv"
+                  source "$(Agent.TempDirectory)/check-static-glibc-venv/bin/activate"
+                  python -m pip install --quiet -r toolkit/scripts/requirements.txt
+
+                  mapfile -t specs < <(
+                    find SPECS SPECS-EXTENDED SPECS-SIGNED -type f -name '*.spec' -print
+                  )
+                  python toolkit/scripts/check_static_glibc.py "${specs[@]}"
+                displayName: "Check static glibc dependencies"

--- a/.pipelines/prchecks/ado/CheckStaticGlibc.yml
+++ b/.pipelines/prchecks/ado/CheckStaticGlibc.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Keep this definition in lock-step with .github/workflows/check-static-glibc.yml.
+
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 

--- a/.pipelines/prchecks/ado/CheckStaticGlibc.yml
+++ b/.pipelines/prchecks/ado/CheckStaticGlibc.yml
@@ -6,11 +6,6 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
-pr:
-  branches:
-    include:
-      - fasttrack/3.0
-
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckStaticGlibc.yml
+++ b/.pipelines/prchecks/ado/CheckStaticGlibc.yml
@@ -6,6 +6,11 @@
 # Triggers are configured on the ADO pipeline definition.
 trigger: none
 
+pr:
+  branches:
+    include:
+      - fasttrack/3.0
+
 parameters:
   - name: debug
     type: boolean

--- a/.pipelines/prchecks/ado/CheckStaticGlibc.yml
+++ b/.pipelines/prchecks/ado/CheckStaticGlibc.yml
@@ -50,6 +50,14 @@ extends:
               - checkout: self
                 fetchDepth: 1
 
+              - bash: |
+                  set -euo pipefail
+
+                  echo "Installing Python 3.12 or later."
+                  sudo tdnf install -y python3 python3-pip
+                  python3 -c 'import sys; assert sys.version_info >= (3, 12), sys.version'
+                displayName: "Install Python 3.12 or later"
+
               - task: PipAuthenticate@1
                 displayName: "Authenticate internal pip feed"
                 inputs:
@@ -59,13 +67,16 @@ extends:
               - bash: |
                   set -euo pipefail
 
-                  python3 --version | grep -E '^Python 3\.12(\.|$)'
+                  echo "Creating the virtual environment and installing dependencies."
                   python3 -m venv "$(Agent.TempDirectory)/check-static-glibc-venv"
                   source "$(Agent.TempDirectory)/check-static-glibc-venv/bin/activate"
                   python -m pip install --quiet -r toolkit/scripts/requirements.txt
 
+                  echo "Collecting spec files."
                   mapfile -t specs < <(
                     find SPECS SPECS-EXTENDED SPECS-SIGNED -type f -name '*.spec' -print
                   )
+
+                  echo "Checking static glibc dependencies."
                   python toolkit/scripts/check_static_glibc.py "${specs[@]}"
                 displayName: "Check static glibc dependencies"


### PR DESCRIPTION
## What

Add four 1ES-governed Azure Pipeline definitions under `.pipelines/prchecks/ado/`:

- Check Manifests
- Spec Entanglement Mismatch Check
- Spec files check
- Static glibc version check

## Why

Provide Azure Pipeline equivalents for the existing P0 repository validations while keeping the current GitHub Actions unchanged during parity testing.

## Risk

This is a draft. No existing trigger or workflow is modified. The new definitions are inactive until corresponding pipeline definitions and PR policies are configured. Runtime parity must be validated in Azure Pipelines before this PR is ready.

## Verification

- Parsed all four YAML files.
- Validated every inline Bash block with `bash -n`.
- Ran deterministic checks for governed-template usage, pool selection, internal feed authentication, Python 3.12 enforcement, and source-script parity.
- Ran `git diff --check` and public-hygiene scans.
- Runtime-validated positive and negative paths through isolated pull requests: all four positive runs succeeded, each deliberate invalid change failed with its intended diagnostic, and Azure Repos build policies queued on both PR creation and source updates.

Review strategy: self-review only.