### PR TITLE
imageconfig: marketplace-gen2-kernel-mshv: pin shim to 15.8

### DIFF
--- a/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
+++ b/toolkit/imageconfigs/marketplace-gen2-kernel-mshv.json
@@ -56,7 +56,7 @@
                 }
             ],
             "PackageLists": [
-                "packagelists/core-packages-image.json",
+                "packagelists/core-packages-image-mshv.json",
                 "packagelists/marketplace-tools-packages.json",
                 "packagelists/azurevm-packages.json",
                 "packagelists/hyperv-packages.json",

--- a/toolkit/imageconfigs/packagelists/core-packages-image-mshv.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image-mshv.json
@@ -1,0 +1,15 @@
+{
+    "_comment": "Mirror of core-packages-image.json, except 'shim' is pinned to 15.8. shim 16.1 declares 'Conflicts: mshv-bootloader-lx', which is pulled in by packagelists/nested-virtualization-packages.json. Remove the pin and use core-packages-image.json again once a shim-16.1-compatible lxhvloader ships. See work item 63139272.",
+    "packages": [
+        "shim=15.8",
+        "grub2-efi-binary",
+        "ca-certificates",
+        "cronie-anacron",
+        "logrotate",
+        "core-packages-base-image",
+        "dracut-hostonly",
+        "dracut-vrf",
+        "initramfs",
+        "shadow-utils"
+    ]
+}


### PR DESCRIPTION
shim 16.1 declares "Conflicts: mshv-bootloader-lx" because it is incompatible with every released lxhvloader. The mshv marketplace image pulls in both sides of that conflict: shim comes from packagelists/core-packages-image.json and mshv-bootloader-lx from packagelists/nested-virtualization-packages.json (also transitively, since mshv requires it), so the image no longer builds.

imagepkgfetcher hits it first:

  package shim-16.1-1.azl3.x86_64 conflicts with mshv-bootloader-lx
  provided by mshv-bootloader-lx-1:26100.30000.2607061535.1-1.azl3.x86_64

but recovers by falling back to per-package transactions, where shim and mshv-bootloader-lx are never resolved together. It therefore clones shim 16.1 and the build only dies later in imager, once shim 16.1 is already installed in the image root and no other shim is available:

  package mshv-1:26100.30000.2607061535.1-1.azl3.x86_64 requires
  mshv-bootloader-lx, but none of the providers can be installed

Add packagelists/core-packages-image-mshv.json, a copy of core-packages-image.json with shim pinned to 15.8, and use it for marketplace-gen2-kernel-mshv. The pin still picks up 15.8 servicing releases. marketplace-gen2-aarch64-kernel-mshv is unaffected: it does not include the nested virtualization package list.

Drop the pin and go back to core-packages-image.json once a shim-16.1-compatible lxhvloader ships. See work item 63139272.


test run: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1198771&view=results (mshv marketplace image builds and shim 15.8 is pulled from PMC as expected, despite shim 16.1 being available (I think from stage 2) https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1198771&view=logs&j=2ccbf1db-6c73-5af8-5ba2-cf05469dcf51&t=9474b2c8-eb59-5aaf-6ad6-cdd8c70d7276&l=10011)
<img width="743" height="51" alt="image" src="https://github.com/user-attachments/assets/879ab2d1-5449-4e3e-bfa6-5435160be3ae" />

this branch is on top of shim 16.1 https://github.com/microsoft/azurelinux/blob/saul/pin-shim/SPECS/shim/shim.spec#L39