### PR TITLE
fix(vm-iso-installer): enable NFS live root in initrd

### DIFF
--- a/base/images/vm-iso-installer/dracut-nfs.conf
+++ b/base/images/vm-iso-installer/dracut-nfs.conf
@@ -1,0 +1,11 @@
+# Include dracut's NFS module in the live installer initrd.
+#
+# Without it, `root=live:nfs://<server>:/<path>/squashfs.img` fails: the kernel
+# NFS modules ship in the initrd, but dmsquash-live/url-lib.sh only registers
+# the NFS handler when `nfs_to_var` is present, and that helper comes from the
+# dracut `nfs` module.
+#
+# kiwi builds the live initrd by running dracut inside this image root, so this
+# drop-in is merged with kiwi's own 02-livecd.conf (dmsquash-live, livenet,
+# pollcdrom). Both use `+=`, so the module lists accumulate.
+add_dracutmodules+=" nfs "

--- a/base/images/vm-iso-installer/vm-iso-installer.kiwi
+++ b/base/images/vm-iso-installer/vm-iso-installer.kiwi
@@ -75,6 +75,10 @@
             target="/etc/anaconda/conf.d/azurelinux.conf"
             permissions="0644" />
         <file
+            name="dracut-nfs.conf"
+            target="/etc/dracut.conf.d/10-nfs.conf"
+            permissions="0644" />
+        <file
             name="anaconda-launcher.sh"
             target="/usr/local/bin/anaconda-launcher.sh"
             permissions="0755" />
@@ -107,6 +111,14 @@
 
         <!-- ISO live boot (Fedora dmsquash-live) -->
         <package name="dracut-live" />
+
+        <!-- NFS-served live root (root=live:nfs://...). dracut's 95nfs module
+             is skipped at initrd build time unless rpcbind, the nfs-utils
+             helpers (rpc.statd, mount.nfs, mount.nfs4) and sed are installed
+             in this image root. sed is otherwise only present transitively. -->
+        <package name="nfs-utils" />
+        <package name="rpcbind" />
+        <package name="sed" />
 
         <!-- Hyper-V guest integration -->
         <package name="hyperv-daemons" />


### PR DESCRIPTION
Fixes #17913

## Problem

PXE deployments of the live installer can only fetch the squashfs over HTTP
(`root=live:http://...`), which pulls the whole image into RAM and forces
installer VMs to be sized at 4 GB. `root=live:nfs://...` would mount the
squashfs in place, but it does not work today.

The root cause is in `url-lib.sh`, which registers the NFS handler
conditionally:

```sh
command -v nfs_to_var > /dev/null && add_url_handler nfs_fetch_url nfs nfs4
```

`nfs_to_var` lives in `nfs-lib.sh`, shipped by dracut's `95nfs` module. kiwi
builds the live initrd with `--add ' dmsquash-live livenet pollcdrom '
--omit ' multipath '`, so `nfs` is never added and the handler is never
registered. The kernel NFS modules are in the initrd; only the userspace half
is missing.

## Change

Add an `/etc/dracut.conf.d` drop-in requesting the `nfs` module. kiwi runs
dracut inside the image root and writes its own `02-livecd.conf` in the same
directory, so both files are merged and the `add_dracutmodules` lists
accumulate (`kiwi/builder/live.py`, `kiwi/boot/image/dracut.py`).

The module is only built in if its prerequisites exist at initrd build time.
`95nfs`'s `check()` requires `rpcbind` (or `portmap`) plus `rpc.statd`,
`mount.nfs`, `mount.nfs4`, `umount`, `sed`, `chmod` and `chown`; if any is
missing the module is skipped silently. `umount` comes from `util-linux` and
`chmod`/`chown` from `coreutils`, both already in the image, so this adds
`nfs-utils` and `rpcbind`. `sed` is currently present only as a transitive
dependency — it is listed explicitly so a future dependency change cannot
silently drop the `nfs` module again.

## Verification

Built locally with `azldev image build vm-iso-installer` (azldev `v0.3.0`, the
version pinned by `.azldev-version`; kiwi 10.3.0) and inspected the resulting
initrd from `/boot/x86_64/loader/initrd`:

- `lsinitrd` module list now contains `nfs`, alongside the unchanged
  `dmsquash-live`, `livenet`, `pollcdrom`, `url-lib` and `network`.
  `multipath` is still omitted.
- `nfs_to_var()` is defined in `usr/lib/nfs-lib.sh`, so the `url-lib.sh`
  conditional above is satisfied and the `nfs`/`nfs4` URL handlers register.
- `mount.nfs`, `mount.nfs4`, `rpc.statd`, `rpcbind` and `nfsroot` are present,
  along with the `90-parse-nfsroot.sh` and `99-nfsroot-cleanup.sh` hooks.
- The image manifest lists `nfs-utils`, `rpcbind`, `sed`, `libtirpc`,
  `libnfsidmap` and `keyutils`.

`azldev config dump` passes. No component or spec is touched, so no re-render
or lock update is required.

## Size impact

Measured against the `azl4-dev` x86_64 repo metadata: the three added packages
are 0.81 MB of RPMs / 2.21 MB installed, with an upper bound of roughly 8 MB
installed once every possible new transitive dependency is counted — most of
which the image already carries via systemd, dnf5 and anaconda. The built ISO
is 965 MB with an 839 MB squashfs.

## Not covered

This verifies that the initrd contains the NFS machinery and that the URL
handler registers. An end-to-end PXE boot against a live NFS server was not
exercised.
