### PR TITLE
Sodiff: detect name-embedded-version soname transitions (thrift, LLVM)

### DIFF
--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -65,14 +65,30 @@ for rpmpackage in $pkgs; do
             # SO file not found, meaning this might be a new .SO
             # or a new version of a preexisting .SO.
             # Check if the previous version exists in the database.
+            #
+            # Derive a version-independent "family" pattern for the .so so we can
+            # locate a predecessor already published in the repo. Two SONAME
+            # styles must be handled:
+            #   1. Conventional:   libfoo.so.<ver>  -> family "libfoo.so"
+            #   2. Name-embedded:  libfoo-<ver>.so  -> family "libfoo-*.so"
+            # Style 2 is used by libraries whose ABI is versioned by package
+            # version (e.g. Apache Thrift's libthrift-0.24.0.so, LLVM's
+            # libLLVM-18.so). For these, every version bump is a SONAME change,
+            # so the changing version lives in the library *base name*. The old
+            # logic only stripped a version that trailed ".so", so it treated
+            # every such release as a brand-new library and never scanned for
+            # orphaned dependents that still required the previous version.
+            sofile_base=$(echo "$sofile" | sed -E 's/[(].*$//')
+            if echo "$sofile_base" | grep -qE '^.*-[0-9][0-9.]*[.]so$' ; then
+                sofile_no_ver=$(echo "$sofile_base" | sed -E 's/-[0-9][0-9.]*[.]so$/-*.so/')
+            else
+                sofile_no_ver=$(echo "$sofile_base" | sed -E 's/[.]so[.].*$/.so/')
+            fi
 
-            # Remove version part from .SO file
-            sofile_no_ver=$(echo "$sofile" | sed -E 's/[.]so[(.].+/.so/')
-
-            # check for generic .so in the repo
+            # check for a prior version of this .so family in the repo
             sos_found=$( 2>/dev/null $dnf_command repoquery $common_options --whatprovides "${sofile_no_ver}*" | wc -l )
             if ! [ "$sos_found" -eq 0 ] ; then
-                # Generic version of SO was found.
+                # A prior version of the SO family was found.
                 # This means it's a new version of a preexisting SO.
                 # Log which packages depend on this functionality
                 echo "Packages that require $sofile_no_ver:"
@@ -120,4 +136,3 @@ if [[ $pkgsFound -gt 0 ]]; then
 else
     echo "No Packages with Conflicting .so Files Found."
 fi
-


### PR DESCRIPTION
## Problem

Sodiff's ABI check compares built-package sonames against the **published** base repo (`azurelinux-official-base.repo` -> packages.microsoft.com prod/base), which is correct. But its version-normalization step only strips a version that trails `.so` (conventional `libfoo.so.<ver>`):

```sh
sofile_no_ver=$(echo "$sofile" | sed -E 's/[.]so[(.].+/.so/')
```

Libraries that **bake the version into the base name** -- Apache Thrift (`libthrift-0.24.0.so`), LLVM (`libLLVM-18.so`) -- keep their version after this sed. The predecessor lookup `--whatprovides "libthrift-0.24.0.so*"` then cannot match the published `libthrift-0.15.0.so`, so Sodiff concludes *"brand-new library, no predecessor,"* **skips the entire `--whatrequires` dependent scan**, and exits clean.

### Real-world impact
thrift was bumped 0.15.0 -> 0.24.0 in #18239 (14-CVE HIGH). Sodiff passed. But published `parquet-libs-15.0.0-8` (a libarrow subpackage) still hard-required `libthrift-0.15.0.so()(64bit)` and became uninstallable. ~3.5 weeks later this surfaced as a red build in #18543 (libevent) when its dependent `ceph` couldn't dep-install parquet-libs. Fixed out-of-band by the libarrow rebuild #18554.

The thrift naming is **expected**, not a bug -- the spec documents it: *"thrift versions their libraries by package version, so each version change is a SONAME change and dependencies need to be rebuilt."* Sodiff must handle this class.

## Fix

Derive the version-independent `.so` **family** for both SONAME styles before the predecessor/requirer lookups:

- Conventional `libfoo.so.<ver>` -> `libfoo.so` (unchanged behavior)
- Name-embedded `libfoo-<ver>.so` -> `libfoo-*.so` (new)

## Validation

Simulated PMC provide-set harness:

| built soname | before | after |
|---|---|---|
| `libthrift-0.24.0.so` (0.15->0.24) | miss | **caught** |
| `libssl.so.4` (conventional 3->4) | caught | caught (no regression) |
| `libLLVM-18.so` (17->18) | miss | **caught** |
| `libbrandnew.so` (truly new) | no-fire | no-fire (no false positive) |

`bash -n` clean.

## Follow-up (not in this PR)

Bug **#23439** also proposes a `dnf repoclosure` gate (baseline-diff over the built overlay + published tier repos) as defense-in-depth -- it catches *any* unresolved `Requires`, not just soname-shaped ones. Tracked separately.

Bug: #23439
