### PR TITLE
build(ocaml): rebuild wave 11 for ocaml hash rotation

### DIFF
--- a/locks/ocaml-gettext.lock
+++ b/locks/ocaml-gettext.lock
@@ -2,6 +2,6 @@
 version = 1
 import-commit = 'bb2c1fb3b9657fe4ae80607a010b280fe9490705'
 upstream-commit = 'bb2c1fb3b9657fe4ae80607a010b280fe9490705'
-manual-bump = 2
-input-fingerprint = 'sha256:46bbee4a24ff6f635d70bdc2eb371760c3267ce4bf56c13f335d41f46d7f5c27'
+manual-bump = 3
+input-fingerprint = 'sha256:2871cabe759b03d87e529881591852c4c19933d0e6fb9e2c234cd847d4d9b2e9'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/o/ocaml-gettext/ocaml-gettext.spec
+++ b/specs/o/ocaml-gettext/ocaml-gettext.spec
@@ -15,7 +15,7 @@ ExcludeArch: %{ix86}
 
 Name:           ocaml-gettext
 Version:        0.5.0
-Release: 9%{?dist}
+Release: 10%{?dist}
 Summary:        OCaml library for i18n
 
 License:        LGPL-2.1-or-later with OCaml-LGPL-linking-exception


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order matters — please read before merging.**
> Wave 11 of a 13-PR stack (#18574 .. #18586). Merge only after wave 10 (#18584)
> has **finished building in Koji** — not merely been merged. These packages hard-bind to
> `ocaml()`/`ocamlx()` interface hashes, so building out of order strands them again.

Release bump only. These components' ocaml()/ocamlx() interface hashes were
invalidated by the ocaml 5.3.0-5 -> -7 rebuild.

Components (1): ocaml-gettext

Wave 11 of 13.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>