### PR TITLE
fix(azurelinux-release): deny network modules for CIS

### DIFF
--- a/base/comps/azurelinux-release/60-azurelinux-cis-module-denylist.conf
+++ b/base/comps/azurelinux-release/60-azurelinux-cis-module-denylist.conf
@@ -1,0 +1,14 @@
+# Deny unused network protocol modules by default. Administrators who need a
+# protocol can override this policy with /etc/modprobe.d/60-azurelinux-cis-module-denylist.conf.
+
+install atm /bin/false
+blacklist atm
+
+install can /bin/false
+blacklist can
+
+install tipc /bin/false
+blacklist tipc
+
+install sctp /bin/false
+blacklist sctp

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        26%{?dist}
+Release:        27%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -61,6 +61,7 @@ Source27:       azurelinux-sudo.conf
 Source28:       azurelinux-sudo.logrotate
 Source29:       azurelinux-sugroup.conf
 Source30:       azurelinux-sshd-cis.conf
+Source31:       60-azurelinux-cis-module-denylist.conf
 
 BuildArch:      noarch
 
@@ -419,6 +420,8 @@ install -Dm0644 %{SOURCE16} -t %{buildroot}%{_prefix}/share/dnf5/libdnf.conf.d/
 
 # Install sysctl configuration
 install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
+# Install CIS network protocol module policy.
+install -Dm0644 %{SOURCE31} -t %{buildroot}%{_prefix}/lib/modprobe.d/
 
 
 
@@ -453,6 +456,7 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 %{_sysconfdir}/swid/swidtags.d
 %{_prefix}/share/dnf5/libdnf.conf.d/20-azurelinux-defaults.conf
 %{_sysctldir}/70-azurelinux-hardening.conf
+%{_prefix}/lib/modprobe.d/60-azurelinux-cis-module-denylist.conf
 %attr(0440,root,root) %config(noreplace) %{_sysconfdir}/sudoers.d/10-azurelinux-cis
 %attr(0644,root,root) %{_prefix}/lib/tmpfiles.d/azurelinux-sudo.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/azurelinux-sudo
@@ -501,6 +505,9 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 
 %changelog
+* Sun Aug 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-27
+- Deny unused CIS network protocol modules by default
+
 * Mon Aug 17 2026 Tobias Brick <tobiasb@microsoft.com> - 4.0-26
 - Configure CIS SSH server defaults for Azure Linux cloud images
 

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,4 +1,4 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 manual-bump = 2
-input-fingerprint = 'sha256:cafddb7727e0736208a8b0333f6ee025b9b8b27f8c7d76a7457a8269259a4205'
+input-fingerprint = 'sha256:492bcb45f221a3c5f8701e5764369a886dd8928114b00aed35d91f1dbdc58792'

--- a/specs/a/azurelinux-release/60-azurelinux-cis-module-denylist.conf
+++ b/specs/a/azurelinux-release/60-azurelinux-cis-module-denylist.conf
@@ -1,0 +1,14 @@
+# Deny unused network protocol modules by default. Administrators who need a
+# protocol can override this policy with /etc/modprobe.d/60-azurelinux-cis-module-denylist.conf.
+
+install atm /bin/false
+blacklist atm
+
+install can /bin/false
+blacklist can
+
+install tipc /bin/false
+blacklist tipc
+
+install sctp /bin/false
+blacklist sctp

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        26%{?dist}
+Release:        27%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -64,6 +64,7 @@ Source27:       azurelinux-sudo.conf
 Source28:       azurelinux-sudo.logrotate
 Source29:       azurelinux-sugroup.conf
 Source30:       azurelinux-sshd-cis.conf
+Source31:       60-azurelinux-cis-module-denylist.conf
 
 BuildArch:      noarch
 
@@ -422,6 +423,8 @@ install -Dm0644 %{SOURCE16} -t %{buildroot}%{_prefix}/share/dnf5/libdnf.conf.d/
 
 # Install sysctl configuration
 install -Dm0644 %{SOURCE22} -t %{buildroot}%{_sysctldir}/
+# Install CIS network protocol module policy.
+install -Dm0644 %{SOURCE31} -t %{buildroot}%{_prefix}/lib/modprobe.d/
 
 
 
@@ -456,6 +459,7 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 %{_sysconfdir}/swid/swidtags.d
 %{_prefix}/share/dnf5/libdnf.conf.d/20-azurelinux-defaults.conf
 %{_sysctldir}/70-azurelinux-hardening.conf
+%{_prefix}/lib/modprobe.d/60-azurelinux-cis-module-denylist.conf
 %attr(0440,root,root) %config(noreplace) %{_sysconfdir}/sudoers.d/10-azurelinux-cis
 %attr(0644,root,root) %{_prefix}/lib/tmpfiles.d/azurelinux-sudo.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/azurelinux-sudo
@@ -504,6 +508,9 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 
 %changelog
+* Sun Aug 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-27
+- Deny unused CIS network protocol modules by default
+
 * Mon Aug 17 2026 Tobias Brick <tobiasb@microsoft.com> - 4.0-26
 - Configure CIS SSH server defaults for Azure Linux cloud images
 


### PR DESCRIPTION
### Summary

Add a customer-overridable modprobe policy that prevents loading the unused ATM, CAN, TIPC, and SCTP network protocol modules.

### Validation

Built and installed on a clean AZL4 Marketplace VM. All four relevant CIS-CAT rules pass.

Addresses [AB#22877](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22877), [AB#22878](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22878), [AB#22879](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22879), [AB#22880](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22880)
