### PR TITLE
libarrow: rebuild for thrift 0.24.0

### DIFF
--- a/SPECS/libarrow/libarrow.spec
+++ b/SPECS/libarrow/libarrow.spec
@@ -13,7 +13,7 @@
  
 Name:	libarrow
 Version:	15.0.0
-Release:	8%{?dist}
+Release:	9%{?dist}
 Summary:	A toolbox for accelerated data interchange and in-memory processing
 License:	Apache-2.0
 URL:		https://arrow.apache.org/
@@ -245,6 +245,9 @@ popd
 %exclude %{_datadir}/gdb/auto-load%{_libdir}/libarrow.so.*-gdb.py
 
 %changelog
+* Sat Aug 22 2026 Kshitiz Godara <kgodara@microsoft.com> - 15.0.0-9
+- Bump up to build with latest libthrift.
+
 * Mon Mar 09 2026 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 15.0.0-8
 - Patch to fix CVE-2026-25087.
 


### PR DESCRIPTION
thrift 0.24.0-1 replaced libthrift-0.15.0.so with libthrift-0.24.0.so, since thrift encodes its version in the library filename. parquet-libs was linked against the old soname, so resolution fails:

  nothing provides libthrift-0.15.0.so()(64bit) needed by
  parquet-libs-15.0.0-8.azl3.x86_64

This also blocks the thrift CVE fixes from reaching users: upgrading thrift removes the soname the installed parquet-libs requires, so the upgrade is refused outright.

Rebuild against thrift 0.24.0. No source changes; bump release to 9.

ceph reaches thrift only transitively via libparquet.so.1500, whose soname tracks libarrow's version rather than its release, so ceph needs no rebuild.

[Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1187731&view=results)