### PR TITLE
ci: update actions on supported branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,28 @@ updates:
         patterns:
           - "*"
 
-  # GitHub Actions used by PR-check workflows.
+  # GitHub Actions used by PR-check workflows on the default branch.
   - package-ecosystem: github-actions
     directory: /
+    target-branch: "4.0"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    # github-actions cooldown only supports a flat default-days (no semver granularity).
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # GitHub Actions used by PR-check workflows on the development branch.
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: "3.0-dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
         patterns:
           - "*"
 
-  # GitHub Actions used by PR-check workflows on the default branch.
+  # GitHub Actions used by PR-check workflows.
   - package-ecosystem: github-actions
     directory: /
     target-branch: "4.0"
@@ -43,7 +43,7 @@ updates:
         patterns:
           - "*"
 
-  # GitHub Actions used by PR-check workflows on the development branch.
+  # GitHub Actions used by PR-check workflows on the 3.0-dev branch.
   - package-ecosystem: github-actions
     directory: /
     target-branch: "3.0-dev"


### PR DESCRIPTION
## What

Extend the default-branch Dependabot configuration so grouped GitHub Actions updates target both supported branches:

- `4.0`
- `3.0-dev`

Both entries run weekly and retain the existing seven-day release cooldown.

## Why

Dependabot reads `.github/dependabot.yml` from the default branch. Explicit target entries allow the same central configuration to maintain action pins on both branches.

## Risk

Low. This changes only Dependabot scheduling. It may open one grouped action-update PR per target branch when eligible updates exist.

## Verification

- Parsed `.github/dependabot.yml` as YAML.
- Verified exactly two GitHub Actions entries target `4.0` and `3.0-dev`.
- Verified both entries use weekly scheduling, grouped updates, and a seven-day cooldown.
- Ran `git diff --check`.
- Review strategy: self-review only.

## Related

- #18535

