### PR TITLE
build(ocaml): rebuild wave 12 for ocaml hash rotation

### DIFF
--- a/locks/guestfs-tools.lock
+++ b/locks/guestfs-tools.lock
@@ -2,6 +2,6 @@
 version = 1
 import-commit = 'a948c9aaa7a4fcdf132073c4a7781a5cfc413593'
 upstream-commit = 'a948c9aaa7a4fcdf132073c4a7781a5cfc413593'
-manual-bump = 2
-input-fingerprint = 'sha256:902ac834b52ce5ab7fe5d8ac9caa083e7e43ab2cf92eab29ba118a75d435b8ad'
+manual-bump = 3
+input-fingerprint = 'sha256:8660cb36e520552be6eebabcab37577ee7d5b18797ea30207a4cc2876aa4098f'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/guestfs-tools/guestfs-tools.spec
+++ b/specs/g/guestfs-tools/guestfs-tools.spec
@@ -19,7 +19,7 @@
 Summary:       Tools to access and modify virtual machine disk images
 Name:          guestfs-tools
 Version:       1.55.5
-Release: 4%{?dist}
+Release: 5%{?dist}
 License:       GPL-2.0-or-later AND LGPL-2.0-or-later
 
 # Build only for architectures that have a kernel


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order matters — please read before merging.**
> Wave 12 of a 13-PR stack (#18574 .. #18586). Merge only after wave 11 (#18585)
> has **finished building in Koji** — not merely been merged. These packages hard-bind to
> `ocaml()`/`ocamlx()` interface hashes, so building out of order strands them again.

Release bump only. These components' ocaml()/ocamlx() interface hashes were
invalidated by the ocaml 5.3.0-5 -> -7 rebuild.

Components (1): guestfs-tools

Wave 12 of 13.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>