### PR TITLE
fix(guestfs-tools): work around SymCrypt allocator interposition

### DIFF
--- a/base/comps/guestfs-tools/0002-tests-disable-glibc-malloc-check.patch
+++ b/base/comps/guestfs-tools/0002-tests-disable-glibc-malloc-check.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Fri, 4 Sep 2026 15:36:00 +0000
+Subject: [PATCH] tests: disable glibc malloc check
+
+The legacy glibc malloc checker interposes allocation APIs through
+libc_malloc_debug.so.0. SymCrypt has unversioned allocator references that
+can bind aligned_alloc to libc while binding free to the debug allocator,
+causing OpenSSL consumers to abort during provider initialization.
+
+Keep malloc perturbation enabled to retain detection of uninitialized and
+use-after-free behavior without enabling the incompatible checked allocator.
+---
+ run.in | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/run.in b/run.in
+index 4053fd2..be5cf48 100755
+--- a/run.in
++++ b/run.in
+@@ -100,14 +100,12 @@ if [ -z "$VIRT_BUILDER_DIRS" ]; then
+     export VIRT_BUILDER_DIRS
+ fi
+ 
+-# This is a cheap way to find some use-after-free and uninitialized
+-# read problems when using glibc.  But if we are valgrinding then
+-# don't use this because it can stop valgrind from working.
++# Perturb allocated and freed memory to find some use-after-free and
++# uninitialized read problems. Disable it when running under valgrind.
+ if [ -z "$VG" ]; then
+     random_val="$(@AWK@ 'BEGIN{srand(); print 1+int(255*rand())}' < /dev/null)"
+-    LD_PRELOAD="${LD_PRELOAD:+"$LD_PRELOAD:"}libc_malloc_debug.so.0"
+-    GLIBC_TUNABLES=glibc.malloc.check=1:glibc.malloc.perturb=$random_val
+-    export LD_PRELOAD GLIBC_TUNABLES
++    GLIBC_TUNABLES=glibc.malloc.perturb=$random_val
++    export GLIBC_TUNABLES
+ fi
+ 
+ # Do we have libtool?  If we have it then we can use it to make
+-- 
+2.55.0
+

--- a/base/comps/guestfs-tools/guestfs-tools.comp.toml
+++ b/base/comps/guestfs-tools/guestfs-tools.comp.toml
@@ -15,6 +15,37 @@ description = "Drop the Windows phony-guest image (windows.img) from the test su
 type = "patch-add"
 source = "0001-tests-do-not-build-the-Windows-phony-guest-image.patch"
 
+[[components.guestfs-tools.overlays]]
+description = "Disable glibc's legacy checked allocator because it splits SymCrypt allocations between libc and malloc-debug; retain malloc perturbation and the full test suite. Tracks AB#23502."
+type = "patch-add"
+source = "0002-tests-disable-glibc-malloc-check.patch"
+
+[components.guestfs-tools.overlays.metadata]
+category = "azl-temp-workaround"
+upstream-status = "inapplicable"
+bugs = [
+    { url = "https://dev.azure.com/mariner-org/mariner/_workitems/edit/23502" },
+    { url = "https://github.com/microsoft/SymCrypt/issues/62" },
+]
+
+# The direct backend can still select passt, which cannot create a user
+# namespace in the restricted mock/Koji sandbox. Shadow passt with a probe shim
+# that exits 2 so libguestfs falls back to QEMU SLIRP for the full test suite.
+[[components.guestfs-tools.overlays]]
+description = "Run %check with the direct libguestfs backend and force its QEMU SLIRP fallback because passt cannot create a user namespace in the restricted mock/Koji sandbox."
+type = "spec-prepend-lines"
+section = "%check"
+lines = [
+    "# Azure Linux mock blocks the user namespace required by passt. Make the passt",
+    "# capability probe fail so libguestfs uses its QEMU SLIRP fallback during tests.",
+    "export LIBGUESTFS_BACKEND=direct",
+    "mkdir -p .check-bin",
+    "printf '%s\\n' '#!/bin/sh' 'exit 2' > .check-bin/passt",
+    "chmod 0755 .check-bin/passt",
+    '''export PATH="$PWD/.check-bin:$PATH"''',
+]
+metadata = { category = "azl-compatibility", upstream-status = "inapplicable" }
+
 # test-virt-diff.sh is a golden-output test that modifies the fedora phony guest
 # and expects virt-diff to report only those changes. In this build environment
 # virt-diff additionally reports the guest's separate ext2 /boot partition entries

--- a/locks/guestfs-tools.lock
+++ b/locks/guestfs-tools.lock
@@ -3,5 +3,5 @@ version = 1
 import-commit = 'a948c9aaa7a4fcdf132073c4a7781a5cfc413593'
 upstream-commit = 'a948c9aaa7a4fcdf132073c4a7781a5cfc413593'
 manual-bump = 2
