### PR TITLE
dasel: fix ptest failure with Go 1.27 (reflect.TypeFor / go.mod language version)

### DIFF
--- a/SPECS/dasel/dasel.spec
+++ b/SPECS/dasel/dasel.spec
@@ -1,7 +1,7 @@
 Summary:        Dasel (short for data-selector) allows you to query and modify data structures using selector strings. Comparable to jq, yq, and xmlstarlet, but for any data format.
 Name:           dasel
 Version:        2.8.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -18,6 +18,7 @@ Patch6:         CVE-2026-27136.patch
 Patch7:         CVE-2026-25680.patch
 Patch8:         CVE-2026-25681.patch
 Patch9:         CVE-2026-42502.patch
+Patch10:        fix-go-mod-language-version.patch
 BuildRequires:  golang >= 1.22
 
 %description
@@ -51,6 +52,10 @@ go test ./...
 %{_bindir}/dasel
 
 %changelog
+* Thu Sep 10 2026 Kanishk Bansal <kanbansal@microsoft.com> - 2.8.1-5
+- Add patch to declare go 1.22 in go.mod, matching the reflect.TypeFor usage in value.go
+- Fixes %%check failure with Go 1.27, which runs the stdversion vet analyzer by default
+
 * Wed May 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.8.1-4
 - Patch for CVE-2026-42506, CVE-2026-27136, CVE-2026-25680, CVE-2026-42502, CVE-2026-25681
 

--- a/SPECS/dasel/dasel.spec
+++ b/SPECS/dasel/dasel.spec
@@ -54,7 +54,7 @@ go test ./...
 %changelog
 * Thu Sep 10 2026 Kanishk Bansal <kanbansal@microsoft.com> - 2.8.1-5
 - Add patch to declare go 1.22 in go.mod, matching the reflect.TypeFor usage in value.go
-- Fixes %%check failure with Go 1.27, which runs the stdversion vet analyzer by default
+- Fixes check failure with Go 1.27, which runs the stdversion vet analyzer by default
 
 * Wed May 27 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.8.1-4
 - Patch for CVE-2026-42506, CVE-2026-27136, CVE-2026-25680, CVE-2026-42502, CVE-2026-25681
@@ -68,3 +68,4 @@ go test ./...
 * Tue Jun 17 2025 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 2.8.1-1
 - Original version for Azure Linux (license: MIT)
 - License verified
+

--- a/SPECS/dasel/fix-go-mod-language-version.patch
+++ b/SPECS/dasel/fix-go-mod-language-version.patch
@@ -17,14 +17,6 @@ standard library in Go 1.22:
 
 Go 1.27 added the `stdversion` analyzer to the set of vet checks that
 `go test` runs by default (`defaultVetFlags` in cmd/go/internal/test).
-That analyzer reports the use of standard library symbols newer than the
-language version declared in go.mod, so the %check section now fails with:
-
-    # github.com/tomwright/dasel/v2
-    # [github.com/tomwright/dasel/v2]
-    ./value.go:329:34: reflect.TypeFor requires go1.22 or later (module is go1.21)
-    ./value.go:330:38: reflect.TypeFor requires go1.22 or later (module is go1.21)
-    FAIL	github.com/tomwright/dasel/v2 [build failed]
 
 `go build` is unaffected, so only the test run breaks. Declaring `go 1.22`
 makes go.mod match the code's real requirement, which the spec already

--- a/SPECS/dasel/fix-go-mod-language-version.patch
+++ b/SPECS/dasel/fix-go-mod-language-version.patch
@@ -1,0 +1,53 @@
+From: Kanishk Bansal <kanbansal@microsoft.com>
+Date: Thu Sep 10 2026
+Subject: [PATCH] go.mod: declare the Go language version actually required (1.22)
+
+What
+----
+Bump the `go` directive in go.mod from `go 1.21` to `go 1.22`.
+
+Why
+---
+dasel v2.8.1 ships an inconsistent module declaration: go.mod declares
+`go 1.21`, but value.go uses `reflect.TypeFor`, which was added to the
+standard library in Go 1.22:
+
+    value.go:329: var sliceInterfaceType = reflect.TypeFor[[]any]()
+    value.go:330: var mapStringInterfaceType = reflect.TypeFor[map[string]interface{}]()
+
+Go 1.27 added the `stdversion` analyzer to the set of vet checks that
+`go test` runs by default (`defaultVetFlags` in cmd/go/internal/test).
+That analyzer reports the use of standard library symbols newer than the
+language version declared in go.mod, so the %check section now fails with:
+
+    # github.com/tomwright/dasel/v2
+    # [github.com/tomwright/dasel/v2]
+    ./value.go:329:34: reflect.TypeFor requires go1.22 or later (module is go1.21)
+    ./value.go:330:38: reflect.TypeFor requires go1.22 or later (module is go1.21)
+    FAIL	github.com/tomwright/dasel/v2 [build failed]
+
+`go build` is unaffected, so only the test run breaks. Declaring `go 1.22`
+makes go.mod match the code's real requirement, which the spec already
+encodes via `BuildRequires: golang >= 1.22`.
+
+Upstream reference
+------------------
+None. dasel v2.8.1 is the final release of the v2 line; upstream development
+moved to the v3 module path (github.com/tomwright/dasel/v3, go 1.25), so this
+defect will never be fixed on v2 and no upstream commit can be backported.
+
+Droppable
+---------
+Drop this patch when dasel is upgraded to a release whose go.mod declares
+go >= 1.22 (i.e. the v3 series).
+
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/tomwright/dasel/v2
+ 
+-go 1.21
++go 1.22
+ 
+ require (
+ 	github.com/alecthomas/chroma/v2 v2.13.0


### PR DESCRIPTION
dasel: fix ptest failure with Go 1.27 (reflect.TypeFor / go.mod language version)
    
    dasel v2.8.1 ships an inconsistent module declaration: go.mod declares
    `go 1.21`, but value.go:329-330 uses reflect.TypeFor, which was added to
    the standard library in Go 1.22.
    
    Go 1.27.0 added the `stdversion` analyzer to defaultVetFlags, the set of
    vet checks `go test` runs by default. That analyzer reports standard
    library symbols newer than the language version declared in go.mod, so
    after golang was bumped to 1.27.x the %check section started failing:
    
        # github.com/tomwright/dasel/v2
        # [github.com/tomwright/dasel/v2]
        ./value.go:329:34: reflect.TypeFor requires go1.22 or later (module is go1.21)
        ./value.go:330:38: reflect.TypeFor requires go1.22 or later (module is go1.21)
        FAIL        github.com/tomwright/dasel/v2 [build failed]
    
    `go build` is unaffected, which is why only the test run broke.
    
    Add fix-go-mod-language-version.patch to declare `go 1.22` in go.mod,
    matching the code's real requirement and the `BuildRequires: golang >= 1.22`
    the spec already carries. Bump Release and add a changelog entry.
    
    dasel v2.8.1 is the final v2 release (upstream moved to the v3 module
    path), so there is no upstream commit to backport. The patch can be
    path), so there is no upstream commit to backport. The patch can be
    dropped when dasel is upgraded to a release declaring go >= 1.22.