### PR TITLE
Update SymCrypt-OpenSSL to 1.10.1

### DIFF
--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "SymCrypt-OpenSSL-1.10.0.tar.gz": "015aa57c7d8bf6089cdd53bb7ce9fa52e5e37aa0281531b7406440cd4e3a3b7f"
+    "SymCrypt-OpenSSL-1.10.1.tar.gz": "b8ee950705e3e212c4e0c54d728f28c0fcaede608ef5845ac61434dfe4e88a9b"
   }
 }

--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
@@ -1,6 +1,6 @@
 Summary:        The SymCrypt engine for OpenSSL (SCOSSL) allows the use of OpenSSL with SymCrypt as the provider for core cryptographic operations
 Name:           SymCrypt-OpenSSL
-Version:        1.10.0
+Version:        1.10.1
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -89,6 +89,9 @@ install SymCryptProvider/symcrypt_prov.cnf %{buildroot}%{_sysconfdir}/pki/tls/sy
 %dir %attr(1733, root, root) %{_localstatedir}/log/keysinuse/
 
 %changelog
+* Wed Sep 02 2026 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.10.1-1
+- Upgrade to SymCrypt-OpenSSL 1.10.1 with keysinuse fork-handling fixes and minor bugfixes
+
 * Thu Jul 9 2026 Maxwell Moyer-McKee <mamckee@microsoft.com> - 1.10.0-1
 - Add ML-KEM and ML-KEM hybrid
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29056,8 +29056,8 @@
         "type": "other",
         "other": {
           "name": "SymCrypt-OpenSSL",
-          "version": "1.10.0",
-          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.10.0.tar.gz"
+          "version": "1.10.1",
+          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.10.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
This PR bumps SymCrypt-OpenSSL to 1.10.1 with performance improvements for the keysinuse integration, specifically the forking process support. The changes also introduce a new configuration value for tweaking the keysinuse forking behavior when needed. [changes](https://github.com/microsoft/SymCrypt-OpenSSL/pull/174)