### PR TITLE
build(ocaml): rebuild wave 9 for ocaml hash rotation

### DIFF
--- a/locks/ocaml-ounit.lock
+++ b/locks/ocaml-ounit.lock
@@ -2,6 +2,6 @@
 version = 1
 import-commit = '26fa4c7e334e68c7211097d3f519a5478a7b2646'
 upstream-commit = '26fa4c7e334e68c7211097d3f519a5478a7b2646'
-manual-bump = 2
-input-fingerprint = 'sha256:ac9a9a4fd6f08adff3428d9b85a25456fb7230d24f36d5551e82b85f70b81f42'
+manual-bump = 3
+input-fingerprint = 'sha256:6192b272f63a4b02db16ed367ee675c1b03d6270c56ec3c8fb16d403d057e1bb'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/o/ocaml-ounit/ocaml-ounit.spec
+++ b/specs/o/ocaml-ounit/ocaml-ounit.spec
@@ -10,7 +10,7 @@ ExcludeArch: %{ix86}
 
 Name:           ocaml-ounit
 Version:        2.2.7
-Release: 19%{?dist}
+Release: 20%{?dist}
 Summary:        Unit test framework for OCaml
 
 License:        MIT


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order matters — please read before merging.**
> Wave 9 of a 13-PR stack (#18574 .. #18586). Merge only after wave 8 (#18582)
> has **finished building in Koji** — not merely been merged. These packages hard-bind to
> `ocaml()`/`ocamlx()` interface hashes, so building out of order strands them again.

Release bump only. These components' ocaml()/ocamlx() interface hashes were
invalidated by the ocaml 5.3.0-5 -> -7 rebuild.

Components (1): ocaml-ounit

Wave 9 of 13.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>