### PR TITLE
chore(kernel): fix SBAT data and addon.efi names

### DIFF
--- a/base/comps/kernel/kernel.sbat.template
+++ b/base/comps/kernel/kernel.sbat.template
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-kernel.@SBAT_SUFFIX,1,Red Hat,kernel-core,@KVER,mailto:secalert@redhat.com
+kernel.@SBAT_SUFFIX,1,Microsoft,kernel-core,@KVER,https://github.com/microsoft/azurelinux/issues

--- a/base/comps/kernel/kernel.spec
+++ b/base/comps/kernel/kernel.spec
@@ -171,6 +171,12 @@ Summary: The Linux kernel
 %endif
 
 #
+%if 0%{?azl4}
+%define uki_addon_distro azurelinux
+%else
+%define uki_addon_distro %{primary_target}
+%endif
+
 # genspec.sh variables
 #
 
@@ -2913,7 +2919,7 @@ BuildKernel() {
 
   KernelAddonsDirOut="$KernelUnifiedImage.extra.d"
   mkdir -p $KernelAddonsDirOut
-  python3 %{SOURCE151} %{SOURCE152} $KernelAddonsDirOut virt %{primary_target} %{_target_cpu} @uki-addons.sbat
+  python3 %{SOURCE151} %{SOURCE152} $KernelAddonsDirOut virt %{uki_addon_distro} %{_target_cpu} @uki-addons.sbat
 
 %if %{signkernel}
 	%{log_msg "Sign the EFI UKI kernel"}
@@ -4622,6 +4628,7 @@ fi\
 %changelog
 * Wed Aug 26 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 6.18.39-1.4
 - feat(kernel): add Azure Linux SBAT records
+- fix(kernel): name UKI addons for Azure Linux
 
 * Mon Aug 24 2026 Rachel Menge <rachelmenge@microsoft.com> - 6.18.39-1.3
 - chore(kernel): tidy release macros

--- a/base/comps/kernel/kernel.spec
+++ b/base/comps/kernel/kernel.spec
@@ -17,7 +17,7 @@
 # When rebuilding without a version change, bump azl_pkgrelease (manual release).
 # This corresponds to upstream Fedora's %{pkgrelease} macro; we use it in the
 # %{specrelease} macro below instead of a hardcoded value.
-%define azl_pkgrelease 3
+%define azl_pkgrelease 4
 # NVIDIA open GPU kernel module version (built as a kmod subpackage).
 %define nvidia_open_version 595.58.03
 
@@ -132,6 +132,9 @@ Summary: The Linux kernel
 %endif
 
 # RHEL/CentOS specific .SBAT entries
+%if 0%{?azl4}
+%global sbat_suffix azurelinux
+%else
 %if 0%{?centos}
 %global sbat_suffix centos
 %else
@@ -139,6 +142,7 @@ Summary: The Linux kernel
 %global sbat_suffix fedora
 %else
 %global sbat_suffix rhel
+%endif
 %endif
 %endif
 
@@ -4616,6 +4620,9 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Wed Aug 26 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 6.18.39-1.4
+- feat(kernel): add Azure Linux SBAT records
+
 * Mon Aug 24 2026 Rachel Menge <rachelmenge@microsoft.com> - 6.18.39-1.3
 - chore(kernel): tidy release macros
 

--- a/base/comps/kernel/uki-addons.sbat.template
+++ b/base/comps/kernel/uki-addons.sbat.template
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-kernel-uki-virt-addons.@SBAT_SUFFIX,1,Red Hat,kernel-uki-virt-addons,@KVER,mailto:secalert@redhat.com
+kernel-uki-virt-addons.@SBAT_SUFFIX,1,Microsoft,kernel-uki-virt-addons,@KVER,https://github.com/microsoft/azurelinux/issues

--- a/base/comps/kernel/uki.sbat.template
+++ b/base/comps/kernel/uki.sbat.template
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-kernel-uki-virt.@SBAT_SUFFIX,1,Red Hat,kernel-uki-virt,@KVER,mailto:secalert@redhat.com
+kernel-uki-virt.@SBAT_SUFFIX,1,Microsoft,kernel-uki-virt,@KVER,https://github.com/microsoft/azurelinux/issues

--- a/locks/kernel.lock
+++ b/locks/kernel.lock
@@ -1,5 +1,5 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 manual-bump = 2
-input-fingerprint = 'sha256:66be53c1264ba148acc86f57050d7265641db12cf90df3f995ea9f8ef34167c2'
+input-fingerprint = 'sha256:a207fedcacfafd5c8a502eabe7165f13b75637bcffea4bb2d2b62a2a3b475609'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/k/kernel/kernel.sbat.template
+++ b/specs/k/kernel/kernel.sbat.template
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-kernel.@SBAT_SUFFIX,1,Red Hat,kernel-core,@KVER,mailto:secalert@redhat.com
+kernel.@SBAT_SUFFIX,1,Microsoft,kernel-core,@KVER,https://github.com/microsoft/azurelinux/issues

--- a/specs/k/kernel/kernel.spec
+++ b/specs/k/kernel/kernel.spec
@@ -20,7 +20,7 @@
 # When rebuilding without a version change, bump azl_pkgrelease (manual release).
 # This corresponds to upstream Fedora's %{pkgrelease} macro; we use it in the
 # %{specrelease} macro below instead of a hardcoded value.
-%define azl_pkgrelease 3
+%define azl_pkgrelease 4
 # NVIDIA open GPU kernel module version (built as a kmod subpackage).
 %define nvidia_open_version 595.58.03
 
@@ -135,6 +135,9 @@ Summary: The Linux kernel
 %endif
 
 # RHEL/CentOS specific .SBAT entries
+%if 0%{?azl4}
+%global sbat_suffix azurelinux
+%else
 %if 0%{?centos}
 %global sbat_suffix centos
 %else
@@ -142,6 +145,7 @@ Summary: The Linux kernel
 %global sbat_suffix fedora
 %else
 %global sbat_suffix rhel
+%endif
 %endif
 %endif
 
@@ -170,6 +174,12 @@ Summary: The Linux kernel
 %endif
 
 #
+%if 0%{?azl4}
+%define uki_addon_distro azurelinux
+%else
+%define uki_addon_distro %{primary_target}
+%endif
+
 # genspec.sh variables
 #
 
@@ -2912,7 +2922,7 @@ BuildKernel() {
 
   KernelAddonsDirOut="$KernelUnifiedImage.extra.d"
   mkdir -p $KernelAddonsDirOut
-  python3 %{SOURCE151} %{SOURCE152} $KernelAddonsDirOut virt %{primary_target} %{_target_cpu} @uki-addons.sbat
+  python3 %{SOURCE151} %{SOURCE152} $KernelAddonsDirOut virt %{uki_addon_distro} %{_target_cpu} @uki-addons.sbat
 
 %if %{signkernel}
 	%{log_msg "Sign the EFI UKI kernel"}
@@ -4619,6 +4629,10 @@ fi\
 
 # AZL-KMOD-FILES-ANCHOR — do not remove (kmod overlays chain here)
 %changelog
+* Wed Aug 26 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 6.18.39-1.4
+- feat(kernel): add Azure Linux SBAT records
+- fix(kernel): name UKI addons for Azure Linux
+
 * Mon Aug 24 2026 Rachel Menge <rachelmenge@microsoft.com> - 6.18.39-1.3
 - chore(kernel): tidy release macros
 

--- a/specs/k/kernel/uki-addons.sbat.template
+++ b/specs/k/kernel/uki-addons.sbat.template
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-kernel-uki-virt-addons.@SBAT_SUFFIX,1,Red Hat,kernel-uki-virt-addons,@KVER,mailto:secalert@redhat.com
+kernel-uki-virt-addons.@SBAT_SUFFIX,1,Microsoft,kernel-uki-virt-addons,@KVER,https://github.com/microsoft/azurelinux/issues

--- a/specs/k/kernel/uki.sbat.template
+++ b/specs/k/kernel/uki.sbat.template
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-kernel-uki-virt.@SBAT_SUFFIX,1,Red Hat,kernel-uki-virt,@KVER,mailto:secalert@redhat.com
+kernel-uki-virt.@SBAT_SUFFIX,1,Microsoft,kernel-uki-virt,@KVER,https://github.com/microsoft/azurelinux/issues


### PR DESCRIPTION
### Summary

- Add Azure Linux SBAT component records to the kernel UKI and UKI addon EFI binaries.
- Name UKI addon EFI files with `.azurelinux.<arch>.addon.efi` rather than `.fedora.<arch>.addon.efi`.

### Validation

Built kernel artifacts were inspected with `objdump -s -j .sbat`.

vmlinuz-virt.efi
```
sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
systemd-stub,1,The systemd Developers,systemd,258,https://systemd.io/
systemd-stub.azurelinux,1,Azure Linux,systemd,258.4-5.azl4,https://aka.ms/azurelinux
kernel-uki-virt.azurelinux,1,Microsoft,kernel-uki-virt,6.18.39-1.4.azl4.x86_64,https://github.com/microsoft/azurelinux/issues
```

fips-enable-virt.azurelinux.x86_64.addon.efi
```
sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
kernel-uki-virt-addons.azurelinux,1,Microsoft,kernel-uki-virt-addons,6.18.39-1.4.azl4.x86_64,https://github.com/microsoft/azurelinux/issues
```

The `kernel-uki-virt-addons` RPM now contains Azure Linux-named EFI files:

crashkernel-1536M-virt.azurelinux.x86_64.addon.efi
crashkernel-192M-virt.azurelinux.x86_64.addon.efi
crashkernel-1G-virt.azurelinux.x86_64.addon.efi
crashkernel-256M-virt.azurelinux.x86_64.addon.efi
crashkernel-2G-virt.azurelinux.x86_64.addon.efi
crashkernel-512M-virt.azurelinux.x86_64.addon.efi
crashkernel-default-virt.azurelinux.x86_64.addon.efi
debug-virt.azurelinux.x86_64.addon.efi
fips-disable-virt.azurelinux.x86_64.addon.efi
fips-enable-virt.azurelinux.x86_64.addon.efi
systemd-volatile-overlay-virt.azurelinux.x86_64.addon.efi


Fixes [AB#20616](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/20616), [AB#22661](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22661)