### PR TITLE
fix(containerd2): require openssl-libs >= 3.3.7-5 for Go 1.27 TLS

### DIFF
--- a/SPECS/containerd2/containerd2.spec
+++ b/SPECS/containerd2/containerd2.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: %{upstream_name}2
 Version: 2.2.4
-Release: 7%{?dist}
+Release: 8%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -42,6 +42,7 @@ BuildRequires: make
 BuildRequires: systemd-rpm-macros
 
 Requires: runc >= 1.2.2
+Requires: openssl-libs >= 3.3.7-5
 
 # This package replaces the old name of containerd
 Provides: containerd = %{version}-%{release}
@@ -109,6 +110,10 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Wed Sep 02 2026 Aadhar Agarwal <aadagarwal@microsoft.com> - 2.2.4-8
+- Require openssl-libs >= 3.3.7-5 to prevent Go 1.27 systemcrypto TLS failures
+  during provider-backed ML-KEM key generation.
+
 * Wed Sep 02 2026 Muhammad Falak R Wani <mwani@microsoft.com> - 2.2.4-7
 - Drop 'GOEXPERIMENT=ms_nocgo_opensslcrypto', removed in Go 1.27. Systemcrypto is
   now selected automatically and supports CGO_ENABLED=0 on Linux.


### PR DESCRIPTION
### Problem
Go 1.27 `systemcrypto` can fail TLS on Azure Linux 3 with `openssl-libs-3.3.7-4` during provider-backed ML-KEM key generation. `containerd2` lacked a versioned OpenSSL dependency, allowing this incompatible combination.

### Fix
Require `openssl-libs >= 3.3.7-5`, which contains the fix from #18630, and bump `containerd2` to `2.2.4-8`

### Validation
Buddy build: [1195846](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1195846&view=results) using daily build id `3-0-20260826` passes completely

Buddy build: [1195818](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1195818&view=results) using daily build id `latest` builds the packages but fails the `Test Packages Installation` section as openssl 3.3.7-5 is not found