### PR TITLE
build(ocaml): rebuild wave 0 for ocaml hash rotation

### DIFF
--- a/locks/ocaml.lock
+++ b/locks/ocaml.lock
@@ -2,6 +2,6 @@
 version = 1
 import-commit = 'b9c837a4530b0d20fa88ba22e315745e00a7322a'
 upstream-commit = 'b9c837a4530b0d20fa88ba22e315745e00a7322a'
-manual-bump = 2
-input-fingerprint = 'sha256:47f66634d1d2e44a97acb05e71ddb69594d5d0419c22855f5dacd71e118b768e'
+manual-bump = 3
+input-fingerprint = 'sha256:b0f2de910fabf5df918880550479222480f912b6e9748f54e7ede81fe8c3fcb7'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/o/ocaml/ocaml.spec
+++ b/specs/o/ocaml/ocaml.spec
@@ -49,7 +49,7 @@ ExcludeArch: %{ix86}
 
 Name:           ocaml
 Version:        5.3.0
-Release: 7%{?dist}
+Release: 8%{?dist}
 
 Summary:        OCaml compiler and programming environment
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order matters — please read before merging.**
> This is the root of a 13-PR stack (#18574 .. #18586) rebuilding the OCaml tree
> after `ocaml` 5.3.0-5 → -7 rotated every `ocaml()`/`ocamlx()` interface hash.
> Each later wave must wait for the previous wave to **finish building in Koji** — not
> merely to be merged. Merging ahead of the build is what produced the current breakage.

Rebuild of ocaml itself. The 5.3.0-5 -> -7 rebuild rotated every
ocaml()/ocamlx() interface-hash provide, stranding all 42 downstream
packages on hashes that no longer exist.

Wave 0 of 13.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>