### PR TITLE
build(ocaml): rebuild wave 10 for ocaml hash rotation

### DIFF
--- a/locks/ocaml-fileutils.lock
+++ b/locks/ocaml-fileutils.lock
@@ -2,6 +2,6 @@
 version = 1
 import-commit = '09b1b038dda43d6d07e7a1466b4798571d0c44cd'
 upstream-commit = '09b1b038dda43d6d07e7a1466b4798571d0c44cd'
-manual-bump = 2
-input-fingerprint = 'sha256:5a16e5d36b9bc9a3cdbe6024afaacf4324b818ca98fd0e5307d48301ba33d57e'
+manual-bump = 3
+input-fingerprint = 'sha256:62a485cd3a0bc9f5f731236ec55883b5934e54d68c3b32fb41156a7966be5e9f'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/o/ocaml-fileutils/ocaml-fileutils.spec
+++ b/specs/o/ocaml-fileutils/ocaml-fileutils.spec
@@ -12,7 +12,7 @@ ExcludeArch: %{ix86}
 
 Name:           ocaml-fileutils
 Version:        0.6.6
-Release: 7%{?dist}
+Release: 8%{?dist}
 Summary:        OCaml library for common file and filename operations
 
 License:        LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order matters — please read before merging.**
> Wave 10 of a 13-PR stack (#18574 .. #18586). Merge only after wave 9 (#18583)
> has **finished building in Koji** — not merely been merged. These packages hard-bind to
> `ocaml()`/`ocamlx()` interface hashes, so building out of order strands them again.

Release bump only. These components' ocaml()/ocamlx() interface hashes were
invalidated by the ocaml 5.3.0-5 -> -7 rebuild.

Components (1): ocaml-fileutils

Wave 10 of 13.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>