### PR TITLE
systemd: lock disks while running filesystem checks

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        34%{?dist}
+Release:        35%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Fri Aug 28 2026 Pawel Winogrodzki <pawelwi@microsoft.com> - 255-35
+- Bump release to match systemd spec.
+
 * Mon Aug 17 2026 Aditya Singh <v-aditysing@microsoft.com> - 255-34
 - Bump release to match systemd spec.
 

--- a/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
+++ b/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
@@ -1,3 +1,11 @@
+Lock the whole parent disk while fsck runs so udev cannot probe sibling
+partitions during filesystem repair.
+
+Do not combine this implementation with native e2fsprogs (e2fsck)
+whole-disk locking. systemd-fsck retains its lock descriptor while waiting
+for fsck, so an independently opened exclusive lock in the child would
+deadlock.
+
 diff --git a/src/fsck/fsck.c b/src/fsck/fsck.c
 index 000ed69..8eb209a 100644
 --- a/src/fsck/fsck.c
@@ -64,13 +72,10 @@ index 000ed69..8eb209a 100644
          _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
          _cleanup_free_ char *dpath = NULL;
          _cleanup_fclose_ FILE *console = NULL;
-@@ -333,6 +372,13 @@ static int run(int argc, char *argv[]) {
+@@ -333,6 +372,10 @@ static int run(int argc, char *argv[]) {
                  }
          }
 
-+        /* Do not combine this implementation with native e2fsprogs (e2fsck) whole-disk locking.
-+         * systemd-fsck retains this descriptor while waiting for fsck, so an independently opened exclusive
-+         * lock in the child would deadlock. */
 +        lock_fd = lock_whole_disk(device);
 +        if (lock_fd < 0)
 +                return lock_fd;

--- a/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
+++ b/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
@@ -1,6 +1,9 @@
 Lock the whole parent disk while fsck runs so udev cannot probe sibling
 partitions during filesystem repair.
 
+Wait up to 60 seconds for the lock. If the timeout expires, warn and run
+the filesystem check without the lock to preserve the previous behavior.
+
 Do not combine this implementation with native e2fsprogs (e2fsck)
 whole-disk locking. systemd-fsck retains its lock descriptor while waiting
 for fsck, so an independently opened exclusive lock in the child would
@@ -26,7 +29,15 @@ index 000ed69..8eb209a 100644
  #include "main-func.h"
  #include "parse-util.h"
  #include "path-util.h"
-@@ -233,8 +235,45 @@ static int fsck_progress_socket(void) {
+@@ -32,6 +34,7 @@
+ #include "socket-util.h"
+ #include "special.h"
+ #include "stdio-util.h"
++#include "time-util.h"
+
+ static bool arg_skip = false;
+ static bool arg_force = false;
+@@ -233,8 +236,47 @@ static int fsck_progress_socket(void) {
          return TAKE_FD(fd);
  }
 
@@ -58,7 +69,9 @@ index 000ed69..8eb209a 100644
 +                                       "Path '%s' no longer refers to block device %u:%u.",
 +                                       whole_disk, major(devno), minor(devno));
 +
-+        r = lock_generic(fd, LOCK_BSD, LOCK_EX);
++        r = lock_generic_with_timeout(fd, LOCK_BSD, LOCK_EX, 60 * USEC_PER_SEC);
++        if (r == -ETIMEDOUT)
++                return r;
 +        if (r < 0)
 +                return log_error_errno(r, "Failed to lock whole block device '%s': %m", whole_disk);
 +
@@ -72,12 +85,17 @@ index 000ed69..8eb209a 100644
          _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
          _cleanup_free_ char *dpath = NULL;
          _cleanup_fclose_ FILE *console = NULL;
-@@ -333,6 +372,10 @@ static int run(int argc, char *argv[]) {
+@@ -333,6 +375,15 @@ static int run(int argc, char *argv[]) {
                  }
          }
 
 +        lock_fd = lock_whole_disk(device);
-+        if (lock_fd < 0)
++        if (lock_fd == -ETIMEDOUT) {
++                log_warning(
++                                "Timed out waiting 60 seconds for whole block device lock for '%s'; proceeding without lock.",
++                                device);
++                lock_fd = -EBADF;
++        } else if (lock_fd < 0)
 +                return lock_fd;
 +
          console = fopen("/dev/console", "we");

--- a/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
+++ b/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
@@ -64,10 +64,13 @@ index 000ed69..8eb209a 100644
          _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
          _cleanup_free_ char *dpath = NULL;
          _cleanup_fclose_ FILE *console = NULL;
-@@ -333,6 +372,10 @@ static int run(int argc, char *argv[]) {
+@@ -333,6 +372,13 @@ static int run(int argc, char *argv[]) {
                  }
          }
 
++        /* Do not combine this implementation with native e2fsprogs (e2fsck) whole-disk locking.
++         * systemd-fsck retains this descriptor while waiting for fsck, so an independently opened exclusive
++         * lock in the child would deadlock. */
 +        lock_fd = lock_whole_disk(device);
 +        if (lock_fd < 0)
 +                return lock_fd;

