### PR TITLE
fix(toolkit): pin Marketplace Gen2 root to PARTUUID

### DIFF
--- a/toolkit/imageconfigs/marketplace-gen2-aarch64-fips.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64-fips.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64-kernel-hwe-fips.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64-kernel-hwe-fips.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64-kernel-hwe.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64-kernel-hwe.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64-kernel-mshv.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64-kernel-mshv.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-amd64.yaml
+++ b/toolkit/imageconfigs/marketplace-gen2-amd64.yaml
@@ -32,6 +32,7 @@ storage:
   - deviceId: rootfs
     type: ext4
     mountPoint:
+      idType: part-uuid
       path: /
 
 os:

--- a/toolkit/imageconfigs/marketplace-gen2-arm64.yaml
+++ b/toolkit/imageconfigs/marketplace-gen2-arm64.yaml
@@ -32,6 +32,7 @@ storage:
   - deviceId: rootfs
     type: ext4
     mountPoint:
+      idType: part-uuid
       path: /
 
 os:

--- a/toolkit/imageconfigs/marketplace-gen2-cvm.json
+++ b/toolkit/imageconfigs/marketplace-gen2-cvm.json
@@ -43,6 +43,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-fips.json
+++ b/toolkit/imageconfigs/marketplace-gen2-fips.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-kernel-hwe-fips.json
+++ b/toolkit/imageconfigs/marketplace-gen2-kernel-hwe-fips.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-kernel-hwe.json
+++ b/toolkit/imageconfigs/marketplace-gen2-kernel-hwe.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
+++ b/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -52,6 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "MountIdentifier": "partuuid",
                     "MountPoint": "/"
                 }
             ],

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -4,12 +4,51 @@
 package imagecustomizerapi
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
+
+func TestMarketplaceGen2RootUsesPartUuid(t *testing.T) {
+	configFiles, err := filepath.Glob("../../imageconfigs/marketplace-gen2-*.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, configFiles)
+
+	for _, configFile := range configFiles {
+		t.Run(filepath.Base(configFile), func(t *testing.T) {
+			var config struct {
+				Storage struct {
+					FileSystems []struct {
+						DeviceId   string     `yaml:"deviceId"`
+						MountPoint MountPoint `yaml:"mountPoint"`
+					} `yaml:"filesystems"`
+				} `yaml:"storage"`
+			}
+
+			configData, err := os.ReadFile(configFile)
+			require.NoError(t, err)
+			require.NoError(t, yaml.Unmarshal(configData, &config))
+
+			var root *MountPoint
+			for i := range config.Storage.FileSystems {
+				fileSystem := &config.Storage.FileSystems[i]
+				if fileSystem.MountPoint.Path == "/" {
+					root = &fileSystem.MountPoint
+					break
+				}
+			}
+
+			require.NotNil(t, root)
+			assert.Equal(t, MountIdentifierTypePartUuid, root.IdType)
+		})
+	}
+}
 
 func TestConfigIsValid(t *testing.T) {
 	config := &Config{

--- a/toolkit/tools/imagegen/configuration/configuration_test.go
+++ b/toolkit/tools/imagegen/configuration/configuration_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -60,6 +62,24 @@ func TestConfigurationShouldContainExpectedFields(t *testing.T) {
 	logger.Log.Infof("Actual: %v", actualConfiguration)
 
 	assert.Equal(t, expectedConfiguration, actualConfiguration)
+}
+
+func TestMarketplaceGen2RootUsesPartUuid(t *testing.T) {
+	configFiles, err := filepath.Glob("../../../imageconfigs/marketplace-gen2*.json")
+	require.NoError(t, err)
+	require.NotEmpty(t, configFiles)
+
+	for _, configFile := range configFiles {
+		t.Run(filepath.Base(configFile), func(t *testing.T) {
+			config, err := Load(configFile)
+			require.NoError(t, err)
+			require.NotEmpty(t, config.SystemConfigs)
+
+			root := config.SystemConfigs[0].GetRootPartitionSetting()
+			require.NotNil(t, root)
+			assert.Equal(t, MountIdentifierPartUuid, root.MountIdentifier)
+		})
+	}
 }
 
 func TestShouldErrorForMissingFile(t *testing.T) {


### PR DESCRIPTION
## What

Explicitly configure every Marketplace Gen2 root filesystem to use its GPT
`PARTUUID` in both the current YAML and legacy JSON image builders.

Add table-driven tests that load every Marketplace Gen2 configuration and
require the root mount identifier to remain `PARTUUID`.

## Why

During initramfs boot, filesystem metadata can be temporarily unavailable
while udev processes a synthesized block-device change event. A root path
based on filesystem `UUID` can disappear during that window even though the
partition remains present.

GPT `PARTUUID` is derived from the partition table and remains available
without probing filesystem metadata. Pinning it explicitly makes the root
device contract independent of that transient probe and prevents future
configuration-default changes from restoring the weaker behavior.

## Risk

Low. All affected Marketplace Gen2 configurations use GPT partition tables.
Both image builders already default to `PARTUUID`; this change makes the
existing intended behavior explicit and adds regression coverage.

Encrypted-root handling ignores this mount identifier, and the affected
configurations do not define verity roots.

## Verification

- `go test ./imagegen/configuration ./imagecustomizerapi -count=1`
- Confirmed every `marketplace-gen2*.json` root uses `partuuid`.
- Confirmed every `marketplace-gen2-*.yaml` root uses `part-uuid`.
- Quick review found no meaningful compatibility or regression issues.
