### PR TITLE
ci: run CodeQL on no-UMI pool

### DIFF
--- a/.pipelines/CodeQL/CodeQL.yml
+++ b/.pipelines/CodeQL/CodeQL.yml
@@ -16,3 +16,5 @@ stages:
   - stage: CodeQlAnalysis
     jobs:
     - template: SDL/CodeQL-CBL-Mariner.yml@CBL-Mariner-Pipelines
+      parameters:
+        poolName: "$(DEV_AMD64_Managed_NoUMI_AZL3)"


### PR DESCRIPTION
## What
Run the CodeQL job on the no-UMI build pool.

## Why
The job does not access secrets or managed identities, so the identity-enabled pool is unnecessary.

## Risk
Low. The change only selects an equivalent pool without managed identity.

## Verification
- Parsed the pipeline YAML.
- Runtime validation is in progress before merge.

Review strategy: Self-review only.