--- a/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
+++ b/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
@@ -1,0 +1,77 @@
+diff --git a/src/fsck/fsck.c b/src/fsck/fsck.c
+index 000ed69..8eb209a 100644
+--- a/src/fsck/fsck.c
++++ b/src/fsck/fsck.c
+@@ -15,6 +15,7 @@
+ #include "sd-device.h"
+
+ #include "alloc-util.h"
++#include "blockdev-util.h"
+ #include "bus-common-errors.h"
+ #include "bus-error.h"
+ #include "bus-locator.h"
+@@ -23,6 +24,7 @@
+ #include "fd-util.h"
+ #include "fs-util.h"
+ #include "fsck-util.h"
++#include "lock-util.h"
+ #include "main-func.h"
+ #include "parse-util.h"
+ #include "path-util.h"
+@@ -233,8 +235,45 @@ static int fsck_progress_socket(void) {
+         return TAKE_FD(fd);
+ }
+
++static int lock_whole_disk(const char *device) {
++        _cleanup_free_ char *whole_disk = NULL;
++        _cleanup_close_ int fd = -EBADF;
++        struct stat st;
++        dev_t devno;
++        int r;
++
++        assert(device);
++
++        r = path_get_whole_disk(device, /* backing = */ false, &devno);
++        if (r < 0)
++                return log_error_errno(r, "Failed to find whole block device for '%s': %m", device);
++
++        r = devname_from_devnum(S_IFBLK, devno, &whole_disk);
++        if (r < 0)
++                return log_error_errno(r, "Failed to resolve whole block device for '%s': %m", device);
++
++        fd = open(whole_disk, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
++        if (fd < 0)
++                return log_error_errno(errno, "Failed to open whole block device '%s': %m", whole_disk);
++
++        if (fstat(fd, &st) < 0)
++                return log_error_errno(errno, "Failed to stat whole block device '%s': %m", whole_disk);
++        if (!S_ISBLK(st.st_mode) || st.st_rdev != devno)
++                return log_error_errno(SYNTHETIC_ERRNO(ENXIO),
++                                       "Path '%s' no longer refers to block device %u:%u.",
++                                       whole_disk, major(devno), minor(devno));
++
++        r = lock_generic(fd, LOCK_BSD, LOCK_EX);
++        if (r < 0)
++                return log_error_errno(r, "Failed to lock whole block device '%s': %m", whole_disk);
++
++        log_debug("Locked whole block device %s while checking %s.", whole_disk, device);
++        return TAKE_FD(fd);
++}
++
+ static int run(int argc, char *argv[]) {
+         _cleanup_close_pair_ int progress_pipe[2] = EBADF_PAIR;
++        _cleanup_close_ int lock_fd = -EBADF;
+         _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
+         _cleanup_free_ char *dpath = NULL;
+         _cleanup_fclose_ FILE *console = NULL;
+@@ -333,6 +372,10 @@ static int run(int argc, char *argv[]) {
+                 }
+         }
+
++        lock_fd = lock_whole_disk(device);
++        if (lock_fd < 0)
++                return lock_fd;
++
+         console = fopen("/dev/console", "we");
+         if (console &&
+             arg_show_progress &&

--- a/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
+++ b/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
@@ -37,10 +37,12 @@ index 000ed69..8eb209a 100644
 
  static bool arg_skip = false;
  static bool arg_force = false;
-@@ -233,8 +236,47 @@ static int fsck_progress_socket(void) {
+@@ -233,8 +236,49 @@ static int fsck_progress_socket(void) {
          return TAKE_FD(fd);
  }
 
++static const usec_t whole_disk_lock_timeout = 60 * USEC_PER_SEC;
++
 +static int lock_whole_disk(const char *device) {
 +        _cleanup_free_ char *whole_disk = NULL;
 +        _cleanup_close_ int fd = -EBADF;
@@ -69,7 +71,7 @@ index 000ed69..8eb209a 100644
 +                                       "Path '%s' no longer refers to block device %u:%u.",
 +                                       whole_disk, major(devno), minor(devno));
 +
-+        r = lock_generic_with_timeout(fd, LOCK_BSD, LOCK_EX, 60 * USEC_PER_SEC);
++        r = lock_generic_with_timeout(fd, LOCK_BSD, LOCK_EX, whole_disk_lock_timeout);
 +        if (r == -ETIMEDOUT)
 +                return r;
 +        if (r < 0)
@@ -85,14 +87,15 @@ index 000ed69..8eb209a 100644
          _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
          _cleanup_free_ char *dpath = NULL;
          _cleanup_fclose_ FILE *console = NULL;
-@@ -333,6 +375,15 @@ static int run(int argc, char *argv[]) {
+@@ -333,6 +377,16 @@ static int run(int argc, char *argv[]) {
                  }
          }
 
 +        lock_fd = lock_whole_disk(device);
 +        if (lock_fd == -ETIMEDOUT) {
 +                log_warning(
-+                                "Timed out waiting 60 seconds for whole block device lock for '%s'; proceeding without lock.",
++                                "Timed out waiting %s for whole block device lock for '%s'; proceeding without lock.",
++                                FORMAT_TIMESPAN(whole_disk_lock_timeout, USEC_PER_SEC),
 +                                device);
 +                lock_fd = -EBADF;
 +        } else if (lock_fd < 0)

--- a/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
+++ b/SPECS/systemd/systemd-fsck-lock-whole-disk.patch
@@ -4,10 +4,16 @@ partitions during filesystem repair.
 Wait up to 60 seconds for the lock. If the timeout expires, warn and run
 the filesystem check without the lock to preserve the previous behavior.
 
-Do not combine this implementation with native e2fsprogs (e2fsck)
-whole-disk locking. systemd-fsck retains its lock descriptor while waiting
-for fsck, so an independently opened exclusive lock in the child would
-deadlock.
+This downstream workaround tracks the competing upstream proposals:
+
+- https://github.com/systemd/systemd/issues/43695
+- https://github.com/systemd/systemd/pull/43696
+- https://lore.kernel.org/linux-ext4/20260824224006.GB6038@frogsfrogsfrogs/t/
+
+Remove this patch when the selected upstream solution is integrated. It
+cannot coexist with native e2fsprogs (e2fsck) whole-disk locking:
+systemd-fsck retains its lock descriptor while waiting for fsck, so an
+independently opened exclusive lock in the child would deadlock.
 
 diff --git a/src/fsck/fsck.c b/src/fsck/fsck.c
 index 000ed69..8eb209a 100644

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -161,12 +161,6 @@ Patch0913:      network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch
 Patch0914:      Prevent-corruption-from-stale-alias-state-on-daemon-reload.patch
 Patch0915:      CVE-2026-15059.patch
 Patch0916:      CVE-2026-16742.patch
-
-# Alternative to the proposed native e2fsprogs whole-disk lock:
-# https://lore.kernel.org/linux-ext4/20260824161512.1332649-1-naraghavan@linux.microsoft.com/
-# Do not ship both implementations. systemd-fsck retains its exclusive
-# lock while waiting for fsck; native e2fsck locking would then block on
-# a second independently-opened lock and deadlock boot.
 Patch0917:      systemd-fsck-lock-whole-disk.patch
 
 %ifarch %{ix86} x86_64 aarch64

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        34%{?dist}
+Release:        35%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -161,6 +161,13 @@ Patch0913:      network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch
 Patch0914:      Prevent-corruption-from-stale-alias-state-on-daemon-reload.patch
 Patch0915:      CVE-2026-15059.patch
 Patch0916:      CVE-2026-16742.patch
+
+# Alternative to the proposed native e2fsprogs whole-disk lock:
+# https://lore.kernel.org/linux-ext4/20260824161512.1332649-1-naraghavan@linux.microsoft.com/
+# Do not ship both implementations. systemd-fsck retains its exclusive
+# lock while waiting for fsck; native e2fsck locking would then block on
+# a second independently-opened lock and deadlock boot.
+Patch0917:      systemd-fsck-lock-whole-disk.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1259,6 +1266,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Fri Aug 28 2026 Pawel Winogrodzki <pawelwi@microsoft.com> - 255-35
+- Lock the whole disk in systemd-fsck while its child fsck process checks
+  the filesystem.
+
 * Thu Aug 13 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 255-34
 - Patch for CVE-2026-16742, CVE-2026-15059
 


### PR DESCRIPTION
> [!IMPORTANT]
> This is an Azure Linux workaround until the upstream [systemd issue](https://github.com/systemd/systemd/issues/43695) and [e2fsprogs discussion](https://lore.kernel.org/linux-ext4/20260824224006.GB6038@frogsfrogsfrogs/t/) resolve whole-disk lock ownership and the selected fix is integrated.
>
> Remove this patch during that integration. Do not combine it with checker-native whole-disk locking: `systemd-fsck` retains the lock while waiting for child `fsck`, so a second lock attempt in the child would deadlock boot.

## Change

- Patch `systemd-fsck` to hold an exclusive whole-disk BSD lock while a filesystem checker runs.
- Wait up to 60 seconds for the lock, then warn and continue unlocked to preserve previous behavior.
- Apply the same locking policy when `fsck.repair=no` requests a read-only check.
- Update `systemd` and `systemd-boot-signed` together to release 255-35.

## Why

During ext4 journal replay, `systemd-udevd` can probe metadata while `e2fsck` is updating it. A transient failed probe can remove the root filesystem UUID link and cancel the generated initrd mount transaction. The exclusive writer lock makes `udev` defer its shared probe until filesystem metadata is consistent.

The corresponding upstream systemd implementation is staged in [systemd/systemd#43696](https://github.com/systemd/systemd/pull/43696).

## Verification

- Built and tested `systemd` packages on x86_64 and aarch64; all selected `systemd` package tests passed.
- Installed the complete exact-head RPM set on Azure Linux 3 and verified host/initramfs `systemd-fsck` hashes matched.
- Rebooted successfully with no failed units and `emergency.target` inactive.
- Verified normal lock acquisition completed in 8 ms.
- Forced contention beyond 60 seconds and verified the warning, unlocked fallback, and successful checker completion.
- Completed a 20-attempt resize campaign with zero UUID removals or root lookup failures while locking was enabled.
