### PR TITLE
tracelogging: Modifying patch file containing the %check

### DIFF
--- a/SPECS/tracelogging/migrate-to-use-catch2-v3.patch
+++ b/SPECS/tracelogging/migrate-to-use-catch2-v3.patch
@@ -8,7 +8,7 @@ Azure Linux ships Catch2 3.x, which removed the v2 single-header
 
 Link the tests against Catch2::Catch2WithMain for the entry point and
 switch the includes to the split <catch2/catch_all.hpp> header so the
-%check build compiles against the shipped Catch2.
+module test compiles against the shipped Catch2.
 ---
  test/CMakeLists.txt       | 2 +-
  test/CatchMain.cpp        | 3 +--

--- a/SPECS/tracelogging/tracelogging.spec
+++ b/SPECS/tracelogging/tracelogging.spec
@@ -1,7 +1,7 @@
 Summary:        tracelogging one-line structure logging API on top of LTTNG
 Name:           tracelogging
 Version:        0.3.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -67,6 +67,10 @@ mkdir build && cd build
 %{_libdir}/cmake/tracelogging
 
 %changelog
+* Thu Aug 27 2026 Kshitiz Godara <kgodara@microsoft.com> - 0.3.1-4
+- Updating patch commit message so that few pipelines doesn't treat
+  the patch file as spec file.
+
 * Tue Aug 25 2026 Kshitiz Godara <kgodara@microsoft.com> - 0.3.1-3
 - Update patch name to not start with module name.
 


### PR DESCRIPTION
The patch file contains keyword %check which is causing it considered as spec file in few pipelines. This PR modifies it so that it doesn't match that and considered as spec file.

[Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1191603&view=results)