### PR TITLE
fix(nbdkit): work around SymCrypt allocator interposition

### DIFF
--- a/base/comps/nbdkit/0001-tests-disable-glibc-malloc-check.patch
+++ b/base/comps/nbdkit/0001-tests-disable-glibc-malloc-check.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Thu, 3 Sep 2026 20:17:00 +0000
+Subject: [PATCH] tests: work around SymCrypt allocator interposition
+
+The glibc malloc-debug checker interposes allocation APIs through
+libc_malloc_debug.so.0. SymCrypt has unversioned allocator references that
+can bind aligned_alloc to libc while binding free to the debug allocator,
+causing OpenSSL consumers to abort during provider initialization.
+
+Work around the incompatible allocator bindings by disabling malloc-debug
+checking. Keep malloc perturbation enabled with values in glibc's valid
+1-255 range to retain detection of uninitialized and use-after-free behavior.
+---
+ tests/Makefile.am | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 3af137f..cf49212 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -69,18 +69,15 @@ TESTS_ENVIRONMENT = \
+ 	LIBNBD_DEBUG=1 \
+ 	$(NULL)
+ 
+-# Enable malloc-check as a cheap way to find some use-after-free and
+-# uninitialized read problems when using glibc, and doesn't affect
+-# normal operation or other libc.
++# Perturb allocated and freed memory as a cheap way to find some
++# use-after-free and uninitialized read problems.
+-random = $(shell bash -c 'echo $$(( 1 + (RANDOM & 255) ))')
++random = $(shell bash -c 'echo $$(( 1 + (RANDOM % 255) ))')
+ if HAVE_GLIBC_234
+ TESTS_ENVIRONMENT += \
+-	LD_PRELOAD="$${LD_PRELOAD:+"$$LD_PRELOAD:"}libc_malloc_debug.so.0" \
+-	GLIBC_TUNABLES=glibc.malloc.check=1:glibc.malloc.perturb=$(random) \
++	GLIBC_TUNABLES=glibc.malloc.perturb=$(random) \
+ 	$(NULL)
+ else
+ TESTS_ENVIRONMENT += \
+-	MALLOC_CHECK_=1 \
+ 	MALLOC_PERTURB_=$(random) \
+ 	$(NULL)
+ endif
+-- 
+2.55.0

--- a/base/comps/nbdkit/overlays/0003-disable-glibc-malloc-check.overlay.toml
+++ b/base/comps/nbdkit/overlays/0003-disable-glibc-malloc-check.overlay.toml
@@ -1,0 +1,16 @@
+# Work around SymCrypt's unversioned allocator references splitting between
+# libc and libc_malloc_debug when glibc's checked allocator is enabled. The
+# incompatible bindings cause a crash on free() during SymCrypt load.
+
+[metadata]
+category = "azl-temp-workaround"
+upstream-status = "inapplicable"
+bugs = [
+    { url = "https://dev.azure.com/mariner-org/mariner/_workitems/edit/23389" },
+    { url = "https://github.com/microsoft/SymCrypt/issues/62" },
+]
+
+[[overlays]]
+description = "Work around SymCrypt allocator interposition in tests"
+type = "patch-add"
+source = "../0001-tests-disable-glibc-malloc-check.patch"

--- a/locks/nbdkit.lock
+++ b/locks/nbdkit.lock
@@ -3,5 +3,5 @@ version = 1
 import-commit = 'e033665ff8146ea184d31f82bc22ec3183bc212b'
 upstream-commit = 'e033665ff8146ea184d31f82bc22ec3183bc212b'
 manual-bump = 2
-input-fingerprint = 'sha256:667190fddaa6c95a055d3d56d748cc0a73691dffa1b945541c1f742434563f9e'
+input-fingerprint = 'sha256:17b89b1807b0c13d2d41017e03c11d509dcf31bf74380c75f63979a618ce1ac4'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/n/nbdkit/0001-tests-disable-glibc-malloc-check.patch
+++ b/specs/n/nbdkit/0001-tests-disable-glibc-malloc-check.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Thu, 3 Sep 2026 20:17:00 +0000
+Subject: [PATCH] tests: work around SymCrypt allocator interposition
+
+The glibc malloc-debug checker interposes allocation APIs through
+libc_malloc_debug.so.0. SymCrypt has unversioned allocator references that
+can bind aligned_alloc to libc while binding free to the debug allocator,
+causing OpenSSL consumers to abort during provider initialization.
+
+Work around the incompatible allocator bindings by disabling malloc-debug
+checking. Keep malloc perturbation enabled with values in glibc's valid
+1-255 range to retain detection of uninitialized and use-after-free behavior.
+---
+ tests/Makefile.am | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 3af137f..cf49212 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -69,18 +69,15 @@ TESTS_ENVIRONMENT = \
+ 	LIBNBD_DEBUG=1 \
+ 	$(NULL)
+ 
+-# Enable malloc-check as a cheap way to find some use-after-free and
+-# uninitialized read problems when using glibc, and doesn't affect
+-# normal operation or other libc.
++# Perturb allocated and freed memory as a cheap way to find some
++# use-after-free and uninitialized read problems.
+-random = $(shell bash -c 'echo $$(( 1 + (RANDOM & 255) ))')
++random = $(shell bash -c 'echo $$(( 1 + (RANDOM % 255) ))')
+ if HAVE_GLIBC_234
+ TESTS_ENVIRONMENT += \
+-	LD_PRELOAD="$${LD_PRELOAD:+"$$LD_PRELOAD:"}libc_malloc_debug.so.0" \
+-	GLIBC_TUNABLES=glibc.malloc.check=1:glibc.malloc.perturb=$(random) \
++	GLIBC_TUNABLES=glibc.malloc.perturb=$(random) \
+ 	$(NULL)
+ else
+ TESTS_ENVIRONMENT += \
+-	MALLOC_CHECK_=1 \
+ 	MALLOC_PERTURB_=$(random) \
+ 	$(NULL)
+ endif
+-- 
+2.55.0

--- a/specs/n/nbdkit/nbdkit.spec
+++ b/specs/n/nbdkit/nbdkit.spec
@@ -58,7 +58,7 @@
 
 Name:           nbdkit
 Version:        1.46.2
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary:        NBD server
 
 License:        BSD-3-Clause
@@ -223,6 +223,7 @@ Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
 %endif
 
 
+Patch0: 0001-tests-disable-glibc-malloc-check.patch
 %description
 NBD is a protocol for accessing block devices (hard disks and
 disk-like things) over the network.


### PR DESCRIPTION
Work around [microsoft/SymCrypt#62](https://github.com/microsoft/SymCrypt/issues/62) by disabling glibc malloc-debug checking in the nbdkit test environment. Retain malloc perturbation and the full test suite.

[AB#23389](https://dev.azure.com/mariner-org/mariner/_workitems/edit/23389)

**Validation:** stage2 and stage2-prod builds pass all 442 tests (366 passed, 76 skipped).