### PR TITLE
python-markdown: fix html.parser incompatibility with Python 3.12.14

### DIFF
--- a/SPECS/python-markdown/0002-Fix-handling-of-incomplete-HTML-tags-in-code-spans.patch
+++ b/SPECS/python-markdown/0002-Fix-handling-of-incomplete-HTML-tags-in-code-spans.patch
@@ -1,0 +1,45 @@
+From 15346cd3a73f108bf11c57907b32737f8365d6bd Mon Sep 17 00:00:00 2001
+From: facelessuser <faceless.shop@gmail.com>
+Date: Mon, 21 Jul 2025 08:56:43 -0600
+Subject: [PATCH] Fix failing cases for Python 3.14
+
+New change requires us to monkey patch `locatetagend` to prevent
+capturing incomplete tags in code spans.
+
+Upstream: https://github.com/Python-Markdown/markdown/pull/1548
+(released in Python-Markdown 3.9.0)
+
+The `docs/changelog.md` hunk of the upstream commit is dropped as the
+file is not shipped in the sdist used here.
+---
+ markdown/htmlparser.py | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/markdown/htmlparser.py b/markdown/htmlparser.py
+index 478e70216..63e5df31b 100644
+--- a/markdown/htmlparser.py
++++ b/markdown/htmlparser.py
+@@ -69,6 +69,20 @@ htmlparser.locatestarttagend_tolerant = re.compile(r"""
+    )?
+   \s*                                 # trailing whitespace
+ """, re.VERBOSE)
++htmlparser.locatetagend = re.compile(r"""
++  [a-zA-Z][^`\t\n\r\f />]*           # tag name
++  [\t\n\r\f /]*                     # optional whitespace before attribute name
++  (?:(?<=['"\t\n\r\f /])[^`\t\n\r\f />][^\t\n\r\f /=>]*  # attribute name
++    (?:=                            # value indicator
++      (?:'[^']*'                    # LITA-enclosed value
++        |"[^"]*"                    # LIT-enclosed value
++        |(?!['"])[^>\t\n\r\f ]*     # bare value
++       )
++     )?
++    [\t\n\r\f /]*                   # possibly followed by a space
++   )*
++   >?
++""", re.VERBOSE)
+ 
+ # Match a blank line at the start of a block of text (two newlines).
+ # The newlines may be preceded by additional whitespace.
+-- 
+2.51.0
+

--- a/SPECS/python-markdown/python-markdown.spec
+++ b/SPECS/python-markdown/python-markdown.spec
@@ -3,7 +3,7 @@
 Summary:        Markdown implementation in Python
 Name:           python-%{pkgname}
 Version:        3.8.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -11,6 +11,7 @@ URL:            https://python-markdown.github.io/
 Source0:        https://github.com/Python-Markdown/markdown/releases/download/%{version}/%{pkgname}-%{version}.tar.gz#/python-%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 Patch0:         0001-fix-pyproject-license-for-setuptools.patch
+Patch1:         0002-Fix-handling-of-incomplete-HTML-tags-in-code-spans.patch
 
 %description
 This is a Python implementation of John Grubers Markdown. It is
@@ -37,9 +38,6 @@ there are a few known issues.
 
 %prep
 %autosetup -p1 -n %{pkgname}-%{version}
-# Skip 2 tests that fail due to Python 3.12 html.parser behavior changes
-sed -i 's/def test_raw_missing_close_bracket/def _skip_test_raw_missing_close_bracket/' tests/test_syntax/blocks/test_html_blocks.py
-sed -i 's/def test_unclosed_comment_/def _skip_test_unclosed_comment_/' tests/test_syntax/blocks/test_html_blocks.py
 
 %build
 %pyproject_wheel
@@ -53,7 +51,6 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
   LICENSE.md > LICENSE.html
 
 %check
-# Skip test_raw_missing_close_bracket and test_unclosed_comment_ (Python 3.12 html.parser changes)
 %{__python3} -m unittest discover -v
 
 
@@ -66,6 +63,11 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %{_bindir}/markdown_py
 
 %changelog
+* Thu Sep 10 2026 Kshitiz Godara <kgodara@microsoft.com> - 3.8.2-3
+- Add upstream patch (PR #1548) to fix incomplete HTML tags in code spans
+  with the new html.parser backported into Python 3.12.14.
+- Drop the %%prep test skips, no longer needed with Python 3.12.14.
+
 * Wed Jun 17 2026 Kshitiz Godara <kgodara@microsoft.com> - 3.8.2-2
 - Use %%{pkgname} (lowercase) for %%autosetup -n so the directory inside
   the upstream tarball (markdown-3.8.2) matches; skip 2 tests broken by


### PR DESCRIPTION
CPython 3.12.14 backported the 3.14-era html.parser rewrite (locatetagend, new attrfind_tolerant, commentclose '--!?>'), which 3.12.9 did not have. Under the new parser an unterminated tag in a code span, e.g. `<div`, is buffered as an incomplete start tag and swallows the following real <div>, so the block is wrapped in <p> instead of being emitted as raw HTML. This broke 4 tests:

  test_syntax.blocks.test_html_blocks.TestHTMLBlocks
    - test_raw_unclosed_tag_in_code_span
    - test_raw_unclosed_tag_in_code_span_space test_syntax.extensions.test_md_in_html.TestDefaultwMdInHTML
    - test_raw_unclosed_tag_in_code_span
    - test_raw_unclosed_tag_in_code_span_space

Backport the upstream fix (commit 15346cd, PR Python-Markdown/markdown#1548, fixes #1547, released in 3.9.0), which monkeypatches htmlparser.locatetagend to exclude backticks from tag names, attribute names and bare values.

Also drop the existing prep section sed test skips for test_raw_missing_close_bracket and test_unclosed_comment_. Those were only needed for the partial html.parser CVE backports in python3-3.12.9; markdown 3.8.2 already handles the complete parser now shipped in 3.12.14.

Verified against the new parser: 1010 tests, OK (skipped=64).


[Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1199862&view=results)