### PR TITLE
Change systemd fsck device dependencies to Wants

### DIFF
--- a/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
+++ b/SPECS-SIGNED/systemd-boot-signed/systemd-boot-signed.spec
@@ -20,7 +20,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        34%{?dist}
+Release:        35%{?dist}
 License:        LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,6 +98,9 @@ popd
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Thu Sep 10 2026 Pawel Winogrodzki <pawelwi@microsoft.com> - 255-35
+- Bump release to match the systemd spec.
+
 * Mon Aug 17 2026 Aditya Singh <v-aditysing@microsoft.com> - 255-34
 - Bump release to match systemd spec.
 

--- a/SPECS/systemd/systemd-fsck-wants-device.patch
+++ b/SPECS/systemd/systemd-fsck-wants-device.patch
@@ -1,0 +1,49 @@
+Use Wants instead of BindsTo for the generated initrd root filesystem
+checker and the static systemd-fsck@ template. Keep their After ordering
+so initial device discovery still precedes the filesystem check.
+
+This experimental alternative avoids stopping the checker solely because
+udev temporarily withdraws its filesystem UUID alias. It adds no device
+locks and leaves sysroot.mount dependencies and its UUID-based source
+unchanged. The generated systemd-fsck-usr.service retains BindsTo.
+
+Wants does not propagate device activation failure or automatically stop
+the checker on device removal. This change also does not restore a
+missing UUID link or retry a failed root mount.
+
+Related issue: https://github.com/systemd/systemd/issues/43695
+
+diff --git a/src/shared/generator.c b/src/shared/generator.c
+--- a/src/shared/generator.c
++++ b/src/shared/generator.c
+@@ -225,7 +225,7 @@ static int write_fsck_sysroot_service(
+                 "Documentation=man:%2$s(8)\n"
+                 "\n"
+                 "DefaultDependencies=no\n"
+-                "BindsTo=%3$s\n"
++                "%7$s=%3$s\n"
+                 "Conflicts=shutdown.target\n"
+                 "After=%4$s%5$slocal-fs-pre.target %3$s\n"
+                 "Before=shutdown.target\n"
+@@ -240,7 +240,8 @@ static int write_fsck_sysroot_service(
+                 device,
+                 strempty(extra_after),
+                 isempty(extra_after) ? "" : " ",
+-                escaped2);
++                escaped2,
++                streq(unit, SPECIAL_FSCK_ROOT_SERVICE) ? "Wants" : "BindsTo");
+
+         r = fflush_and_check(f);
+         if (r < 0)
+diff --git a/units/systemd-fsck@.service.in b/units/systemd-fsck@.service.in
+--- a/units/systemd-fsck@.service.in
++++ b/units/systemd-fsck@.service.in
+@@ -11,7 +11,7 @@
+ Description=File System Check on %f
+ Documentation=man:systemd-fsck@.service(8)
+ DefaultDependencies=no
+-BindsTo=%i.device
++Wants=%i.device
+ Conflicts=shutdown.target
+ After=%i.device systemd-fsck-root.service local-fs-pre.target
+ Before=systemd-quotacheck.service shutdown.target

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        34%{?dist}
+Release:        35%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -161,6 +161,7 @@ Patch0913:      network-also-check-ID_NET_MANAGED_BY-property-on-rec.patch
 Patch0914:      Prevent-corruption-from-stale-alias-state-on-daemon-reload.patch
 Patch0915:      CVE-2026-15059.patch
 Patch0916:      CVE-2026-16742.patch
+Patch0917:      systemd-fsck-wants-device.patch
 
 %ifarch %{ix86} x86_64 aarch64
 %global want_bootloader 1
@@ -1259,6 +1260,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Thu Sep 10 2026 Pawel Winogrodzki <pawelwi@microsoft.com> - 255-35
+- Use Wants for the generated root filesystem checker and the fsck service
+  template device dependencies.
+
 * Thu Aug 13 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 255-34
 - Patch for CVE-2026-16742, CVE-2026-15059
 


### PR DESCRIPTION
## Change

- Replace `BindsTo=` with `Wants=` in the generated initrd `systemd-fsck-root.service` and the static `systemd-fsck@.service` template.
- Preserve `After=` ordering, the generated `systemd-fsck-usr.service` binding, and the UUID-based source and dependencies of `sysroot.mount`.
- Add no device locks.
- Update `systemd` and `systemd-boot-signed` together to release 255-35.

## Why

A transient filesystem probe failure can remove the root UUID alias and cause `BindsTo=` to stop a filesystem check, canceling dependent boot jobs. This dependency-only alternative lets the checker finish despite loss of the alias.

Related issue: https://github.com/systemd/systemd/issues/43695

This is an alternative to #18653, not an additional patch to combine with it.

## Risk

`Wants=` does not propagate device activation failure and does not automatically stop the checker when the device disappears. The static template change applies to all instances, including non-root filesystem checks.

This change does not recreate UUID links, retry failed mounts, or rebuild canceled boot transactions. `sysroot.mount` can still fail if its UUID path is absent when the mount runs. The draft remains experimental.

## Verification

- The native patch applies to pristine systemd v255 without fuzz.
- Ten baseline VM boots reached switch-root with empty root-fsck `BindsTo=`, the expected UUID `Wants=`, unchanged root-mount dependencies, and verbose serial logging.
- The ten-VM E4ds_v6/E8ds_v6 resize campaign was interrupted by a serial-log download error. It has not established whether this change survives the UUID-loss race; the controller error is not classified as a guest boot failure.
- The experiment uses a generator-output wrapper and a static-unit override on stock binaries. This PR expresses the same dependency changes in the systemd sources; the rebuilt RPM has not yet been tested.
- Local spec-guideline execution is blocked by Python/WSL tooling. Package CI results are pending.
- Review strategy: self-review.
