### PR TITLE
toolkit: fix encrypted ISO installer hang

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -589,8 +589,9 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 		partIDToFsTypeMap[partition.ID] = partFsType
 	}
 
-	// Wait for the disk's metadata to populate.
-	err = RefreshPartitions(diskDevPath)
+	// sfdisk already updated the partition table. LUKS/LVM may now hold
+	// partions open, so wait for metadata without issuing BLKRRPART
+	err = WaitForDiskDevice(diskDevPath)
 	if err != nil {
 		return
 	}
@@ -1110,7 +1111,7 @@ func requestKernelRereadPartitionTable(diskDevPath string) error {
 
 	waitTime := 125 * time.Millisecond
 	retries := 10
-	for i := 0; ; i = 1 {
+	for i := 0; ; i++ {
 		_, _, errno := unix.Syscall(unix.SYS_IOCTL, diskFile.Fd(), unix.BLKRRPART, 0)
 		switch {
 		case errno == unix.EBUSY && i < retries:


### PR DESCRIPTION
Use WaitForDiskDevice instead of RefreshPartitions after partition
setup. sfdisk already updates the kernel partition table, while the
opened LUKS/LVM mapping keeps the root partition busy and causes a
subsequent BLKRRPART request to return EBUSY.

Also increment the partition-reread retry counter instead of resetting
it to 1, restoring the retry limit and preventing indefinite backoff.
Keep the metadata synchronization checks without rereading an in-use
partition table.

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
