### PR TITLE
chore(schema): regenerate azldev.schema.json for pinned azldev v0.3.0

### DIFF
--- a/external/schemas/azldev.schema.json
+++ b/external/schemas/azldev.schema.json
@@ -53,6 +53,11 @@
           "title": "Undefined macros",
           "description": "Macro names to undefine when passing to the builder."
         },
+        "emit-upstream-provenance": {
+          "type": "boolean",
+          "title": "Emit upstream provenance macros",
+          "description": "Inject %fedora_upstream_version/release macros derived from the pristine upstream Fedora spec (Fedora upstream components only)."
+        },
         "check": {
           "$ref": "#/$defs/CheckConfig",
           "title": "Check configuration",
@@ -592,6 +597,26 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "GitSourceConfig": {
+      "properties": {
+        "git-url": {
+          "type": "string",
+          "title": "Git URL",
+          "description": "URL of the git repository"
+        },
+        "ref": {
+          "type": "string",
+          "title": "Ref",
+          "description": "Commit SHA to check out (full hex hash)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "git-url",
+        "ref"
+      ]
+    },
     "ImageCapabilities": {
       "properties": {
         "machine-bootable": {
@@ -709,13 +734,61 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "LisaConfig": {
+      "properties": {
+        "framework": {
+          "$ref": "#/$defs/GitSourceConfig",
+          "title": "Framework",
+          "description": "Git source for the LISA framework"
+        },
+        "test-cases": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Test cases",
+          "description": "LISA test case names to run; combined into a generated runbook's criteria"
+        },
+        "pip-pre-install": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Pip pre-install",
+          "description": "Pip packages to install before the framework (for overriding version pins)"
+        },
+        "pip-extras": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Pip extras",
+          "description": "Pip extras to install from the LISA framework package"
+        },
+        "extra-args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Extra arguments",
+          "description": "Additional arguments passed to LISA. Supports {image-path} {image-name} {capabilities} placeholders."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "framework",
+        "test-cases"
+      ]
+    },
     "Origin": {
       "properties": {
         "type": {
           "type": "string",
           "enum": [
             "download",
-            "custom"
+            "custom",
+            "overlay"
           ],
           "title": "Origin type",
           "description": "Type of origin for this source file"
@@ -1332,6 +1405,11 @@
           "$ref": "#/$defs/PytestConfig",
           "title": "Pytest config",
           "description": "Pytest-specific configuration (required when type is pytest)"
+        },
+        "lisa": {
+          "$ref": "#/$defs/LisaConfig",
+          "title": "LISA config",
+          "description": "LISA-specific configuration used to generate and run a LISA runbook (optional)"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
The checked-in external/schemas/azldev.schema.json was stale: generated from an older azldev and never refreshed when .azldev-version was bumped to v0.3.0 (261ae74). It was missing the 'overlay' source-file origin type (and other v0.3.0 schema additions), so schema-based validation rejected valid archive-overlay components even though the pinned azldev binary accepts them. Regenerated with 'azldev config generate-schema' built from the exact pinned commit (v0.3.0).