### PR TITLE
feat(installer): add nvme-cli to ISO and target

### DIFF
--- a/base/images/vm-iso-installer/config.sh
+++ b/base/images/vm-iso-installer/config.sh
@@ -60,6 +60,7 @@ INSTALL_PKGS=(
     efibootmgr
     kernel
     kernel-modules
+    nvme-cli
     openssh-server
     openssh-clients
     sudo

--- a/base/images/vm-iso-installer/vm-iso-installer.kiwi
+++ b/base/images/vm-iso-installer/vm-iso-installer.kiwi
@@ -57,6 +57,7 @@
         <package name="kernel-modules" />
         <!-- Provides xmllint for parsing Kiwi's effective config XML in config.sh. -->
         <package name="libxml2" />
+        <package name="nvme-cli" />
         <package name="selinux-policy-targeted" />
         <package name="setup" />
         <package name="shadow-utils" />


### PR DESCRIPTION
Provide NVMe device management before and after installation. Include nvme-cli in the live image and target package list, which also populates the offline repository and both normal and encrypted kickstarts.

Fixes: [AB#23494](https://dev.azure.com/mariner-org/36d030d6-1d99-4ebd-878b-09af1f4f722f/_workitems/edit/23494)