### PR TITLE
build(ocaml): rebuild wave 8 for ocaml hash rotation

### DIFF
--- a/locks/ocaml-lwt.lock
+++ b/locks/ocaml-lwt.lock
@@ -2,6 +2,6 @@
 version = 1
 import-commit = '1a45e4585bbb4e15d525f4ee6d35698f6aa2f3c5'
 upstream-commit = '1a45e4585bbb4e15d525f4ee6d35698f6aa2f3c5'
-manual-bump = 2
-input-fingerprint = 'sha256:e986c53f59ff72cedbf7ad719121247183d2bfe37e25bd534ae0fb173481c7ee'
+manual-bump = 3
+input-fingerprint = 'sha256:b1d34019c964e4aed9b43f5e8219c43d8a9d3d250e8838f0b7d50af6bcd0c904'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/o/ocaml-lwt/ocaml-lwt.spec
+++ b/specs/o/ocaml-lwt/ocaml-lwt.spec
@@ -8,7 +8,7 @@ ExcludeArch: %{ix86}
 
 Name:           ocaml-lwt
 Version:        5.9.1
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary:        OCaml lightweight thread library
 
 # The project as a whole is MIT.  The following files are BSD-2-Clause:


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order matters — please read before merging.**
> Wave 8 of a 13-PR stack (#18574 .. #18586). Merge only after wave 7 (#18581)
> has **finished building in Koji** — not merely been merged. These packages hard-bind to
> `ocaml()`/`ocamlx()` interface hashes, so building out of order strands them again.

Release bump only. These components' ocaml()/ocamlx() interface hashes were
invalidated by the ocaml 5.3.0-5 -> -7 rebuild.

Components (1): ocaml-lwt

Wave 8 of 13.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>