### PR TITLE
Upgrade `nodejs` to 24.21.0 for CVE-2026-18149 CVE-2026-18540

### DIFF
--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -3,6 +3,6 @@
   "btest402.js": "fabaf4dacc13e93d54f825b87ffde18573214b149388a5f96176236dd31d7768",
   "icu4c-78.3-data-bin-b.zip": "cb751fc5d46e218b6c71d69d9dea7ba98da937e2e41b662ad8313c9363d8b7e2",
   "icu4c-78.3-data-bin-l.zip": "982619632b78887f1895b063e96e8c3cc7f99283337c8abbd05aa71635de613c",
-  "node-v24.20.0.tar.xz": "4dadfdceb1ad917bdabd5bc215ad36c57ccfc30b61ebf540abe87df2ddb76277"
+  "node-v24.21.0.tar.xz": "d3259a4073b633d085a399b5064133c1d5e1c616c6283648edd6c65ef53c8402"
  }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -15,7 +15,7 @@ Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-Version:        24.20.0
+Version:        24.21.0
 Release:        1%{?dist}
 License:        BSD AND MIT AND Public Domain AND NAIST-2003 AND Artistic-2.0
 Vendor:         Microsoft Corporation
@@ -193,6 +193,9 @@ make cctest
 %{_prefix}/lib/node_modules/*
 
 %changelog
+* Wed Sep 09 2026 Kanishk Bansal <kanbansal@microsoft.com> - 24.21.0-1
+- Upgrade to 24.21.0 for CVE-2026-18149 CVE-2026-18540
+
 * Tue Sep 01 2026 Aditya Singh <v-aditysing@microsoft.com> - 24.20.0-1
 - Upgrade to 24.20.0 'Krypton' (LTS) (bundled npm 11.19.0).
 - Bundled ICU version remains the same as 78.3

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14602,8 +14602,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "24.20.0",
-          "downloadUrl": "https://nodejs.org/download/release/v24.20.0/node-v24.20.0.tar.xz"
+          "version": "24.21.0",
+          "downloadUrl": "https://nodejs.org/download/release/v24.21.0/node-v24.21.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
- Upgrade `nodejs` to 24.21.0 for CVE-2026-18149 CVE-2026-18540