-input-fingerprint = 'sha256:902ac834b52ce5ab7fe5d8ac9caa083e7e43ab2cf92eab29ba118a75d435b8ad'
+input-fingerprint = 'sha256:c3bc0023a9612cadda639be7e60ed694dd91e073a64c7e2139fd1b8e9bb6a283'
 resolution-input-hash = 'sha256:466421704711c4fd3c71f0b2ed715a0e61d49e3e26f3a2637fee755795849c8e'

--- a/specs/g/guestfs-tools/0002-tests-disable-glibc-malloc-check.patch
+++ b/specs/g/guestfs-tools/0002-tests-disable-glibc-malloc-check.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Fri, 4 Sep 2026 15:36:00 +0000
+Subject: [PATCH] tests: disable glibc malloc check
+
+The legacy glibc malloc checker interposes allocation APIs through
+libc_malloc_debug.so.0. SymCrypt has unversioned allocator references that
+can bind aligned_alloc to libc while binding free to the debug allocator,
+causing OpenSSL consumers to abort during provider initialization.
+
+Keep malloc perturbation enabled to retain detection of uninitialized and
+use-after-free behavior without enabling the incompatible checked allocator.
+---
+ run.in | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/run.in b/run.in
+index 4053fd2..be5cf48 100755
+--- a/run.in
++++ b/run.in
+@@ -100,14 +100,12 @@ if [ -z "$VIRT_BUILDER_DIRS" ]; then
+     export VIRT_BUILDER_DIRS
+ fi
+ 
+-# This is a cheap way to find some use-after-free and uninitialized
+-# read problems when using glibc.  But if we are valgrinding then
+-# don't use this because it can stop valgrind from working.
++# Perturb allocated and freed memory to find some use-after-free and
++# uninitialized read problems. Disable it when running under valgrind.
+ if [ -z "$VG" ]; then
+     random_val="$(@AWK@ 'BEGIN{srand(); print 1+int(255*rand())}' < /dev/null)"
+-    LD_PRELOAD="${LD_PRELOAD:+"$LD_PRELOAD:"}libc_malloc_debug.so.0"
+-    GLIBC_TUNABLES=glibc.malloc.check=1:glibc.malloc.perturb=$random_val
+-    export LD_PRELOAD GLIBC_TUNABLES
++    GLIBC_TUNABLES=glibc.malloc.perturb=$random_val
++    export GLIBC_TUNABLES
+ fi
+ 
+ # Do we have libtool?  If we have it then we can use it to make
+-- 
+2.55.0
+

--- a/specs/g/guestfs-tools/guestfs-tools.spec
+++ b/specs/g/guestfs-tools/guestfs-tools.spec
@@ -19,7 +19,7 @@
 Summary:       Tools to access and modify virtual machine disk images
 Name:          guestfs-tools
 Version:       1.55.5
-Release: 4%{?dist}
+Release: 5%{?dist}
 License:       GPL-2.0-or-later AND LGPL-2.0-or-later
 
 # Build only for architectures that have a kernel
@@ -119,6 +119,7 @@ Obsoletes:     libguestfs-tools-c <= 1:1.45.2-1
 
 
 Patch0: 0001-tests-do-not-build-the-Windows-phony-guest-image.patch
+Patch1: 0002-tests-disable-glibc-malloc-check.patch
 %description
 guestfs-tools is a set of tools that can be used to make batch
 configuration changes to guests, get disk used/free statistics
@@ -260,6 +261,13 @@ make V=1 %{?_smp_mflags}
 # image to make the test modification -- a build-environment artifact the upstream
 # golden output does not expect. virt-diff itself is unaffected.
 export SKIP_TEST_VIRT_DIFF_SH=1
+# Azure Linux mock blocks the user namespace required by passt. Make the passt
+# capability probe fail so libguestfs uses its QEMU SLIRP fallback during tests.
+export LIBGUESTFS_BACKEND=direct
+mkdir -p .check-bin
+printf '%s\n' '#!/bin/sh' 'exit 2' > .check-bin/passt
+chmod 0755 .check-bin/passt
+export PATH="$PWD/.check-bin:$PATH"
 %ifarch %{test_arches}
 # Only run the tests with non-debug (ie. non-Rawhide) kernels.
 # XXX This tests for any debug kernel installed.


### PR DESCRIPTION
Work around [microsoft/SymCrypt#62](https://github.com/microsoft/SymCrypt/issues/62) by disabling glibc's legacy checked allocator in the guestfs-tools build and test wrapper. Retain malloc perturbation and the full test suite.

`run.in` is not installed, so this does not change shipped guestfs-tools runtime behavior.

[AB#23502](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/23502)

**Validation:** stage2-prod package build completes with `%check` enabled.
