### PR TITLE
fix(azurelinux-release): persist CIS sysctl defaults

### DIFF
--- a/base/comps/azurelinux-release/70-azurelinux-hardening.conf
+++ b/base/comps/azurelinux-release/70-azurelinux-hardening.conf
@@ -42,6 +42,12 @@ net.ipv6.conf.default.accept_redirects = 0
 net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.send_redirects = 0
 
+# Disable secure redirects and router advertisements.
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+net.ipv6.conf.all.accept_ra = 0
+net.ipv6.conf.default.accept_ra = 0
+
 # Disable source-routed packets
 net.ipv4.conf.all.accept_source_route = 0
 net.ipv6.conf.all.accept_source_route = 0

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -505,6 +505,9 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 
 %changelog
+* Wed Aug 26 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-28
+- Disable secure redirects and IPv6 router advertisements for CIS hardening
+
 * Sun Aug 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-27
 - Deny unused CIS network protocol modules by default
 

--- a/locks/azurelinux-release.lock
+++ b/locks/azurelinux-release.lock
@@ -1,4 +1,4 @@
 # Managed by azldev component update. Do not edit manually.
 version = 1
 manual-bump = 2
-input-fingerprint = 'sha256:492bcb45f221a3c5f8701e5764369a886dd8928114b00aed35d91f1dbdc58792'
+input-fingerprint = 'sha256:ee01a38d6e16fb2938136774cc8eccc9d6598001863ba7b0f69c1112b5c6b071'

--- a/specs/a/azurelinux-release/70-azurelinux-hardening.conf
+++ b/specs/a/azurelinux-release/70-azurelinux-hardening.conf
@@ -42,6 +42,12 @@ net.ipv6.conf.default.accept_redirects = 0
 net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.send_redirects = 0
 
+# Disable secure redirects and router advertisements.
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+net.ipv6.conf.all.accept_ra = 0
+net.ipv6.conf.default.accept_ra = 0
+
 # Disable source-routed packets
 net.ipv4.conf.all.accept_source_route = 0
 net.ipv6.conf.all.accept_source_route = 0

--- a/specs/a/azurelinux-release/azurelinux-release.spec
+++ b/specs/a/azurelinux-release/azurelinux-release.spec
@@ -39,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -508,6 +508,9 @@ install -Dm0644 %{SOURCE29} %{buildroot}%{_prefix}/lib/sysusers.d/azurelinux-sug
 
 
 %changelog
+* Wed Aug 26 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-28
+- Disable secure redirects and IPv6 router advertisements for CIS hardening
+
 * Sun Aug 23 2026 Lynsey Rydberg <lyrydber@microsoft.com> - 4.0-27
 - Deny unused CIS network protocol modules by default
 


### PR DESCRIPTION
### Summary

Persist CIS network sysctl settings in `70-azurelinux-hardening.conf`:

- `net.ipv4.conf.all.secure_redirects = 0`
- `net.ipv4.conf.default.secure_redirects = 0`
- `net.ipv6.conf.all.accept_ra = 0`
- `net.ipv6.conf.default.accept_ra = 0`

Resolves:
- [AB#22889](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22889) — Ensure net.ipv4.conf.all.secure_redirects is configured
- [AB#22890](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22890) — Ensure net.ipv4.conf.default.secure_redirects is configured
- [AB#22901](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22901) — Ensure net.ipv6.conf.all.accept_ra is configured
- [AB#22902](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/22902) — Ensure net.ipv6.conf.default.accept_ra is configured

### Testing

Built `azurelinux-release`, installed on an AZL4 VM, applied the sysctl policy, and ran CIS-CAT Level 1 Server. All four controls pass.